### PR TITLE
Add server API contract and sync client integration spec

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -33,6 +33,20 @@ jobs:
             - Test coverage gaps for new business logic
             Post inline comments on specific lines where relevant. Summarize findings as a PR comment.
 
+            After completing your review, resolve any previously-posted review threads whose
+            issues are now fixed in the current code. Use the gh CLI and environment variables
+            already present in the runner — do not interpolate untrusted event payload fields
+            into shell commands. Steps:
+            1. Determine the PR number: gh pr view --json number -q .number
+            2. Parse owner and repo from the GITHUB_REPOSITORY environment variable.
+            3. Fetch open threads via gh api graphql, passing owner, repo, and number as
+               -f variables so no user-controlled data is shell-interpolated.
+            4. For each unresolved thread, read its comment body, check whether the current
+               code addresses the issue, and if so resolve it via the resolveReviewThread
+               GraphQL mutation.
+            Only resolve threads where the fix is clearly present — leave threads open if
+            the issue is partially addressed or still present.
+
       - name: Interactive @claude mentions
         if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')
         uses: anthropics/claude-code-action@v1

--- a/docs/reference/server-api-contract.md
+++ b/docs/reference/server-api-contract.md
@@ -1,0 +1,506 @@
+# API Contract
+
+Base URL: `https://api.moneybin.app` (production), `http://localhost:3000` (development).
+
+## Authentication
+
+All endpoints except `/health` and `/auth/*` require a valid JWT in the `Authorization` header:
+
+```
+Authorization: Bearer <jwt-token>
+```
+
+The JWT is issued by Auth0 (via server proxy) and validated against the Auth0 JWKS endpoint. Clients never talk to Auth0 directly -- all auth flows go through `api.moneybin.app`.
+
+## Error Response Format
+
+All error responses use a consistent JSON shape:
+
+```json
+{
+  "error": "Human-readable error message",
+  "details": {}
+}
+```
+
+The `details` field is optional and included only when additional context is available (e.g., validation errors).
+
+## HTTP Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 200 | Success |
+| 201 | Created |
+| 202 | Accepted (polling response for device flow) |
+| 204 | No Content (successful deletion) |
+| 400 | Bad Request (malformed input) |
+| 401 | Unauthorized (missing or invalid JWT) |
+| 403 | Forbidden (valid JWT but insufficient permissions) |
+| 404 | Not Found |
+| 422 | Unprocessable Entity (valid JSON but failed validation) |
+| 500 | Internal Server Error |
+| 501 | Not Implemented (stub endpoints during phased rollout) |
+
+---
+
+## Health
+
+### `GET /health`
+
+Health check endpoint. No authentication required.
+
+**Response** `200`
+
+```json
+{
+  "status": "ok",
+  "timestamp": "2026-04-07T12:00:00.000Z"
+}
+```
+
+---
+
+## Auth Endpoints (No JWT Required)
+
+These endpoints are part of the authentication flow and do not require an existing JWT.
+
+### `POST /auth/device/code`
+
+Initiates the Device Authorization Flow for CLI clients. The server proxies the request to Auth0.
+
+**Request body**: None.
+
+**Response** `200`
+
+```json
+{
+  "device_code": "Ag_EE...",
+  "user_code": "ABCD-EFGH",
+  "verification_uri": "https://your-tenant.auth0.com/activate",
+  "verification_uri_complete": "https://your-tenant.auth0.com/activate?user_code=ABCD-EFGH",
+  "expires_in": 900,
+  "interval": 5
+}
+```
+
+The CLI displays `user_code` and `verification_uri_complete` to the user, who visits the URL in a browser to authorize. The CLI then polls `POST /auth/device/token`.
+
+### `POST /auth/device/token`
+
+Polls for a device token after the user has authorized the device. The server proxies the request to Auth0.
+
+**Request body**
+
+```json
+{
+  "device_code": "Ag_EE..."
+}
+```
+
+**Response** `200` (authorized)
+
+```json
+{
+  "access_token": "eyJ...",
+  "id_token": "eyJ...",
+  "refresh_token": "v1.M...",
+  "token_type": "Bearer",
+  "expires_in": 86400
+}
+```
+
+**Response** `202` (pending -- user has not yet authorized)
+
+```json
+{
+  "status": "pending"
+}
+```
+
+**Response** `202` (slow_down -- polling too fast)
+
+```json
+{
+  "status": "slow_down"
+}
+```
+
+**Errors**
+
+- `400` if `device_code` is missing or the device code has expired.
+- `403` if the user denied authorization.
+
+### `GET /auth/login`
+
+Redirects the user to Auth0 Universal Login (Authorization Code Flow for web clients).
+
+**Response** `302` redirect to Auth0 login page with CSRF state cookie set.
+
+### `GET /auth/callback`
+
+Auth0 redirects here after successful Authorization Code Flow authentication. The server validates the state parameter (CSRF check), exchanges the authorization code for tokens, and establishes a session.
+
+**Query Parameters**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `code` | string | Authorization code from Auth0 |
+| `state` | string | CSRF state parameter (must match cookie) |
+
+**Response** `302` redirect to the web UI with session established.
+
+### `GET /auth/logout`
+
+Clears the session and redirects to Auth0's logout endpoint.
+
+**Response** `302` redirect to Auth0 logout, then to post-logout URL.
+
+---
+
+## Auth Endpoints (JWT Required)
+
+### `GET /auth/session`
+
+Returns the currently authenticated user's information. `id` is the server's local UUID (not the Auth0 `sub`).
+
+**Response** `200`
+
+```json
+{
+  "user": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "email": "user@example.com"
+  }
+}
+```
+
+**Error** `401` if no valid JWT.
+
+---
+
+## Sync Endpoints (JWT Required)
+
+### `POST /sync/link-token`
+
+Creates a Plaid Link token. The client uses this token to initialize Plaid Link in the browser.
+
+**Request body**: None.
+
+**Response** `200`
+
+```json
+{
+  "link_token": "link-sandbox-abc123...",
+  "expiration": "2026-04-07T12:30:00Z"
+}
+```
+
+### `POST /sync/exchange-token`
+
+Exchanges a Plaid public token (received after the user completes Plaid Link) for a persistent access token. The server encrypts the access token with AES-256-GCM and stores it in the `plaid_items` table.
+
+**Request body**
+
+```json
+{
+  "public_token": "public-sandbox-abc123...",
+  "institution_id": "ins_123",
+  "institution_name": "Chase"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `public_token` | string | yes | Public token from Plaid Link completion |
+| `institution_id` | string | no | Plaid institution identifier |
+| `institution_name` | string | no | Human-readable institution name |
+
+**Response** `201`
+
+```json
+{
+  "item_id": "item_abc123..."
+}
+```
+
+**Errors**
+
+- `400` if `public_token` is missing.
+- `422` if the token exchange fails with Plaid.
+
+### `POST /sync/trigger`
+
+Triggers a sync job. If `item_id` is provided, syncs only that institution. If omitted, syncs all connected institutions in parallel (`Promise.allSettled`). Blocks until complete.
+
+**Request body**
+
+```json
+{
+  "item_id": "item_abc123..."
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `item_id` | string | no | Specific Plaid Item to sync. Omit to sync all institutions in parallel. |
+
+**Response** `201`
+
+```json
+{
+  "job_id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "completed",
+  "transaction_count": 142
+}
+```
+
+The response always reflects the final job state since sync is synchronous. In a future async implementation, the response would return `status: "pending"` and the client would use the existing polling flow.
+
+### `GET /sync/status`
+
+Returns the current status of a sync job, including per-institution results.
+
+**Query Parameters**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `job_id` | string (UUID) | yes | The sync job identifier |
+
+**Response** `200`
+
+```json
+{
+  "job_id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "completed",
+  "transaction_count": 142,
+  "error": null,
+  "started_at": "2026-04-07T12:00:00.000Z",
+  "completed_at": "2026-04-07T12:00:05.000Z",
+  "results": [
+    {
+      "item_id": "item_abc",
+      "institution_name": "Chase",
+      "status": "completed",
+      "transaction_count": 80
+    },
+    {
+      "item_id": "item_def",
+      "institution_name": "Schwab",
+      "status": "failed",
+      "error": "ITEM_LOGIN_REQUIRED"
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `job_id` | string (UUID) | Job identifier |
+| `status` | string | One of: `pending`, `running`, `completed`, `failed` |
+| `transaction_count` | number or null | Total transactions fetched across all institutions |
+| `error` | string or null | Top-level error message (set on complete failure) |
+| `started_at` | string or null | ISO 8601 timestamp when processing began |
+| `completed_at` | string or null | ISO 8601 timestamp when processing finished |
+| `results` | array or null | Per-institution outcomes (from JSONB column) |
+
+**Errors**
+
+- `400` if `job_id` query parameter is missing.
+- `404` if the job does not exist or belongs to another user.
+
+### `GET /sync/data`
+
+Returns the sync results as JSON. The client calls this after `status` returns `completed`. Data is held in an in-memory TTL store (30-minute default) and expires after that window.
+
+**Query Parameters**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `job_id` | string (UUID) | yes | The completed sync job identifier |
+
+**Response** `200`
+
+```
+Content-Type: application/json
+```
+
+See [Sync Data Format](#sync-data-format) for the full response shape.
+
+**Errors**
+
+- `400` if `job_id` query parameter is missing.
+- `404` if the job does not exist, belongs to another user, or has expired from the TTL store.
+- `422` if the job has not completed yet.
+
+---
+
+## Institution Endpoints (JWT Required)
+
+### `GET /institutions`
+
+Lists all connected institutions for the authenticated user.
+
+**Response** `200`
+
+```json
+[
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "item_id": "item_abc123...",
+    "institution_name": "Chase",
+    "status": "active",
+    "last_sync": "2026-04-07T12:00:00.000Z",
+    "created_at": "2026-03-15T08:30:00.000Z"
+  }
+]
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string (UUID) | Internal identifier for this connection |
+| `item_id` | string | Plaid Item identifier |
+| `institution_name` | string or null | Human-readable institution name |
+| `status` | string | Connection status: `active`, `error`, `revoked` |
+| `last_sync` | string or null | ISO 8601 timestamp of last successful sync |
+| `created_at` | string | ISO 8601 timestamp when institution was connected |
+
+### `DELETE /institutions/:id`
+
+Disconnects an institution. Revokes the Plaid access token and removes the connection from the database.
+
+**Path Parameters**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) | Internal identifier for the institution connection |
+
+**Response** `204 No Content`
+
+**Errors**
+
+- `404` if the institution does not exist or belongs to another user.
+
+---
+
+## Sync Data Format
+
+The `GET /sync/data` endpoint returns JSON. Data volumes are small (hundreds to low thousands of transactions per sync), making JSON a natural fit that eliminates heavy server-side Parquet dependencies.
+
+```json
+{
+  "accounts": [
+    {
+      "account_id": "acc_001",
+      "account_type": "depository",
+      "account_subtype": "checking",
+      "institution_name": "Chase",
+      "official_name": "Total Checking",
+      "mask": "1234"
+    }
+  ],
+  "transactions": [
+    {
+      "transaction_id": "txn_001",
+      "account_id": "acc_001",
+      "transaction_date": "2026-04-07",
+      "amount": 42.50,
+      "description": "COFFEE SHOP",
+      "merchant_name": "Best Coffee",
+      "category": "FOOD_AND_DRINK",
+      "pending": false
+    }
+  ],
+  "balances": [
+    {
+      "account_id": "acc_001",
+      "balance_date": "2026-04-08",
+      "current_balance": 1234.56,
+      "available_balance": 1200.00
+    }
+  ],
+  "removed_transactions": ["txn_old_001"],
+  "metadata": {
+    "job_id": "550e8400-e29b-41d4-a716-446655440000",
+    "synced_at": "2026-04-08T12:00:00.000Z",
+    "institutions": [
+      {
+        "item_id": "item_abc",
+        "institution_name": "Chase",
+        "status": "completed",
+        "transaction_count": 80
+      },
+      {
+        "item_id": "item_def",
+        "institution_name": "Schwab",
+        "status": "failed",
+        "error": "ITEM_LOGIN_REQUIRED"
+      }
+    ]
+  }
+}
+```
+
+### Field Reference
+
+#### `accounts[]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `account_id` | string | Plaid account identifier; stable across syncs |
+| `account_type` | string | Plaid account type: `depository`, `credit`, `loan`, `investment`, `other` |
+| `account_subtype` | string | Plaid account subtype: `checking`, `savings`, `credit card`, etc. |
+| `institution_name` | string | Human-readable institution name |
+| `official_name` | string | Official account name from the institution |
+| `mask` | string | Last 4 digits of the account number |
+
+#### `transactions[]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `transaction_id` | string | Plaid transaction identifier; unique and stable |
+| `account_id` | string | Plaid account identifier |
+| `transaction_date` | string (YYYY-MM-DD) | Date the transaction posted or is pending |
+| `amount` | number | Transaction amount in **Plaid convention: positive = expense, negative = income** |
+| `description` | string | Transaction description from the institution |
+| `merchant_name` | string or null | Normalized merchant name from Plaid |
+| `category` | string or null | Plaid's primary transaction category |
+| `pending` | boolean | `true` if the transaction has not yet posted |
+
+#### `balances[]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `account_id` | string | Plaid account identifier |
+| `balance_date` | string (YYYY-MM-DD) | Date the balance was captured |
+| `current_balance` | number | Total current balance including pending transactions |
+| `available_balance` | number or null | Available balance; may be null for credit accounts |
+
+#### `removed_transactions[]`
+
+Array of `transaction_id` strings for transactions that Plaid has removed (e.g., reversed or duplicate). The client should delete these from local storage.
+
+#### `metadata`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `job_id` | string (UUID) | Sync job identifier |
+| `synced_at` | string (ISO 8601) | When the server fetched this data from Plaid |
+| `institutions[]` | array | Per-institution sync outcomes |
+
+### Amount Sign Convention
+
+Plaid and moneybin use opposite sign conventions for transaction amounts:
+
+| System | Expense | Income |
+|--------|---------|--------|
+| Plaid (server delivers this) | Positive | Negative |
+| moneybin core convention | Negative | Positive |
+
+The server delivers Plaid's native convention. The moneybin client's staging model `prep.stg_plaid__transactions` negates the amount (`-1 * amount`) to align with the project-wide convention before data reaches the core layer.
+
+### Client-Side Metadata
+
+The JSON response does not include `source_file`, `extracted_at`, or `loaded_at` fields. These are client-side metadata:
+- `source_file`: The client generates a logical identifier such as `sync_{job_id}`
+- `extracted_at`: Set from `metadata.synced_at`
+- `loaded_at`: Set to the current timestamp during DuckDB insertion

