### PR TITLE
Optimize test suite: 17x speedup, remove unnecessary httpfs, fix migrate bug

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -46,6 +46,20 @@ When a function delegates to an external system (SQLMesh, DuckDB CLI, keyring, s
 - **Mocks must raise real library exceptions**: if keyring raises `PasswordDeleteError`, the mock must too — not the project wrapper the code is supposed to produce.
 - **Integration tests for subsystem boundaries** (`@pytest.mark.integration`, `make test-all`): one test per boundary that exercises the real interaction (encrypted DB + SQLMesh, passphrase lock/unlock cycle, key rotation round-trip).
 
+## Database Fixtures
+
+- **Always pass `no_auto_upgrade=True`** when creating `Database` instances in tests, unless the test is specifically verifying migration behavior. Without this, each test spawns a `sqlmesh migrate` subprocess (~1.5s per test).
+- **Use `mock_secret_store`** from the root `conftest.py` (or create a local `MagicMock` with `get_key.return_value = "test-key"`) — never hit the real keyring.
+- **Avoid `autouse=True` on expensive fixtures.** Use `pytestmark = pytest.mark.usefixtures("fixture_name")` at module level, and add the fixture as an explicit parameter to any inner fixtures that depend on it (e.g., `_insert_data(self, mcp_db: object)`).
+
+```python
+# CORRECT — fast test database
+Database(tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True)
+
+# WRONG — spawns sqlmesh subprocess, runs migrations on every test
+Database(tmp_path / "test.duckdb", secret_store=mock_store)
+```
+
 ## Best Practices
 
 - Arrange-Act-Assert structure.

--- a/docs/specs/privacy-data-protection.md
+++ b/docs/specs/privacy-data-protection.md
@@ -73,8 +73,7 @@ duration of the shell session.
 ### Encryption at Rest
 1. All new databases are encrypted with AES-256-GCM via DuckDB's encryption extension.
    Unencrypted databases are never the default state.
-2. The `httpfs` extension is loaded for OpenSSL-backed encryption writes (hardware AES
-   acceleration, negligible overhead).
+2. DuckDB handles AES-256-GCM encryption natively; no additional extensions required.
 3. DuckDB temp files are automatically encrypted when the database is encrypted.
 4. Two key modes are supported, chosen at `db init` time:
    - **Auto-key (default):** Random 256-bit key generated and stored in OS keychain.
@@ -127,14 +126,13 @@ duration of the shell session.
 17. The `Database` class owns the full initialization sequence:
     a. Retrieve encryption key via `SecretStore().get_key("DATABASE__ENCRYPTION_KEY")`
     b. Open in-memory DuckDB connection
-    c. Load required extensions (`httpfs`)
-    d. Attach encrypted database file via `ATTACH ... (ENCRYPTION_KEY ?)`
-    e. `USE <attached_db>`
-    f. Run `init_schemas()` (idempotent baseline DDL)
-    g. Run `MigrationRunner.apply_all()` (pending schema migrations)
-    h. Check SQLMesh version, run `sqlmesh migrate` if needed
-    i. Record version state in `app.versions`
-    j. Connection is ready
+    c. Attach encrypted database file via `ATTACH ... (ENCRYPTION_KEY ?)`
+    d. `USE <attached_db>`
+    e. Run `init_schemas()` (idempotent baseline DDL)
+    f. Run `MigrationRunner.apply_all()` (pending schema migrations)
+    g. Check SQLMesh version, run `sqlmesh migrate` if needed
+    h. Record version state in `app.versions`
+    i. Connection is ready
 18. The `Database` class exposes:
     - `conn` property — the underlying `duckdb.DuckDBPyConnection`
     - `execute(query, params)` — parameterized SQL execution
@@ -447,8 +445,8 @@ this spec — the CLI is the primary interface for infrastructure concerns.
 ### Unit: `Database` class
 - **Key retrieval:** delegates to `SecretStore.get_key("DATABASE__ENCRYPTION_KEY")`.
   Mock `SecretStore` in tests.
-- **Initialization:** creates in-memory connection, loads `httpfs`, attaches encrypted
-  file, sets temp directory, runs init_schemas, runs migrations.
+- **Initialization:** creates in-memory connection, attaches encrypted
+  file, runs init_schemas, runs migrations.
 - **Singleton:** `get_database()` returns same instance on repeated calls. Cache
   invalidation on profile change.
 - **Auto-key mode:** `db init` generates 256-bit key, stores via
@@ -505,8 +503,7 @@ this spec — the CLI is the primary interface for infrastructure concerns.
 ## Dependencies
 - `keyring` — OS keychain abstraction (macOS Keychain, Linux Secret Service, Windows
   Credential Manager)
-- `duckdb` — encryption extension (built-in since v1.4), `httpfs` extension (for
-  OpenSSL-backed writes)
+- `duckdb` — encryption extension (built-in since v1.4)
 - `argon2-cffi` — Argon2id passphrase key derivation (ADR-013)
 - `secrets` (stdlib) — random key generation
 - `re` (stdlib) — PII pattern matching in log formatter

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -43,13 +43,12 @@ class Database:
     sequence:
         a. Retrieve encryption key via SecretStore
         b. Open in-memory DuckDB connection
-        c. Load required extensions (httpfs)
-        d. Attach encrypted database file
-        e. USE <attached_db>
-        f. Run init_schemas() (idempotent baseline DDL)
-        g. Run pending schema migrations via MigrationRunner
-        h. Run sqlmesh migrate if SQLMesh version changed
-        i. Record component versions in app.versions
+        c. Attach encrypted database file
+        d. USE <attached_db>
+        e. Run init_schemas() (idempotent baseline DDL)
+        f. Run pending schema migrations via MigrationRunner
+        g. Run sqlmesh migrate if SQLMesh version changed
+        h. Record component versions in app.versions
 
     The Database class does NOT own query logic, transaction boundaries,
     domain rules, or data access patterns. It is infrastructure.
@@ -65,6 +64,7 @@ class Database:
         db_path: Path,
         *,
         secret_store: SecretStore | None = None,
+        no_auto_upgrade: bool | None = None,
     ) -> None:
         """Initialize and open the encrypted database connection.
 
@@ -72,6 +72,8 @@ class Database:
             db_path: Path to the DuckDB database file.
             secret_store: SecretStore instance for key retrieval. If None,
                 creates a new one.
+            no_auto_upgrade: If True, skip versioned migrations and SQLMesh
+                migrate on startup. If None, reads from config.
 
         Raises:
             DatabaseKeyError: If the encryption key cannot be retrieved.
@@ -100,10 +102,7 @@ class Database:
         # Step b: Open in-memory connection
         self._conn = duckdb.connect()
 
-        # Step c: Load required extensions
-        self._conn.execute("INSTALL httpfs; LOAD httpfs;")
-
-        # Step d: Attach encrypted database file.
+        # Step c: Attach encrypted database file.
         # ATTACH does not support parameterized queries in DuckDB — the path
         # and key must be interpolated as string literals. The path comes from
         # our own config (trusted), and the key is from SecretStore (trusted).
@@ -114,7 +113,7 @@ class Database:
             f"ATTACH '{safe_path}' AS moneybin (TYPE DUCKDB, ENCRYPTION_KEY '{safe_key}')"
         )
 
-        # Step e: USE attached database
+        # Step d: USE attached database
         self._conn.execute("USE moneybin")
 
         # Set file permissions on new databases (macOS/Linux)
@@ -128,12 +127,12 @@ class Database:
         if not is_new and sys.platform != "win32":
             self._check_permissions(db_path)
 
-        # Step f: Run init_schemas (idempotent)
+        # Step e: Run init_schemas (idempotent)
         from moneybin.schema import init_schemas
 
         init_schemas(self._conn)
 
-        # Steps g-i: Auto-upgrade (migrations + version tracking)
+        # Steps f-h: Auto-upgrade (migrations + version tracking)
         from moneybin.migrations import (
             MigrationError,
             MigrationRunner,
@@ -141,8 +140,11 @@ class Database:
             record_version,
         )
 
-        settings = get_settings()
-        if not settings.database.no_auto_upgrade:
+        skip_upgrade = no_auto_upgrade
+        if skip_upgrade is None:
+            settings = get_settings()
+            skip_upgrade = settings.database.no_auto_upgrade
+        if not skip_upgrade:
             current_pkg_version = importlib.metadata.version("moneybin")
             stored_versions = get_current_versions(self)
             stored_pkg_version = stored_versions.get("moneybin")
@@ -186,10 +188,10 @@ class Database:
                 sqlmesh_version = importlib.metadata.version("sqlmesh")
                 stored_sqlmesh = stored_versions.get("sqlmesh")
                 if stored_sqlmesh != sqlmesh_version:
-                    self._run_sqlmesh_migrate()
-                    record_version(self, "sqlmesh", sqlmesh_version)
-                    if stored_sqlmesh is not None:
-                        logger.info("  ✅ SQLMesh state updated")
+                    if self._run_sqlmesh_migrate():
+                        record_version(self, "sqlmesh", sqlmesh_version)
+                        if stored_sqlmesh is not None:
+                            logger.info("  ✅ SQLMesh state updated")
             except importlib.metadata.PackageNotFoundError:
                 pass  # SQLMesh not installed — skip
 
@@ -211,11 +213,15 @@ class Database:
         except OSError:
             pass
 
-    def _run_sqlmesh_migrate(self) -> None:
+    def _run_sqlmesh_migrate(self) -> bool:
         """Run sqlmesh migrate to update SQLMesh internal state.
 
         Called when the installed SQLMesh version differs from the recorded
         version. Uses subprocess to invoke the sqlmesh CLI.
