### PR TITLE
Fix AI review workflow: add id-token write permission for OIDC

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -18,6 +18,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
The `claude-code-action` attempts OIDC token authentication before falling back to the `ANTHROPIC_API_KEY` secret. Without `id-token: write` in the workflow permissions, the runner cannot obtain the OIDC token and the action fails immediately.

## Impact
- No workflow changes for contributors — this only affects the GitHub Actions runner permissions.
- AI review will now run successfully on new PRs and `@claude` comments once this is on `main`.

## Changes
### `.github/workflows/ai-review.yml`
Added `id-token: write` to the job's permissions block so the runner can request an OIDC token as required by `anthropics/claude-code-action@beta`.

## Testing
Reproduces the error seen in the failed run: `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`. This permission is the documented fix for that error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)