### PR TITLE
Have review bot resolve fixed threads on re-review

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -34,6 +34,20 @@ jobs:
             - Test coverage gaps for new business logic
             Post inline comments on specific lines where relevant. Summarize findings as a PR comment.
 
+            After completing your review, resolve any previously-posted review threads whose
+            issues are now fixed in the current code. Use the gh CLI and environment variables
+            already present in the runner — do not interpolate untrusted event payload fields
+            into shell commands. Steps:
+            1. Determine the PR number: gh pr view --json number -q .number
+            2. Parse owner and repo from the GITHUB_REPOSITORY environment variable.
+            3. Fetch open threads via gh api graphql, passing owner, repo, and number as
+               -f variables so no user-controlled data is shell-interpolated.
+            4. For each unresolved thread, read its comment body, check whether the current
+               code addresses the issue, and if so resolve it via the resolveReviewThread
+               GraphQL mutation.
+            Only resolve threads where the fix is clearly present — leave threads open if
+            the issue is partially addressed or still present.
+
       - name: Interactive @claude mentions
         if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
### Summary
Extends the automated PR review prompt to resolve previously-posted inline comment threads whose issues are now addressed in the current code. On each re-review pass the bot will check each open thread against the current code and resolve it if the fix is clearly present.

### Impact
- No workflow changes for contributors
- Open review threads will be auto-resolved after a fix is pushed, rather than requiring manual resolution

### Changes
- Updated `ai-review.yml` prompt to instruct the bot to fetch open threads via GraphQL, evaluate each against the current code, and call `resolveReviewThread` for threads whose issues are fixed
- Uses `GITHUB_REPOSITORY` env var and `gh pr view` for safe ref resolution (no untrusted shell interpolation)

### Testing
Trigger a re-review on a PR with open threads after pushing fixes — threads for resolved issues should be marked resolved automatically.