+
+        Returns:
+            True if migration succeeded or was skipped (no sqlmesh dir),
+            False if migration failed.
         """
         import subprocess  # noqa: S404  # subprocess is required to invoke the sqlmesh CLI
 
@@ -224,7 +230,7 @@ class Database:
         sqlmesh_root = Path(__file__).resolve().parents[2] / "sqlmesh"
         if not sqlmesh_root.is_dir():
             logger.debug("sqlmesh project dir not found, skipping migrate")
-            return
+            return True
         try:
             subprocess.run(  # noqa: S603  # fixed args from trusted internal config, not user input
                 ["uv", "run", "sqlmesh", "-p", str(sqlmesh_root), "migrate"],  # noqa: S607  # uv is a trusted internal tool
@@ -233,12 +239,15 @@ class Database:
                 text=True,
             )
             logger.debug("sqlmesh migrate completed successfully")
+            return True
         except subprocess.CalledProcessError as exc:
             logger.warning(
                 f"⚠️  sqlmesh migrate failed (exit {exc.returncode}): {exc.stderr.strip()}"
             )
+            return False
         except FileNotFoundError:
             logger.debug("sqlmesh CLI not found, skipping migrate")
+            return True
 
     @property
     def conn(self) -> duckdb.DuckDBPyConnection:

--- a/tests/moneybin/conftest.py
+++ b/tests/moneybin/conftest.py
@@ -115,6 +115,6 @@ def db(tmp_path: Path, mock_secret_store: MagicMock) -> Generator[Database, None
         A Database instance ready for test queries.
     """
     db_path = tmp_path / "test.duckdb"
