### PR TITLE
Fix AI review: provide github_token to bypass OIDC

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -25,3 +25,4 @@ jobs:
       - uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
`issue_comment` events on GitHub do not support OIDC token issuance, so `claude-code-action` exhausts all 3 OIDC attempts before failing. Providing `github_token` explicitly tells the action to skip OIDC and use the `ANTHROPIC_API_KEY` secret directly.

## Impact
No workflow changes for contributors. `@claude` comments on PRs will now trigger the AI review successfully.

## Changes
- Added `github_token: ${{ secrets.GITHUB_TOKEN }}` to the action's `with` block in `ai-review.yml`

## Notes
`ANTHROPIC_API_KEY` must be set in repo Settings → Secrets → Actions (already done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)