--- a/docs/reference/server-api-contract.md
+++ b/docs/reference/server-api-contract.md
@@ -37,7 +37,8 @@ The `details` field is optional and included only when additional context is ava
 | 401 | Unauthorized (missing or invalid JWT) |
 | 403 | Forbidden (valid JWT but insufficient permissions) |
 | 404 | Not Found |
-| 422 | Unprocessable Entity (valid JSON but failed validation) |
+| 409 | Conflict (resource exists but is in the wrong state, e.g. job not yet complete) |
+| 422 | Unprocessable Entity (valid JSON but failed semantic validation) |
 | 500 | Internal Server Error |
 | 501 | Not Implemented (stub endpoints during phased rollout) |
 
@@ -124,6 +125,8 @@ Polls for a device token after the user has authorized the device. The server pr
   "status": "slow_down"
 }
 ```
+
+> **RFC 8628 §3.5 compliance:** On a `slow_down` response, the client MUST increase its polling interval by at least 5 seconds and use that new interval for all subsequent polls in the same flow.
 
 **Errors**
 
@@ -236,13 +239,15 @@ Triggers a sync job. If `item_id` is provided, syncs only that institution. If o
 
 ```json
 {
-  "item_id": "item_abc123..."
+  "item_id": "item_abc123...",
+  "reset_cursor": false
 }
 ```
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `item_id` | string | no | Specific Plaid Item to sync. Omit to sync all institutions in parallel. |
+| `reset_cursor` | boolean | no | If `true`, resets the Plaid transaction cursor and re-fetches all available history. Default `false`. |
 
 **Response** `201`
 
@@ -330,7 +335,9 @@ See [Sync Data Format](#sync-data-format) for the full response shape.
 
 - `400` if `job_id` query parameter is missing.
 - `404` if the job does not exist, belongs to another user, or has expired from the TTL store.
-- `422` if the job has not completed yet.
+- `409` if the job has not completed yet.
+
+> **TTL recovery:** Data expires from the in-memory store 30 minutes after the job completes. If the client misses this window (e.g. crashes after `POST /sync/trigger`), it can recover by calling `POST /sync/trigger` again — triggering a new sync is idempotent with respect to the underlying Plaid cursor state.
 
 ---
 
@@ -379,6 +386,8 @@ Disconnects an institution. Revokes the Plaid access token and removes the conne
 **Errors**
 
 - `404` if the institution does not exist or belongs to another user.
+
+> **Finding the `id`:** `POST /sync/exchange-token` returns only `item_id` (the Plaid identifier). The internal UUID required here is different — it can be obtained from the `id` field in the `GET /institutions` response. Clients that need to disconnect must call `GET /institutions` first to resolve `item_id → id`.
 
 ---
 

--- a/docs/specs/database-migration.md
+++ b/docs/specs/database-migration.md
@@ -1,0 +1,99 @@
+# Feature: Database Migration System
+
+## Status
+<!-- draft | ready | in-progress | implemented -->
+draft
+
+## Goal
+Provide a versioned migration system for MoneyBin's DuckDB database that handles both
+moneybin schema changes (app/raw tables) and third-party library state upgrades (e.g.
+SQLMesh state tables), so that database upgrades are automated, repeatable, and safe.
+
+## Background
+- SQLMesh stores its own state in the DuckDB file and requires `sqlmesh migrate` when
+  the SQLMesh package version changes. Today this fails silently at runtime
+  (see `sqlmesh/config.py` and `categorization_service.py:ensure_seed_table`).
+- MoneyBin's own `app.*` / `raw.*` schema DDL is applied idempotently at startup via
+  `init_schemas`, but there is no mechanism for destructive or additive changes after
+  initial creation (e.g. renaming a column, adding a NOT NULL constraint, backfilling data).
+- Without a migration layer, users who upgrade the package against an existing database
+  can encounter silent data corruption or hard crashes.
+
+## Requirements
+
+1. Migrations are versioned with a monotonic integer (e.g. `0001`, `0002`) and stored
+   under `src/moneybin/sql/migrations/`.
+2. A `schema_versions` table in the `app` schema tracks applied migration IDs, applied
+   timestamps, and the moneybin package version at time of application.
+3. Migrations run automatically at app startup (before `init_schemas` logic) if unapplied
+   versions exist; no manual `migrate` command required for normal upgrades.
+4. A `moneybin db migrate` CLI command allows running migrations explicitly and supports
+   `--dry-run` to preview SQL without executing.
+5. SQLMesh state upgrades (`sqlmesh migrate`) are detected and invoked automatically when
+   the installed SQLMesh version differs from the version recorded in the database; this
+   replaces the current crash-at-runtime behavior.
+6. Migrations are transactional where DuckDB supports it; a failed migration rolls back
+   and surfaces a clear error rather than leaving the database in a partial state.
+7. Downgrade / rollback is out of scope for v1 — migrations are forward-only.
+
+## Data Model
+
+```sql
+/* Tracks applied moneybin schema migrations */
+CREATE TABLE IF NOT EXISTS app.schema_versions (
+    migration_id    VARCHAR NOT NULL,    -- Zero-padded integer, e.g. '0001'
+    description     VARCHAR NOT NULL,    -- Human-readable summary of the migration
+    applied_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    moneybin_version VARCHAR,            -- moneybin package version at apply time
+    PRIMARY KEY (migration_id)
+);
+```
+
+## Implementation Plan
+
+### Files to Create
+- `src/moneybin/sql/migrations/` — directory for numbered `.sql` migration files
+- `src/moneybin/db/migrations.py` — `MigrationRunner` class: discover, filter, apply
+- `src/moneybin/cli/db.py` (or extend existing) — `moneybin db migrate` command
+
+### Files to Modify
+- `src/moneybin/db/schema.py` — call `MigrationRunner` before `init_schemas` at startup
+- `sqlmesh/config.py` — replace crash-on-version-mismatch with auto `sqlmesh migrate`
+- `src/moneybin/config.py` — expose installed SQLMesh version for version-check logic
+
+### Key Decisions
+- **Discovery**: migrations are plain `.sql` files named `NNNN_description.sql`; no Python
+  migration objects needed for v1.
+- **SQLMesh version tracking**: store last-migrated SQLMesh version in a separate
+  `app.library_versions` table (or a dedicated row in `schema_versions` with a reserved
+  prefix like `sqlmesh_*`).
+- **Startup behavior**: fail fast with a clear message if migration fails rather than
+  continuing with a potentially corrupt state.
+
+## CLI Interface
+
+```
+moneybin db migrate [--dry-run] [--profile PROFILE]
+```
+
+- `--dry-run`: print SQL that would be executed, then exit 0
+- Output: one line per migration applied, e.g. `✅ Applied 0003_add_budget_table`
+
+## MCP Interface
+N/A — migrations are an infrastructure concern, not exposed via MCP tools.
+
+## Testing Strategy
+- Unit: `MigrationRunner` with an in-memory DuckDB; verify ordered application, idempotency
+  on re-run, and correct version tracking.
+- Integration: apply a sequence of migrations against a temp DB; verify final schema state.
+- Regression: test that a version mismatch between installed SQLMesh and recorded DB version
+  triggers auto-migration rather than a crash.
+
+## Dependencies
+- DuckDB (already a dependency)
+- SQLMesh (already a dependency) — `sqlmesh migrate` CLI or Python API
+
+## Out of Scope
+- Downgrade / rollback
+- Multi-user / concurrent migration locking (single-user local DB)
+- Migration generation tooling (migrations are written by hand for v1)

--- a/docs/specs/sync-client-integration.md
+++ b/docs/specs/sync-client-integration.md
@@ -1,0 +1,516 @@
+# Sync Client Integration
+
+## Status
+draft
+
+## Goal
+Enable the moneybin Python client to authenticate with moneybin-server, sync bank data via the REST API, load JSON payloads into DuckDB `raw.plaid_*` tables, and transform Plaid data through SQLMesh staging views into core tables alongside existing OFX and CSV sources.
+
+## Background
+- [moneybin plaid-integration spec](https://github.com/bsaffel/moneybin/blob/main/docs/specs/plaid-integration.md) -- Raw table schemas, staging views, core integration plan
+- [moneybin CLAUDE.md](https://github.com/bsaffel/moneybin/blob/main/CLAUDE.md) -- Python code standards, architecture layers, sign convention
+- [server-api-contract.md](../reference/server-api-contract.md) -- Full API surface; build against this
+- [ADR-002: Privacy Tiers](https://github.com/bsaffel/moneybin/blob/main/docs/architecture/002-privacy-tiers.md) -- Encrypted Sync tier
+- [ADR-007: JSON over Parquet](https://github.com/bsaffel/moneybin/blob/main/docs/architecture/007-json-over-parquet-for-sync.md) -- Why JSON instead of Parquet
+- Server API endpoints: `POST /sync/link-token`, `POST /sync/exchange-token`, `POST /sync/trigger`, `GET /sync/status`, `GET /sync/data`
+- All changes in this phase are made in the **moneybin** Python project at `/Users/bsaffel/Workspace/moneybin/`
+
+## Requirements
+
+1. Client authenticates with moneybin-server via Device Authorization Flow (server-proxied to Auth0).
+2. Client can initiate Plaid Link flow to connect bank accounts.
+3. Client triggers sync jobs and polls for completion.
+4. Client downloads JSON payload and loads into `raw.plaid_*` DuckDB tables.
+5. Deduplication on primary keys prevents duplicate records on re-sync.
+6. SQLMesh staging views standardize Plaid data and flip amount sign (Plaid positive = expense becomes MoneyBin negative = expense).
+7. Core models include Plaid data via `UNION ALL` with `source_system = 'plaid'`.
+8. CLI commands provide full sync workflow (login, link, run, status).
+9. MCP tools expose sync operations to AI assistants.
+
+## Sync Flow
+
+```
+1. POST /sync/trigger
+   -> { job_id: "uuid", status: "completed", transaction_count: 142 }
+
+2. GET /sync/status?job_id=<uuid>
+   -> poll until status == "completed"
+   (sync is currently synchronous, so status is already completed after trigger)
+
+3. GET /sync/data?job_id=<uuid>
+   -> JSON: { accounts: [...], transactions: [...], balances: [...],
+              removed_transactions: [...], metadata: { job_id, synced_at, institutions } }
+
+4. Parse JSON and load into DuckDB raw.plaid_* tables via read_json()
+
+5. Run sqlmesh run to propagate through staging and core layers
+```
+
+## Data Model
+
+### Raw tables (DuckDB)
+
+Three tables in the `raw` schema, matching the JSON payload from moneybin-server.
+
+```sql
+-- raw.plaid_accounts (PK: account_id, source_file)
+-- raw.plaid_transactions (PK: transaction_id, source_file)
+-- raw.plaid_balances (PK: account_id, balance_date, source_file)
+```
+
+Column schemas match `docs/specs/plaid-integration.md` in the moneybin project. Note: `source_file`, `extracted_at`, and `loaded_at` are client-side fields not present in the JSON response -- the client generates them:
+- `source_file`: logical identifier, e.g. `sync_{job_id}`
+- `extracted_at`: from `metadata.synced_at` in the JSON response
+- `loaded_at`: current timestamp at DuckDB insertion time
+
+### Staging views (SQLMesh)
+
+| View | Schema | Key transformation |
+|------|--------|--------------------|
+| `prep.stg_plaid__accounts` | `prep` | Standardize column names to match OFX staging output |
+| `prep.stg_plaid__transactions` | `prep` | Flip amount sign: `-1 * amount`; trim description fields |
+| `prep.stg_plaid__balances` | `prep` | Standardize column names |
+
+### Core model changes
+
+| Model | Change |
+|-------|--------|
+| `core.dim_accounts` | Add `plaid_accounts` CTE selecting from `prep.stg_plaid__accounts` with `source_system = 'plaid'`, UNION ALL into `all_accounts` |
+| `core.fct_transactions` | Add `plaid_transactions` CTE selecting from `prep.stg_plaid__transactions` with `source_system = 'plaid'`, UNION ALL into `all_transactions` |
+
+## Implementation Plan
+
+### Files to Create
+
+#### 1. HTTP sync client -- `src/moneybin/connectors/sync_client.py`
+
+`SyncClient` class using `httpx` for all server communication.
+
+**Methods:**
+- `login() -> AuthToken` -- Device Authorization Flow: POST to `/auth/device/code`, display verification URL and user code, poll `/auth/device/token` for token.
+- `create_link_token() -> LinkTokenResponse` -- POST `/sync/link-token`. Returns link token and expiration for Plaid Link.
+- `exchange_token(public_token: str, institution: InstitutionInfo) -> ExchangeResponse` -- POST `/sync/exchange-token`. Sends public token from Plaid Link callback.
+- `trigger_sync(item_id: str | None = None, force: bool = False) -> SyncJobResponse` -- POST `/sync/trigger`. Starts a sync job on the server.
+- `get_status(job_id: str) -> SyncStatusResponse` -- GET `/sync/status?job_id={job_id}`. Polls sync job status.
+- `download_data(job_id: str) -> SyncDataResponse` -- GET `/sync/data?job_id={job_id}`. Downloads JSON sync payload.
+
+**Auth handling:**
+- Store JWT in OS keychain via `keyring` library (macOS Keychain, Linux Secret Service, Windows Credential Locker).
+- Fall back to `~/.moneybin/.token` file with `0600` permissions if keyring unavailable.
+- Attach `Authorization: Bearer {token}` header to all authenticated requests.
+- Refresh token automatically when expired (Auth0 refresh token flow).
+
+**Configuration:**
+- Server URL from `SyncConfig.server_url` (already in `src/moneybin/config.py`).
+
+**Response models** (Pydantic):
+```python
+class AuthToken(BaseModel):
+    access_token: str
+    refresh_token: str | None
+    expires_at: datetime
+
+
+class LinkTokenResponse(BaseModel):
+    link_token: str
+    expiration: datetime
+
+
+class InstitutionInfo(BaseModel):
+    institution_id: str
+    name: str
+
+
+class ExchangeResponse(BaseModel):
+    item_id: str
+    institution_name: str
+
+
+class SyncJobResponse(BaseModel):
+    job_id: str
+    status: str
+    transaction_count: int | None
+
+
+class SyncStatusResponse(BaseModel):
+    job_id: str
+    status: str  # pending, running, completed, failed
+    transaction_count: int | None
+    error: str | None
+    started_at: datetime | None
+    completed_at: datetime | None
+    results: list[dict] | None
+
+
+class SyncDataResponse(BaseModel):
+    accounts: list[dict]
+    transactions: list[dict]
+    balances: list[dict]
+    removed_transactions: list[str]
+    metadata: dict
+
+
+class ConnectedInstitution(BaseModel):
+    item_id: str
+    institution_id: str | None
+    institution_name: str | None
+    status: str
+    last_sync: datetime | None
+```
+
+#### 2. Plaid data loader -- `src/moneybin/loaders/plaid_loader.py`
+
+`PlaidLoader` class following the `OFXLoader` pattern.
+
+**Methods:**
+- `__init__(database_path: Path | str)` -- Store path, resolve SQL schema directory.
+- `create_raw_tables() -> None` -- Execute DDL files for `raw.plaid_accounts`, `raw.plaid_transactions`, `raw.plaid_balances`.
+- `load_json(sync_data: SyncDataResponse, job_id: str) -> dict[str, int]` -- Load JSON arrays into raw tables using DuckDB's `read_json()`, return row counts per table.
+- `handle_removed_transactions(removed_ids: list[str]) -> int` -- Delete removed transactions from `raw.plaid_transactions`.
+
+**Loading pattern using read_json:**
+```python
+# Write JSON arrays to temp files, then use DuckDB read_json()
+import tempfile
+import json
+
+with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+    json.dump(sync_data.transactions, f)
+    temp_path = f.name
+
+conn.execute(f"""
+    INSERT OR REPLACE INTO raw.plaid_transactions
+    SELECT
+        transaction_id, account_id, transaction_date::DATE,
+        amount, description, merchant_name, category, pending,
+        '{source_file}' AS source_file,
+        '{extracted_at}'::TIMESTAMP AS extracted_at,
+        CURRENT_TIMESTAMP AS loaded_at
+    FROM read_json('{temp_path}',
+        columns = {{
+            transaction_id: 'VARCHAR',
+            account_id: 'VARCHAR',
+            transaction_date: 'VARCHAR',
+            amount: 'DECIMAL(18,2)',
+            description: 'VARCHAR',
+            merchant_name: 'VARCHAR',
+            category: 'VARCHAR',
+            pending: 'BOOLEAN'
+        }}
+    )
+""")
+```
+
+#### 3. Raw table DDL -- `src/moneybin/sql/schema/`
+
+One file per table, following the existing DDL pattern.
+
+**`raw_plaid_accounts.sql`**
+```sql
+/* Bank accounts connected via Plaid Link; one record per account per sync payload */
+CREATE TABLE IF NOT EXISTS raw.plaid_accounts (
+    account_id VARCHAR, -- Plaid account_id; stable identifier across syncs; part of primary key
+    account_type VARCHAR, -- Plaid account type: depository, credit, loan, investment, other
+    account_subtype VARCHAR, -- Plaid account subtype: checking, savings, credit card, mortgage, etc.
+    institution_name VARCHAR, -- Human-readable institution name from Plaid
+    official_name VARCHAR, -- Official account name from the institution, e.g. "Platinum Checking"
+    mask VARCHAR, -- Last 4 digits of the account number
+    source_file VARCHAR, -- Logical identifier generated by client: sync_{job_id}; part of primary key
+    extracted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- When the server fetched this data from Plaid (from metadata.synced_at)
+    loaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- When this record was inserted into the database
+    PRIMARY KEY (account_id, source_file)
+);
+```
+
+**`raw_plaid_transactions.sql`**
+```sql
+/* Transaction records fetched from Plaid transactions/sync endpoint; one record per transaction per sync payload */
+CREATE TABLE IF NOT EXISTS raw.plaid_transactions (
+    transaction_id VARCHAR, -- Plaid transaction_id; stable unique identifier; part of primary key
+    account_id VARCHAR, -- Plaid account_id this transaction belongs to; foreign key to raw.plaid_accounts
+    transaction_date DATE, -- Date the transaction posted; from Plaid date field
+    amount DECIMAL(18, 2), -- Plaid amount; CAUTION: Plaid convention is positive = expense; sign flip happens in staging
+    description VARCHAR, -- Plaid name field; merchant or payee description
+    merchant_name VARCHAR, -- Plaid merchant_name field; normalized merchant name; NULL when Plaid cannot identify
+    category VARCHAR, -- Plaid personal_finance_category.primary; broad spending category
+    pending BOOLEAN DEFAULT false, -- True if transaction has not yet settled
+    source_file VARCHAR, -- Logical identifier generated by client: sync_{job_id}; part of primary key
+    extracted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- When the server fetched this data from Plaid (from metadata.synced_at)
+    loaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- When this record was inserted into the database
+    PRIMARY KEY (transaction_id, source_file)
+);
+```
+
+**`raw_plaid_balances.sql`**
+```sql
+/* Account balance snapshots from Plaid; one record per account per balance date per sync payload */
+CREATE TABLE IF NOT EXISTS raw.plaid_balances (
+    account_id VARCHAR, -- Plaid account_id; foreign key to raw.plaid_accounts; part of primary key
+    balance_date DATE, -- Date the balance was reported; part of primary key
+    current_balance DECIMAL(18, 2), -- Current balance including pending transactions
+    available_balance DECIMAL(18, 2), -- Available balance (current minus holds); NULL for credit accounts
+    source_file VARCHAR, -- Logical identifier generated by client: sync_{job_id}; part of primary key
+    extracted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- When the server fetched this data from Plaid (from metadata.synced_at)
+    loaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- When this record was inserted into the database
+    PRIMARY KEY (account_id, balance_date, source_file)
+);
+```
+
+#### 4. SQLMesh staging models -- `sqlmesh/models/prep/`
+
+**`stg_plaid__accounts.sql`**
+```sql
+MODEL (
+  name prep.stg_plaid__accounts,
+  kind VIEW
+);
+
+SELECT
+  account_id,
+  NULL::VARCHAR AS routing_number,
+  account_type,
+  institution_name,
+  NULL::VARCHAR AS institution_fid,
+  official_name,
+  mask,
+  account_subtype,
+  source_file,
+  extracted_at,
+  loaded_at
+FROM raw.plaid_accounts
+```
+
+**`stg_plaid__transactions.sql`**
+```sql
+MODEL (
+  name prep.stg_plaid__transactions,
+  kind VIEW
+);
+
+SELECT
+  transaction_id,
+  account_id,
+  transaction_date AS posted_date,
+  -1 * amount AS amount,
+  TRIM(description) AS description,
+  TRIM(merchant_name) AS merchant_name,
+  category,
+  pending AS is_pending,
+  source_file,
+  extracted_at,
+  loaded_at
+FROM raw.plaid_transactions
+```
+
+The `-1 * amount` in the SELECT flips Plaid's sign convention (positive = expense) to MoneyBin's convention (negative = expense, positive = income).
+
+**`stg_plaid__balances.sql`**
+```sql
+MODEL (
+  name prep.stg_plaid__balances,
+  kind VIEW
+);
+
+SELECT
+  account_id,
+  balance_date,
+  current_balance,
+  available_balance,
+  source_file,
+  extracted_at,
+  loaded_at
+FROM raw.plaid_balances
+```
+
+#### 5. CLI commands -- `src/moneybin/cli/commands/sync.py`
+
+Replace the current stub with working commands. All commands are thin wrappers around `SyncClient`.
+
+```
+moneybin sync login          Device Authorization Flow (via server proxy)
+moneybin sync link           Create link token, open Plaid Link
+moneybin sync run [--force]  Trigger sync, poll, download JSON, load, transform
+moneybin sync status         Show connected institutions and last sync
+```
+
+#### 6. MCP tools -- additions to `src/moneybin/mcp/write_tools.py`
+
+```
+sync.trigger    Trigger a data sync (calls SyncClient.trigger_sync)
+sync.status     Show sync status and connected accounts
+sync.connect    Initiate a bank connection (returns link token and URL)
+```
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `sqlmesh/models/core/dim_accounts.sql` | Add `plaid_accounts` CTE + UNION ALL into `all_accounts` |
+| `sqlmesh/models/core/fct_transactions.sql` | Add `plaid_transactions` CTE + UNION ALL into `all_transactions` |
+| `src/moneybin/cli/commands/sync.py` | Replace stub with working login, link, run, status commands |
+| `src/moneybin/mcp/write_tools.py` | Add sync.trigger, sync.status, sync.connect tools |
+| `src/moneybin/config.py` | No changes needed; `SyncConfig` already has required fields |
+| `pyproject.toml` | Add `httpx` and `keyring` dependencies |
+
+### Key Decisions
+
+- **httpx over requests**: Async-capable, better type stubs, modern API. Aligns with the project's preference for modern libraries.
+- **Keyring for token storage**: Uses OS-native credential stores. Falls back to file-based storage for environments without a keyring service (CI, Docker).
+- **JSON as transfer format**: DuckDB reads JSON via `read_json()`. No intermediate Parquet conversion needed. See ADR-007.
+- **INSERT OR REPLACE for dedup**: Same pattern as OFXLoader. Primary keys prevent duplicate records without requiring separate dedup logic.
+- **Amount sign flip in staging only**: Raw tables preserve Plaid's original convention. The flip happens in `stg_plaid__transactions` so raw data is always faithful to the source.
+- **Polling for sync status**: The client polls `GET /sync/status` at intervals. Currently sync is synchronous so the job is completed immediately after trigger. The polling loop will activate automatically if the server moves to async execution in Phase 4.
+- **source_file as logical key**: Without Parquet files, `source_file` is a logical identifier generated by the client: `sync_{job_id}`. This preserves the deduplication semantics and the ability to re-load a specific sync without creating duplicates.
+
+## CLI Interface
+
+```bash
+# Authentication
+moneybin sync login
+# Calls POST /auth/device/code, displays device code and verification URL
+# User visits URL and authorizes in browser
+# Client polls POST /auth/device/token until authorized
+# Stores JWT in OS keychain
+
+# Connect a bank
+moneybin sync link
+# Creates link token via server, opens Plaid Link sandbox URL in browser
+# User completes Plaid Link flow, client exchanges public token
+
+# Sync data
+moneybin sync run
+# Triggers sync job, polls for completion, downloads JSON,
+# loads into raw.plaid_* tables, runs sqlmesh to refresh staging + core
+
+moneybin sync run --force
+# Full re-sync: ignores cursor, re-fetches all available transaction history
+
+# Check status
+moneybin sync status
+# Displays connected institutions, account counts, last sync times
+```
+
+### CLI output examples
+
+```
+$ moneybin sync login
+To sign in, visit: https://your-tenant.auth0.com/activate
+Enter code: ABCD-EFGH
+Waiting for authorization...
+Logged in as user@example.com
+
+$ moneybin sync link
+Opening Plaid Link...
+Connected Chase (****1234, ****5678)
+
+$ moneybin sync run
+Starting sync for all connected institutions...
+Waiting for sync job abc-123... completed (142 transactions)
+Loading accounts... 2 accounts
+Loading transactions... 142 transactions
+Loading balances... 2 balance snapshots
+Running SQLMesh plan...
+Synced 142 transactions from 1 institution
+
+$ moneybin sync status
+Chase (connected 2026-03-15)
+  Accounts: ****1234 (checking), ****5678 (savings)
+  Last sync: 2026-04-07 14:30 UTC (142 transactions)
+```
+
+## MCP Interface
+
+### Tools
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `sync.trigger` | Trigger a data sync from connected banks | `institution_name: str \| None` (optional filter) |
+| `sync.status` | Show connected institutions and sync status | None |
+| `sync.connect` | Start bank connection flow | None; returns link token URL for user to visit |
+
+MCP tools require an active auth session (same JWT from `moneybin sync login`). If not authenticated, tools return an error message directing the user to run `moneybin sync login` first.
+
+Plaid data flows through existing core tables after sync, so all existing MCP read tools (transactions, accounts, balances, spending summaries) automatically include Plaid-sourced data.
+
+## Testing Strategy
+
+### Unit tests
+
+- `SyncClient` methods with mocked httpx responses (success, auth error, server error, timeout)
+- `PlaidLoader.load_json()` with test JSON data and in-memory DuckDB
+- Token storage and retrieval (keyring mock + file fallback)
+- Device Authorization Flow polling logic (success, timeout, denied)
+
+### SQL tests
+
+- `stg_plaid__transactions`: Verify amount sign flip (-1 * positive becomes negative)
+- `stg_plaid__accounts`: Verify column mapping to core-compatible schema
+- `dim_accounts`: Verify Plaid accounts appear with `source_system = 'plaid'`
+- `fct_transactions`: Verify Plaid transactions appear with correct sign convention and `source_system = 'plaid'`
+- Dedup: Load same JSON twice, verify no duplicate rows in raw tables
+
+### CLI tests
+
+- `sync login`: Mock Device Authorization Flow, verify token stored
+- `sync run`: Mock SyncClient, verify download + load + SQLMesh sequence
+- `sync status`: Mock SyncClient, verify output formatting
+- Error cases: server unreachable, auth expired, sync job failed
+
+### Integration tests (marked `@pytest.mark.integration`)
+
+- Full flow with running moneybin-server (Plaid Sandbox): login, link, sync, verify data in DuckDB
+- Incremental sync: first sync loads N transactions, second sync loads only new ones
+
+## Dependencies
+
+### New Python packages (add via `uv add`)
+- `httpx >= 0.27.0` -- HTTP client for server API calls
+- `keyring >= 25.0.0` -- OS-native credential storage for JWT tokens
+
+### Existing packages (already in moneybin)
+- `duckdb` -- Database engine
+- `polars` -- DataFrame operations
+- `typer` -- CLI framework
+- `pydantic` -- Response models and config
+- `fastmcp` -- MCP server
+
+### External requirements
+- Running moneybin-server instance (Phases 1-2 complete)
+- Auth0 tenant configured with Device Authorization Flow enabled
+- Plaid Sandbox credentials (for testing)
+
+## Verification
+
+```bash
+cd /Users/bsaffel/Workspace/moneybin
+
+# Authenticate
+uv run moneybin sync login
+
+# Connect a bank (Plaid Sandbox)
+uv run moneybin sync link
+
+# Sync transactions
+uv run moneybin sync run
+
+# Verify data loaded
+uv run moneybin db shell
+# SELECT COUNT(*) FROM raw.plaid_transactions;
+# SELECT * FROM core.fct_transactions WHERE source_system = 'plaid' LIMIT 5;
+# Verify amounts are negative for expenses:
+# SELECT amount, description FROM core.fct_transactions
+#   WHERE source_system = 'plaid' AND amount > 0 LIMIT 5;
+# (should be income transactions only)
+
+# Run pre-commit checks
+uv run ruff format . && uv run ruff check . && uv run pyright && uv run pytest tests/
+```
+
+## Out of Scope
+
+- E2E encryption of JSON payloads (Phase 5 in moneybin-server)
+- MCP App UI widgets for Plaid Link
+- Investment and liability data from Plaid
+- Multi-device token sync
+- Webhook-based real-time sync (polling is sufficient for MVP)
+- Offline queue for sync commands when server is unreachable

--- a/docs/specs/sync-client-integration.md
+++ b/docs/specs/sync-client-integration.md
@@ -150,7 +150,7 @@ class SyncDataResponse(BaseModel):
 
 
 class ConnectedInstitution(BaseModel):
-    id: str                   # internal UUID; required for DELETE /institutions/:id
+    id: str  # internal UUID; required for DELETE /institutions/:id
     item_id: str
     institution_name: str | None
     status: str
@@ -200,7 +200,11 @@ conn.execute(
         }
     )
     """,
-    {"source_file": source_file, "extracted_at": extracted_at, "temp_path": str(temp_path)},
+    {
+        "source_file": source_file,
+        "extracted_at": extracted_at,
+        "temp_path": str(temp_path),
+    },
 )
 ```
 