-    database = Database(db_path, secret_store=mock_secret_store)
+    database = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
     yield database
     database.close()

--- a/tests/moneybin/test_database.py
+++ b/tests/moneybin/test_database.py
@@ -39,7 +39,7 @@ class TestDatabaseInit:
     ) -> None:
         """New database file is created and encrypted."""
         db_path = db_dir / "moneybin.duckdb"
-        db = Database(db_path, secret_store=mock_secret_store)
+        db = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
         try:
             assert db_path.exists()
             mock_secret_store.get_key.assert_called_once_with(
@@ -55,7 +55,7 @@ class TestDatabaseInit:
         if sys.platform == "win32":
             pytest.skip("File permissions not enforced on Windows")
         db_path = db_dir / "moneybin.duckdb"
-        db = Database(db_path, secret_store=mock_secret_store)
+        db = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
         try:
             mode = db_path.stat().st_mode & 0o777
             assert mode == 0o600
@@ -67,7 +67,7 @@ class TestDatabaseInit:
     ) -> None:
         """Database file cannot be opened without the encryption key."""
         db_path = db_dir / "moneybin.duckdb"
-        db = Database(db_path, secret_store=mock_secret_store)
+        db = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
         db.execute("CREATE TABLE test_data (id INTEGER, name VARCHAR)")
         db.execute("INSERT INTO test_data VALUES (1, 'Alice')")
         db.close()
@@ -83,7 +83,7 @@ class TestDatabaseInit:
     ) -> None:
         """Schema initialization runs on first open."""
         db_path = db_dir / "moneybin.duckdb"
