### PR TITLE
Skip AI code review for Dependabot PRs

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   review:
     name: Claude Review
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
Skips the Claude AI review workflow when Dependabot opens or updates a PR. These PRs are routine dependency version bumps that don't benefit from code review, and running the review on them wastes API credits.

## Impact
- Dependabot PRs will show the review job as "skipped" instead of running it. No branch protection changes needed.
- No impact on human-authored PRs or `@claude` mentions.

## Changes
#### AI review workflow
Added a job-level `if` condition to skip the entire review job when the actor is `dependabot[bot]`.

## Testing
Verify the condition syntax matches GitHub's docs for filtering by actor. Next Dependabot PR will confirm the job is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)