### PR TITLE
Refactor: consolidate duplicated patterns, f-string logging, type safety

### DIFF
--- a/.claude/rules/shipping.md
+++ b/.claude/rules/shipping.md
@@ -27,6 +27,10 @@ The goal is that someone reading the README gets an accurate picture of what Mon
 
 - Add a 🗓️ entry to the relevant roadmap table in `README.md`.
 
+## Pre-Push Quality Pass
+
+After implementation is complete and documentation is updated, run `/simplify` **before the final commit and push**. This reviews the changed code for reuse opportunities, quality issues, and efficiency problems — then fixes what it finds. The goal is to catch copy-paste patterns, redundant state, missing validations, and other issues that accumulate during implementation before they land on `main`.
+
 ## Principle
 
 The README is the project's storefront. It must stay honest — never claim shipped status for designed-only features — but it should also stay *current*. A shipped feature that isn't in the README is invisible to users.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -60,6 +60,22 @@ Database(tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True
 Database(tmp_path / "test.duckdb", secret_store=mock_store)
 ```
 
+## Test Fixture Factories
+
+When a dataclass or model requires 3+ fields and appears in multiple tests, write a module-level `_make_thing()` factory with sensible defaults. Tests override only the fields they care about, keeping the focus on the behavior under test rather than construction boilerplate.
+
+```python
+# Good — factory with defaults, tests override what matters
+def _make_migration(version: int = 1, filename: str = "V001__test.sql", **kw):
+    return Migration(version=version, filename=filename, content=b"SELECT 1;", ...)
+
+mock_runner.pending.return_value = [_make_migration(version=2, filename="V002__new.sql")]
+
+# Bad — full constructor repeated in every test
+Migration(version=2, name="new", filename="V002__new.sql", checksum="def456",
+          content=b"SELECT 1;", path=Path("/tmp/V002__new.sql"), file_type="sql")
+```
+
 ## Best Practices
 
 - Arrange-Act-Assert structure.

--- a/src/moneybin/cli/commands/categorize.py
+++ b/src/moneybin/cli/commands/categorize.py
@@ -29,17 +29,15 @@ def apply_rules_cmd() -> None:
         stats = apply_deterministic_categorization(db)
         if stats["total"] > 0:
             logger.info(
-                "\u2705 Categorized %d transactions (%d merchant, %d rule)",
-                stats["total"],
-                stats["merchant"],
-                stats["rule"],
+                f"\u2705 Categorized {stats['total']} transactions "
+                f"({stats['merchant']} merchant, {stats['rule']} rule)"
             )
         else:
             logger.info(
                 "\u2705 No uncategorized transactions matched rules or merchants"
             )
     except FileNotFoundError as e:
-        logger.error("%s", e)
+        logger.error(f"{e}")
         raise typer.Exit(1) from e
     except DatabaseKeyError:
         logger.error(
@@ -62,9 +60,9 @@ def seed_cmd() -> None:
     try:
         db = get_database()
         count = seed_categories(db)
-        logger.info("\u2705 Seeded %d new categories", count)
+        logger.info(f"\u2705 Seeded {count} new categories")
     except FileNotFoundError as e:
-        logger.error("%s", e)
+        logger.error(f"{e}")
         raise typer.Exit(1) from e
     except DatabaseKeyError:
         logger.error(
@@ -84,7 +82,7 @@ def stats_cmd() -> None:
         db = get_database()
         stats = get_categorization_stats(db)
     except FileNotFoundError as e:
-        logger.error("%s", e)
+        logger.error(f"{e}")
         raise typer.Exit(1) from e
     except DatabaseKeyError:
         logger.error(
@@ -99,15 +97,15 @@ def stats_cmd() -> None:
     pct = stats["pct_categorized"]
 
     logger.info("Categorization coverage:")
-    logger.info("  Total transactions:   %d", total)
-    logger.info("  Categorized:          %d (%.1f%%)", categorized, pct)
-    logger.info("  Uncategorized:        %d", uncategorized)
+    logger.info(f"  Total transactions:   {total}")
+    logger.info(f"  Categorized:          {categorized} ({pct:.1f}%)")
+    logger.info(f"  Uncategorized:        {uncategorized}")
 
     # Show breakdown by source
     for key, value in stats.items():
         if key.startswith("by_"):
             source = key[3:]
-            logger.info("  By %s:  %s", source, value)
+            logger.info(f"  By {source}:  {value}")
 
 
 @app.command("list-rules")
@@ -128,7 +126,7 @@ def list_rules_cmd() -> None:
             """
         ).fetchall()
     except FileNotFoundError as e:
-        logger.error("%s", e)
+        logger.error(f"{e}")
         raise typer.Exit(1) from e
     except DatabaseKeyError:
         logger.error(
@@ -145,12 +143,5 @@ def list_rules_cmd() -> None:
     for rule_id, name, pattern, match_type, cat, subcat, priority in rows:
         sub = f" / {subcat}" if subcat else ""
         logger.info(
-            "  [%s] %s: '%s' (%s) -> %s%s (priority: %d)",
-            rule_id,
-            name,
-            pattern,
-            match_type,
-            cat,
-            sub,
-            priority,
+            f"  [{rule_id}] {name}: '{pattern}' ({match_type}) -> {cat}{sub} (priority: {priority})"
         )

--- a/src/moneybin/cli/commands/db.py
+++ b/src/moneybin/cli/commands/db.py
@@ -227,7 +227,8 @@ def _run_duckdb_cli(
         logger.error(f"❌ {error_noun} failed: {e}")
         raise typer.Exit(1) from e
     except KeyboardInterrupt:
-        logger.info(f"\n{exit_msg}")
+        if exit_msg:
+            logger.info(f"\n{exit_msg}")
         sys.exit(0)
     finally:
         init_script.unlink(missing_ok=True)

--- a/src/moneybin/cli/commands/db.py
+++ b/src/moneybin/cli/commands/db.py
@@ -309,6 +309,7 @@ def run_query(
         start_msg="",
         hint_msg="",
         error_noun="Query",
+        exit_msg="",
     )
 
 

--- a/src/moneybin/cli/commands/db.py
+++ b/src/moneybin/cli/commands/db.py
@@ -71,6 +71,7 @@ def _create_init_script(db_path: Path) -> Path:
     Returns:
         Path to the temporary init script.
     """
+    from moneybin.database import build_attach_sql
     from moneybin.secrets import SecretStore
 
     store = SecretStore()
@@ -81,12 +82,7 @@ def _create_init_script(db_path: Path) -> Path:
     try:
         with os.fdopen(fd, "w") as f:
             f.write("LOAD httpfs;\n")
-            safe_db_path = str(db_path).replace("'", "''")
-            safe_key = encryption_key.replace("'", "''")
-            f.write(
-                f"ATTACH '{safe_db_path}' AS moneybin "
-                f"(TYPE DUCKDB, ENCRYPTION_KEY '{safe_key}');\n"  # noqa: S608  # trusted internal values, single-quote escaped
-            )
+            f.write(f"{build_attach_sql(db_path, encryption_key)};\n")
             f.write("USE moneybin;\n")
         if sys.platform != "win32":
             os.chmod(script_path, 0o600)
@@ -173,7 +169,68 @@ def init_db(
     db = Database(db_path, secret_store=store)
     db.close()
 
-    logger.info("✅ Encrypted database created: %s", db_path)
+    logger.info(f"✅ Encrypted database created: {db_path}")
+
+
+def _run_duckdb_cli(
+    db_path: Path,
+    *,
+    extra_args: list[str] | None = None,
+    start_msg: str = "🦆 Opening DuckDB interactive shell...",
+    hint_msg: str = "   Type .help for commands, .quit to exit",
+    error_noun: str = "DuckDB shell",
+    exit_msg: str = "✅ DuckDB shell closed",
+) -> None:
+    """Run DuckDB CLI with encrypted database attached.
+
+    Handles the common preamble shared by shell, ui, and query commands:
+    db existence check, CLI availability check, init script lifecycle,
+    and subprocess error handling.
+
+    Args:
+        db_path: Path to the encrypted DuckDB database file.
+        extra_args: Additional CLI arguments (e.g. ["-ui"], ["-csv", "-c", sql]).
+        start_msg: Log message before launching.
+        hint_msg: Secondary log hint (empty string to skip).
+        error_noun: Noun for error messages (e.g. "DuckDB shell", "DuckDB UI").
+        exit_msg: Log message on KeyboardInterrupt.
+    """
+    if not db_path.exists():
+        logger.error(f"❌ Database file not found: {db_path}")
+        logger.info("💡 Run 'moneybin db init' to create the database first")
+        raise typer.Exit(1)
+
+    duckdb_path = _check_duckdb_cli()
+    if duckdb_path is None:
+        logger.error("❌ DuckDB CLI not found in PATH")
+        logger.info("💡 Install from: https://duckdb.org/docs/installation/")
+        raise typer.Exit(1)
+
+    from moneybin.secrets import SecretNotFoundError
+
+    try:
+        init_script = _create_init_script(db_path)
+    except SecretNotFoundError:
+        logger.error("❌ Database is locked — run 'moneybin db unlock' first")
+        raise typer.Exit(1) from None
+
+    try:
+        if start_msg:
+            logger.info(start_msg)
+        if hint_msg:
+            logger.info(hint_msg)
+        cmd = [duckdb_path, "-init", str(init_script)]
+        if extra_args:
+            cmd.extend(extra_args)
+        subprocess.run(cmd, check=True)  # noqa: S603 — cmd built from static args and validated flags
+    except subprocess.CalledProcessError as e:
+        logger.error(f"❌ {error_noun} failed: {e}")
+        raise typer.Exit(1) from e
+    except KeyboardInterrupt:
+        logger.info(f"\n{exit_msg}")
+        sys.exit(0)
+    finally:
+        init_script.unlink(missing_ok=True)
 
 
 @app.command("shell")
@@ -188,40 +245,7 @@ def open_shell(
     """Open an interactive DuckDB SQL shell with encrypted database attached."""
     from moneybin.config import get_settings
 
-    db_path = database or get_settings().database.path
-
-    if not db_path.exists():
-        logger.error(f"❌ Database file not found: {db_path}")
-        logger.info("💡 Run 'moneybin db init' to create the database first")
-        raise typer.Exit(1)
-
-    duckdb_path = _check_duckdb_cli()
-    if duckdb_path is None:
-        logger.error("❌ DuckDB CLI not found in PATH")
-        logger.info("💡 Install from: https://duckdb.org/docs/installation/")
-        raise typer.Exit(1)
-
-    from moneybin.secrets import SecretNotFoundError
-
-    try:
-        init_script = _create_init_script(db_path)
-    except SecretNotFoundError:
-        logger.error("❌ Database is locked — run 'moneybin db unlock' first")
-        raise typer.Exit(1) from None
-
-    try:
-        logger.info("🦆 Opening DuckDB interactive shell...")
-        logger.info("   Type .help for commands, .quit to exit")
-        cmd = [duckdb_path, "-init", str(init_script)]
-        subprocess.run(cmd, check=True)  # noqa: S603 — cmd built from static args
-    except subprocess.CalledProcessError as e:
-        logger.error(f"❌ DuckDB shell failed: {e}")
-        raise typer.Exit(1) from e
-    except KeyboardInterrupt:
-        logger.info("\n✅ DuckDB shell closed")
-        sys.exit(0)
-    finally:
-        init_script.unlink(missing_ok=True)
+    _run_duckdb_cli(database or get_settings().database.path)
 
 
 @app.command("ui")
@@ -236,40 +260,14 @@ def open_ui(
     """Open DuckDB web UI with encrypted database auto-attached."""
     from moneybin.config import get_settings
 
-    db_path = database or get_settings().database.path
-
-    if not db_path.exists():
-        logger.error(f"❌ Database file not found: {db_path}")
-        logger.info("💡 Run 'moneybin db init' to create the database first")
-        raise typer.Exit(1)
-
-    duckdb_path = _check_duckdb_cli()
-    if duckdb_path is None:
-        logger.error("❌ DuckDB CLI not found in PATH")
-        logger.info("💡 Install from: https://duckdb.org/docs/installation/")
-        raise typer.Exit(1)
-
-    from moneybin.secrets import SecretNotFoundError
-
-    try:
-        init_script = _create_init_script(db_path)
-    except SecretNotFoundError:
-        logger.error("❌ Database is locked — run 'moneybin db unlock' first")
-        raise typer.Exit(1) from None
-
-    try:
-        logger.info("🚀 Opening DuckDB web UI...")
-        logger.info("   Press Ctrl+C to stop the server")
-        cmd = [duckdb_path, "-init", str(init_script), "-ui"]
-        subprocess.run(cmd, check=True)  # noqa: S603 — cmd built from static args
-    except subprocess.CalledProcessError as e:
-        logger.error(f"❌ DuckDB UI failed to start: {e}")
-        raise typer.Exit(1) from e
-    except KeyboardInterrupt:
-        logger.info("\n✅ DuckDB UI stopped")
-        sys.exit(0)
-    finally:
-        init_script.unlink(missing_ok=True)
+    _run_duckdb_cli(
+        database or get_settings().database.path,
+        extra_args=["-ui"],
+        start_msg="🚀 Opening DuckDB web UI...",
+        hint_msg="   Press Ctrl+C to stop the server",
+        error_noun="DuckDB UI",
+        exit_msg="✅ DuckDB UI stopped",
+    )
 
 
 @app.command("query")
@@ -291,19 +289,6 @@ def run_query(
     """Execute a SQL query against the encrypted DuckDB database."""
     from moneybin.config import get_settings
 
-    db_path = database or get_settings().database.path
-
-    if not db_path.exists():
-        logger.error(f"❌ Database file not found: {db_path}")
-        logger.info("💡 Run 'moneybin db init' to create the database first")
-        raise typer.Exit(1)
-
-    duckdb_path = _check_duckdb_cli()
-    if duckdb_path is None:
-        logger.error("❌ DuckDB CLI not found in PATH")
-        logger.info("💡 Install from: https://duckdb.org/docs/installation/")
-        raise typer.Exit(1)
-
     format_map = {
         "table": "-table",
         "csv": "-csv",
@@ -311,29 +296,20 @@ def run_query(
         "markdown": "-markdown",
         "box": "-box",
     }
+    extra_args: list[str] = []
+    if output_format in format_map:
+        extra_args.append(format_map[output_format])
+    else:
+        logger.warning(f"⚠️  Unknown format '{output_format}', using table")
+    extra_args.extend(["-c", sql])
 
-    from moneybin.secrets import SecretNotFoundError
-
-    try:
-        init_script = _create_init_script(db_path)
-    except SecretNotFoundError:
-        logger.error("❌ Database is locked — run 'moneybin db unlock' first")
-        raise typer.Exit(1) from None
-
-    try:
-        cmd = [duckdb_path, "-init", str(init_script)]
-        if output_format in format_map:
-            cmd.append(format_map[output_format])
-        else:
-            logger.warning(f"⚠️  Unknown format '{output_format}', using table")
-        cmd.extend(["-c", sql])
-
-        subprocess.run(cmd, check=True)  # noqa: S603 — cmd built from static args and format flag
-    except subprocess.CalledProcessError as e:
-        logger.error(f"❌ Query failed: {e}")
-        raise typer.Exit(1) from e
-    finally:
-        init_script.unlink(missing_ok=True)
+    _run_duckdb_cli(
+        database or get_settings().database.path,
+        extra_args=extra_args,
+        start_msg="",
+        hint_msg="",
+        error_noun="Query",
+    )
 
 
 @app.command("info")
@@ -366,10 +342,10 @@ def db_info(
     else:
         size_str = f"{file_size / (1024 * 1024):.1f} MB"
 
-    logger.info("Database: %s", db_path)
-    logger.info("  File size: %s", size_str)
+    logger.info(f"Database: {db_path}")
+    logger.info(f"  File size: {size_str}")
     logger.info("  Encryption: AES-256-GCM (always on)")
-    logger.info("  Key mode: %s", settings.database.encryption_key_mode)
+    logger.info(f"  Key mode: {settings.database.encryption_key_mode}")
 
     # Check lock state
     store = SecretStore()
@@ -393,7 +369,7 @@ def db_info(
 
             from sqlglot import exp
 
-            logger.info("  Tables: %d", len(tables))
+            logger.info(f"  Tables: {len(tables)}")
             for schema, table in tables:
                 safe_schema = exp.to_identifier(schema, quoted=True).sql("duckdb")  # type: ignore[reportUnknownMemberType]  # sqlglot has no stubs
                 safe_table = exp.to_identifier(table, quoted=True).sql("duckdb")  # type: ignore[reportUnknownMemberType]  # sqlglot has no stubs
@@ -401,12 +377,12 @@ def db_info(
                     f"SELECT COUNT(*) FROM {safe_schema}.{safe_table}"  # noqa: S608 — sqlglot-quoted catalog identifiers
                 ).fetchone()
                 count = count_result[0] if count_result else 0
-                logger.info("    %s.%s: %d rows", schema, table, count)
+                logger.info(f"    {schema}.{table}: {count} rows")
 
             # DuckDB version
             version = db.sql("SELECT version()").fetchone()
             if version:
-                logger.info("  DuckDB version: %s", version[0])
+                logger.info(f"  DuckDB version: {version[0]}")
         finally:
             db.close()
     except Exception as e:  # noqa: BLE001 — duckdb raises untyped errors on connection/encryption failure
@@ -453,7 +429,7 @@ def db_backup(
             pass
 
     file_size = backup_path.stat().st_size / (1024 * 1024)
-    logger.info("✅ Backup created: %s (%.1f MB)", backup_path, file_size)
+    logger.info(f"✅ Backup created: {backup_path} ({file_size:.1f} MB)")
 
 
 @app.command("restore")
@@ -483,12 +459,12 @@ def db_restore(
     if from_path is None:
         backup_dir = settings.database.backup_path or db_path.parent / "backups"
         if not backup_dir.exists():
-            logger.error("❌ No backup directory found: %s", backup_dir)
+            logger.error(f"❌ No backup directory found: {backup_dir}")
             raise typer.Exit(1)
 
         backups: list[Path] = sorted(backup_dir.glob("*.duckdb"), reverse=True)
         if not backups:
-            logger.error("❌ No backups found in %s", backup_dir)
+            logger.error(f"❌ No backups found in {backup_dir}")
             raise typer.Exit(1)
 
         if latest:
@@ -497,7 +473,7 @@ def db_restore(
             logger.info("Available backups:")
             for i, b in enumerate(backups, 1):
                 size = b.stat().st_size / (1024 * 1024)
-                logger.info("  %d. %s (%.1f MB)", i, b.name, size)
+                logger.info(f"  {i}. {b.name} ({size:.1f} MB)")
 
             choice = typer.prompt("Select backup number", type=int)
             if choice < 1 or choice > len(backups):
@@ -506,17 +482,15 @@ def db_restore(
             from_path = backups[choice - 1]
 
     # from_path is guaranteed non-None here (either provided or selected above)
-    from typing import cast
+    selected_path: Path = from_path  # type: ignore[assignment]  # Pyright can't narrow across Typer Option | None
 
-    resolved_path = cast(Path, from_path)
-
-    if not resolved_path.exists():
-        logger.error(f"❌ Backup file not found: {resolved_path}")
+    if not selected_path.exists():
+        logger.error(f"❌ Backup file not found: {selected_path}")
         raise typer.Exit(1)
 
     if not yes:
         confirm = typer.confirm(
-            f"Restore from {resolved_path.name}? Current database will be backed up first."
+            f"Restore from {selected_path.name}? Current database will be backed up first."
         )
         if not confirm:
             raise typer.Exit(0)
@@ -528,9 +502,9 @@ def db_restore(
         timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
         auto_backup = backup_dir / f"moneybin_{timestamp}_pre_restore.duckdb"
         shutil.copy2(str(db_path), str(auto_backup))
-        logger.info("Auto-backed up current database: %s", auto_backup.name)
+        logger.info(f"Auto-backed up current database: {auto_backup.name}")
 
-    shutil.copy2(str(resolved_path), str(db_path))
+    shutil.copy2(str(selected_path), str(db_path))
     if sys.platform != "win32":
         try:
             db_path.chmod(0o600)
@@ -541,7 +515,7 @@ def db_restore(
     try:
         db = Database(db_path, secret_store=store)
         db.close()
-        logger.info("✅ Database restored from %s", resolved_path.name)
+        logger.info(f"✅ Database restored from {selected_path.name}")
     except DatabaseKeyError:
         logger.warning(
             "⚠️  Could not open restored database with current key. "
@@ -618,7 +592,7 @@ def db_unlock() -> None:
 
     if not settings.database.path.exists():
         store.delete_key("DATABASE__ENCRYPTION_KEY")
-        logger.error("❌ Database file not found: %s", settings.database.path)
+        logger.error(f"❌ Database file not found: {settings.database.path}")
         logger.info("💡 Run 'moneybin db init --passphrase' to create a new database.")
         raise typer.Exit(1)
     try:
@@ -692,24 +666,16 @@ def db_rotate_key(
         raise typer.Exit(1) from None
     new_key = secrets_mod.token_hex(32)
 
+    from moneybin.database import build_attach_sql
+
     rotated_path = db_path.with_suffix(".rotated.duckdb")
     # Direct duckdb.connect() required here: COPY FROM DATABASE needs two
     # simultaneous open connections; the Database class wraps a single one.
     conn = duckdb_mod.connect()
     try:
         conn.execute("LOAD httpfs;")
-        safe_db_path = str(db_path).replace("'", "''")
-        safe_old_key = old_key.replace("'", "''")
-        conn.execute(
-            f"ATTACH '{safe_db_path}' AS old_db "
-            f"(TYPE DUCKDB, ENCRYPTION_KEY '{safe_old_key}')"  # noqa: S608  # trusted internal values, single-quote escaped
-        )
-        safe_rotated_path = str(rotated_path).replace("'", "''")
-        safe_new_key = new_key.replace("'", "''")
-        conn.execute(
-            f"ATTACH '{safe_rotated_path}' AS new_db "
-            f"(TYPE DUCKDB, ENCRYPTION_KEY '{safe_new_key}')"  # noqa: S608  # trusted internal values, single-quote escaped
-        )
+        conn.execute(build_attach_sql(db_path, old_key, alias="old_db"))
+        conn.execute(build_attach_sql(rotated_path, new_key, alias="new_db"))
         conn.execute("COPY FROM DATABASE old_db TO new_db")
     except Exception as e:  # noqa: BLE001 — duckdb raises untyped errors on ATTACH/COPY failure
         logger.error(f"❌ Key rotation failed: {e}")

--- a/src/moneybin/cli/commands/import_cmd.py
+++ b/src/moneybin/cli/commands/import_cmd.py
@@ -151,7 +151,7 @@ def _print_import_status(db: Database) -> None:
                 if dates and dates[0]:
                     date_info = f"  ({dates[0]} to {dates[1]})"
             except Exception:  # noqa: BLE001 — column may not exist in all tables
-                logger.debug("Could not get date range for %s.%s", schema, table)
+                logger.debug(f"Could not get date range for {schema}.{table}")
 
         print(f"  {schema}.{table}: {count:,} rows{date_info}")
 

--- a/src/moneybin/cli/commands/migrate.py
+++ b/src/moneybin/cli/commands/migrate.py
@@ -12,7 +12,6 @@ import typer
 
 from moneybin.database import DatabaseKeyError, get_database
 from moneybin.migrations import MigrationRunner, get_current_versions
-from moneybin.tables import SCHEMA_MIGRATIONS
 
 logger = logging.getLogger(__name__)
 
@@ -53,10 +52,7 @@ def migrate_apply(
         logger.warning(f"⚠️  {warning.reason}")
 
     if result.failed:
-        msg = result.error_message or f"Migration {result.failed_migration} failed"
-        logger.error(f"❌ {msg}")
-        logger.info("💡 See logs for details")
-        logger.error("🐛 Report issues at https://github.com/bsaffel/moneybin/issues")
+        result.log_failure()
         raise typer.Exit(1) from None
 
     if result.applied_count > 0:
@@ -78,18 +74,15 @@ def migrate_status() -> None:
     runner = MigrationRunner(db)
 
     # Applied migrations
-    applied_rows = db.execute(
-        f"SELECT version, filename, success, execution_ms, applied_at "  # noqa: S608 — SCHEMA_MIGRATIONS is a compile-time TableRef constant
-        f"FROM {SCHEMA_MIGRATIONS.full_name} ORDER BY version"
-    ).fetchall()
+    applied = runner.applied_details()
 
-    if applied_rows:
+    if applied:
         logger.info("Applied migrations:")
-        for version, filename, success, exec_ms, applied_at in applied_rows:
-            status = "✅" if success else "❌"
-            time_str = f" ({exec_ms}ms)" if exec_ms is not None else ""
+        for m in applied:
+            status = "✅" if m.success else "❌"
+            time_str = f" ({m.execution_ms}ms)" if m.execution_ms is not None else ""
             logger.info(
-                f"  {status} V{version:03d} {filename}{time_str} — {applied_at}"
+                f"  {status} V{m.version:03d} {m.filename}{time_str} — {m.applied_at}"
             )
     else:
         logger.info("No applied migrations")

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -38,21 +38,27 @@ def build_attach_sql(
 ) -> str:
     """Build a DuckDB ATTACH statement for an encrypted database.
 
-    Single-quote escapes the path and key to prevent injection. Both values
-    must come from trusted sources (config, SecretStore) — never user input.
+    Single-quote escapes the path and key to prevent injection. The alias
+    is double-quoted via sqlglot as defense in depth. All three parameters
+    must come from trusted sources (config, SecretStore, hardcoded literals)
+    — never user input.
 
     Args:
         db_path: Path to the DuckDB database file.
         encryption_key: AES-256-GCM encryption key.
-        alias: Database alias in DuckDB (default "moneybin").
+        alias: Database alias in DuckDB (default "moneybin"). Must be a
+            simple identifier — callers should only pass hardcoded literals.
 
     Returns:
         ATTACH SQL string ready for execution.
     """
+    from sqlglot import exp
+
     safe_path = str(db_path).replace("'", "''")
     safe_key = encryption_key.replace("'", "''")
+    safe_alias = exp.to_identifier(alias, quoted=True).sql("duckdb")  # type: ignore[reportUnknownMemberType]  # sqlglot has no stubs
     return (
-        f"ATTACH '{safe_path}' AS {alias} "  # noqa: S608 — trusted internal values, single-quote escaped
+        f"ATTACH '{safe_path}' AS {safe_alias} "  # noqa: S608 — trusted internal values, single-quote escaped, alias sqlglot-quoted
         f"(TYPE DUCKDB, ENCRYPTION_KEY '{safe_key}')"
     )
 

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -30,6 +30,31 @@ from moneybin.secrets import SecretNotFoundError, SecretStore
 logger = logging.getLogger(__name__)
 
 _KEY_NAME = "DATABASE__ENCRYPTION_KEY"
+_DATABASE_ALIAS = "moneybin"
+
+
+def build_attach_sql(
+    db_path: Path, encryption_key: str, *, alias: str = _DATABASE_ALIAS
+) -> str:
+    """Build a DuckDB ATTACH statement for an encrypted database.
+
+    Single-quote escapes the path and key to prevent injection. Both values
+    must come from trusted sources (config, SecretStore) — never user input.
+
+    Args:
+        db_path: Path to the DuckDB database file.
+        encryption_key: AES-256-GCM encryption key.
+        alias: Database alias in DuckDB (default "moneybin").
+
+    Returns:
+        ATTACH SQL string ready for execution.
+    """
+    safe_path = str(db_path).replace("'", "''")
+    safe_key = encryption_key.replace("'", "''")
+    return (
+        f"ATTACH '{safe_path}' AS {alias} "  # noqa: S608 — trusted internal values, single-quote escaped
+        f"(TYPE DUCKDB, ENCRYPTION_KEY '{safe_key}')"
+    )
 
 
 class DatabaseKeyError(Exception):
@@ -84,7 +109,6 @@ class Database:
 
         store = secret_store or SecretStore()
 
-        # Step a: Retrieve encryption key
         try:
             encryption_key = store.get_key(_KEY_NAME)
         except SecretNotFoundError as e:
@@ -99,22 +123,10 @@ class Database:
 
         is_new = not db_path.exists()
 
-        # Step b: Open in-memory connection
         self._conn = duckdb.connect()
 
-        # Step c: Attach encrypted database file.
-        # ATTACH does not support parameterized queries in DuckDB — the path
-        # and key must be interpolated as string literals. The path comes from
-        # our own config (trusted), and the key is from SecretStore (trusted).
-        # Both are escaped by replacing single-quotes to prevent injection.
-        safe_path = str(db_path).replace("'", "''")
-        safe_key = encryption_key.replace("'", "''")
-        self._conn.execute(  # noqa: S608  # identifiers from trusted config, not user input
-            f"ATTACH '{safe_path}' AS moneybin (TYPE DUCKDB, ENCRYPTION_KEY '{safe_key}')"
-        )
-
-        # Step d: USE attached database
-        self._conn.execute("USE moneybin")
+        self._conn.execute(build_attach_sql(db_path, encryption_key))
+        self._conn.execute(f"USE {_DATABASE_ALIAS}")
 
         # Set file permissions on new databases (macOS/Linux)
         if is_new and sys.platform != "win32":
@@ -127,12 +139,10 @@ class Database:
         if not is_new and sys.platform != "win32":
             self._check_permissions(db_path)
 
-        # Step e: Run init_schemas (idempotent)
         from moneybin.schema import init_schemas
 
         init_schemas(self._conn)
 
-        # Steps f-h: Auto-upgrade (migrations + version tracking)
         from moneybin.migrations import (
             MigrationError,
             MigrationRunner,
@@ -162,15 +172,7 @@ class Database:
                 result = runner.apply_all()
 
                 if result.failed:
-                    msg = (
-                        result.error_message
-                        or f"Migration {result.failed_migration} failed"
-                    )
-                    logger.error(f"❌ {msg}")
-                    logger.info("💡 See logs for details")
-                    logger.error(
-                        "🐛 Report issues at https://github.com/bsaffel/moneybin/issues"
-                    )
+                    result.log_failure()
                     raise MigrationError(
                         f"Migration failed: {result.failed_migration or 'stuck migration'}. "
                         f"See logs for details."

--- a/src/moneybin/extractors/csv_extractor.py
+++ b/src/moneybin/extractors/csv_extractor.py
@@ -92,7 +92,7 @@ class CSVExtractor:
                 "Use --account-id on the CLI."
             )
 
-        logger.info("Extracting data from CSV file: %s", file_path)
+        logger.info(f"Extracting data from CSV file: {file_path}")
 
         # Resolve profile
         if profile is None:
@@ -219,7 +219,7 @@ class CSVExtractor:
             # Parse date
             date_str = str(row.get(profile.date_column, "")).strip()
             if not date_str:
-                logger.debug("Skipping row %d: empty date", row_index)
+                logger.debug(f"Skipping row {row_index}: empty date")
                 continue
 
             try:
@@ -247,7 +247,7 @@ class CSVExtractor:
             # Parse amount
             amount = self._parse_amount(row, profile)
             if amount is None:
-                logger.debug("Skipping row %d: could not parse amount", row_index)
+                logger.debug(f"Skipping row {row_index}: could not parse amount")
                 continue
 
             # Build description

--- a/src/moneybin/extractors/csv_profiles.py
+++ b/src/moneybin/extractors/csv_profiles.py
@@ -142,7 +142,7 @@ def save_profile(profile: CSVProfile, profiles_dir: Path) -> Path:
     with open(output_path, "w") as f:
         yaml.dump(data, f, default_flow_style=False, sort_keys=False)
 
-    logger.info("Saved CSV profile '%s' to %s", profile.name, output_path)
+    logger.info(f"Saved CSV profile '{profile.name}' to {output_path}")
     return output_path
 
 
@@ -187,7 +187,7 @@ def load_profiles(user_profiles_dir: Path) -> dict[str, CSVProfile]:
                 profile = _load_profile_from_yaml(yaml_path)
                 profiles[profile.name] = profile
             except Exception:
-                logger.warning("Skipping invalid built-in profile: %s", yaml_path)
+                logger.warning(f"Skipping invalid built-in profile: {yaml_path}")
 
     # Load user profiles (override built-ins with same name)
     if user_profiles_dir.is_dir():
@@ -196,7 +196,7 @@ def load_profiles(user_profiles_dir: Path) -> dict[str, CSVProfile]:
                 profile = _load_profile_from_yaml(yaml_path)
                 profiles[profile.name] = profile
             except Exception:
-                logger.warning("Skipping invalid user profile: %s", yaml_path)
+                logger.warning(f"Skipping invalid user profile: {yaml_path}")
 
     return profiles
 
@@ -248,7 +248,7 @@ def ensure_default_profiles(user_profiles_dir: Path) -> None:
     for yaml_path in _BUILTIN_PROFILES_DIR.glob("*.yaml"):
         dest = user_profiles_dir / yaml_path.name
         shutil.copy2(yaml_path, dest)
-        logger.info("Copied built-in profile %s to %s", yaml_path.name, dest)
+        logger.info(f"Copied built-in profile {yaml_path.name} to {dest}")
 
 
 def list_profile_names(user_profiles_dir: Path) -> list[str]:

--- a/src/moneybin/extractors/w2_extractor.py
+++ b/src/moneybin/extractors/w2_extractor.py
@@ -317,7 +317,7 @@ class W2Extractor:
             )
             df = pl.DataFrame([df_data])
 
-            logger.info("✅ Extracted W2 for tax year %s", w2_schema.tax_year)
+            logger.info(f"✅ Extracted W2 for tax year {w2_schema.tax_year}")
 
             return df
 

--- a/src/moneybin/loaders/csv_loader.py
+++ b/src/moneybin/loaders/csv_loader.py
@@ -25,7 +25,7 @@ class CSVLoader:
         """
         self.db = db
         self.sql_dir = Path(__file__).parent.parent / "sql" / "schema"
-        logger.info("Initialized CSV loader for database: %s", db.path)
+        logger.info(f"Initialized CSV loader for database: {db.path}")
 
     def create_raw_tables(self) -> None:
         """Create raw CSV tables in DuckDB by executing SQL schema files.
@@ -46,7 +46,7 @@ class CSVLoader:
             with open(sql_path) as f:
                 sql_content = f.read()
                 self.db.execute(sql_content)
-                logger.debug("Executed schema file: %s", sql_file)
+                logger.debug(f"Executed schema file: {sql_file}")
 
         logger.info("Created CSV raw tables in DuckDB")
 
@@ -61,20 +61,18 @@ class CSVLoader:
         """
         row_counts: dict[str, int] = {}
 
-        self.create_raw_tables()
-
         # Load accounts
         if len(data.get("accounts", pl.DataFrame())) > 0:
             df = data["accounts"]
             self.db.ingest_dataframe("raw.csv_accounts", df, on_conflict="upsert")
             row_counts["accounts"] = len(df)
-            logger.info("Loaded %d account(s)", row_counts["accounts"])
+            logger.info(f"Loaded {row_counts['accounts']} account(s)")
 
         # Load transactions
         if len(data.get("transactions", pl.DataFrame())) > 0:
             df = data["transactions"]
             self.db.ingest_dataframe("raw.csv_transactions", df, on_conflict="upsert")
             row_counts["transactions"] = len(df)
-            logger.info("Loaded %d transaction(s)", row_counts["transactions"])
+            logger.info(f"Loaded {row_counts['transactions']} transaction(s)")
 
         return row_counts

--- a/src/moneybin/loaders/ofx_loader.py
+++ b/src/moneybin/loaders/ofx_loader.py
@@ -65,12 +65,8 @@ class OFXLoader:
         """
         row_counts = {}
 
-        # Ensure tables exist
-        self.create_raw_tables()
-
-        # INSERT queries reference local Polars DataFrames via DuckDB's Python
-        # frame scan (FROM df). This requires the raw conn.execute() rather than
-        # db.execute() — use db.conn directly for INSERT FROM df only.
+        # Use conn directly for INSERT with inline type casts (::TIMESTAMP)
+        # and CASE expressions that ingest_dataframe's SELECT * doesn't support.
         conn = self.db.conn
 
         # Load institutions (use INSERT OR REPLACE for idempotency)

--- a/src/moneybin/loaders/w2_loader.py
+++ b/src/moneybin/loaders/w2_loader.py
@@ -62,12 +62,8 @@ class W2Loader:
         """
         row_count = 0
 
-        # Ensure tables exist
-        self.create_raw_tables()
-
-        # INSERT queries reference local Polars DataFrames via DuckDB's Python
-        # frame scan (FROM df). This requires the raw conn.execute() rather than
-        # db.execute() — use db.conn directly for INSERT FROM df only.
+        # Use conn directly for INSERT with inline type casts (::JSON,
+        # ::TIMESTAMP) and CASE expressions that ingest_dataframe doesn't support.
         conn = self.db.conn
 
         # Load W2 forms (use INSERT OR REPLACE for idempotency)

--- a/src/moneybin/mcp/resources.py
+++ b/src/moneybin/mcp/resources.py
@@ -52,7 +52,7 @@ def schema_table_detail(table_name: str) -> str:
     The table_name can be schema-qualified (e.g. 'raw.ofx_transactions')
     or just the table name (searches all schemas).
     """
-    logger.info("Resource read: schema/%s", table_name)
+    logger.info(f"Resource read: schema/{table_name}")
     db = get_db()
 
     # Handle schema-qualified names
@@ -208,7 +208,7 @@ def w2_by_year(tax_year: str) -> str:
     Args:
         tax_year: The tax year (e.g. '2024').
     """
-    logger.info("Resource read: w2/%s", tax_year)
+    logger.info(f"Resource read: w2/{tax_year}")
     db = get_db()
 
     if not table_exists(W2_FORMS):

--- a/src/moneybin/mcp/tools.py
+++ b/src/moneybin/mcp/tools.py
@@ -63,7 +63,7 @@ def _query_to_json(sql: str, params: list[object] | None = None) -> str:
         records = [dict(zip(columns, row, strict=False)) for row in rows]
         return truncate_result(json.dumps(records, indent=2, default=str))
     except Exception as e:
-        logger.exception("Query failed: %s", sql)
+        logger.exception(f"Query failed: {sql}")
         return json.dumps({"error": str(e)})
 
 
@@ -103,7 +103,7 @@ def describe_table(table_name: str, schema_name: str = "raw") -> str:
         table_name: Name of the table to describe.
         schema_name: Schema containing the table (default: 'raw').
     """
-    logger.info("Tool called: describe_table(%s.%s)", schema_name, table_name)
+    logger.info(f"Tool called: describe_table({schema_name}.{table_name})")
 
     error = check_table_allowed(f"{schema_name}.{table_name}")
     if error:

--- a/src/moneybin/mcp/write_tools.py
+++ b/src/moneybin/mcp/write_tools.py
@@ -14,6 +14,7 @@ import duckdb
 
 from moneybin.database import get_database
 from moneybin.services.categorization_service import (
+    MatchType,
     create_merchant,
     match_merchant,
     normalize_description,
@@ -33,6 +34,28 @@ from moneybin.tables import (
 from .server import mcp, table_exists
 
 logger = logging.getLogger(__name__)
+
+_VALID_MATCH_TYPES: set[MatchType] = {"exact", "contains", "regex"}
+
+
+def _validate_match_type(match_type: str) -> MatchType:
+    """Validate and narrow a match_type string at the MCP boundary.
+
+    Args:
+        match_type: Raw string from MCP tool input.
+
+    Returns:
+        Validated MatchType literal.
+
+    Raises:
+        ValueError: If match_type is not one of the valid values.
+    """
+    if match_type not in _VALID_MATCH_TYPES:
+        raise ValueError(
+            f"Invalid match_type: '{match_type}'. "
+            f"Must be one of: {', '.join(sorted(_VALID_MATCH_TYPES))}"
+        )
+    return match_type  # type: ignore[return-value]  # validated above
 
 
 # ---------------------------------------------------------------------------
@@ -82,7 +105,7 @@ def import_file(
         institution: Institution name (OFX) or CSV profile name (optional,
             auto-detects for CSV).
     """
-    logger.info("Tool called: import_file(%s)", file_path)
+    logger.info(f"Tool called: import_file({file_path})")
 
     # Expand ~ and resolve to canonical path (collapses '..' and follows
     # symlinks), then verify the result stays within the user's home directory.
@@ -106,7 +129,7 @@ def import_file(
     except ValueError as e:
         return f"Error: {e}"
     except Exception as e:
-        logger.exception("Import failed: %s", file_path)
+        logger.exception(f"Import failed: {file_path}")
         return f"Import failed: {e}"
 
 
@@ -134,7 +157,7 @@ def categorize_transaction(
         subcategory: Optional subcategory (e.g. 'Groceries', 'Restaurants').
         categorized_by: Who is categorizing: 'user' (default), 'ai', 'rule', 'plaid'.
     """
-    logger.info("Tool called: categorize_transaction(%s, %s)", transaction_id, category)
+    logger.info(f"Tool called: categorize_transaction({transaction_id}, {category})")
 
     try:
         db = get_database()
@@ -265,7 +288,7 @@ def toggle_category(category_id: str, is_active: bool) -> str:
         category_id: The category ID to toggle (e.g. 'FND-COF').
         is_active: True to enable, False to disable.
     """
-    logger.info("Tool called: toggle_category(%s, %s)", category_id, is_active)
+    logger.info(f"Tool called: toggle_category({category_id}, {is_active})")
 
     try:
         db = get_database()
@@ -300,7 +323,7 @@ def create_category(
         subcategory: Optional subcategory (e.g. 'Daycare', 'Babysitter').
         description: Optional description of this category.
     """
-    logger.info("Tool called: create_category(%s, %s)", category, subcategory)
+    logger.info(f"Tool called: create_category({category}, {subcategory})")
 
     import uuid as _uuid
 
@@ -353,7 +376,12 @@ def create_merchant_mapping(
         category: Optional default category for this merchant.
         subcategory: Optional default subcategory.
     """
-    logger.info("Tool called: create_merchant_mapping(%s)", canonical_name)
+    logger.info(f"Tool called: create_merchant_mapping({canonical_name})")
+
+    try:
+        validated_match_type = _validate_match_type(match_type)
+    except ValueError as e:
+        return f"Error: {e}"
 
     try:
         db = get_database()
@@ -361,7 +389,7 @@ def create_merchant_mapping(
             db,
             raw_pattern,
             canonical_name,
-            match_type=match_type,
+            match_type=validated_match_type,
             category=category,
             subcategory=subcategory,
             created_by="user",
@@ -406,7 +434,12 @@ def create_categorization_rule(
         account_id: Optional account ID filter.
         priority: Rule priority (lower = higher priority, default 100).
     """
-    logger.info("Tool called: create_categorization_rule(%s)", name)
+    logger.info(f"Tool called: create_categorization_rule({name})")
+
+    try:
+        validated_match_type = _validate_match_type(match_type)
+    except ValueError as e:
+        return f"Error: {e}"
 
     import uuid as _uuid
 
@@ -428,7 +461,7 @@ def create_categorization_rule(
                 rule_id,
                 name,
                 merchant_pattern,
-                match_type,
+                validated_match_type,
                 min_amount,
                 max_amount,
                 account_id,
@@ -450,7 +483,7 @@ def delete_categorization_rule(rule_id: str) -> str:
     Args:
         rule_id: The rule ID to delete.
     """
-    logger.info("Tool called: delete_categorization_rule(%s)", rule_id)
+    logger.info(f"Tool called: delete_categorization_rule({rule_id})")
 
     try:
         db = get_database()
@@ -494,7 +527,7 @@ def bulk_categorize(
             mappings from transaction descriptions so future similar
             transactions are categorized automatically.
     """
-    logger.info("Tool called: bulk_categorize(%d items)", len(categorizations))
+    logger.info(f"Tool called: bulk_categorize({len(categorizations)} items)")
 
     if not categorizations:
         return "No categorizations provided."
@@ -601,7 +634,7 @@ def bulk_create_categorization_rules(
             - account_id: optional account ID filter
             - priority: rule priority (default 100, lower = higher priority)
     """
-    logger.info("Tool called: bulk_create_categorization_rules(%d items)", len(rules))
+    logger.info(f"Tool called: bulk_create_categorization_rules({len(rules)} items)")
 
     if not rules:
         return "No rules provided."
@@ -622,7 +655,14 @@ def bulk_create_categorization_rules(
                 continue
 
             subcategory = str(item.get("subcategory", "")).strip() or None
-            match_type = str(item.get("match_type", "contains")).strip()
+            raw_match_type = str(item.get("match_type", "contains")).strip()
+            try:
+                match_type = _validate_match_type(raw_match_type)
+            except ValueError:
+                errors.append(
+                    f"Skipped rule with invalid match_type '{raw_match_type}': {item}"
+                )
+                continue
             min_amount = item.get("min_amount")
             max_amount = item.get("max_amount")
             account_id = item.get("account_id")
@@ -683,7 +723,7 @@ def bulk_create_merchant_mappings(
             - category: optional default category
             - subcategory: optional default subcategory
     """
-    logger.info("Tool called: bulk_create_merchant_mappings(%d items)", len(mappings))
+    logger.info(f"Tool called: bulk_create_merchant_mappings({len(mappings)} items)")
 
     if not mappings:
         return "No mappings provided."
@@ -702,7 +742,14 @@ def bulk_create_merchant_mappings(
                 )
                 continue
 
-            match_type = str(item.get("match_type", "contains")).strip()
+            raw_match_type = str(item.get("match_type", "contains")).strip()
+            try:
+                match_type = _validate_match_type(raw_match_type)
+            except ValueError:
+                errors.append(
+                    f"Skipped mapping with invalid match_type '{raw_match_type}': {item}"
+                )
+                continue
             category = str(item.get("category", "")).strip() or None
             subcategory = str(item.get("subcategory", "")).strip() or None
 
@@ -748,7 +795,7 @@ def set_budget(
         monthly_amount: Monthly budget amount in dollars.
         start_month: Starting month (YYYY-MM). Defaults to current month.
     """
-    logger.info("Tool called: set_budget(%s)", category)
+    logger.info(f"Tool called: set_budget({category})")
 
     db = get_database()
 
@@ -1026,7 +1073,7 @@ def csv_preview_file(file_path: str) -> str:
     Args:
         file_path: Absolute path to the CSV file.
     """
-    logger.info("Tool called: csv_preview_file(%s)", file_path)
+    logger.info(f"Tool called: csv_preview_file({file_path})")
 
     import csv as csv_mod
     from pathlib import Path
@@ -1153,7 +1200,7 @@ def csv_save_profile(
         skip_rows: Rows to skip before header (default 0).
         encoding: File encoding (default 'utf-8').
     """
-    logger.info("Tool called: csv_save_profile(%s)", name)
+    logger.info(f"Tool called: csv_save_profile({name})")
 
     from moneybin.config import get_raw_data_path
     from moneybin.extractors.csv_profiles import CSVProfile, save_profile

--- a/src/moneybin/mcp/write_tools.py
+++ b/src/moneybin/mcp/write_tools.py
@@ -7,6 +7,7 @@ layer with privacy validation.
 
 import json
 import logging
+import typing
 import uuid
 from pathlib import Path
 
@@ -35,7 +36,7 @@ from .server import mcp, table_exists
 
 logger = logging.getLogger(__name__)
 
-_VALID_MATCH_TYPES: set[MatchType] = {"exact", "contains", "regex"}
+_VALID_MATCH_TYPES: frozenset[MatchType] = frozenset(typing.get_args(MatchType))
 
 
 def _validate_match_type(match_type: str) -> MatchType:

--- a/src/moneybin/migrations.py
+++ b/src/moneybin/migrations.py
@@ -39,6 +39,7 @@ class Migration:
         name: Snake-case description parsed from filename.
         filename: Full filename including extension.
         checksum: Lowercase hex SHA-256 of file contents.
+        content: Raw file bytes (cached from discovery to avoid re-reads).
         path: Absolute path to the migration file.
         file_type: File extension — "sql" or "py".
     """
@@ -47,6 +48,7 @@ class Migration:
     name: str
     filename: str
     checksum: str
+    content: bytes
     path: Path
     file_type: str
 
@@ -79,6 +81,7 @@ class Migration:
             name=name,
             filename=path.name,
             checksum=checksum,
+            content=content,
             path=path,
             file_type=file_type,
         )
@@ -109,7 +112,6 @@ def discover_migrations(migrations_dir: Path | None = None) -> list[Migration]:
             continue
         migrations.append(Migration.from_file(path))
 
-    # Check for duplicate versions
     seen: dict[int, str] = {}
     for m in migrations:
         if m.version in seen:
@@ -133,15 +135,25 @@ class MigrationResult:
 
     Attributes:
         applied_count: Number of migrations successfully applied.
-        failed: Whether any migration failed.
         failed_migration: Filename of the failed migration, if any.
         error_message: Human-readable details for display to the user.
     """
 
     applied_count: int = 0
-    failed: bool = False
     failed_migration: str | None = None
     error_message: str | None = None
+
+    @property
+    def failed(self) -> bool:
+        """Whether any migration failed."""
+        return self.failed_migration is not None or self.error_message is not None
+
+    def log_failure(self) -> None:
+        """Log the failure details with standard icon formatting."""
+        msg = self.error_message or f"Migration {self.failed_migration} failed"
+        logger.error(f"❌ {msg}")
+        logger.info("💡 See logs for details")
+        logger.error("🐛 Report issues at https://github.com/bsaffel/moneybin/issues")
 
 
 @dataclass(frozen=True)
@@ -157,6 +169,25 @@ class DriftWarning:
     version: int
     filename: str
     reason: str
+
+
+@dataclass(frozen=True)
+class AppliedMigration:
+    """A migration record from the tracking table.
+
+    Attributes:
+        version: Migration version number.
+        filename: Migration filename.
+        success: Whether the migration succeeded.
+        execution_ms: Execution time in milliseconds (may be None).
+        applied_at: Timestamp when the migration was applied.
+    """
+
+    version: int
+    filename: str
+    success: bool
+    execution_ms: int | None
+    applied_at: str
 
 
 class MigrationRunner:
@@ -180,6 +211,14 @@ class MigrationRunner:
         """Initialize the runner."""
         self._db = db
         self._migrations_dir = migrations_dir or _MIGRATIONS_DIR
+        self._cached_migrations: list[Migration] | None = None
+
+    @property
+    def _migrations(self) -> list[Migration]:
+        """Lazily discover and cache migration files."""
+        if self._cached_migrations is None:
+            self._cached_migrations = discover_migrations(self._migrations_dir)
+        return self._cached_migrations
 
     def check_drift(self) -> list[DriftWarning]:
         """Check for checksum drift between applied migrations and current files.
@@ -194,10 +233,7 @@ class MigrationRunner:
         if not applied_rows:
             return []
 
-        # Build lookup of current files
-        current_files: dict[int, Migration] = {}
-        for m in discover_migrations(self._migrations_dir):
-            current_files[m.version] = m
+        current_files: dict[int, Migration] = {m.version: m for m in self._migrations}
 
         warnings: list[DriftWarning] = []
         for version, filename, stored_checksum in applied_rows:
@@ -254,6 +290,27 @@ class MigrationRunner:
         ).fetchall()
         return {row[0]: row[1] for row in rows}
 
+    def applied_details(self) -> list[AppliedMigration]:
+        """Return full details of all applied migrations, ordered by version.
+
+        Returns:
+            List of AppliedMigration records.
+        """
+        rows = self._db.execute(
+            "SELECT version, filename, success, execution_ms, applied_at "
+            "FROM app.schema_migrations ORDER BY version"
+        ).fetchall()
+        return [
+            AppliedMigration(
+                version=row[0],
+                filename=row[1],
+                success=row[2],
+                execution_ms=row[3],
+                applied_at=row[4],
+            )
+            for row in rows
+        ]
+
     def pending(self) -> list[Migration]:
         """Return migrations that have not yet been applied, sorted by version.
 
@@ -261,8 +318,34 @@ class MigrationRunner:
             List of unapplied Migration objects in version order.
         """
         applied = self.applied_versions()
-        all_migrations = discover_migrations(self._migrations_dir)
-        return [m for m in all_migrations if m.version not in applied]
+        return [m for m in self._migrations if m.version not in applied]
+
+    def _record_migration(
+        self,
+        migration: Migration,
+        *,
+        success: bool,
+        elapsed_ms: int,
+    ) -> None:
+        """Write a row to the migration tracking table.
+
+        Args:
+            migration: The migration being recorded.
+            success: Whether the migration succeeded.
+            elapsed_ms: Execution time in milliseconds.
+        """
+        self._db.execute(
+            "INSERT INTO app.schema_migrations "
+            "(version, filename, checksum, success, execution_ms) "
+            "VALUES (?, ?, ?, ?, ?)",
+            [
+                migration.version,
+                migration.filename,
+                migration.checksum,
+                success,
+                elapsed_ms,
+            ],
+        )
 
     def apply_one(self, migration: Migration) -> None:
         """Apply a single migration within a transaction.
@@ -295,8 +378,7 @@ class MigrationRunner:
             self._db.execute("BEGIN TRANSACTION")
 
             if migration.file_type == "sql":
-                sql = migration.path.read_text()
-                self._db.execute(sql)
+                self._db.execute(migration.content.decode())
             else:
                 self._execute_python_migration(migration)
 
@@ -304,12 +386,7 @@ class MigrationRunner:
 
             # Record success inside the transaction so DDL and tracking
             # are committed atomically — prevents orphaned DDL on crash.
-            self._db.execute(
-                "INSERT INTO app.schema_migrations "
-                "(version, filename, checksum, success, execution_ms) "
-                "VALUES (?, ?, ?, TRUE, ?)",
-                [migration.version, migration.filename, migration.checksum, elapsed_ms],
-            )
+            self._record_migration(migration, success=True, elapsed_ms=elapsed_ms)
             self._db.execute("COMMIT")
             logger.info(f"Applied {migration.filename} in {elapsed_ms}ms")
 
@@ -320,19 +397,8 @@ class MigrationRunner:
             except Exception:  # noqa: BLE001 S110 — rollback is best-effort; original exc re-raised below
                 pass
 
-            # Record failure — best-effort; original exception takes priority
             try:
-                self._db.execute(
-                    "INSERT INTO app.schema_migrations "
-                    "(version, filename, checksum, success, execution_ms) "
-                    "VALUES (?, ?, ?, FALSE, ?)",
-                    [
-                        migration.version,
-                        migration.filename,
-                        migration.checksum,
-                        elapsed_ms,
-                    ],
-                )
+                self._record_migration(migration, success=False, elapsed_ms=elapsed_ms)
             except Exception:  # noqa: BLE001 S110 — failure tracking is best-effort; original exc re-raised below
                 logger.warning("Failed to record migration failure in tracking table")
             raise MigrationError(
@@ -342,16 +408,13 @@ class MigrationRunner:
     def apply_all(self) -> MigrationResult:
         """Apply all pending migrations in version order.
 
-        Checks for stuck migrations first. Stops on first failure.
-
         Returns:
             MigrationResult with counts and failure info.
         """
-        # Check for stuck state before doing anything
         try:
             self.check_stuck()
         except MigrationError as exc:
-            return MigrationResult(failed=True, error_message=str(exc))
+            return MigrationResult(error_message=str(exc))
 
         pending = self.pending()
         if not pending:
@@ -363,9 +426,9 @@ class MigrationRunner:
             try:
                 self.apply_one(migration)
                 result.applied_count += 1
-            except MigrationError:
-                result.failed = True
+            except MigrationError as exc:
                 result.failed_migration = migration.filename
+                result.error_message = str(exc)
                 break
 
         return result

--- a/src/moneybin/migrations.py
+++ b/src/moneybin/migrations.py
@@ -20,6 +20,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from moneybin.database import Database
 
 logger = logging.getLogger(__name__)
@@ -187,7 +189,7 @@ class AppliedMigration:
     filename: str
     success: bool
     execution_ms: int | None
-    applied_at: str
+    applied_at: datetime
 
 
 class MigrationRunner:

--- a/src/moneybin/schema.py
+++ b/src/moneybin/schema.py
@@ -32,7 +32,6 @@ logger = logging.getLogger(__name__)
 
 _SQL_DIR = Path(__file__).resolve().parent / "sql" / "schema"
 
-# Execution order: schemas first, then tables
 _SCHEMA_FILES: list[str] = [
     "raw_schema.sql",
     "core_schema.sql",
@@ -93,11 +92,10 @@ def _apply_comments(conn: duckdb.DuckDBPyConnection, sql: str) -> None:
                 try:
                     safe_desc = description.replace("'", "''")
                     conn.execute(f"COMMENT ON TABLE {table_name} IS '{safe_desc}'")
-                    logger.debug("Applied table comment to %s", table_name)
+                    logger.debug(f"Applied table comment to {table_name}")
                 except duckdb.CatalogException:
                     logger.debug(
-                        "Skipping table comment for %s — table does not exist yet",
-                        table_name,
+                        f"Skipping table comment for {table_name} — table does not exist yet"
                     )
 
         # Column-level comments: trailing -- text on each column definition
@@ -112,14 +110,11 @@ def _apply_comments(conn: duckdb.DuckDBPyConnection, sql: str) -> None:
                 conn.execute(
                     f"COMMENT ON COLUMN {table_name}.{col_def.name} IS '{safe_comment}'"
                 )
-                logger.debug(
-                    "Applied column comment to %s.%s", table_name, col_def.name
-                )
+                logger.debug(f"Applied column comment to {table_name}.{col_def.name}")
             except duckdb.CatalogException:
                 logger.debug(
-                    "Skipping column comment for %s.%s — table does not exist yet",
-                    table_name,
-                    col_def.name,
+                    f"Skipping column comment for {table_name}.{col_def.name}"
+                    " — table does not exist yet"
                 )
 
 
@@ -132,11 +127,11 @@ def init_schemas(conn: duckdb.DuckDBPyConnection) -> None:
     for sql_file in _SCHEMA_FILES:
         sql_path = _SQL_DIR / sql_file
         if not sql_path.exists():
-            logger.warning("Schema file not found, skipping: %s", sql_file)
+            logger.warning(f"Schema file not found, skipping: {sql_file}")
             continue
         sql = sql_path.read_text()
         conn.execute(sql)
         _apply_comments(conn, sql)
-        logger.debug("Executed %s", sql_file)
+        logger.debug(f"Executed {sql_file}")
 
-    logger.debug("Executed %d schema files from %s", len(_SCHEMA_FILES), _SQL_DIR)
+    logger.debug(f"Executed {len(_SCHEMA_FILES)} schema files from {_SQL_DIR}")

--- a/src/moneybin/secrets.py
+++ b/src/moneybin/secrets.py
@@ -98,7 +98,7 @@ class SecretStore:
             value: Secret value to store.
         """
         keyring.set_password(_SERVICE_NAME, name, value)
-        logger.debug("Stored secret '%s' in OS keychain", name)
+        logger.debug(f"Stored secret '{name}' in OS keychain")
 
     def delete_key(self, name: str) -> None:
         """Remove a secret from the OS keychain.
@@ -115,4 +115,4 @@ class SecretStore:
             raise SecretNotFoundError(
                 f"Secret '{name}' not found in keychain."
             ) from None
-        logger.debug("Removed secret '%s' from OS keychain", name)
+        logger.debug(f"Removed secret '{name}' from OS keychain")

--- a/src/moneybin/services/categorization_service.py
+++ b/src/moneybin/services/categorization_service.py
@@ -9,6 +9,7 @@ import logging
 import re
 import uuid
 from pathlib import Path
+from typing import Literal
 
 import duckdb
 
@@ -23,6 +24,8 @@ from moneybin.tables import (
 )
 
 logger = logging.getLogger(__name__)
+
+MatchType = Literal["exact", "contains", "regex"]
 
 # -- Merchant name normalization patterns --
 
@@ -97,30 +100,24 @@ def _matches_pattern(text: str, pattern: str, match_type: str) -> bool:
         try:
             return bool(re.search(pattern, text, re.IGNORECASE))
         except re.error:
-            logger.warning("Invalid regex pattern: %s", pattern)
+            logger.warning(f"Invalid regex pattern: {pattern}")
             return False
     else:
-        logger.warning("Unknown match_type: %s", match_type)
+        logger.warning(f"Unknown match_type: {match_type}")
         return False
 
 
-def match_merchant(db: Database, description: str) -> dict[str, str | None] | None:
-    """Look up a merchant by raw description.
+def _fetch_merchants(db: Database) -> list[tuple[str, ...]] | None:
+    """Fetch all merchant mappings ordered by match priority.
 
     Args:
         db: Database instance (read-only access is sufficient).
-        description: Transaction description to match.
 
     Returns:
-        Dict with merchant_id, canonical_name, category, subcategory
-        if found, otherwise None.
+        List of merchant rows, or None if the table doesn't exist.
     """
-    normalized = normalize_description(description)
-    if not normalized:
-        return None
-
     try:
-        rows = db.execute(
+        return db.execute(
             f"""
             SELECT merchant_id, raw_pattern, match_type,
                    canonical_name, category, subcategory
@@ -136,11 +133,29 @@ def match_merchant(db: Database, description: str) -> dict[str, str | None] | No
     except duckdb.CatalogException:
         return None
 
-    for row in rows:
+
+def _match_description(
+    description: str,
+    merchants: list[tuple[str, ...]],
+) -> dict[str, str | None] | None:
+    """Match a description against a pre-fetched merchant list.
+
+    Args:
+        description: Transaction description to match.
+        merchants: Pre-fetched merchant rows from ``_fetch_merchants()``.
+
+    Returns:
+        Dict with merchant_id, canonical_name, category, subcategory
+        if found, otherwise None.
+    """
+    normalized = normalize_description(description)
+    if not normalized:
+        return None
+
+    for row in merchants:
         merchant_id, raw_pattern, match_type, canonical_name, category, subcategory = (
             row
         )
-        # Match against both raw description and normalized form
         if _matches_pattern(description, raw_pattern, match_type) or _matches_pattern(
             normalized, raw_pattern, match_type
         ):
@@ -154,12 +169,30 @@ def match_merchant(db: Database, description: str) -> dict[str, str | None] | No
     return None
 
 
+def match_merchant(db: Database, description: str) -> dict[str, str | None] | None:
+    """Look up a merchant by raw description.
+
+    Args:
+        db: Database instance (read-only access is sufficient).
+        description: Transaction description to match.
+
+    Returns:
+        Dict with merchant_id, canonical_name, category, subcategory
+        if found, otherwise None.
+    """
+    merchants = _fetch_merchants(db)
+    if merchants is None:
+        return None
+
+    return _match_description(description, merchants)
+
+
 def create_merchant(
     db: Database,
     raw_pattern: str,
     canonical_name: str,
     *,
-    match_type: str = "contains",
+    match_type: MatchType = "contains",
     category: str | None = None,
     subcategory: str | None = None,
     created_by: str = "ai",
@@ -196,7 +229,7 @@ def create_merchant(
             created_by,
         ],
     )
-    logger.info("Created merchant mapping: %s -> %s", raw_pattern, canonical_name)
+    logger.info(f"Created merchant mapping: {raw_pattern} -> {canonical_name}")
     return merchant_id
 
 
@@ -205,8 +238,8 @@ def apply_merchant_categories(
 ) -> int:
     """Apply merchant-based categories to uncategorized transactions.
 
-    For each uncategorized transaction, checks if a merchant mapping exists
-    that matches the description and has a category assigned.
+    Fetches all merchants once, then matches each uncategorized transaction
+    in Python — avoids a per-transaction DB query.
 
     Args:
         db: Database instance (read-write).
@@ -214,6 +247,10 @@ def apply_merchant_categories(
     Returns:
         Number of transactions categorized.
     """
+    merchants = _fetch_merchants(db)
+    if not merchants:
+        return 0
+
     try:
         uncategorized = db.execute(
             f"""
@@ -234,7 +271,7 @@ def apply_merchant_categories(
 
     categorized_count = 0
     for txn_id, description in uncategorized:
-        merchant = match_merchant(db, description)
+        merchant = _match_description(description, merchants)
         if merchant and merchant.get("category"):
             db.execute(
                 f"""
@@ -253,7 +290,7 @@ def apply_merchant_categories(
             categorized_count += 1
 
     if categorized_count:
-        logger.info("Merchant matching categorized %d transactions", categorized_count)
+        logger.info(f"Merchant matching categorized {categorized_count} transactions")
     return categorized_count
 
 
@@ -324,24 +361,20 @@ def apply_rules(
                 subcategory,
             ) = rule
 
-            # Check pattern match (against both raw and normalized)
             if not (
                 _matches_pattern(description, pattern, match_type)
                 or _matches_pattern(normalized, pattern, match_type)
             ):
                 continue
 
-            # Check amount range
             if min_amount is not None and amount < float(min_amount):
                 continue
             if max_amount is not None and amount > float(max_amount):
                 continue
 
-            # Check account filter
             if rule_account_id is not None and account_id != rule_account_id:
                 continue
 
-            # Rule matches — apply it
             db.execute(
                 f"""
                 INSERT OR IGNORE INTO {TRANSACTION_CATEGORIES.full_name}
@@ -355,7 +388,7 @@ def apply_rules(
             break  # First matching rule wins
 
     if categorized_count:
-        logger.info("Rule engine categorized %d transactions", categorized_count)
+        logger.info(f"Rule engine categorized {categorized_count} transactions")
     return categorized_count
 
 
@@ -477,7 +510,7 @@ def seed_categories(db: Database) -> int:
     count_after = result[0] if result else 0
 
     inserted = count_after - count_before
-    logger.info("Seeded %d categories (%d total)", inserted, count_after)
+    logger.info(f"Seeded {inserted} categories ({count_after} total)")
     return inserted
 
 

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -53,6 +53,41 @@ class ImportResult:
         return "\n".join(lines)
 
 
+def _query_date_range(
+    db: Database,
+    table: str,
+    date_column: str,
+    file_path: Path,
+) -> str:
+    """Query min/max date range for a source file from a raw table.
+
+    Args:
+        db: Database instance.
+        table: Qualified table name (e.g. ``raw.ofx_transactions``).
+        date_column: Column containing the date value.
+        file_path: Source file path to filter on.
+
+    Returns:
+        Date range string like ``"2024-01-01 to 2024-03-31"``, or empty
+        string if unavailable.
+    """
+    try:
+        result = db.execute(
+            f"""
+            SELECT MIN({date_column}) AS min_date,
+                   MAX({date_column}) AS max_date
+            FROM {table}
+            WHERE source_file = ?
+            """,
+            [str(file_path)],
+        ).fetchone()
+        if result and result[0]:
+            return f"{result[0]} to {result[1]}"
+    except Exception:
+        logger.debug(f"Could not determine date range from {table}", exc_info=True)
+    return ""
+
+
 def _detect_file_type(file_path: Path) -> str:
     """Detect file type from extension.
 
@@ -102,6 +137,7 @@ def _run_transforms(db_path: Path) -> bool:
     )
     from sqlmesh.core.engine_adapter.duckdb import DuckDBEngineAdapter
 
+    from moneybin.database import build_attach_sql
     from moneybin.secrets import SecretStore
     from sqlmesh import (
         Context,  # type: ignore[import-untyped] — sqlmesh has no type stubs
@@ -112,15 +148,9 @@ def _run_transforms(db_path: Path) -> bool:
     store = SecretStore()
     encryption_key = store.get_key("DATABASE__ENCRYPTION_KEY")
 
-    # Create an in-memory DuckDB connection and ATTACH the encrypted file.
-    # This mirrors the pattern in Database.__init__.
     conn = duckdb_mod.connect()
-    safe_path = str(db_path).replace("'", "''")
-    safe_key = encryption_key.replace("'", "''")
     conn.execute("INSTALL httpfs; LOAD httpfs;")
-    conn.execute(
-        f"ATTACH '{safe_path}' AS moneybin (TYPE DUCKDB, ENCRYPTION_KEY '{safe_key}')"  # noqa: S608  # trusted internal values, single-quote escaped
-    )
+    conn.execute(build_attach_sql(db_path, encryption_key))
     conn.execute("USE moneybin")
 
     # Pre-populate SQLMesh's adapter cache (keyed by database path).
@@ -192,23 +222,10 @@ def _import_ofx(
     result.balances = row_counts.get("balances", 0)
     result.details = row_counts
 
-    # Get date range from transactions
     if result.transactions > 0:
-        try:
-            date_result = db.execute(
-                """
-                SELECT
-                    MIN(CAST(date_posted AS DATE)) AS min_date,
-                    MAX(CAST(date_posted AS DATE)) AS max_date
-                FROM raw.ofx_transactions
-                WHERE source_file = ?
-                """,
-                [str(file_path)],
-            ).fetchone()
-            if date_result and date_result[0]:
-                result.date_range = f"{date_result[0]} to {date_result[1]}"
-        except Exception:
-            logger.debug("Could not determine date range from transactions")
+        result.date_range = _query_date_range(
+            db, "raw.ofx_transactions", "CAST(date_posted AS DATE)", file_path
+        )
 
     return result
 
@@ -300,23 +317,10 @@ def _import_csv(
     result.transactions = row_counts.get("transactions", 0)
     result.details = row_counts
 
-    # Get date range from transactions
     if result.transactions > 0:
-        try:
-            date_result = db.execute(
-                """
-                SELECT
-                    MIN(transaction_date) AS min_date,
-                    MAX(transaction_date) AS max_date
-                FROM raw.csv_transactions
-                WHERE source_file = ?
-                """,
-                [str(file_path)],
-            ).fetchone()
-            if date_result and date_result[0]:
-                result.date_range = f"{date_result[0]} to {date_result[1]}"
-        except Exception:
-            logger.debug("Could not determine date range from CSV transactions")
+        result.date_range = _query_date_range(
+            db, "raw.csv_transactions", "transaction_date", file_path
+        )
 
     return result
 
@@ -356,7 +360,7 @@ def import_file(
         raise FileNotFoundError(f"File not found: {path}")
 
     file_type = _detect_file_type(path)
-    logger.info("Importing %s file: %s", file_type, path)
+    logger.info(f"Importing {file_type} file: {path}")
 
     if file_type == "ofx":
         result = _import_ofx(db, path, institution=institution)
@@ -374,7 +378,7 @@ def import_file(
         # Apply deterministic categorization to new transactions
         _apply_categorization(db)
 
-    logger.info("Import complete: %s", result.summary())
+    logger.info(f"Import complete: {result.summary()}")
     return result
 
 

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -56,15 +56,20 @@ class ImportResult:
 def _query_date_range(
     db: Database,
     table: str,
-    date_column: str,
+    date_expr: str,
     file_path: Path,
 ) -> str:
     """Query min/max date range for a source file from a raw table.
 
+    Both ``table`` and ``date_expr`` are interpolated into SQL — callers
+    must only pass hardcoded trusted strings, never user input.
+
     Args:
         db: Database instance.
         table: Qualified table name (e.g. ``raw.ofx_transactions``).
-        date_column: Column containing the date value.
+        date_expr: SQL expression for the date value — may be a bare column
+            name (``transaction_date``) or a cast expression
+            (``CAST(date_posted AS DATE)``).
         file_path: Source file path to filter on.
 
     Returns:
@@ -74,16 +79,16 @@ def _query_date_range(
     try:
         result = db.execute(
             f"""
-            SELECT MIN({date_column}) AS min_date,
-                   MAX({date_column}) AS max_date
+            SELECT MIN({date_expr}) AS min_date,
+                   MAX({date_expr}) AS max_date
             FROM {table}
             WHERE source_file = ?
-            """,
+            """,  # noqa: S608 — table and date_expr are hardcoded by callers, not user input
             [str(file_path)],
         ).fetchone()
         if result and result[0]:
             return f"{result[0]} to {result[1]}"
-    except Exception:
+    except Exception:  # noqa: BLE001 — date range is best-effort; any DB failure returns empty string
         logger.debug(f"Could not determine date range from {table}", exc_info=True)
     return ""
 
@@ -399,10 +404,8 @@ def _apply_categorization(db: Database) -> None:
         stats = apply_deterministic_categorization(db)
         if stats["total"] > 0:
             logger.info(
-                "Auto-categorized %d transactions (%d merchant, %d rule)",
-                stats["total"],
-                stats["merchant"],
-                stats["rule"],
+                f"Auto-categorized {stats['total']} transactions "
+                f"({stats['merchant']} merchant, {stats['rule']} rule)"
             )
     except Exception:
         logger.debug(

--- a/src/moneybin/services/profile_service.py
+++ b/src/moneybin/services/profile_service.py
@@ -27,6 +27,24 @@ logger = logging.getLogger(__name__)
 _SAFE_KEY = re.compile(r"^[a-z][a-z0-9_]*$")
 
 
+def _read_yaml(path: Path) -> dict[str, object]:
+    """Read a YAML file and return its contents as a dict.
+
+    Returns an empty dict if the file doesn't exist or isn't a mapping.
+
+    Args:
+        path: Path to the YAML file.
+
+    Returns:
+        Parsed dict, or empty dict.
+    """
+    if not path.exists():
+        return {}
+    with open(path) as f:
+        loaded = yaml.safe_load(f)
+    return loaded if isinstance(loaded, dict) else {}
+
+
 class ProfileExistsError(Exception):
     """Raised when attempting to create a profile that already exists."""
 
@@ -176,20 +194,14 @@ class ProfileService:
             ProfileNotFoundError: If the named profile directory does not exist.
             ValueError: If the name contains no valid characters.
         """
+        active = get_default_profile()
         if name is None:
-            name = get_default_profile() or "default"
+            name = active or "default"
         normalized = normalize_profile_name(name)
         profile_dir = self._profile_dir(name)
         if not profile_dir.exists():
             raise ProfileNotFoundError(f"Profile '{normalized}' not found")
-        config_path = profile_dir / "config.yaml"
-        config_data: dict[str, object] = {}
-        if config_path.exists():
-            with open(config_path) as f:
-                loaded = yaml.safe_load(f)
-                if isinstance(loaded, dict):
-                    config_data = loaded
-        active = get_default_profile()
+        config_data = _read_yaml(profile_dir / "config.yaml")
         db_path = profile_dir / "moneybin.duckdb"
         return {
             "name": normalized,
@@ -226,20 +238,17 @@ class ProfileService:
             profile_name = entry.name
             profile_dir = self._profiles_dir / profile_name
 
-            # Skip profiles that already completed migration
             if (profile_dir / "config.yaml").exists():
                 continue
 
             try:
                 profile_dir.mkdir(parents=True, exist_ok=True)
 
-                # Move database files
                 for db_file in entry.glob("*.duckdb"):
                     dest = profile_dir / db_file.name
                     if not dest.exists():
                         shutil.move(str(db_file), str(dest))
 
-                # Move backups (file-by-file merge like logs handler)
                 old_backups = entry / "backups"
                 if old_backups.exists():
                     new_backups = profile_dir / "backups"
@@ -250,7 +259,6 @@ class ProfileService:
                             shutil.move(str(f), str(dest))
                     shutil.rmtree(old_backups)
 
-                # Move temp
                 old_temp = entry / "temp"
                 if old_temp.exists():
                     new_temp = profile_dir / "temp"
@@ -259,7 +267,6 @@ class ProfileService:
                     else:
                         shutil.rmtree(old_temp)
 
-                # Move logs
                 old_logs = self._base / "logs" / profile_name
                 if old_logs.exists():
                     new_logs = profile_dir / "logs"
@@ -282,27 +289,22 @@ class ProfileService:
                 )
                 continue
 
-            # Ensure dirs exist
             (profile_dir / "logs").mkdir(exist_ok=True)
             (profile_dir / "temp").mkdir(exist_ok=True)
 
-            # Generate config if needed
             if not (profile_dir / "config.yaml").exists():
                 generate_profile_config(profile_dir, profile_name)
 
             migrated.append(profile_name)
             logger.info(f"Migrated profile: {profile_name}")
 
-        # Migrate global config key
         from moneybin.utils.user_config import get_user_config_path
 
         config_path = get_user_config_path()
         if config_path.exists():
             try:
-                with open(config_path) as f:
-                    raw = yaml.safe_load(f)
-                if isinstance(raw, dict) and "default_profile" in raw:
-                    raw_config: dict[str, object] = raw
+                raw_config = _read_yaml(config_path)
+                if "default_profile" in raw_config:
                     raw_config["active_profile"] = raw_config.pop("default_profile")
                     with open(config_path, "w") as f:
                         yaml.safe_dump(
@@ -341,12 +343,7 @@ class ProfileService:
         if not profile_dir.exists():
             raise ProfileNotFoundError(f"Profile '{normalized}' not found")
         config_path = profile_dir / "config.yaml"
-        data: dict[str, object] = {}
-        if config_path.exists():
-            with open(config_path) as f:
-                loaded = yaml.safe_load(f)
-                if isinstance(loaded, dict):
-                    data = loaded
+        data = _read_yaml(config_path)
         parts = key.split(".")
         if len(parts) != 2:
             raise ValueError(

--- a/tests/moneybin/test_cli/test_migrate_command.py
+++ b/tests/moneybin/test_cli/test_migrate_command.py
@@ -7,8 +7,27 @@ import pytest
 from typer.testing import CliRunner
 
 from moneybin.cli.commands.migrate import app
+from moneybin.migrations import Migration
 
 runner = CliRunner()
+
+
+def _migration(
+    version: int = 1,
+    name: str = "test",
+    filename: str = "V001__test.sql",
+    checksum: str = "abc123",
+) -> Migration:
+    """Build a Migration with sensible defaults for CLI tests."""
+    return Migration(
+        version=version,
+        name=name,
+        filename=filename,
+        checksum=checksum,
+        content=b"SELECT 1;",
+        path=Path(f"/tmp/{filename}"),  # noqa: S108  # temp path in test only
+        file_type="sql",
+    )
 
 
 class TestMigrateApply:
@@ -51,19 +70,8 @@ class TestMigrateApply:
         self, mock_runner_cls: MagicMock, mock_get_db: MagicMock
     ) -> None:
         """Dry run lists pending migrations without executing."""
-        from moneybin.migrations import Migration
-
         mock_runner = mock_runner_cls.return_value
-        mock_runner.pending.return_value = [
-            Migration(
-                version=1,
-                name="test",
-                filename="V001__test.sql",
-                checksum="abc123",
-                path=Path("/tmp/V001__test.sql"),  # noqa: S108  # temp path in test only
-                file_type="sql",
-            )
-        ]
+        mock_runner.pending.return_value = [_migration()]
 
         result = runner.invoke(app, ["apply", "--dry-run"])
         assert result.exit_code == 0
@@ -92,7 +100,8 @@ class TestMigrateApply:
 
         mock_runner = mock_runner_cls.return_value
         mock_runner.apply_all.return_value = MigrationResult(
-            failed=True, failed_migration="V002__bad.sql"
+            failed_migration="V002__bad.sql",
+            error_message="Migration V002__bad.sql failed",
         )
         mock_runner.check_drift.return_value = []
 
@@ -153,26 +162,25 @@ class TestMigrateStatus:
         """Status command exits 0 and logs applied and pending migrations."""
         import logging
 
-        from moneybin.migrations import Migration
+        from moneybin.migrations import AppliedMigration
 
         mock_runner = mock_runner_cls.return_value
         mock_runner.pending.return_value = [
-            Migration(
-                version=2,
-                name="new",
-                filename="V002__new.sql",
-                checksum="def456",
-                path=Path("/tmp/V002__new.sql"),  # noqa: S108  # temp path in test only
-                file_type="sql",
+            _migration(
+                version=2, name="new", filename="V002__new.sql", checksum="def456"
+            )
+        ]
+        mock_runner.applied_details.return_value = [
+            AppliedMigration(
+                version=1,
+                filename="V001__init.sql",
+                success=True,
+                execution_ms=42,
+                applied_at="2026-01-01 00:00:00",
             )
         ]
         mock_runner.check_drift.return_value = []
         mock_get_versions.return_value = {"moneybin": "0.2.0"}
-
-        mock_db = mock_get_db.return_value
-        mock_db.execute.return_value.fetchall.return_value = [
-            (1, "V001__init.sql", True, 42, "2026-01-01 00:00:00")
-        ]
 
         with caplog.at_level(logging.INFO, logger="moneybin.cli.commands.migrate"):
             result = runner.invoke(app, ["status"])
@@ -197,11 +205,9 @@ class TestMigrateStatus:
 
         mock_runner = mock_runner_cls.return_value
         mock_runner.pending.return_value = []
+        mock_runner.applied_details.return_value = []
         mock_runner.check_drift.return_value = []
         mock_get_versions.return_value = {}
-
-        mock_db = mock_get_db.return_value
-        mock_db.execute.return_value.fetchall.return_value = []
 
         with caplog.at_level(logging.INFO, logger="moneybin.cli.commands.migrate"):
             result = runner.invoke(app, ["status"])

--- a/tests/moneybin/test_cli/test_migrate_command.py
+++ b/tests/moneybin/test_cli/test_migrate_command.py
@@ -161,6 +161,7 @@ class TestMigrateStatus:
     ) -> None:
         """Status command exits 0 and logs applied and pending migrations."""
         import logging
+        from datetime import datetime
 
         from moneybin.migrations import AppliedMigration
 
@@ -176,7 +177,7 @@ class TestMigrateStatus:
                 filename="V001__init.sql",
                 success=True,
                 execution_ms=42,
-                applied_at="2026-01-01 00:00:00",
+                applied_at=datetime(2026, 1, 1),
             )
         ]
         mock_runner.check_drift.return_value = []


### PR DESCRIPTION
## Summary

Sweep of code quality improvements across the codebase: extracting duplicated logic into shared helpers, converting legacy `%s`-style log formatting to the project's f-string convention, adding `MatchType` validation at the MCP boundary, and optimizing the merchant categorization hot path to avoid per-transaction DB queries.

## Impact

- No behavioral changes to CLI commands, MCP tools, or data processing
- `Migration` dataclass gains a `content` field — any code constructing `Migration` directly (tests) must include it
- `MigrationResult` no longer has a settable `failed` field — it's now a computed property derived from `failed_migration` and `error_message`

## Changes

### DRY: Shared helpers extracted
- `build_attach_sql()` in `database.py` replaces 4 inline ATTACH SQL builders (Database.__init__, db shell init script, key rotation, SQLMesh transform)
- `_run_duckdb_cli()` in `db.py` replaces duplicated preamble across `shell`, `ui`, and `query` commands
- `_query_date_range()` in `import_service.py` replaces identical OFX/CSV date range queries
- `_read_yaml()` in `profile_service.py` replaces 3 inline YAML-load-with-fallback patterns

### Type safety: MCP match_type validation
- Added `MatchType = Literal["exact", "contains", "regex"]` to categorization_service
- Added `_validate_match_type()` at the MCP tool boundary in write_tools.py
- Applied to `create_merchant_mapping`, `create_categorization_rule`, and both bulk operations

### Performance: Merchant matching optimization
- Split `match_merchant()` into `_fetch_merchants()` + `_match_description()`
- `apply_merchant_categories()` now fetches all merchants once and matches in Python, eliminating per-transaction DB roundtrips

### Migration system refinements
- `MigrationResult.failed` is now a computed property (no redundant boolean)
- `log_failure()` centralizes error display (was duplicated in database.py and migrate CLI)
- `AppliedMigration` dataclass + `applied_details()` replace raw SQL in the status command
- `_record_migration()` replaces duplicated INSERT statements
- Migration discovery is lazily cached per runner instance
- `Migration.content` caches file bytes from discovery to avoid re-reads during apply

### Logging convention
- Converted all remaining `%s`/`%d` lazy log formatting to f-strings across 14 files

### Loader cleanup
- Removed redundant `create_raw_tables()` calls from `csv_loader.load()` and `ofx_loader.load()` — `init_schemas()` already handles table creation
- Updated comments in OFX/W2 loaders to accurately describe why `conn` is used directly

### Rules & tests
- Added "Pre-Push Quality Pass" section to `.claude/rules/shipping.md`
- Added "Test Fixture Factories" section to `.claude/rules/testing.md`
- Added `_migration()` factory to migrate CLI tests; updated all test cases for new Migration/MigrationResult APIs

## Testing

All existing tests updated to match new APIs. Run `make check test` to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)