-        db = Database(db_path, secret_store=mock_secret_store)
+        db = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
         try:
             # init_schemas creates the raw, core, and app schemas
             result = db.execute(
@@ -115,7 +115,9 @@ class TestDatabaseOperations:
         self, db_dir: Path, mock_secret_store: MagicMock
     ) -> Generator[Database, None, None]:
         db_path = db_dir / "moneybin.duckdb"
-        database = Database(db_path, secret_store=mock_secret_store)
+        database = Database(
+            db_path, secret_store=mock_secret_store, no_auto_upgrade=True
+        )
         yield database
         database.close()
 
@@ -145,7 +147,7 @@ class TestDatabaseOperations:
     ) -> None:
         """After close(), conn access raises."""
         db_path = db_dir / "moneybin.duckdb"
-        db = Database(db_path, secret_store=mock_secret_store)
+        db = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
         db.close()
         with pytest.raises(RuntimeError, match="closed"):
             _ = db.conn
@@ -159,7 +161,9 @@ class TestIngestDataframe:
         self, db_dir: Path, mock_secret_store: MagicMock
     ) -> Generator[Database, None, None]:
         db_path = db_dir / "moneybin.duckdb"
-        database = Database(db_path, secret_store=mock_secret_store)
+        database = Database(
+            db_path, secret_store=mock_secret_store, no_auto_upgrade=True
+        )
         database.execute(
             "CREATE TABLE test_items (id INTEGER, name VARCHAR, score DECIMAL(5,2))"
         )

--- a/tests/moneybin/test_loaders/test_csv_loader.py
+++ b/tests/moneybin/test_loaders/test_csv_loader.py
@@ -15,7 +15,9 @@ def test_db(tmp_path: Path) -> Database:
     """A temporary Database instance for testing."""
     mock_store = MagicMock()
     mock_store.get_key.return_value = "test-key"
-    return Database(tmp_path / "test.duckdb", secret_store=mock_store)
+    return Database(
+        tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True
+    )
 
 
 @pytest.fixture()

--- a/tests/moneybin/test_loaders/test_ofx_loader.py
+++ b/tests/moneybin/test_loaders/test_ofx_loader.py
@@ -15,7 +15,9 @@ def test_db(tmp_path: Path) -> Database:
     """Create a temporary test Database instance."""
     mock_store = MagicMock()
     mock_store.get_key.return_value = "test-key"
-    return Database(tmp_path / "test.duckdb", secret_store=mock_store)
+    return Database(
+        tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True
+    )
 
 
 @pytest.fixture

--- a/tests/moneybin/test_loaders/test_w2_loader.py
+++ b/tests/moneybin/test_loaders/test_w2_loader.py
@@ -19,7 +19,9 @@ def test_db(tmp_path: Path) -> Database:
     """Create a temporary test Database instance."""
     mock_store = MagicMock()
     mock_store.get_key.return_value = "test-key"
-    return Database(tmp_path / "test.duckdb", secret_store=mock_store)
+    return Database(
+        tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True
+    )
 
 
 @pytest.fixture

