### PR TITLE
Fix SQLMesh state vanishing after transform apply

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,8 @@ venv/
 .DS_Store
 ._*
 
-# Profiles info
-profiles/
+# MoneyBin runtime state (profiles, config, data, logs) when running in-repo
+/.moneybin/
 
 # Data files (exclude sensitive financial data)
 data/
@@ -85,9 +85,6 @@ pyrightconfig.json
 # Claude Code local settings (personal, not shared)
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
-
-# Stray local config (real config lives under <base>/config.yaml)
-/config.yaml
 
 # MCP config (contains local paths and credentials)
 .mcp.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-# Read AGENTS.md for project conventions
+# @AGENTS.md

--- a/docs/specs/cli-restructure.md
+++ b/docs/specs/cli-restructure.md
@@ -272,8 +272,8 @@ Replaces current logic entirely. Solves the `distribution-roadmap.md` concern.
 | Priority | Source | Resolves to | Use case |
 |---|---|---|---|
 | 1 | `MONEYBIN_HOME` env var | Whatever the user sets | Explicit override (CI, custom installs) |
-| 2 | `MONEYBIN_ENVIRONMENT=development` | `cwd` | Developer working in repo checkout |
-| 3 | Repo checkout detection (`.git` + `pyproject.toml` with `name = "moneybin"`) | `cwd` | Developer who didn't set env var |
+| 2 | `MONEYBIN_ENVIRONMENT=development` | `<cwd>/.moneybin` | Developer working in repo checkout |
+| 3 | Repo checkout detection (`.git` + `pyproject.toml` with `name = "moneybin"`) | `<cwd>/.moneybin` | Developer who didn't set env var |
 | 4 | Default | `~/.moneybin/` | Installed package user (the common case) |
 
 This inverts the current default (which is `cwd`) to `~/.moneybin/`. Installed users get the right thing with zero config. Developers get the right thing automatically via repo detection.

--- a/docs/tech/cli-startup-flow.md
+++ b/docs/tech/cli-startup-flow.md
@@ -243,13 +243,13 @@ flowchart TD
     A[get_base_dir] --> B{MONEYBIN_HOME<br/>env var set?}
     B -->|yes| C["Use $MONEYBIN_HOME"]
     B -->|no| D{MONEYBIN_ENVIRONMENT<br/>== 'development'?}
-    D -->|yes| E[Use cwd]
+    D -->|yes| E["Use cwd/.moneybin"]
     D -->|no| F{cwd is moneybin<br/>repo checkout?}
