### PR TITLE
Fix MCP SQL guards and match dedup refresh

### DIFF
--- a/src/moneybin/cli/commands/matches.py
+++ b/src/moneybin/cli/commands/matches.py
@@ -15,16 +15,6 @@ app = typer.Typer(
 logger = logging.getLogger(__name__)
 
 
-def _run_transforms_after_match_change() -> None:
-    """Refresh SQLMesh models after accepted match decisions change."""
-    from moneybin.config import get_settings
-    from moneybin.services.import_service import run_transforms
-
-    db = get_database()
-    db.close()
-    run_transforms(get_settings().database.path)
-
-
 @app.command("run")
 def matches_run(
     skip_transform: bool = typer.Option(
@@ -81,6 +71,7 @@ def matches_review(
     ),
 ) -> None:
     """Review pending match proposals. Interactive by default."""
+    from moneybin.config import get_settings
     from moneybin.matching.persistence import get_pending_matches, update_match_status
 
     if decision and not match_id:
@@ -101,9 +92,11 @@ def matches_review(
             update_match_status(db, match_id, status=status, decided_by="user")
             logger.info(f"{status.capitalize()} {match_id[:8]}")
             if status == "accepted":
-                accepted_count = 1
                 if not skip_transform:
-                    _run_transforms_after_match_change()
+                    from moneybin.services.import_service import run_transforms
+
+                    db.close()
+                    run_transforms(get_settings().database.path)
             return
 
         pending = get_pending_matches(db)
@@ -121,7 +114,10 @@ def matches_review(
                 accepted_count += 1
             logger.info(f"Accepted {len(pending)} pending match(es)")
             if accepted_count and not skip_transform:
-                _run_transforms_after_match_change()
+                from moneybin.services.import_service import run_transforms
+
+                db.close()
+                run_transforms(get_settings().database.path)
             return
 
         # Interactive review
@@ -158,7 +154,10 @@ def matches_review(
                 break
 
         if accepted_count and not skip_transform:
-            _run_transforms_after_match_change()
+            from moneybin.services.import_service import run_transforms
+
+            db.close()
+            run_transforms(get_settings().database.path)
 
     except DatabaseKeyError as e:
         from moneybin.database import database_key_error_hint

--- a/src/moneybin/cli/commands/matches.py
+++ b/src/moneybin/cli/commands/matches.py
@@ -15,6 +15,16 @@ app = typer.Typer(
 logger = logging.getLogger(__name__)
 
 
+def _run_transforms_after_match_change() -> None:
+    """Refresh SQLMesh models after accepted match decisions change."""
+    from moneybin.config import get_settings
+    from moneybin.services.import_service import run_transforms
+
+    db = get_database()
+    db.close()
+    run_transforms(get_settings().database.path)
+
+
 @app.command("run")
 def matches_run(
     skip_transform: bool = typer.Option(
@@ -56,6 +66,11 @@ def matches_review(
     accept_all: bool = typer.Option(
         False, "--accept-all", help="Accept all pending matches without prompting"
     ),
+    skip_transform: bool = typer.Option(
+        False,
+        "--skip-transform",
+        help="Skip SQLMesh transforms after accepting matches",
+    ),
     match_id: str | None = typer.Option(
         None, "--match-id", help="Specific match ID to act on (use with --decision)"
     ),
@@ -78,12 +93,17 @@ def matches_review(
 
     try:
         db = get_database()
+        accepted_count = 0
 
         # Non-interactive: single match decision
         if match_id and decision:
             status = "accepted" if decision == "accept" else "rejected"
             update_match_status(db, match_id, status=status, decided_by="user")
             logger.info(f"{status.capitalize()} {match_id[:8]}")
+            if status == "accepted":
+                accepted_count = 1
+                if not skip_transform:
+                    _run_transforms_after_match_change()
             return
 
         pending = get_pending_matches(db)
@@ -98,7 +118,10 @@ def matches_review(
                 update_match_status(
                     db, match["match_id"], status="accepted", decided_by="user"
                 )
+                accepted_count += 1
             logger.info(f"Accepted {len(pending)} pending match(es)")
+            if accepted_count and not skip_transform:
+                _run_transforms_after_match_change()
             return
 
         # Interactive review
@@ -124,6 +147,7 @@ def matches_review(
                 update_match_status(
                     db, match["match_id"], status="accepted", decided_by="user"
                 )
+                accepted_count += 1
                 logger.info(f"Accepted {match['match_id'][:8]}")
             elif action.lower().startswith("r"):
                 update_match_status(
@@ -132,6 +156,9 @@ def matches_review(
                 logger.info(f"Rejected {match['match_id'][:8]}")
             elif action.lower().startswith("q"):
                 break
+
+        if accepted_count and not skip_transform:
+            _run_transforms_after_match_change()
 
     except DatabaseKeyError as e:
         from moneybin.database import database_key_error_hint

--- a/src/moneybin/extractors/tabular/transforms.py
+++ b/src/moneybin/extractors/tabular/transforms.py
@@ -222,7 +222,6 @@ def transform_dataframe(
         original_date_strs=original_date_strs,
         parsed_amounts=parsed_amounts,
         descriptions=descriptions,
-        row_numbers=row_numbers,
         source_type=source_type,
     )
 
@@ -566,7 +565,6 @@ def _generate_transaction_ids(
     original_date_strs: list[str],
     parsed_amounts: list[Decimal | None],
     descriptions: list[str],
-    row_numbers: list[int],
     source_type: str,
 ) -> list[str]:
     """Generate transaction IDs using source ID if available, else content hash.
@@ -574,7 +572,7 @@ def _generate_transaction_ids(
     ID strategy (per identifiers.md):
     1. Source-provided ID → "{account_id}:{source_txn_id}"
     2. Content hash → "{source_type}_{sha256_16hex}"
-       Input: "{date}|{amount}|{description}|{account_id}|{row_number}"
+       Input: "{date}|{amount}|{description}|{account_id}"
 
     Args:
         df: Source DataFrame.
@@ -583,7 +581,6 @@ def _generate_transaction_ids(
         original_date_strs: Raw date strings, one per row.
         parsed_amounts: Parsed Decimal amounts (None for invalid rows).
         descriptions: Description strings, one per row.
-        row_numbers: 1-based row numbers.
         source_type: File type prefix for content-hash IDs.
 
     Returns:
@@ -608,8 +605,7 @@ def _generate_transaction_ids(
                 str(parsed_amounts[idx]) if parsed_amounts[idx] is not None else ""
             )
             desc_str = descriptions[idx] if idx < len(descriptions) else ""
-            row_str = str(row_numbers[idx]) if idx < len(row_numbers) else ""
-            raw_key = f"{date_str}|{amount_str}|{desc_str}|{acct_id}|{row_str}"
+            raw_key = f"{date_str}|{amount_str}|{desc_str}|{acct_id}"
             digest = hashlib.sha256(raw_key.encode()).hexdigest()[:16]
             ids.append(f"{source_type}_{digest}")
 

--- a/src/moneybin/matching/scoring.py
+++ b/src/moneybin/matching/scoring.py
@@ -154,7 +154,18 @@ def _get_candidates(
             ON a.account_id = b.account_id
             AND a.amount = b.amount
             AND ABS(DATEDIFF('day', a.transaction_date, b.transaction_date)) <= ?
-            AND a.source_transaction_id < b.source_transaction_id
+            AND (
+                a.source_type < b.source_type
+                OR (
+                    a.source_type = b.source_type
+                    AND a.source_origin < b.source_origin
+                )
+                OR (
+                    a.source_type = b.source_type
+                    AND a.source_origin = b.source_origin
+                    AND a.source_transaction_id < b.source_transaction_id
+                )
+            )
             {source_filter}
         ORDER BY desc_sim DESC
     """  # noqa: S608 — table name validated above; date_window_days is parameterized

--- a/src/moneybin/matching/scoring.py
+++ b/src/moneybin/matching/scoring.py
@@ -155,16 +155,13 @@ def _get_candidates(
             AND a.amount = b.amount
             AND ABS(DATEDIFF('day', a.transaction_date, b.transaction_date)) <= ?
             AND (
-                a.source_type < b.source_type
-                OR (
-                    a.source_type = b.source_type
-                    AND a.source_origin < b.source_origin
-                )
-                OR (
-                    a.source_type = b.source_type
-                    AND a.source_origin = b.source_origin
-                    AND a.source_transaction_id < b.source_transaction_id
-                )
+                a.source_type,
+                a.source_origin,
+                a.source_transaction_id
+            ) < (
+                b.source_type,
+                b.source_origin,
+                b.source_transaction_id
             )
             {source_filter}
         ORDER BY desc_sim DESC

--- a/src/moneybin/mcp/privacy.py
+++ b/src/moneybin/mcp/privacy.py
@@ -89,7 +89,7 @@ _URL_SCHEME_PATTERNS = re.compile(
 # without using read_csv/read_parquet. A single-quoted table source is not a
 # normal catalog table reference, so reject it before execution.
 _QUOTED_TABLE_SCAN = re.compile(
-    r"\b(FROM|JOIN)\s*'[^']+'",
+    r"(?<!')\b(FROM|JOIN)\s*'[^']+'",
     re.IGNORECASE,
 )
 

--- a/src/moneybin/mcp/privacy.py
+++ b/src/moneybin/mcp/privacy.py
@@ -85,6 +85,14 @@ _URL_SCHEME_PATTERNS = re.compile(
     re.IGNORECASE,
 )
 
+# DuckDB replacement scans can read files with `FROM 'path/to/file.csv'`
+# without using read_csv/read_parquet. A single-quoted table source is not a
+# normal catalog table reference, so reject it before execution.
+_QUOTED_TABLE_SCAN = re.compile(
+    r"\b(FROM|JOIN)\s*'[^']+'",
+    re.IGNORECASE,
+)
+
 # Patterns that indicate read-only SQL statements
 _READ_ONLY_PREFIXES = re.compile(
     r"^\s*(SELECT|WITH|DESCRIBE|SHOW|PRAGMA|EXPLAIN)\b",
@@ -149,6 +157,12 @@ def validate_read_only_query(sql: str) -> str | None:
     if _URL_SCHEME_PATTERNS.search(stripped):
         return (
             "URL literals (https://, s3://, etc.) are not allowed. "
+            "Queries must read from database tables only."
+        )
+
+    if _QUOTED_TABLE_SCAN.search(stripped):
+        return (
+            "Quoted file/table path scans are not allowed through the MCP server. "
             "Queries must read from database tables only."
         )
 

--- a/tests/moneybin/matching/test_scoring.py
+++ b/tests/moneybin/matching/test_scoring.py
@@ -134,6 +134,38 @@ class TestGetCandidatesCrossSource:
         assert candidates[0].source_transaction_id_a == "csv_abc"
         assert candidates[0].source_transaction_id_b == "ofx_xyz"
 
+    def test_finds_cross_source_pair_with_equal_source_ids(
+        self, unioned_table: Database
+    ) -> None:
+        _insert_unioned_row(
+            unioned_table,
+            source_transaction_id="shared-id",
+            account_id="acct1",
+            transaction_date="2026-03-15",
+            amount="-42.50",
+            description="STARBUCKS #1234",
+            source_type="csv",
+            source_origin="chase",
+        )
+        _insert_unioned_row(
+            unioned_table,
+            source_transaction_id="shared-id",
+            account_id="acct1",
+            transaction_date="2026-03-15",
+            amount="-42.50",
+            description="STARBUCKS 1234 NEW YORK",
+            source_type="ofx",
+            source_origin="chase_ofx",
+        )
+
+        candidates = get_candidates_cross_source(
+            unioned_table, table="main._test_unioned", date_window_days=3
+        )
+
+        assert len(candidates) == 1
+        assert candidates[0].source_transaction_id_a == "shared-id"
+        assert candidates[0].source_transaction_id_b == "shared-id"
+
     def test_excludes_same_source_type_and_origin(
         self, unioned_table: Database
     ) -> None:

--- a/tests/moneybin/matching/test_scoring.py
+++ b/tests/moneybin/matching/test_scoring.py
@@ -163,6 +163,8 @@ class TestGetCandidatesCrossSource:
         )
 
         assert len(candidates) == 1
+        assert candidates[0].source_type_a == "csv"
+        assert candidates[0].source_type_b == "ofx"
         assert candidates[0].source_transaction_id_a == "shared-id"
         assert candidates[0].source_transaction_id_b == "shared-id"
 

--- a/tests/moneybin/test_cli/test_matches.py
+++ b/tests/moneybin/test_cli/test_matches.py
@@ -143,6 +143,41 @@ class TestMatchesReview:
         mock_update.assert_called_once()
         mock_run_transforms.assert_not_called()
 
+    @patch("moneybin.config.get_settings")
+    @patch("moneybin.services.import_service.run_transforms")
+    @patch("moneybin.cli.commands.matches.get_database")
+    @patch("moneybin.matching.persistence.get_pending_matches")
+    @patch("moneybin.matching.persistence.update_match_status")
+    def test_interactive_accept_runs_transform(
+        self,
+        mock_update: MagicMock,
+        mock_pending: MagicMock,
+        mock_get_db: MagicMock,
+        mock_run_transforms: MagicMock,
+        mock_get_settings: MagicMock,
+    ) -> None:
+        mock_get_db.return_value = MagicMock()
+        mock_get_settings.return_value.database.path = "test.duckdb"
+        mock_pending.return_value = [
+            {
+                "match_id": "abc123",
+                "confidence_score": 0.9,
+                "source_type_a": "csv",
+                "source_transaction_id_a": "id1",
+                "source_type_b": "ofx",
+                "source_transaction_id_b": "id2",
+            }
+        ]
+
+        result = runner.invoke(app, ["review"], input="a\n")
+
+        assert result.exit_code == 0
+        mock_update.assert_called_once_with(
+            mock_get_db.return_value, "abc123", status="accepted", decided_by="user"
+        )
+        mock_get_db.return_value.close.assert_called_once()
+        mock_run_transforms.assert_called_once_with("test.duckdb")
+
 
 class TestMatchesHistory:
     """Tests for the matches history command."""

--- a/tests/moneybin/test_cli/test_matches.py
+++ b/tests/moneybin/test_cli/test_matches.py
@@ -38,6 +38,104 @@ class TestMatchesRun:
         mock_matcher.run.assert_called_once()
 
 
+class TestMatchesReview:
+    """Tests for the matches review command."""
+
+    @patch("moneybin.cli.commands.matches._run_transforms_after_match_change")
+    @patch("moneybin.cli.commands.matches.get_database")
+    @patch("moneybin.matching.persistence.update_match_status")
+    def test_accept_single_runs_transform(
+        self,
+        mock_update: MagicMock,
+        mock_get_db: MagicMock,
+        mock_run_transforms: MagicMock,
+    ) -> None:
+        mock_get_db.return_value = MagicMock()
+
+        result = runner.invoke(
+            app,
+            ["review", "--match-id", "abc123", "--decision", "accept"],
+        )
+
+        assert result.exit_code == 0
+        mock_update.assert_called_once_with(
+            mock_get_db.return_value, "abc123", status="accepted", decided_by="user"
+        )
+        mock_run_transforms.assert_called_once()
+
+    @patch("moneybin.cli.commands.matches._run_transforms_after_match_change")
+    @patch("moneybin.cli.commands.matches.get_database")
+    @patch("moneybin.matching.persistence.update_match_status")
+    def test_reject_single_does_not_run_transform(
+        self,
+        mock_update: MagicMock,
+        mock_get_db: MagicMock,
+        mock_run_transforms: MagicMock,
+    ) -> None:
+        mock_get_db.return_value = MagicMock()
+
+        result = runner.invoke(
+            app,
+            ["review", "--match-id", "abc123", "--decision", "reject"],
+        )
+
+        assert result.exit_code == 0
+        mock_update.assert_called_once_with(
+            mock_get_db.return_value, "abc123", status="rejected", decided_by="user"
+        )
+        mock_run_transforms.assert_not_called()
+
+    @patch("moneybin.cli.commands.matches._run_transforms_after_match_change")
+    @patch("moneybin.cli.commands.matches.get_database")
+    @patch("moneybin.matching.persistence.get_pending_matches")
+    @patch("moneybin.matching.persistence.update_match_status")
+    def test_accept_all_runs_transform_once(
+        self,
+        mock_update: MagicMock,
+        mock_pending: MagicMock,
+        mock_get_db: MagicMock,
+        mock_run_transforms: MagicMock,
+    ) -> None:
+        mock_get_db.return_value = MagicMock()
+        mock_pending.return_value = [
+            {"match_id": "abc123"},
+            {"match_id": "def456"},
+        ]
+
+        result = runner.invoke(app, ["review", "--accept-all"])
+
+        assert result.exit_code == 0
+        assert mock_update.call_count == 2
+        mock_run_transforms.assert_called_once()
+
+    @patch("moneybin.cli.commands.matches._run_transforms_after_match_change")
+    @patch("moneybin.cli.commands.matches.get_database")
+    @patch("moneybin.matching.persistence.update_match_status")
+    def test_accept_single_can_skip_transform(
+        self,
+        mock_update: MagicMock,
+        mock_get_db: MagicMock,
+        mock_run_transforms: MagicMock,
+    ) -> None:
+        mock_get_db.return_value = MagicMock()
+
+        result = runner.invoke(
+            app,
+            [
+                "review",
+                "--match-id",
+                "abc123",
+                "--decision",
+                "accept",
+                "--skip-transform",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_update.assert_called_once()
+        mock_run_transforms.assert_not_called()
+
+
 class TestMatchesHistory:
     """Tests for the matches history command."""
 

--- a/tests/moneybin/test_cli/test_matches.py
+++ b/tests/moneybin/test_cli/test_matches.py
@@ -41,7 +41,8 @@ class TestMatchesRun:
 class TestMatchesReview:
     """Tests for the matches review command."""
 
-    @patch("moneybin.cli.commands.matches._run_transforms_after_match_change")
+    @patch("moneybin.config.get_settings")
+    @patch("moneybin.services.import_service.run_transforms")
     @patch("moneybin.cli.commands.matches.get_database")
     @patch("moneybin.matching.persistence.update_match_status")
     def test_accept_single_runs_transform(
@@ -49,8 +50,10 @@ class TestMatchesReview:
         mock_update: MagicMock,
         mock_get_db: MagicMock,
         mock_run_transforms: MagicMock,
+        mock_get_settings: MagicMock,
     ) -> None:
         mock_get_db.return_value = MagicMock()
+        mock_get_settings.return_value.database.path = "test.duckdb"
 
         result = runner.invoke(
             app,
@@ -61,9 +64,10 @@ class TestMatchesReview:
         mock_update.assert_called_once_with(
             mock_get_db.return_value, "abc123", status="accepted", decided_by="user"
         )
-        mock_run_transforms.assert_called_once()
+        mock_get_db.return_value.close.assert_called_once()
+        mock_run_transforms.assert_called_once_with("test.duckdb")
 
-    @patch("moneybin.cli.commands.matches._run_transforms_after_match_change")
+    @patch("moneybin.services.import_service.run_transforms")
     @patch("moneybin.cli.commands.matches.get_database")
     @patch("moneybin.matching.persistence.update_match_status")
     def test_reject_single_does_not_run_transform(
@@ -85,7 +89,8 @@ class TestMatchesReview:
         )
         mock_run_transforms.assert_not_called()
 
-    @patch("moneybin.cli.commands.matches._run_transforms_after_match_change")
+    @patch("moneybin.config.get_settings")
+    @patch("moneybin.services.import_service.run_transforms")
     @patch("moneybin.cli.commands.matches.get_database")
     @patch("moneybin.matching.persistence.get_pending_matches")
     @patch("moneybin.matching.persistence.update_match_status")
@@ -95,8 +100,10 @@ class TestMatchesReview:
         mock_pending: MagicMock,
         mock_get_db: MagicMock,
         mock_run_transforms: MagicMock,
+        mock_get_settings: MagicMock,
     ) -> None:
         mock_get_db.return_value = MagicMock()
+        mock_get_settings.return_value.database.path = "test.duckdb"
         mock_pending.return_value = [
             {"match_id": "abc123"},
             {"match_id": "def456"},
@@ -106,9 +113,10 @@ class TestMatchesReview:
 
         assert result.exit_code == 0
         assert mock_update.call_count == 2
-        mock_run_transforms.assert_called_once()
+        mock_get_db.return_value.close.assert_called_once()
+        mock_run_transforms.assert_called_once_with("test.duckdb")
 
-    @patch("moneybin.cli.commands.matches._run_transforms_after_match_change")
+    @patch("moneybin.services.import_service.run_transforms")
     @patch("moneybin.cli.commands.matches.get_database")
     @patch("moneybin.matching.persistence.update_match_status")
     def test_accept_single_can_skip_transform(

--- a/tests/moneybin/test_extractors/test_tabular/test_transforms.py
+++ b/tests/moneybin/test_extractors/test_tabular/test_transforms.py
@@ -108,6 +108,27 @@ class TestTransformBasic:
             r1.transactions["transaction_id"][0] == r2.transactions["transaction_id"][0]
         )
 
+    def test_transaction_id_ignores_source_row_number(self) -> None:
+        original = _make_df(
+            Date=["01/15/2026"],
+            Amount=["-42.50"],
+            Description=["KROGER"],
+        )
+        shifted = _make_df(
+            Date=["01/14/2026", "01/15/2026"],
+            Amount=["-1.00", "-42.50"],
+            Description=["PREVIOUS ROW", "KROGER"],
+        )
+        kwargs = _base_kwargs()
+
+        original_result = transform_dataframe(df=original, **kwargs)
+        shifted_result = transform_dataframe(df=shifted, **kwargs)
+
+        assert (
+            original_result.transactions["transaction_id"][0]
+            == shifted_result.transactions["transaction_id"][1]
+        )
+
     def test_source_transaction_id_used_when_present(self) -> None:
         df = _make_df(
             Date=["01/15/2026"],

--- a/tests/moneybin/test_mcp/test_privacy.py
+++ b/tests/moneybin/test_mcp/test_privacy.py
@@ -139,6 +139,24 @@ class TestValidateReadOnlyQuery:
             assert result is not None, f"URL {url!r} should be blocked"
             assert "URL" in result
 
+    @pytest.mark.unit
+    def test_quoted_path_scans_rejected(self) -> None:
+        for path in [
+            "/Users/example/Downloads/transactions.csv",
+            "relative/transactions.parquet",
+            "~/Downloads/export.json",
+        ]:
+            result = validate_read_only_query(f"SELECT * FROM '{path}'")  # noqa: S608  # building test input string, not executing SQL
+            assert result is not None, f"Path scan {path!r} should be blocked"
+            assert "path scans" in result
+
+    @pytest.mark.unit
+    def test_quoted_identifiers_and_string_filters_allowed(self) -> None:
+        result = validate_read_only_query(
+            """SELECT * FROM "core"."fct_transactions" WHERE description = 'JOIN gym'"""
+        )
+        assert result is None
+
 
 class TestCheckTableAllowed:
     """Tests for table allowlist checking."""

--- a/tests/moneybin/test_mcp/test_privacy.py
+++ b/tests/moneybin/test_mcp/test_privacy.py
@@ -160,6 +160,16 @@ class TestValidateReadOnlyQuery:
         )
         assert result is None
 
+    @pytest.mark.unit
+    def test_bare_keyword_string_filters_allowed(self) -> None:
+        result = validate_read_only_query(
+            """
+            SELECT * FROM "core"."fct_transactions"
+            WHERE action = 'JOIN' AND note = 'something'
+            """
+        )
+        assert result is None
+
 
 class TestCheckTableAllowed:
     """Tests for table allowlist checking."""

--- a/tests/moneybin/test_mcp/test_privacy.py
+++ b/tests/moneybin/test_mcp/test_privacy.py
@@ -153,7 +153,10 @@ class TestValidateReadOnlyQuery:
     @pytest.mark.unit
     def test_quoted_identifiers_and_string_filters_allowed(self) -> None:
         result = validate_read_only_query(
-            """SELECT * FROM "core"."fct_transactions" WHERE description = 'JOIN gym'"""
+            """
+            SELECT * FROM "core"."fct_transactions"
+            WHERE description = 'JOIN gym' OR note = 'FROM here'
+            """
         )
         assert result is None
 


### PR DESCRIPTION
### Summary

This PR fixes four review findings around MCP query safety, transaction match review behavior, source-qualified dedup matching, and stable tabular transaction IDs. It adds regression tests for each issue so the reviewed edge cases stay covered.

### Impact

- MCP `sql.query` no longer permits DuckDB quoted-path replacement scans.
- Accepting pending transaction matches now refreshes core facts by default.
- Users can pass `--skip-transform` to `moneybin matches review` when they intentionally want to defer SQLMesh refresh.
- Tabular content-hash IDs are now stable when unrelated earlier rows are inserted or removed.

### Changes

#### MCP SQL Safety

Rejects single-quoted table sources such as `FROM '/path/file.csv'`, which DuckDB can otherwise execute as file reads.

- Added quoted-path scan detection in `src/moneybin/mcp/privacy.py`
- Added tests for blocked path scans and allowed quoted catalog identifiers/string filters

#### Match Review Refresh

Ensures accepted match decisions are reflected in `core.fct_transactions` without requiring a separate manual transform.

- Added transform refresh after single accept, accept-all, and interactive accepts
- Added `--skip-transform` for explicit deferral
- Added CLI tests for accept, reject, accept-all, and skip-transform behavior

#### Dedup Candidate Pairing

Uses source-qualified ordering in the self-join so equal source transaction IDs from different sources still form candidate pairs.

- Updated matching SQL ordering logic
- Added a regression test for cross-source rows sharing the same source transaction ID

#### Tabular Stable IDs

Aligns content-hash transaction IDs with the identifier convention by hashing date, amount, description, and account ID only.

- Removed source row number from tabular content-hash input
- Added regression coverage for row-position-independent IDs

### Testing

- `make format`
- `make lint`
- `make type-check`
- `uv run pytest tests/moneybin/test_mcp/test_privacy.py tests/moneybin/test_cli/test_matches.py tests/moneybin/matching/test_scoring.py tests/moneybin/test_extractors/test_tabular/test_transforms.py -v`
- `make test`
- `git diff --check`

Full unit suite result: `1030 passed, 9 deselected`.