### PR TITLE
Add `mcp show` and `mcp kill` commands for database lock diagnostics

### DIFF
--- a/src/moneybin/cli/commands/mcp.py
+++ b/src/moneybin/cli/commands/mcp.py
@@ -7,12 +7,78 @@ assistants like Cursor, Claude Desktop, and ChatGPT Desktop.
 
 import importlib
 import logging
+import os
+import subprocess  # noqa: S404
+from pathlib import Path
 from typing import Annotated, Literal, get_args
 
 import typer
 
 app = typer.Typer(help="MCP server for AI assistant integration")
 logger = logging.getLogger(__name__)
+
+
+def _find_db_processes(db_path: Path) -> list[dict[str, str | int]]:
+    """Find processes that have the DuckDB file open, excluding the current process.
+
+    Args:
+        db_path: Path to the DuckDB database file.
+
+    Returns:
+        List of dicts with keys: pid (int), command (str), cmdline (str).
+    """
+    own_pid = os.getpid()
+    try:
+        result = subprocess.run(  # noqa: S603 — lsof with static args, db_path is a validated Path
+            ["lsof", "-F", "pcn", str(db_path)],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except FileNotFoundError:
+        logger.error("❌ lsof not found — cannot inspect file locks")
+        return []
+    except subprocess.TimeoutExpired:
+        logger.error("❌ lsof timed out")
+        return []
+
+    if not result.stdout:
+        return []
+
+    # lsof -F output: each process block starts with p<pid>, then c<cmd>, then n<file>
+    processes: list[dict[str, str | int]] = []
+    seen_pids: set[int] = set()
+    current_pid: int | None = None
+    current_cmd: str = ""
+
+    for line in result.stdout.splitlines():
+        if line.startswith("p"):
+            current_pid = int(line[1:])
+            current_cmd = ""
+        elif line.startswith("c") and current_pid is not None:
+            current_cmd = line[1:]
+        elif (
+            line.startswith("n")
+            and current_pid is not None
+            and current_pid not in seen_pids
+        ):
+            seen_pids.add(current_pid)
+            if current_pid == own_pid:
+                continue
+            ps_result = subprocess.run(  # noqa: S603 — ps with static args and validated int PID
+                ["ps", "-p", str(current_pid), "-o", "args="],  # noqa: S607
+                capture_output=True,
+                text=True,
+            )
+            cmdline = ps_result.stdout.strip()
+            processes.append({
+                "pid": current_pid,
+                "command": current_cmd,
+                "cmdline": cmdline,
+            })
+
+    return processes
+
 
 # Transport types supported by FastMCP.run()
 TransportType = Literal["stdio", "sse", "streamable-http"]
@@ -86,3 +152,90 @@ def serve(
         logger.info("MCP server stopped by user")
     finally:
         close_db()
+
+
+@app.command("show")
+def show() -> None:
+    """Show other processes holding the MoneyBin database file open.
+
+    Useful for diagnosing database lock conflicts. Excludes the current process.
+
+    Examples:
+        moneybin mcp show
+        moneybin --profile=alice mcp show
+    """
+    from moneybin.config import get_database_path
+
+    db_path = get_database_path()
+
+    if not db_path.exists():
+        logger.info("Database file does not exist yet: %s", db_path)
+        return
+
+    processes = _find_db_processes(db_path)
+
+    if not processes:
+        logger.info("No other processes have %s open", db_path.name)
+        return
+
+    typer.echo(f"Processes holding {db_path} open:\n")
+    typer.echo(f"  {'PID':<8} {'COMMAND':<16} ARGS")
+    typer.echo(f"  {'-' * 7:<8} {'-' * 15:<16} {'-' * 40}")
+    for proc in processes:
+        typer.echo(f"  {proc['pid']:<8} {proc['command']:<16} {proc['cmdline']}")
+
+
+@app.command("kill")
+def kill() -> None:
+    """Kill other processes holding the MoneyBin database file open.
+
+    Lists any processes with a lock on the database, then asks for confirmation
+    before sending SIGTERM to each. Use when `mcp serve` won't start because
+    another session is holding the database.
+
+    Examples:
+        moneybin mcp kill
+        moneybin --profile=alice mcp kill
+    """
+    import signal
+
+    from moneybin.config import get_database_path
+
+    db_path = get_database_path()
+
+    if not db_path.exists():
+        logger.info("Database file does not exist yet: %s", db_path)
+        return
+
+    processes = _find_db_processes(db_path)
+
+    if not processes:
+        logger.info("No other processes have %s open", db_path.name)
+        return
+
+    typer.echo(f"Processes holding {db_path} open:\n")
+    typer.echo(f"  {'PID':<8} {'COMMAND':<16} ARGS")
+    typer.echo(f"  {'-' * 7:<8} {'-' * 15:<16} {'-' * 40}")
+    for proc in processes:
+        typer.echo(f"  {proc['pid']:<8} {proc['command']:<16} {proc['cmdline']}")
+    typer.echo()
+
+    count = len(processes)
+    noun = "process" if count == 1 else "processes"
+    if not typer.confirm(f"Send SIGTERM to {count} {noun}?"):
+        raise typer.Exit(0)
+
+    killed = 0
+    for proc in processes:
+        pid = int(proc["pid"])
+        try:
+            os.kill(pid, signal.SIGTERM)
+            logger.info("Sent SIGTERM to PID %d (%s)", pid, proc["command"])
+            killed += 1
+        except ProcessLookupError:
+            logger.warning("⚠️  PID %d already exited", pid)
+        except PermissionError:
+            logger.error("❌ No permission to kill PID %d (%s)", pid, proc["command"])
+
+    if killed:
+        logger.info("✅ Sent SIGTERM to %d %s", killed, noun)

--- a/src/moneybin/mcp/tools.py
+++ b/src/moneybin/mcp/tools.py
@@ -108,10 +108,11 @@ def describe_table(table_name: str, schema_name: str = "raw") -> str:
             column_name,
             data_type,
             is_nullable,
-            column_default
-        FROM information_schema.columns
-        WHERE table_schema = ? AND table_name = ?
-        ORDER BY ordinal_position
+            column_default,
+            comment
+        FROM duckdb_columns()
+        WHERE schema_name = ? AND table_name = ?
+        ORDER BY column_index
     """
     columns_json = _query_to_json(sql, [schema_name, table_name])
 


### PR DESCRIPTION
### Summary
Adds two new `moneybin mcp` subcommands — `show` and `kill` — to help diagnose and resolve DuckDB file lock conflicts that prevent `mcp serve` from starting. Also fixes `describe_table` in MCP tools to use `duckdb_columns()` so column comments are included.

### Impact
- No workflow changes for normal use. These commands are opt-in diagnostics.
- `mcp show` / `mcp kill` are macOS/Linux only (uses `lsof`); Windows not supported.

### Changes

#### `mcp show` and `mcp kill` commands (`cli/commands/mcp.py`)
Extracted a `_find_db_processes()` helper that uses `lsof` to find processes holding the DuckDB file open (excluding the current PID). Both commands share this helper.

- `mcp show` — lists PIDs, command names, and full args of locking processes
- `mcp kill` — shows the same list, prompts for confirmation, then sends SIGTERM to each; handles `ProcessLookupError` and `PermissionError` gracefully

#### `describe_table` fix (`mcp/tools.py`)
Switched from `information_schema.columns` to `duckdb_columns()` to gain access to the `comment` column, which is populated by `COMMENT ON COLUMN` statements.

### Testing
- Manually tested `mcp show` with an active MCP server session holding the DB open.
- Manually tested `mcp kill` confirming SIGTERM prompt and kill behavior.
- `describe_table` fix verified against a table with column comments.