-    F -->|yes| G[Use cwd]
+    F -->|yes| G["Use cwd/.moneybin"]
     F -->|no| H["Use ~/.moneybin/"]
 ```
 
-In development (running from the repo), the base dir is the repo root, so profiles live at `<repo>/profiles/<name>/`. In production, they live at `~/.moneybin/profiles/<name>/`.
+In development (running from the repo), the base dir is `<repo>/.moneybin/`, so profiles live at `<repo>/.moneybin/profiles/<name>/`. In production, they live at `~/.moneybin/profiles/<name>/`.
 
 ## Invariants
 

--- a/src/moneybin/cli/commands/transform.py
+++ b/src/moneybin/cli/commands/transform.py
@@ -80,7 +80,7 @@ def transform_status() -> None:
             env = ctx.state_reader.get_environment("prod")
             if env:
                 logger.info("Environment: prod")
-                if env.finalized_ts:
+                if env.finalized_ts is not None:
                     finalized = datetime.fromtimestamp(
                         env.finalized_ts / 1000, tz=UTC
                     ).astimezone()

--- a/src/moneybin/cli/commands/transform.py
+++ b/src/moneybin/cli/commands/transform.py
@@ -5,6 +5,7 @@ loaded DuckDB data.
 """
 
 import logging
+from datetime import UTC, datetime
 
 import typer
 
@@ -79,7 +80,13 @@ def transform_status() -> None:
             env = ctx.state_reader.get_environment("prod")
             if env:
                 logger.info("Environment: prod")
-                logger.info(f"  Last updated: {env.expiration_ts}")
+                if env.finalized_ts:
+                    finalized = datetime.fromtimestamp(
+                        env.finalized_ts / 1000, tz=UTC
+                    ).astimezone()
+                    logger.info(f"  Last updated: {finalized:%Y-%m-%d %H:%M:%S %Z}")
+                else:
+                    logger.info("  Last updated: never finalized")
             else:
                 logger.info("No SQLMesh environment initialized yet")
                 logger.info("💡 Run 'moneybin transform apply' to initialize")

--- a/src/moneybin/config.py
+++ b/src/moneybin/config.py
@@ -43,8 +43,8 @@ def get_base_dir() -> Path:
 
     Resolution order:
         1. MONEYBIN_HOME env var (explicit override, always wins)
-        2. MONEYBIN_ENVIRONMENT=development: current working directory
-        3. Repo checkout detection (.git + pyproject.toml name=moneybin): cwd
+        2. MONEYBIN_ENVIRONMENT=development: <cwd>/.moneybin
+        3. Repo checkout detection (.git + pyproject.toml name=moneybin): <cwd>/.moneybin
         4. Default: ~/.moneybin/
 
     Returns:
@@ -58,10 +58,10 @@ def get_base_dir() -> Path:
 
     environment = os.getenv("MONEYBIN_ENVIRONMENT")
     if environment == "development":
-        return Path.cwd().resolve()
+        return (Path.cwd() / ".moneybin").resolve()
 
     if _is_moneybin_repo(Path.cwd()):
-        return Path.cwd().resolve()
+        return (Path.cwd() / ".moneybin").resolve()
 
     return (Path.home() / ".moneybin").resolve()
 

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -605,10 +605,18 @@ def sqlmesh_context(
 
     cache_key = str(db_path)
     try:
+        # Each new DuckDB cursor defaults to the `memory` catalog regardless of
+        # the parent connection's USE — without this, SQLMesh writes its state
+        # tables (_environments, _snapshots, _versions) into memory.sqlmesh.*
+        # and they evaporate at process exit.
+        def _pin_cursor_to_moneybin(cur: Any) -> None:
+            cur.execute(f"USE {_DATABASE_ALIAS}")
+
         adapter = DuckDBEngineAdapter(
             lambda: conn,
             default_catalog=_DATABASE_ALIAS,
             register_comments=True,
+            cursor_init=_pin_cursor_to_moneybin,
         )
         BaseDuckDBConnectionConfig._data_file_to_adapter[cache_key] = adapter  # type: ignore[reportPrivateUsage]  # no public API for encrypted DB injection
 

--- a/tests/e2e/test_e2e_mutating.py
+++ b/tests/e2e/test_e2e_mutating.py
@@ -209,6 +209,22 @@ class TestTransformMutating:
         result = run_cli("transform", "apply", env=env, timeout=180)
         result.assert_success()
 
+    def test_transform_state_persists_across_processes(self, tmp_path: Path) -> None:
+        """SQLMesh state must land in the encrypted moneybin catalog, not memory.
+
+        Regression: DuckDB cursors default to the `memory` catalog regardless
+        of the parent connection's USE. Without cursor_init pinning the cursor
+        to `moneybin`, SQLMesh writes _environments/_snapshots/_versions into
+        memory.sqlmesh.* and they evaporate on process exit — leaving `status`
+        to report "No SQLMesh environment initialized" right after `apply`.
+        """
+        env = make_workflow_env(tmp_path, "xformstate")
+        run_cli("transform", "apply", env=env, timeout=180).assert_success()
+        result = run_cli("transform", "status", env=env, timeout=60)
+        result.assert_success()
+        assert "Environment: prod" in result.output
+        assert "No SQLMesh environment initialized" not in result.output
+
     def test_transform_audit(self, tmp_path: Path) -> None:
         env = make_workflow_env(tmp_path, "xformaudit")
         result = run_cli(

--- a/tests/moneybin/test_cli/test_cli_transform.py
+++ b/tests/moneybin/test_cli/test_cli_transform.py
@@ -1,10 +1,13 @@
 """Tests for transform CLI commands."""
 
+import logging
 from collections.abc import Generator
 from contextlib import contextmanager
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
 from typer.testing import CliRunner
 
 from moneybin.cli.commands.transform import app
@@ -37,6 +40,56 @@ class TestTransformStatus:
         mock_ctx_factory.side_effect = ctx_fn
         result = runner.invoke(app, ["status"])
         assert result.exit_code == 0
+
+    @patch("moneybin.cli.commands.transform.get_database")
+    @patch("moneybin.cli.commands.transform.sqlmesh_context")
+    def test_status_formats_finalized_timestamp(
+        self,
+        mock_ctx_factory: MagicMock,
+        _mock_get_db: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """finalized_ts (epoch ms) is rendered as a local-time string."""
+        ctx_fn, mock_ctx = _mock_sqlmesh_context()
+        env = MagicMock()
+        # 2026-01-15 12:34:56 UTC in epoch milliseconds.
+        env.finalized_ts = int(
+            datetime(2026, 1, 15, 12, 34, 56, tzinfo=UTC).timestamp() * 1000
+        )
+        mock_ctx.state_reader.get_environment.return_value = env
+        mock_ctx_factory.side_effect = ctx_fn
+
+        with caplog.at_level(logging.INFO, logger="moneybin.cli.commands.transform"):
+            result = runner.invoke(app, ["status"])
+
+        assert result.exit_code == 0
+        expected = (
+            datetime(2026, 1, 15, 12, 34, 56, tzinfo=UTC)
+            .astimezone()
+            .strftime("%Y-%m-%d %H:%M:%S %Z")
+        )
+        assert f"Last updated: {expected}" in caplog.text
+
+    @patch("moneybin.cli.commands.transform.get_database")
+    @patch("moneybin.cli.commands.transform.sqlmesh_context")
+    def test_status_reports_never_finalized_when_null(
+        self,
+        mock_ctx_factory: MagicMock,
+        _mock_get_db: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Missing finalized_ts is reported as 'never finalized'."""
+        ctx_fn, mock_ctx = _mock_sqlmesh_context()
+        env = MagicMock()
+        env.finalized_ts = None
+        mock_ctx.state_reader.get_environment.return_value = env
+        mock_ctx_factory.side_effect = ctx_fn
+
+        with caplog.at_level(logging.INFO, logger="moneybin.cli.commands.transform"):
+            result = runner.invoke(app, ["status"])
+
+        assert result.exit_code == 0
+        assert "Last updated: never finalized" in caplog.text
 
 
 class TestTransformValidate:

--- a/tests/moneybin/test_get_base_dir.py
+++ b/tests/moneybin/test_get_base_dir.py
@@ -24,7 +24,9 @@ class TestGetBaseDir:
         monkeypatch.delenv("MONEYBIN_ENVIRONMENT", raising=False)
         assert get_base_dir() == (Path.home() / "custom-moneybin").resolve()
 
-    def test_development_env_uses_cwd(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_development_env_uses_dot_moneybin(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Priority 2: MONEYBIN_ENVIRONMENT=development uses <cwd>/.moneybin."""
         monkeypatch.delenv("MONEYBIN_HOME", raising=False)
         monkeypatch.setenv("MONEYBIN_ENVIRONMENT", "development")

--- a/tests/moneybin/test_get_base_dir.py
+++ b/tests/moneybin/test_get_base_dir.py
@@ -25,21 +25,21 @@ class TestGetBaseDir:
         assert get_base_dir() == (Path.home() / "custom-moneybin").resolve()
 
     def test_development_env_uses_cwd(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Priority 2: MONEYBIN_ENVIRONMENT=development uses cwd."""
+        """Priority 2: MONEYBIN_ENVIRONMENT=development uses <cwd>/.moneybin."""
         monkeypatch.delenv("MONEYBIN_HOME", raising=False)
         monkeypatch.setenv("MONEYBIN_ENVIRONMENT", "development")
-        assert get_base_dir() == Path.cwd().resolve()
+        assert get_base_dir() == (Path.cwd() / ".moneybin").resolve()
 
     def test_repo_checkout_detected(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Priority 3: .git + pyproject.toml with name='moneybin' uses cwd."""
+        """Priority 3: .git + pyproject.toml with name='moneybin' uses <cwd>/.moneybin."""
         monkeypatch.delenv("MONEYBIN_HOME", raising=False)
         monkeypatch.delenv("MONEYBIN_ENVIRONMENT", raising=False)
         (tmp_path / ".git").mkdir()
         (tmp_path / "pyproject.toml").write_text('[project]\nname = "moneybin"\n')
         monkeypatch.chdir(tmp_path)
-        assert get_base_dir() == tmp_path.resolve()
+        assert get_base_dir() == (tmp_path / ".moneybin").resolve()
 
     def test_repo_checkout_wrong_project_name(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
### Summary
SQLMesh state tables were being written into DuckDB's in-memory catalog instead of the encrypted `moneybin` database, so `transform status` reported "No SQLMesh environment initialized" immediately after a successful `transform apply`. This PR pins every SQLMesh cursor to the `moneybin` catalog and fixes the timestamp displayed by `transform status`.

### Impact
No workflow changes. Existing users who ran `transform apply` before this fix will need to re-run it once — prior runs left no persisted state.

### Changes

#### Pin SQLMesh cursors to the encrypted catalog
DuckDB cursors default to the `memory` catalog regardless of the parent connection's `USE`. We now pass `cursor_init=lambda cur: cur.execute("USE moneybin")` to `DuckDBEngineAdapter`, ensuring SQLMesh's state writes land in the encrypted database.

#### Correct `transform status` timestamp
- Read `finalized_ts` (epoch ms) instead of `expiration_ts`
- Convert to local time for display; show "never finalized" when null

#### Dev base-dir change (prior commit on branch)
- `08cfb3a` switches the dev profile base dir to `<cwd>/.moneybin` instead of bare `cwd`

### Testing
- New E2E test `test_transform_state_persists_across_processes` runs `apply` then `status` in separate subprocesses and verifies the prod environment is visible
- Existing transform E2E tests still pass