--- a/tests/moneybin/test_mcp/conftest.py
+++ b/tests/moneybin/test_mcp/conftest.py
@@ -16,7 +16,7 @@ from moneybin.database import Database
 from tests.moneybin.db_helpers import create_core_tables_raw
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def mcp_db(tmp_path: Path) -> Generator[Database, None, None]:
     """Create a Database instance with schemas and base reference data for MCP tests.
 
@@ -38,7 +38,7 @@ def mcp_db(tmp_path: Path) -> Generator[Database, None, None]:
     mock_store = MagicMock()
     mock_store.get_key.return_value = "test-encryption-key-256bit-placeholder"
 
-    database = Database(db_path, secret_store=mock_store)
+    database = Database(db_path, secret_store=mock_store, no_auto_upgrade=True)
     conn = database.conn
 
     # Core tables are managed by SQLMesh in production; create test-only

--- a/tests/moneybin/test_mcp/test_categorization_tools.py
+++ b/tests/moneybin/test_mcp/test_categorization_tools.py
@@ -25,6 +25,8 @@ from moneybin.mcp.write_tools import (
     toggle_category,
 )
 
+pytestmark = pytest.mark.usefixtures("mcp_db")
+
 # ---------------------------------------------------------------------------
 # Shared INSERT SQL
 # ---------------------------------------------------------------------------
@@ -121,7 +123,7 @@ class TestGetCategorizationStats:
     """Tests for get_categorization_stats tool."""
 
     @pytest.fixture(autouse=True)
-    def _insert_data(self) -> None:  # pyright: ignore[reportUnusedFunction] — pytest autouse fixture
+    def _insert_data(self, mcp_db: object) -> None:  # pyright: ignore[reportUnusedFunction] — pytest autouse fixture
         db = server.get_db()
         db.execute(_INSERT_TRANSACTIONS)
 
@@ -142,7 +144,7 @@ class TestCategorizeTransaction:
     """Tests for categorize_transaction tool."""
 
     @pytest.fixture(autouse=True)
-    def _insert_data(self) -> None:  # pyright: ignore[reportUnusedFunction] — pytest autouse fixture
+    def _insert_data(self, mcp_db: object) -> None:  # pyright: ignore[reportUnusedFunction] — pytest autouse fixture
         db = server.get_db()
         db.execute(_INSERT_TRANSACTIONS)
 
@@ -288,7 +290,7 @@ class TestBulkCategorize:
     """Tests for bulk_categorize tool."""
 
     @pytest.fixture(autouse=True)
-    def _insert_data(self) -> None:  # pyright: ignore[reportUnusedFunction] — pytest autouse fixture
+    def _insert_data(self, mcp_db: object) -> None:  # pyright: ignore[reportUnusedFunction] — pytest autouse fixture
         db = server.get_db()
         db.execute(_INSERT_TRANSACTIONS)
 

--- a/tests/moneybin/test_mcp/test_resources.py
+++ b/tests/moneybin/test_mcp/test_resources.py
@@ -14,6 +14,8 @@ from moneybin.mcp.resources import (
     w2_by_year,
 )
 
+pytestmark = pytest.mark.usefixtures("mcp_db")
+
 # ---------------------------------------------------------------------------
 # Schema resources
 # ---------------------------------------------------------------------------
@@ -88,7 +90,7 @@ class TestRecentTransactions:
     """Tests for recent transactions resource."""
 
     @pytest.fixture(autouse=True)
-    def _insert_data(self) -> None:  # pyright: ignore[reportUnusedFunction] — pytest autouse fixture
+    def _insert_data(self, mcp_db: object) -> None:  # pyright: ignore[reportUnusedFunction] — pytest autouse fixture
         db = server.get_db()
         db.execute("""
             INSERT INTO core.fct_transactions (
@@ -133,7 +135,7 @@ class TestW2Resource:
     """Tests for W2 tax year resource."""
 
     @pytest.fixture(autouse=True)
-    def _insert_data(self) -> None:  # pyright: ignore[reportUnusedFunction] — pytest autouse fixture
+    def _insert_data(self, mcp_db: object) -> None:  # pyright: ignore[reportUnusedFunction] — pytest autouse fixture
         db = server.get_db()
         db.execute("""
             INSERT INTO raw.w2_forms (

--- a/tests/moneybin/test_mcp/test_server.py
+++ b/tests/moneybin/test_mcp/test_server.py
@@ -6,6 +6,8 @@ import pytest
 from moneybin.mcp import server
 from moneybin.tables import DIM_ACCOUNTS, TableRef
 
+pytestmark = pytest.mark.usefixtures("mcp_db")
+
 
 class TestGetDb:
     """Tests for get_db()."""

--- a/tests/moneybin/test_mcp/test_tools.py
+++ b/tests/moneybin/test_mcp/test_tools.py
@@ -17,6 +17,8 @@ from moneybin.mcp.tools import (
     run_read_query,
 )
 
+pytestmark = pytest.mark.usefixtures("mcp_db")
+
 # ---------------------------------------------------------------------------
 # Shared INSERT SQL for test classes that need transactions or W2 data
 # ---------------------------------------------------------------------------
@@ -86,7 +88,7 @@ class TestDescribeTable:
     """Tests for the describe_table tool."""
 
     @pytest.fixture(autouse=True)
-    def _insert_data(self) -> None:  # pyright: ignore[reportUnusedFunction] — pytest autouse fixture
+    def _insert_data(self, mcp_db: object) -> None:  # pyright: ignore[reportUnusedFunction] — pytest autouse fixture
         db = server.get_db()
         db.execute(_INSERT_TRANSACTIONS)
 
@@ -126,7 +128,7 @@ class TestQueryTransactions:
     """Tests for the query_transactions tool."""
 
     @pytest.fixture(autouse=True)
-    def _insert_data(self) -> None:  # pyright: ignore[reportUnusedFunction] — pytest autouse fixture
+    def _insert_data(self, mcp_db: object) -> None:  # pyright: ignore[reportUnusedFunction] — pytest autouse fixture
         db = server.get_db()
         db.execute(_INSERT_TRANSACTIONS)
 
@@ -202,7 +204,7 @@ class TestGetW2Summary:
     """Tests for the get_w2_summary tool."""
 
     @pytest.fixture(autouse=True)
-    def _insert_data(self) -> None:  # pyright: ignore[reportUnusedFunction] — pytest autouse fixture
+    def _insert_data(self, mcp_db: object) -> None:  # pyright: ignore[reportUnusedFunction] — pytest autouse fixture
         db = server.get_db()
         db.execute(_INSERT_W2)
 
@@ -231,7 +233,7 @@ class TestRunReadQuery:
     """Tests for the run_read_query tool."""
 
     @pytest.fixture(autouse=True)
-    def _insert_data(self) -> None:  # pyright: ignore[reportUnusedFunction] — pytest autouse fixture
+    def _insert_data(self, mcp_db: object) -> None:  # pyright: ignore[reportUnusedFunction] — pytest autouse fixture
         db = server.get_db()
         db.execute(_INSERT_TRANSACTIONS)
 

--- a/tests/moneybin/test_services/test_categorization_service.py
+++ b/tests/moneybin/test_services/test_categorization_service.py
@@ -31,7 +31,9 @@ def db(tmp_path: Path) -> Database:
     """Create a Database with all schemas for testing."""
     mock_store = MagicMock()
     mock_store.get_key.return_value = "test-encryption-key-for-tests"
-    database = Database(tmp_path / "test.duckdb", secret_store=mock_store)
+    database = Database(
+        tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True
+    )
     # Core tables are managed by SQLMesh in production; create concrete
     # tables here so tests can INSERT fixture data directly.
     create_core_tables(database)


### PR DESCRIPTION
## Summary

The unit test suite was taking 5+ minutes due to every test Database instance spawning a `sqlmesh migrate` subprocess and loading an unnecessary extension. This PR eliminates both costs, adds a `no_auto_upgrade` constructor parameter for tests, and fixes a bug where failed sqlmesh migrations were silently recorded as successful.

## Impact

- **Test runtime drops from ~336s to ~19s.** No workflow changes needed — `make test` and `make check test` work as before, just faster.
- **New test convention:** All test `Database` instances must pass `no_auto_upgrade=True` unless specifically testing migration behavior. Added to `.claude/rules/testing.md`.
- **Production behavior unchanged** — `no_auto_upgrade` defaults to `None` (reads from config), so existing startup behavior is identical.

## Changes

### Remove httpfs from Database.__init__
DuckDB handles AES-256-GCM natively; the spec's claim about "OpenSSL-backed encryption writes" via httpfs was incorrect (confirmed by test). Callers that actually need httpfs (import_service.py, db.py CLI) already load it independently. Updated the privacy-data-protection spec to remove all incorrect httpfs references.

### Add `no_auto_upgrade` parameter to Database.__init__
- New keyword-only parameter: `no_auto_upgrade: bool | None = None`
- When `True`, skips migration runner and sqlmesh subprocess
- When `None` (default), falls back to config setting — no behavior change for production
- All test fixtures updated to pass `no_auto_upgrade=True`

### Remove mcp_db autouse fixture
- Changed `mcp_db` from `autouse=True` to opt-in via `pytestmark = pytest.mark.usefixtures("mcp_db")` at module level
- `test_privacy.py` (35 pure SQL-validation tests) no longer pays the database setup cost
- Inner `_insert_data` fixtures now declare `mcp_db` as an explicit parameter for correct ordering

### Fix sqlmesh migrate silent-success bug
- `_run_sqlmesh_migrate()` now returns `bool` (True on success, False on failure)
- `record_version()` only called when migration succeeds
- Previously, a failed migrate (e.g., DB locked) was recorded as success, preventing retry

### Update testing rules
- Added "Database Fixtures" section to `.claude/rules/testing.md` documenting the `no_auto_upgrade=True` convention and autouse guidance

## Testing

- Full `make check test` passes: format, lint (ruff), type-check (pyright), 571 tests in 19s
- Verified encryption works without httpfs via direct DuckDB test
- Verified all 571 tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)