### PR TITLE
Fix sqlmesh migrate subprocess breaking profile isolation

### DIFF
--- a/.claude/rules/cli.md
+++ b/.claude/rules/cli.md
@@ -44,7 +44,7 @@ When a command modifies multiple persistent stores in sequence (e.g., file move 
 ## Command Group Registration
 
 - **Workflow ordering**: Top-level commands in `main.py` are registered in workflow order: setup → ingest → enrich → pipeline → analyze → output → integrations → ops. New commands should be inserted at the appropriate workflow stage.
-- **`no_args_is_help=True`**: Every `typer.Typer()` group must set this flag so bare invocation shows help text consistently. Do not use `invoke_without_command=True` callbacks as a substitute for showing help.
+- **`no_args_is_help=True`**: Every `typer.Typer()` group must set this flag so bare invocation shows help text consistently. Do not use `invoke_without_command=True` callbacks as a substitute — that flag runs the callback even when a subcommand is provided, causing confusing side effects like duplicate setup or output.
 
 ## Conventions
 

--- a/.claude/rules/data-extraction.md
+++ b/.claude/rules/data-extraction.md
@@ -7,7 +7,7 @@ globs: ["src/moneybin/extractors/**", "src/moneybin/connectors/**", "src/moneybi
 
 ## Day-Boundary Extraction
 
-Only extract complete days. Calculate range from last extraction date to yesterday.
+Only extract complete days. Calculate range from last extraction date to yesterday. Partial-day extraction breaks idempotency — re-running the same extraction later in the day would pick up new transactions, producing different record counts and content hashes that defeat dedup.
 
 ```python
 def get_incremental_date_range(

--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -35,13 +35,17 @@ See [`smart-import-tabular.md`](../../docs/specs/smart-import-tabular.md) for th
 
 A column name — especially identifiers — must contain the same logical values in every table and view where it appears. Any column named `X` should be joinable to any other column named `X` across raw, prep, core, and app schemas. When a new layer introduces a new concept (e.g., a synthetic key), give it a new name. Never reuse an existing column name with different semantics.
 
-**One concept, one column name.** If two columns across layers carry the same semantic (same values, same meaning), they must share the same name. Don't introduce a layer-specific alias (e.g., `source_format` in raw vs `source_type` in core) — use one name throughout. The canonical provenance column is `source_type` (values: `csv`, `tsv`, `excel`, `parquet`, `ofx`, `plaid`, etc.) — neutral enough for both file formats and API/sync sources. If a trivial mapping is needed (e.g., `xlsx` → `excel`), resolve it at write time so downstream layers never see the raw variant.
+**One concept, one column name.** If two columns across layers carry the same semantic (same values, same meaning), they must share the same name. Don't introduce a layer-specific alias (e.g., `source_format` in raw vs `source_type` in core) — use one name throughout. The canonical provenance column is `source_type` (values: `csv`, `tsv`, `excel`, `parquet`, `ofx`, `plaid`, etc.) — neutral enough for both file formats and API/sync sources. If a trivial mapping is needed (e.g., `xlsx` → `excel`), resolve it at write time so downstream layers never see the raw variant — if both values coexist, JOIN predicates between layers silently produce empty results.
 
 ## Model Naming Conventions
 
 `stg_`, `int_`, `dim_`, `fct_`, `bridge_`, `agg_`, `seed_` — see CLAUDE.md "Architecture: Data Layers" for the full prefix/schema/purpose table.
 
 `stg_` models use double-underscore to separate source system from entity: `stg_ofx__transactions`. `int_` models use it to separate domain from transformation: `int_transactions__merged`.
+
+## SQLMesh Invocation
+
+**Always use the Python API** (`sqlmesh.Context`), never subprocess. Subprocess calls break profile isolation — child processes read `~/.moneybin/config.yaml` and connect to the wrong database. Since SQLMesh's DuckDB config doesn't support `ENCRYPTION_KEY`, inject a pre-connected adapter into `BaseDuckDBConnectionConfig._data_file_to_adapter` keyed by db path — SQLMesh will reuse it instead of opening its own connection. See `run_transforms()` in `import_service.py` and `_run_sqlmesh_migrate()` in `database.py`.
 
 ## SQL Formatting
 

--- a/.claude/rules/identifiers.md
+++ b/.claude/rules/identifiers.md
@@ -20,7 +20,7 @@ Use the first strategy that applies:
 
 For records whose identity *is* their content — reimporting the same file must produce the same IDs.
 
-- **Algorithm**: SHA-256, truncated to 16 hex chars (64 bits).
+- **Algorithm**: SHA-256, truncated to 16 hex chars (64 bits). 64 bits gives ~1-in-a-billion collision probability at 100k records — sufficient for per-source transaction dedup, and short enough to be readable in logs and debugging. Use full SHA-256 if a single table could exceed ~1M records.
 - **Prefix**: Source-specific prefix to prevent cross-source collisions (`csv_`, `pdf_`, etc.).
 - **Input**: Pipe-delimited concatenation of the fields that define uniqueness.
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -49,7 +49,7 @@ When a function delegates to an external system (SQLMesh, DuckDB CLI, keyring, s
 
 ## Database Fixtures
 
-- **Always pass `no_auto_upgrade=True`** when creating `Database` instances in tests, unless the test is specifically verifying migration behavior. Without this, each test spawns a `sqlmesh migrate` subprocess (~1.5s per test).
+- **Always pass `no_auto_upgrade=True`** when creating `Database` instances in tests, unless the test is specifically verifying migration behavior. Without this, each test creates a SQLMesh `Context` and runs migration checks — slow (~1.5s per test) and requires the full sqlmesh project directory to be resolvable.
 - **Use `mock_secret_store`** from the root `conftest.py` (or create a local `MagicMock` with `get_key.return_value = "test-key"`) — never hit the real keyring.
 - **Avoid `autouse=True` on expensive fixtures.** Use `pytestmark = pytest.mark.usefixtures("fixture_name")` at module level, and add the fixture as an explicit parameter to any inner fixtures that depend on it (e.g., `_insert_data(self, mcp_db: object)`).
 

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -250,16 +250,20 @@ class Database:
             logger.debug("sqlmesh not installed, skipping migrate")
             return True
 
-        conn = self._conn
-        adapter = DuckDBEngineAdapter(
-            lambda: conn,
-            default_catalog=_DATABASE_ALIAS,
-            register_comments=True,
-        )
+        # Adapter construction and cache injection are inside the try block
+        # so that failures degrade gracefully instead of breaking DB init.
+        # Note: _data_file_to_adapter is a class-level dict — not thread-safe
+        # for concurrent init with the same db_path. Acceptable for single-user.
         cache_key = str(self._db_path)
-        BaseDuckDBConnectionConfig._data_file_to_adapter[cache_key] = adapter  # type: ignore[reportPrivateUsage]  # no public API for encrypted DB injection
-
         try:
+            conn = self._conn
+            adapter = DuckDBEngineAdapter(
+                lambda: conn,
+                default_catalog=_DATABASE_ALIAS,
+                register_comments=True,
+            )
+            BaseDuckDBConnectionConfig._data_file_to_adapter[cache_key] = adapter  # type: ignore[reportPrivateUsage]  # no public API for encrypted DB injection
+
             config = Config(
                 default_gateway="moneybin",
                 gateways={
@@ -277,7 +281,10 @@ class Database:
             logger.debug("sqlmesh migrate completed successfully")
             return True
         except Exception:  # noqa: BLE001 — sqlmesh migration failures are non-fatal
-            logger.warning("⚠️  sqlmesh migrate failed — see logs for details")
+            logger.warning(
+                "⚠️  sqlmesh migrate failed — see logs for details",
+                exc_info=True,
+            )
             return False
         finally:
             BaseDuckDBConnectionConfig._data_file_to_adapter.pop(cache_key, None)  # type: ignore[reportPrivateUsage]  # cleanup matches injection above

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -225,37 +225,62 @@ class Database:
         """Run sqlmesh migrate to update SQLMesh internal state.
 
         Called when the installed SQLMesh version differs from the recorded
-        version. Uses subprocess to invoke the sqlmesh CLI.
+        version. Uses the SQLMesh Python API in-process so it inherits the
+        current profile's encrypted connection — no subprocess needed.
 
         Returns:
             True if migration succeeded or was skipped (no sqlmesh dir),
             False if migration failed.
         """
-        import subprocess  # noqa: S404  # subprocess is required to invoke the sqlmesh CLI
-
-        # Assumes editable install — __file__ resolves to the project tree.
-        # Non-editable installs skip cleanly (sqlmesh dir won't exist).
         sqlmesh_root = Path(__file__).resolve().parents[2] / "sqlmesh"
         if not sqlmesh_root.is_dir():
             logger.debug("sqlmesh project dir not found, skipping migrate")
             return True
+
         try:
-            subprocess.run(  # noqa: S603  # fixed args from trusted internal config, not user input
-                ["uv", "run", "sqlmesh", "-p", str(sqlmesh_root), "migrate"],  # noqa: S607  # uv is a trusted internal tool
-                check=True,
-                capture_output=True,
-                text=True,
+            from sqlmesh.core.config import Config, GatewayConfig
+            from sqlmesh.core.config.connection import (
+                BaseDuckDBConnectionConfig,
+                DuckDBConnectionConfig,
             )
+            from sqlmesh.core.engine_adapter.duckdb import DuckDBEngineAdapter
+
+            from sqlmesh import Context  # type: ignore[import-untyped]
+        except ImportError:
+            logger.debug("sqlmesh not installed, skipping migrate")
+            return True
+
+        conn = self._conn
+        adapter = DuckDBEngineAdapter(
+            lambda: conn,
+            default_catalog=_DATABASE_ALIAS,
+            register_comments=True,
+        )
+        cache_key = str(self._db_path)
+        BaseDuckDBConnectionConfig._data_file_to_adapter[cache_key] = adapter  # type: ignore[reportPrivateUsage]  # no public API for encrypted DB injection
+
+        try:
+            config = Config(
+                default_gateway="moneybin",
+                gateways={
+                    "moneybin": GatewayConfig(
+                        connection=DuckDBConnectionConfig(database=str(self._db_path)),
+                    ),
+                },
+            )
+            ctx = Context(
+                paths=str(sqlmesh_root),
+                config=config,
+                gateway="moneybin",
+            )
+            ctx.migrate()
             logger.debug("sqlmesh migrate completed successfully")
             return True
-        except subprocess.CalledProcessError as exc:
-            logger.warning(
-                f"⚠️  sqlmesh migrate failed (exit {exc.returncode}): {exc.stderr.strip()}"
-            )
+        except Exception:  # noqa: BLE001 — sqlmesh migration failures are non-fatal
+            logger.warning("⚠️  sqlmesh migrate failed — see logs for details")
             return False
-        except FileNotFoundError:
-            logger.debug("sqlmesh CLI not found, skipping migrate")
-            return True
+        finally:
+            BaseDuckDBConnectionConfig._data_file_to_adapter.pop(cache_key, None)  # type: ignore[reportPrivateUsage]  # cleanup matches injection above
 
     @property
     def conn(self) -> duckdb.DuckDBPyConnection:

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -229,7 +229,8 @@ class Database:
         current profile's encrypted connection — no subprocess needed.
 
         Returns:
-            True if migration succeeded or was skipped (no sqlmesh dir),
+            True if migration succeeded or was skipped (no sqlmesh dir
+                or sqlmesh not installed),
             False if migration failed.
         """
         sqlmesh_root = Path(__file__).resolve().parents[2] / "sqlmesh"

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -257,10 +257,7 @@ class Database:
         cache_key = str(self._db_path)
         try:
             conn = self._conn
-            if (
-                conn is None
-            ):  # pragma: no cover — unreachable; called from __init__ after connect
-                return True
+            assert conn is not None  # noqa: S101 — invariant: called from __init__ after connect
             adapter = DuckDBEngineAdapter(
                 lambda: conn,
                 default_catalog=_DATABASE_ALIAS,

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -257,7 +257,10 @@ class Database:
         cache_key = str(self._db_path)
         try:
             conn = self._conn
-            assert conn is not None  # noqa: S101 — invariant: called from __init__ after connect
+            if conn is None:
+                raise RuntimeError(
+                    "_run_sqlmesh_migrate called before connection is established"
+                )
             adapter = DuckDBEngineAdapter(
                 lambda: conn,
                 default_catalog=_DATABASE_ALIAS,

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -257,6 +257,10 @@ class Database:
         cache_key = str(self._db_path)
         try:
             conn = self._conn
+            if (
+                conn is None
+            ):  # pragma: no cover — unreachable; called from __init__ after connect
+                return True
             adapter = DuckDBEngineAdapter(
                 lambda: conn,
                 default_catalog=_DATABASE_ALIAS,

--- a/tests/moneybin/test_database.py
+++ b/tests/moneybin/test_database.py
@@ -282,8 +282,13 @@ class TestRunSqlmeshMigrate:
         sqlmesh_root = Path(__file__).resolve().parents[2] / "sqlmesh"
         assert sqlmesh_root.is_dir()  # project has sqlmesh dir
 
-        # Block the import
+        # Evict sqlmesh from module cache so __import__ is actually called.
+        # Without this, cached modules bypass fake_import entirely and the
+        # real migrate path runs — passing for the wrong reason.
         import builtins
+
+        for key in [k for k in sys.modules if k.startswith("sqlmesh")]:
+            monkeypatch.delitem(sys.modules, key)
 
         real_import = builtins.__import__
 

--- a/tests/moneybin/test_database.py
+++ b/tests/moneybin/test_database.py
@@ -271,7 +271,7 @@ class TestRunSqlmeshMigrate:
         self, db: Database, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Returns True immediately when sqlmesh project dir doesn't exist."""
-        monkeypatch.setattr(Path, "is_dir", lambda self: False)  # type: ignore[reportUnknownLambdaType]
+        monkeypatch.setattr("moneybin.database.Path.is_dir", lambda self: False)  # type: ignore[reportUnknownLambdaType]
         assert db._run_sqlmesh_migrate() is True  # type: ignore[reportPrivateUsage]
 
     def test_skips_when_sqlmesh_not_installed(
@@ -306,10 +306,17 @@ class TestRunSqlmeshMigrate:
         cache = BaseDuckDBConnectionConfig._data_file_to_adapter  # type: ignore[reportPrivateUsage]
         cache_key = str(db.path)
 
+        # Verify adapter is in cache when migrate() is called
+        injected_during_migrate: list[bool] = []
+        mock_ctx.migrate.side_effect = lambda: injected_during_migrate.append(
+            cache_key in cache
+        )
+
         result = db._run_sqlmesh_migrate()  # type: ignore[reportPrivateUsage]
 
         assert result is True
         mock_ctx.migrate.assert_called_once()
+        assert injected_during_migrate == [True]  # adapter was present during migrate
         # Cache should be cleaned up in finally
         assert cache_key not in cache
 

--- a/tests/moneybin/test_database.py
+++ b/tests/moneybin/test_database.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import duckdb
 import pytest
+from pytest_mock import MockerFixture
 
 from moneybin.database import Database, DatabaseKeyError, get_database
 
@@ -266,6 +267,13 @@ class TestRunSqlmeshMigrate:
         yield database
         database.close()
 
+    def test_skips_when_no_sqlmesh_dir(
+        self, db: Database, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Returns True immediately when sqlmesh project dir doesn't exist."""
+        monkeypatch.setattr(Path, "is_dir", lambda self: False)  # type: ignore[reportUnknownLambdaType]
+        assert db._run_sqlmesh_migrate() is True  # type: ignore[reportPrivateUsage]
+
     def test_skips_when_sqlmesh_not_installed(
         self, db: Database, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -288,7 +296,7 @@ class TestRunSqlmeshMigrate:
         assert db._run_sqlmesh_migrate() is True  # type: ignore[reportPrivateUsage]
 
     def test_success_calls_migrate_and_cleans_cache(
-        self, db: Database, mocker: MagicMock
+        self, db: Database, mocker: MockerFixture
     ) -> None:
         """Successful path: adapter injected, ctx.migrate() called, cache cleaned."""
         mock_ctx_class = mocker.patch("sqlmesh.Context")
@@ -306,7 +314,7 @@ class TestRunSqlmeshMigrate:
         assert cache_key not in cache
 
     def test_failure_logs_warning_and_returns_false(
-        self, db: Database, mocker: MagicMock, caplog: pytest.LogCaptureFixture
+        self, db: Database, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Failure path: exception caught, warning logged with traceback, False returned."""
         mock_ctx_class = mocker.patch("sqlmesh.Context")

--- a/tests/moneybin/test_database.py
+++ b/tests/moneybin/test_database.py
@@ -3,6 +3,7 @@
 import sys
 from collections.abc import Generator
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import duckdb
@@ -249,6 +250,81 @@ class TestIngestDataframe:
         df = pl.DataFrame({"id": [1]})
         with pytest.raises(ValueError, match="on_conflict"):
             db.ingest_dataframe("test_items", df, on_conflict="bad")
+
+
+class TestRunSqlmeshMigrate:
+    """Database._run_sqlmesh_migrate() — in-process SQLMesh state migration."""
+
+    @pytest.fixture()
+    def db(
+        self, db_dir: Path, mock_secret_store: MagicMock
+    ) -> Generator[Database, None, None]:
+        db_path = db_dir / "moneybin.duckdb"
+        database = Database(
+            db_path, secret_store=mock_secret_store, no_auto_upgrade=True
+        )
+        yield database
+        database.close()
+
+    def test_skips_when_sqlmesh_not_installed(
+        self, db: Database, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Returns True and skips when sqlmesh is not importable."""
+        # Ensure sqlmesh_root exists so we get past the dir check
+        sqlmesh_root = Path(__file__).resolve().parents[2] / "sqlmesh"
+        assert sqlmesh_root.is_dir()  # project has sqlmesh dir
+
+        # Block the import
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name.startswith("sqlmesh"):
+                raise ImportError("mocked")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        assert db._run_sqlmesh_migrate() is True  # type: ignore[reportPrivateUsage]
+
+    def test_success_calls_migrate_and_cleans_cache(
+        self, db: Database, mocker: MagicMock
+    ) -> None:
+        """Successful path: adapter injected, ctx.migrate() called, cache cleaned."""
+        mock_ctx_class = mocker.patch("sqlmesh.Context")
+        mock_ctx = mock_ctx_class.return_value
+        from sqlmesh.core.config.connection import BaseDuckDBConnectionConfig
+
+        cache = BaseDuckDBConnectionConfig._data_file_to_adapter  # type: ignore[reportPrivateUsage]
+        cache_key = str(db.path)
+
+        result = db._run_sqlmesh_migrate()  # type: ignore[reportPrivateUsage]
+
+        assert result is True
+        mock_ctx.migrate.assert_called_once()
+        # Cache should be cleaned up in finally
+        assert cache_key not in cache
+
+    def test_failure_logs_warning_and_returns_false(
+        self, db: Database, mocker: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Failure path: exception caught, warning logged with traceback, False returned."""
+        mock_ctx_class = mocker.patch("sqlmesh.Context")
+        mock_ctx_class.return_value.migrate.side_effect = RuntimeError("boom")
+        from sqlmesh.core.config.connection import BaseDuckDBConnectionConfig
+
+        cache = BaseDuckDBConnectionConfig._data_file_to_adapter  # type: ignore[reportPrivateUsage]
+        cache_key = str(db.path)
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            result = db._run_sqlmesh_migrate()  # type: ignore[reportPrivateUsage]
+
+        assert result is False
+        assert "sqlmesh migrate failed" in caplog.text
+        # Cache should still be cleaned up in finally
+        assert cache_key not in cache
 
 
 class TestGetDatabase:


### PR DESCRIPTION
## Summary

`_run_sqlmesh_migrate()` spawned `sqlmesh migrate` as a subprocess, which loaded its own config and connected to the user's default profile database instead of the active profile. This caused file lock errors during `synthetic generate` when the default profile's DB was already open. Replaced with the SQLMesh Python API (same pattern as `run_transforms()`), eliminating the isolation bug entirely.

## Impact

- No workflow changes. The migration behavior is identical — it just runs in-process now.
- New rule in `database.md`: all SQLMesh invocations must use the Python API, never subprocess.

## Changes

### SQLMesh migrate fix (`database.py`)
Replaced subprocess call to `uv run sqlmesh migrate` with in-process `Context.migrate()`, using the adapter-cache injection pattern to pass the encrypted connection. This inherits the current profile's database connection automatically.

### Rules documentation
- **`database.md`**: Added "SQLMesh Invocation" rule explaining why subprocess is forbidden and how to inject encrypted connections.
- **`cli.md`**: Explained why `invoke_without_command=True` causes problems (runs callback even with subcommands).
- **`data-extraction.md`**: Explained why day-boundary extraction matters (idempotency, dedup).
- **`identifiers.md`**: Explained the collision math behind 16 hex char truncation.
- **`database.md`**: Explained why column name variants between layers break JOINs.
- **`testing.md`**: Updated stale comment about `no_auto_upgrade` — now references SQLMesh Context creation instead of removed subprocess.

## Testing

- `test_database.py`: 17/17 passing
- Format, lint, pyright all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)