--- a/docs/specs/sync-client-integration.md
+++ b/docs/specs/sync-client-integration.md
@@ -13,7 +13,7 @@ Enable the moneybin Python client to authenticate with moneybin-server, sync ban
 - [ADR-002: Privacy Tiers](https://github.com/bsaffel/moneybin/blob/main/docs/architecture/002-privacy-tiers.md) -- Encrypted Sync tier
 - [ADR-007: JSON over Parquet](https://github.com/bsaffel/moneybin/blob/main/docs/architecture/007-json-over-parquet-for-sync.md) -- Why JSON instead of Parquet
 - Server API endpoints: `POST /sync/link-token`, `POST /sync/exchange-token`, `POST /sync/trigger`, `GET /sync/status`, `GET /sync/data`
-- All changes in this phase are made in the **moneybin** Python project at `/Users/bsaffel/Workspace/moneybin/`
+- All changes in this phase are made in the **moneybin** Python project.
 
 ## Requirements
 
@@ -90,7 +90,7 @@ Column schemas match `docs/specs/plaid-integration.md` in the moneybin project. 
 - `login() -> AuthToken` -- Device Authorization Flow: POST to `/auth/device/code`, display verification URL and user code, poll `/auth/device/token` for token.
 - `create_link_token() -> LinkTokenResponse` -- POST `/sync/link-token`. Returns link token and expiration for Plaid Link.
 - `exchange_token(public_token: str, institution: InstitutionInfo) -> ExchangeResponse` -- POST `/sync/exchange-token`. Sends public token from Plaid Link callback.
-- `trigger_sync(item_id: str | None = None, force: bool = False) -> SyncJobResponse` -- POST `/sync/trigger`. Starts a sync job on the server.
+- `trigger_sync(item_id: str | None = None, force: bool = False) -> SyncJobResponse` -- POST `/sync/trigger`. Starts a sync job on the server. When `force=True`, passes `reset_cursor: true` to the server, which resets the Plaid transaction cursor and re-fetches all available history.
 - `get_status(job_id: str) -> SyncStatusResponse` -- GET `/sync/status?job_id={job_id}`. Polls sync job status.
 - `download_data(job_id: str) -> SyncDataResponse` -- GET `/sync/data?job_id={job_id}`. Downloads JSON sync payload.
 
@@ -123,7 +123,6 @@ class InstitutionInfo(BaseModel):
 
 class ExchangeResponse(BaseModel):
     item_id: str
-    institution_name: str
 
 
 class SyncJobResponse(BaseModel):
@@ -151,11 +150,12 @@ class SyncDataResponse(BaseModel):
 
 
 class ConnectedInstitution(BaseModel):
+    id: str                   # internal UUID; required for DELETE /institutions/:id
     item_id: str
-    institution_id: str | None
     institution_name: str | None
     status: str
     last_sync: datetime | None
+    created_at: datetime
 ```
 
 #### 2. Plaid data loader -- `src/moneybin/loaders/plaid_loader.py`
@@ -178,16 +178,17 @@ with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
     json.dump(sync_data.transactions, f)
     temp_path = f.name
 
-conn.execute(f"""
+conn.execute(
+    """
     INSERT OR REPLACE INTO raw.plaid_transactions
     SELECT
         transaction_id, account_id, transaction_date::DATE,
         amount, description, merchant_name, category, pending,
-        '{source_file}' AS source_file,
-        '{extracted_at}'::TIMESTAMP AS extracted_at,
+        $source_file AS source_file,
+        $extracted_at::TIMESTAMP AS extracted_at,
         CURRENT_TIMESTAMP AS loaded_at
-    FROM read_json('{temp_path}',
-        columns = {{
+    FROM read_json($temp_path,
+        columns = {
             transaction_id: 'VARCHAR',
             account_id: 'VARCHAR',
             transaction_date: 'VARCHAR',
@@ -196,9 +197,11 @@ conn.execute(f"""
             merchant_name: 'VARCHAR',
             category: 'VARCHAR',
             pending: 'BOOLEAN'
-        }}
+        }
     )
-""")
+    """,
+    {"source_file": source_file, "extracted_at": extracted_at, "temp_path": str(temp_path)},
+)
 ```
 
 #### 3. Raw table DDL -- `src/moneybin/sql/schema/`
@@ -424,7 +427,7 @@ Chase (connected 2026-03-15)
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `sync.trigger` | Trigger a data sync from connected banks | `institution_name: str \| None` (optional filter) |
+| `sync.trigger` | Trigger a data sync from connected banks | `institution_name: str \| None` (optional filter; the tool resolves this to `item_id` via `GET /institutions` before calling `POST /sync/trigger`) |
 | `sync.status` | Show connected institutions and sync status | None |
 | `sync.connect` | Start bank connection flow | None; returns link token URL for user to visit |
 
@@ -482,7 +485,7 @@ Plaid data flows through existing core tables after sync, so all existing MCP re
 ## Verification
 
 ```bash
-cd /Users/bsaffel/Workspace/moneybin
+# From the moneybin project root:
 
 # Authenticate
 uv run moneybin sync login


### PR DESCRIPTION
### Summary

Adds two new documentation files that define the moneybin-server API surface and the client-side integration plan for syncing bank data via Plaid. These specs are prerequisites for implementing the sync client in the moneybin Python project.

### Impact

- No code changes — documentation only.
- Teammates should review the API contract for accuracy against the current server implementation.
- The sync-client-integration spec will serve as the implementation blueprint for upcoming sync work.

### Changes

#### Server API contract (`docs/reference/server-api-contract.md`)
Documents the full REST API surface for moneybin-server: authentication (Device Authorization Flow), sync endpoints (trigger, status, data download), Plaid Link token management, institution management, error response format, and HTTP status codes.

#### Sync client integration spec (`docs/specs/sync-client-integration.md`)
Comprehensive implementation spec covering:
- SyncClient HTTP connector with httpx and keyring-based token storage
- PlaidLoader for loading JSON payloads into `raw.plaid_*` DuckDB tables
- Raw table DDL, SQLMesh staging views, and core model union changes
- CLI commands (`sync login`, `link`, `run`, `status`) and MCP tools
- Testing strategy across unit, SQL, CLI, and integration layers

### Testing

Documentation only — no tests required. Specs should be reviewed for completeness and consistency with the existing plaid-integration spec and ADR-007.