### PR TITLE
Fix synthetic generate/reset commands touching the current profile

### DIFF
--- a/src/moneybin/cli/commands/synthetic.py
+++ b/src/moneybin/cli/commands/synthetic.py
@@ -51,8 +51,8 @@ def _run_generate(
         seed: Deterministic seed (None for random).
         skip_transform: If True, skip running SQLMesh after generation.
     """
-    from moneybin.config import get_settings, set_current_profile
-    from moneybin.database import DatabaseKeyError, get_database
+    from moneybin.config import get_current_profile, set_current_profile
+    from moneybin.database import DatabaseKeyError, close_database, get_database
     from moneybin.services.import_service import run_transforms
     from moneybin.testing.synthetic.engine import GeneratorEngine
     from moneybin.testing.synthetic.writer import SyntheticWriter
@@ -64,7 +64,8 @@ def _run_generate(
         f"(seed={actual_seed}{f', {years} years' if years else ''})"
     )
 
-    original_profile = get_settings().profile
+    original_profile = get_current_profile()
+    close_database()
     set_current_profile(profile)
 
     try:
@@ -140,9 +141,9 @@ def _run_generate(
             f"✅ Profile {profile!r} ready (seed={actual_seed}). "
             f"Use --profile={profile} with any moneybin command."
         )
-    except typer.Exit:
+    finally:
+        close_database()
         set_current_profile(original_profile)
-        raise
 
 
 @app.command("generate")
@@ -188,72 +189,76 @@ def reset(
     ),
 ) -> None:
     """Wipe a generated profile and regenerate from scratch."""
-    from moneybin.config import get_settings, set_current_profile
+    from moneybin.config import get_current_profile, set_current_profile
     from moneybin.database import DatabaseKeyError, close_database, get_database
 
     target_profile = profile or _PERSONA_PROFILES.get(persona, persona)
 
-    original_profile = get_settings().profile
+    original_profile = get_current_profile()
+    close_database()
     set_current_profile(target_profile)
 
     try:
-        db = get_database()
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
-
-        set_current_profile(original_profile)
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
-
-    # Safety check: only reset profiles created by the generator
-    try:
-        gt_row = db.execute(
-            """SELECT COUNT(*) FROM information_schema.tables
-            WHERE table_schema = 'synthetic' AND table_name = 'ground_truth'"""
-        ).fetchone()
-        gt_exists = gt_row[0] if gt_row else 0
-    except Exception:  # noqa: BLE001 — fresh DB with no synthetic schema
-        gt_exists = 0
-
-    if not gt_exists:
-        logger.error(
-            f"❌ Profile {target_profile!r} was not created by the "
-            f"generator. Refusing to reset."
-        )
-        logger.info(
-            f"💡 To destroy a non-generated profile, use "
-            f"'moneybin db destroy --profile={target_profile}'"
-        )
-        raise typer.Exit(1) from None
-
-    if not yes:
-        confirmed = typer.confirm(
-            f"This will destroy all data in profile {target_profile!r} "
-            f"and regenerate. Continue?"
-        )
-        if not confirmed:
-            raise typer.Abort()
-
-    from moneybin.metrics.registry import SYNTHETIC_RESET_TOTAL
-
-    SYNTHETIC_RESET_TOTAL.labels(persona=persona).inc()
-    logger.info(f"⚙️  Resetting profile {target_profile!r}...")
-    for table, where in _RESET_DELETIONS.items():
         try:
-            db.execute(f"DELETE FROM {table} {where}")  # noqa: S608 — allowlisted table names + literal WHERE clauses
-        except Exception:  # noqa: BLE001,S110 — table may not exist
-            pass
+            db = get_database()
+        except DatabaseKeyError as e:
+            from moneybin.database import database_key_error_hint
 
-    db.close()
-    # Close the singleton so _run_generate gets a fresh connection
-    close_database()
+            logger.error(f"❌ {e}")
+            logger.info(database_key_error_hint())
+            raise typer.Exit(1) from e
 
-    # Regenerate
-    _run_generate(
-        persona=persona,
-        profile=target_profile,
-        years=years,
-        seed=seed,
-        skip_transform=skip_transform,
-    )
+        # Safety check: only reset profiles created by the generator
+        try:
+            gt_row = db.execute(
+                """SELECT COUNT(*) FROM information_schema.tables
+                WHERE table_schema = 'synthetic' AND table_name = 'ground_truth'"""
+            ).fetchone()
+            gt_exists = gt_row[0] if gt_row else 0
+        except Exception:  # noqa: BLE001 — fresh DB with no synthetic schema
+            gt_exists = 0
+
+        if not gt_exists:
+            logger.error(
+                f"❌ Profile {target_profile!r} was not created by the "
+                f"generator. Refusing to reset."
+            )
+            logger.info(
+                f"💡 To destroy a non-generated profile, use "
+                f"'moneybin db destroy --profile={target_profile}'"
+            )
+            raise typer.Exit(1) from None
+
+        if not yes:
+            confirmed = typer.confirm(
+                f"This will destroy all data in profile {target_profile!r} "
+                f"and regenerate. Continue?"
+            )
+            if not confirmed:
+                raise typer.Abort()
+
+        from moneybin.metrics.registry import SYNTHETIC_RESET_TOTAL
+
+        SYNTHETIC_RESET_TOTAL.labels(persona=persona).inc()
+        logger.info(f"⚙️  Resetting profile {target_profile!r}...")
+        for table, where in _RESET_DELETIONS.items():
+            try:
+                db.execute(f"DELETE FROM {table} {where}")  # noqa: S608 — allowlisted table names + literal WHERE clauses
+            except Exception:  # noqa: BLE001,S110 — table may not exist
+                pass
+
+        db.close()
+        # Close the singleton so _run_generate gets a fresh connection
+        close_database()
+
+        # Regenerate
+        _run_generate(
+            persona=persona,
+            profile=target_profile,
+            years=years,
+            seed=seed,
+            skip_transform=skip_transform,
+        )
+    finally:
+        close_database()
+        set_current_profile(original_profile)

--- a/src/moneybin/cli/commands/synthetic.py
+++ b/src/moneybin/cli/commands/synthetic.py
@@ -142,9 +142,10 @@ def _run_generate(
             f"Use --profile={profile} with any moneybin command."
         )
     finally:
-        # When called from reset(), original_profile == profile (reset already
-        # switched), so this is a no-op; reset()'s own finally does the real restore.
         close_database()
+        # When called from reset(), original_profile == profile (reset already
+        # switched), so set_current_profile is a no-op; reset()'s own finally
+        # does the real restore.
         set_current_profile(original_profile)
 
 

--- a/src/moneybin/cli/commands/synthetic.py
+++ b/src/moneybin/cli/commands/synthetic.py
@@ -142,6 +142,8 @@ def _run_generate(
             f"Use --profile={profile} with any moneybin command."
         )
     finally:
+        # When called from reset(), original_profile == profile (reset already
+        # switched), so this is a no-op; reset()'s own finally does the real restore.
         close_database()
         set_current_profile(original_profile)
 

--- a/tests/moneybin/test_synthetic/test_cli.py
+++ b/tests/moneybin/test_synthetic/test_cli.py
@@ -103,6 +103,22 @@ class TestGenerateCommand:
             result = runner.invoke(app, ["generate", "--persona", "bad"])
             assert result.exit_code == 1
 
+    def test_generate_restores_profile_on_error(
+        self,
+        runner: CliRunner,
+        mocker: Any,
+    ) -> None:
+        """Profile must be restored even when generate fails."""
+        from moneybin.database import DatabaseKeyError
+
+        mocker.patch(
+            "moneybin.database.get_database",
+            side_effect=DatabaseKeyError("no key"),
+        )
+        result = runner.invoke(app, ["generate", "--persona", "basic"])
+        assert result.exit_code == 1
+        self.mock_set_profile.assert_called_with("default")
+
 
 class TestResetCommand:
     """Test the 'synthetic reset' CLI command."""
@@ -111,7 +127,7 @@ class TestResetCommand:
     def mock_profile(self, mocker: Any) -> None:
         """Prevent reset from mutating process-wide profile state."""
         mocker.patch("moneybin.config.get_current_profile", return_value="default")
-        mocker.patch("moneybin.config.set_current_profile")
+        self.mock_set_profile = mocker.patch("moneybin.config.set_current_profile")
         mocker.patch("moneybin.database.close_database")
 
     @pytest.fixture
@@ -150,6 +166,8 @@ class TestResetCommand:
             seed=42,
             skip_transform=False,
         )
+        # Profile must be restored after successful reset
+        self.mock_set_profile.assert_called_with("default")
 
     def test_reset_requires_yes_or_prompt(self, runner: CliRunner) -> None:
         """Without --yes, reset should prompt for confirmation."""

--- a/tests/moneybin/test_synthetic/test_cli.py
+++ b/tests/moneybin/test_synthetic/test_cli.py
@@ -20,7 +20,7 @@ class TestGenerateCommand:
     def mock_profile(self, mocker: Any) -> None:
         """Prevent generate/reset from mutating process-wide profile state."""
         mocker.patch("moneybin.config.get_current_profile", return_value="default")
-        mocker.patch("moneybin.config.set_current_profile")
+        self.mock_set_profile = mocker.patch("moneybin.config.set_current_profile")
         mocker.patch("moneybin.database.close_database")
 
     @pytest.fixture
@@ -88,6 +88,8 @@ class TestGenerateCommand:
         assert result.exit_code == 0
         mock_engine.assert_called_once()
         mock_writer.return_value.write.assert_called_once()
+        # Profile must be restored after successful generation
+        self.mock_set_profile.assert_called_with("default")
 
     def test_generate_unknown_persona(
         self,
@@ -131,7 +133,6 @@ class TestResetCommand:
         mock_db.execute.return_value.fetchone.return_value = (1,)
         mock_db.path = Path("/tmp/test.duckdb")
         mocker.patch("moneybin.database.get_database", return_value=mock_db)
-        mocker.patch("moneybin.database.close_database")
 
         # Mock _run_generate to avoid the full pipeline
         mock_run = mocker.patch(

--- a/tests/moneybin/test_synthetic/test_cli.py
+++ b/tests/moneybin/test_synthetic/test_cli.py
@@ -181,3 +181,5 @@ class TestResetCommand:
             result = runner.invoke(app, ["reset", "--persona", "basic"])
             # Should either prompt and abort, or succeed with --yes
             assert result.exit_code != 0 or "Aborted" in (result.output or "")
+        # Profile must be restored even after user declines
+        self.mock_set_profile.assert_called_with("default")

--- a/tests/moneybin/test_synthetic/test_cli.py
+++ b/tests/moneybin/test_synthetic/test_cli.py
@@ -19,10 +19,9 @@ class TestGenerateCommand:
     @pytest.fixture(autouse=True)
     def mock_profile(self, mocker: Any) -> None:
         """Prevent generate/reset from mutating process-wide profile state."""
-        mock_settings = MagicMock()
-        mock_settings.profile = "default"
-        mocker.patch("moneybin.config.get_settings", return_value=mock_settings)
+        mocker.patch("moneybin.config.get_current_profile", return_value="default")
         mocker.patch("moneybin.config.set_current_profile")
+        mocker.patch("moneybin.database.close_database")
 
     @pytest.fixture
     def runner(self) -> CliRunner:
@@ -109,10 +108,9 @@ class TestResetCommand:
     @pytest.fixture(autouse=True)
     def mock_profile(self, mocker: Any) -> None:
         """Prevent reset from mutating process-wide profile state."""
-        mock_settings = MagicMock()
-        mock_settings.profile = "default"
-        mocker.patch("moneybin.config.get_settings", return_value=mock_settings)
+        mocker.patch("moneybin.config.get_current_profile", return_value="default")
         mocker.patch("moneybin.config.set_current_profile")
+        mocker.patch("moneybin.database.close_database")
 
     @pytest.fixture
     def runner(self) -> CliRunner:


### PR DESCRIPTION
## Summary

The synthetic `generate` and `reset` commands called `get_settings()` just to read the current profile name, which triggered full settings initialization (directory creation, credential validation) for the default profile. This caused failures when the default profile's database was locked or misconfigured, even though synthetic commands operate on an entirely separate profile. Additionally, the database singleton was not closed before switching profiles, risking a stale connection, and the original profile was only restored on error — not on success.

## Impact

- No workflow changes for users. Synthetic commands now work independently of the default profile's state.

## Changes

### Profile isolation in `_run_generate()`
- Replaced `get_settings().profile` with `get_current_profile()` — returns the profile name string with zero side effects
- Added `close_database()` before `set_current_profile()` to ensure a fresh DB connection for the target profile
- Changed `except typer.Exit` to `try/finally` so the original profile is always restored

### Profile isolation in `reset()`
- Same three fixes as `_run_generate()`
- Wrapped the entire reset body in `try/finally` for consistent cleanup

## Testing

- `make format` — passed
- `make lint` — passed
- `uv run pyright` on modified file — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)