### PR TITLE
Refactor tabular import internals

### DIFF
--- a/docs/superpowers/plans/2026-04-25-tabular-cleanup-stream-a-refactor.md
+++ b/docs/superpowers/plans/2026-04-25-tabular-cleanup-stream-a-refactor.md
@@ -1,0 +1,932 @@
+# Tabular Import Cleanup — Stream A (Internal Refactor) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tighten internals of the tabular import pipeline — extract a `ResolvedMapping` dataclass, thread `Literal` types through service layer, move balance-validation tunables to config, and extract the repeated `DatabaseKeyError` handler — all with no behavior change.
+
+**Architecture:** Pure refactor inside the existing five-stage pipeline. Three of the four sub-tasks are local to `services/import_service.py`, `extractors/tabular/`, and `cli/commands/`. One (`A4`) introduces a small new module under `cli/`.
+
+**Tech Stack:** Python 3.12, Pydantic v2, Typer, Polars, DuckDB. Tests: pytest.
+
+**Branch:** `refactor/tabular-import-cleanup-stream-a`
+
+**Spec:** [docs/specs/tabular-import-cleanup.md](../../specs/tabular-import-cleanup.md) §Stream A
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/moneybin/extractors/tabular/column_mapper.py` | Column mapping with `MappingResult` dataclass | Modify — change `MappingResult.sign_convention` and `MappingResult.number_format` to `SignConventionType` / `NumberFormatType` |
+| `src/moneybin/services/import_service.py` | `_import_tabular()` — resolves mapping, runs transform, loads | Modify — replace 6 unpacked locals with `ResolvedMapping` instance |
+| `src/moneybin/extractors/tabular/transforms.py` | `transform_dataframe()` and `_validate_running_balance()` | Modify — accept `Literal` types; thread `pass_threshold` and `tolerance` from config |
+| `src/moneybin/config.py` | `TabularConfig` Pydantic model | Modify — add `balance_pass_threshold` and `balance_tolerance_cents` fields |
+| `src/moneybin/cli/utils.py` | New: shared CLI helpers | **Create** — house `handle_database_errors` context manager |
+| `src/moneybin/cli/commands/{import_cmd,stats,matches,categorize,synthetic,mcp,db,migrate,transform}.py` | CLI commands using `get_database()` | Modify — call sites replace 5-line except blocks with `with handle_database_errors() as db:` |
+| `tests/moneybin/test_services/test_tabular_import_service.py` | Existing tabular import service test | Modify — add `ResolvedMapping` round-trip test |
+| `tests/moneybin/test_extractors/test_tabular/test_transforms.py` | Existing balance-validation test (or new file) | Modify — assert config-driven thresholds |
+| `tests/moneybin/test_cli/test_handle_database_errors.py` | New: tests for the context manager | **Create** |
+
+The new `ResolvedMapping` dataclass is local to `import_service.py` (private — only one caller). The `handle_database_errors` helper goes in a new `cli/utils.py` module so all CLI command modules can import it without coupling to any specific command.
+
+---
+
+## Task 1: Add `balance_pass_threshold` and `balance_tolerance_cents` to `TabularConfig`
+
+**Files:**
+- Modify: `src/moneybin/config.py:119-139` (`TabularConfig` body)
+- Test: `tests/moneybin/test_config_profiles.py` (existing) — append a unit test asserting defaults
+
+This task lands the config plumbing first so later tasks can consume it.
+
+- [ ] **Step 1.1: Write the failing test**
+
+Append to `tests/moneybin/test_config_profiles.py`:
+
+```python
+def test_tabular_config_balance_validation_defaults() -> None:
+    """TabularConfig exposes balance validation tunables with safe defaults."""
+    from moneybin.config import TabularConfig
+
+    cfg = TabularConfig()
+    assert cfg.balance_pass_threshold == 0.90
+    assert cfg.balance_tolerance_cents == 1
+
+
+def test_tabular_config_balance_validation_overrides() -> None:
+    """Caller can override balance validation tunables."""
+    from moneybin.config import TabularConfig
+
+    cfg = TabularConfig(balance_pass_threshold=0.95, balance_tolerance_cents=5)
+    assert cfg.balance_pass_threshold == 0.95
+    assert cfg.balance_tolerance_cents == 5
+```
+
+- [ ] **Step 1.2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/moneybin/test_config_profiles.py::test_tabular_config_balance_validation_defaults -v`
+Expected: FAIL with `AttributeError: 'TabularConfig' object has no attribute 'balance_pass_threshold'`
+
+- [ ] **Step 1.3: Add the fields to `TabularConfig`**
+
+Edit `src/moneybin/config.py`, after the `row_refuse_threshold` field inside `TabularConfig` (line 136-139):
+
+```python
+    balance_pass_threshold: float = Field(
+        default=0.90,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Minimum fraction of balance deltas that must match "
+            "for balance validation to pass"
+        ),
+    )
+    balance_tolerance_cents: int = Field(
+        default=1,
+        ge=0,
+        description="Per-delta tolerance in cents for balance validation",
+    )
+```
+
+- [ ] **Step 1.4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/moneybin/test_config_profiles.py -v -k balance_validation`
+Expected: 2 passed
+
+- [ ] **Step 1.5: Run type check**
+
+Run: `uv run pyright src/moneybin/config.py`
+Expected: 0 errors
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add src/moneybin/config.py tests/moneybin/test_config_profiles.py
+git commit -m "Add balance validation tunables to TabularConfig"
+```
+
+---
+
+## Task 2: Thread balance-validation config into `_validate_running_balance`
+
+**Files:**
+- Modify: `src/moneybin/extractors/tabular/transforms.py:94-326` (`transform_dataframe`)
+- Modify: `src/moneybin/extractors/tabular/transforms.py:463-557` (`_validate_running_balance`)
+- Test: `tests/moneybin/test_extractors/test_tabular/test_transforms.py` (existing or create)
+
+The current implementation hardcodes `_balance_tolerance = Decimal("0.01")` and `_pass_threshold = 0.90` inside the function body. After this task, `transform_dataframe` accepts these as keyword arguments with the same defaults, and `_import_tabular` will pass them in from `get_settings().data.tabular`.
+
+- [ ] **Step 2.1: Write the failing test**
+
+If `tests/moneybin/test_extractors/test_tabular/test_transforms.py` does not exist, create it. Append (or write) this test:
+
+```python
+"""Tests for the tabular transform stage."""
+
+from decimal import Decimal
+
+import polars as pl
+
+from moneybin.extractors.tabular.transforms import transform_dataframe
+
+
+def _make_df() -> pl.DataFrame:
+    """Three rows with a perfectly consistent running balance."""
+    return pl.DataFrame({
+        "Date": ["2025-01-01", "2025-01-02", "2025-01-03"],
+        "Description": ["a", "b", "c"],
+        "Amount": ["-10.00", "-20.00", "5.00"],
+        "Balance": ["100.00", "80.00", "85.00"],
+    })
+
+
+def test_transform_uses_custom_balance_tolerance_cents() -> None:
+    """A high tolerance accepts deltas that the default would reject."""
+    df = pl.DataFrame({
+        "Date": ["2025-01-01", "2025-01-02"],
+        "Description": ["a", "b"],
+        # Amount is off by 10 cents from the balance delta
+        "Amount": ["-10.00", "-19.90"],
+        "Balance": ["100.00", "80.00"],
+    })
+    field_mapping = {
+        "transaction_date": "Date",
+        "description": "Description",
+        "amount": "Amount",
+        "balance": "Balance",
+    }
+    result = transform_dataframe(
+        df=df,
+        field_mapping=field_mapping,
+        date_format="%Y-%m-%d",
+        sign_convention="negative_is_expense",
+        number_format="us",
+        account_id="acct1",
+        source_file="t.csv",
+        source_type="csv",
+        source_origin="t",
+        import_id="imp1",
+        balance_pass_threshold=0.90,
+        balance_tolerance_cents=20,  # 0.20 — accepts the 0.10 mismatch
+    )
+    assert result.balance_validated is True
+
+
+def test_transform_default_tolerance_rejects_off_by_ten_cents() -> None:
+    """Default 1-cent tolerance rejects a 10-cent delta mismatch."""
+    df = pl.DataFrame({
+        "Date": ["2025-01-01", "2025-01-02"],
+        "Description": ["a", "b"],
+        "Amount": ["-10.00", "-19.90"],
+        "Balance": ["100.00", "80.00"],
+    })
+    field_mapping = {
+        "transaction_date": "Date",
+        "description": "Description",
+        "amount": "Amount",
+        "balance": "Balance",
+    }
+    result = transform_dataframe(
+        df=df,
+        field_mapping=field_mapping,
+        date_format="%Y-%m-%d",
+        sign_convention="negative_is_expense",
+        number_format="us",
+        account_id="acct1",
+        source_file="t.csv",
+        source_type="csv",
+        source_origin="t",
+        import_id="imp1",
+    )
+    # forward 0/1, inverted 0/1 — neither passes
+    assert result.balance_validated is False
+```
+
+- [ ] **Step 2.2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/moneybin/test_extractors/test_tabular/test_transforms.py -v`
+Expected: FAIL with `TypeError: transform_dataframe() got an unexpected keyword argument 'balance_pass_threshold'`
+
+- [ ] **Step 2.3: Add the new parameters to `transform_dataframe`**
+
+Edit `src/moneybin/extractors/tabular/transforms.py`. In the `transform_dataframe` signature (around line 94-106), add two keyword-only parameters with defaults:
+
+```python
+def transform_dataframe(
+    *,
+    df: pl.DataFrame,
+    field_mapping: dict[str, str],
+    date_format: str,
+    sign_convention: str,
+    number_format: str,
+    account_id: str | list[str],
+    source_file: str,
+    source_type: str,
+    source_origin: str,
+    import_id: str,
+    balance_pass_threshold: float = 0.90,
+    balance_tolerance_cents: int = 1,
+) -> TransformResult:
+```
+
+In the same function, find the `_validate_running_balance(...)` call near the end (around line 324). Pass the new arguments through:
+
+```python
+            result = _validate_running_balance(
+                result,
+                balance_strs,
+                number_format,
+                pass_threshold=balance_pass_threshold,
+                tolerance_cents=balance_tolerance_cents,
+            )
+```
+
+Update `_validate_running_balance` signature (around line 463-468):
+
+```python
+def _validate_running_balance(
+    result: TransformResult,
+    balance_strs: list[str],
+    number_format: str,
+    *,
+    pass_threshold: float = 0.90,
+    tolerance_cents: int = 1,
+) -> TransformResult:
+```
+
+Inside the function body, replace:
+
+```python
+    _balance_tolerance = Decimal("0.01")
+    _pass_threshold = 0.90
+```
+
+with:
+
+```python
+    _balance_tolerance = (Decimal(tolerance_cents) / Decimal(100)).quantize(
+        Decimal("0.01")
+    )
+    _pass_threshold = pass_threshold
+```
+
+Leave the rest of the function unchanged — `_balance_tolerance` and `_pass_threshold` are still referenced below.
+
+- [ ] **Step 2.4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/moneybin/test_extractors/test_tabular/test_transforms.py -v`
+Expected: 2 passed
+
+- [ ] **Step 2.5: Run the full transforms test suite to verify no regression**
+
+Run: `uv run pytest tests/moneybin/test_extractors/test_tabular/ -v`
+Expected: all green
+
+- [ ] **Step 2.6: Wire `_import_tabular` to read from config**
+
+Edit `src/moneybin/services/import_service.py`. In `_import_tabular`, before the `transform_dataframe(...)` call (around line 451), add:
+
+```python
+    from moneybin.config import get_settings
+
+    tabular_cfg = get_settings().data.tabular
+```
+
+(If `get_settings` is already imported in another scope inside the function via `_run_matching`, leave that alone — keep the local import for clarity.)
+
+Then update the `transform_dataframe(...)` call to pass through the two new kwargs:
+
+```python
+        transform_result = transform_dataframe(
+            df=df,
+            field_mapping=mapping_result_mapping,
+            date_format=mapping_result_date_format,
+            sign_convention=mapping_result_sign_convention,
+            number_format=mapping_result_number_format,
+            account_id=account_ids,
+            source_file=str(file_path),
+            source_type=source_type,
+            source_origin=source_origin,
+            import_id=import_id,
+            balance_pass_threshold=tabular_cfg.balance_pass_threshold,
+            balance_tolerance_cents=tabular_cfg.balance_tolerance_cents,
+        )
+```
+
+- [ ] **Step 2.7: Run the broader test suite**
+
+Run: `uv run pytest tests/moneybin/test_services/test_tabular_import_service.py tests/moneybin/test_extractors/test_tabular/ -v`
+Expected: all green
+
+- [ ] **Step 2.8: Commit**
+
+```bash
+git add src/moneybin/extractors/tabular/transforms.py \
+        src/moneybin/services/import_service.py \
+        tests/moneybin/test_extractors/test_tabular/test_transforms.py
+git commit -m "Move tabular balance-validation tunables to TabularConfig"
+```
+
+---
+
+## Task 3: Tighten `Literal` types through `column_mapper` → `transforms`
+
+**Files:**
+- Modify: `src/moneybin/extractors/tabular/column_mapper.py:44-77` (`MappingResult` dataclass)
+- Modify: `src/moneybin/extractors/tabular/transforms.py:94-106` (`transform_dataframe` signature)
+- Modify: `src/moneybin/extractors/tabular/transforms.py:362-368` (`_extract_amounts` signature)
+
+`SignConventionType` and `NumberFormatType` already exist in `extractors/tabular/formats.py:28-31`. This task just imports them where they belong.
+
+- [ ] **Step 3.1: Update `MappingResult` to use the literal types**
+
+Edit `src/moneybin/extractors/tabular/column_mapper.py`. Add to the imports (around line 12):
+
+```python
+from moneybin.extractors.tabular.formats import (
+    NumberFormatType,
+    SignConventionType,
+)
+```
+
+Update the `MappingResult` dataclass (around line 44-77):
+
+```python
+@dataclass
+class MappingResult:
+    """Result of column mapping (Stage 3 output)."""
+
+    field_mapping: dict[str, str]
+    """Destination field → source column name."""
+
+    confidence: str
+    """Confidence tier: high, medium, low."""
+
+    date_format: str | None = None
+    """Detected date format string."""
+
+    number_format: NumberFormatType = "us"
+    """Detected number format convention."""
+
+    sign_convention: SignConventionType = "negative_is_expense"
+    """Detected sign convention."""
+
+    sign_needs_confirmation: bool = False
+    """True if sign convention is ambiguous."""
+
+    is_multi_account: bool = False
+    """True if account-identifying columns were detected."""
+
+    unmapped_columns: list[str] = field(default_factory=list)
+    """Source columns with no destination field match."""
+
+    flagged_fields: list[str] = field(default_factory=list)
+    """Fields matched with low confidence (content-only)."""
+
+    sample_values: dict[str, list[str]] = field(default_factory=dict)
+    """Sample values for each mapped field."""
+```
+
+- [ ] **Step 3.2: Update `transform_dataframe` signature**
+
+Edit `src/moneybin/extractors/tabular/transforms.py`. Add to imports (around line 17-22):
+
+```python
+from moneybin.extractors.tabular.formats import (
+    NumberFormatType,
+    SignConventionType,
+)
+```
+
+Update the signature so `sign_convention` and `number_format` use literals:
+
+```python
+def transform_dataframe(
+    *,
+    df: pl.DataFrame,
+    field_mapping: dict[str, str],
+    date_format: str,
+    sign_convention: SignConventionType,
+    number_format: NumberFormatType,
+    account_id: str | list[str],
+    source_file: str,
+    source_type: str,
+    source_origin: str,
+    import_id: str,
+    balance_pass_threshold: float = 0.90,
+    balance_tolerance_cents: int = 1,
+) -> TransformResult:
+```
+
+Apply the same change to `_extract_amounts` (around line 362-368):
+
+```python
+def _extract_amounts(
+    *,
+    df: pl.DataFrame,
+    field_mapping: dict[str, str],
+    sign_convention: SignConventionType,
+    number_format: NumberFormatType,
+) -> tuple[list[Decimal | None], dict[int, str]]:
+```
+
+- [ ] **Step 3.3: Run pyright on touched files**
+
+Run: `uv run pyright src/moneybin/extractors/tabular/transforms.py src/moneybin/extractors/tabular/column_mapper.py src/moneybin/services/import_service.py`
+Expected: 0 errors. (`_import_tabular` already reads from `TabularFormat`'s typed fields and validates CLI overrides against the literal sets — the call sites are already type-correct, so no changes needed there.)
+
+- [ ] **Step 3.4: Run the affected test suites**
+
+Run: `uv run pytest tests/moneybin/test_extractors/test_tabular/ tests/moneybin/test_services/test_tabular_import_service.py -v`
+Expected: all green.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add src/moneybin/extractors/tabular/column_mapper.py \
+        src/moneybin/extractors/tabular/transforms.py
+git commit -m "Use Literal types for sign_convention and number_format in tabular pipeline"
+```
+
+---
+
+## Task 4: Extract `ResolvedMapping` dataclass in `_import_tabular`
+
+**Files:**
+- Modify: `src/moneybin/services/import_service.py:239-557` (`_import_tabular`)
+- Test: `tests/moneybin/test_services/test_tabular_import_service.py` — add a focused unit test
+
+The current code unpacks 6 locals (`mapping_result_mapping`, `_date_format`, `_sign_convention`, `_number_format`, `_is_multi_account`, `_confidence`, `format_source`) in two branches around lines 355-373 of `import_service.py`. This task replaces them with a single `ResolvedMapping` instance.
+
+- [ ] **Step 4.1: Write the failing test**
+
+Add to `tests/moneybin/test_services/test_tabular_import_service.py`:
+
+```python
+def test_resolved_mapping_round_trip() -> None:
+    """ResolvedMapping is constructible and exposes the resolved tabular fields."""
+    from moneybin.services.import_service import ResolvedMapping
+
+    rm = ResolvedMapping(
+        field_mapping={"transaction_date": "Date", "amount": "Amt"},
+        date_format="%Y-%m-%d",
+        sign_convention="negative_is_expense",
+        number_format="us",
+        is_multi_account=False,
+        confidence="high",
+    )
+    assert rm.field_mapping["amount"] == "Amt"
+    assert rm.sign_convention == "negative_is_expense"
+    # Frozen — assignment must raise
+    import dataclasses
+
+    try:
+        rm.confidence = "low"  # type: ignore[misc]
+    except dataclasses.FrozenInstanceError:
+        pass
+    else:
+        raise AssertionError("ResolvedMapping must be frozen")
+```
+
+- [ ] **Step 4.2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/moneybin/test_services/test_tabular_import_service.py::test_resolved_mapping_round_trip -v`
+Expected: FAIL with `ImportError: cannot import name 'ResolvedMapping'`
+
+- [ ] **Step 4.3: Define `ResolvedMapping` in `import_service.py`**
+
+Edit `src/moneybin/services/import_service.py`. Near the top of the file, after the existing `ImportResult` dataclass (after line 60), insert:
+
+```python
+from moneybin.extractors.tabular.formats import (
+    NumberFormatType,
+    SignConventionType,
+)
+
+
+@dataclass(frozen=True)
+class ResolvedMapping:
+    """Final per-import mapping from the matched format or auto-detection.
+
+    Both the matched-format branch and the auto-detect branch in
+    ``_import_tabular`` produce one of these. Downstream code reads from
+    the instance instead of six unpacked local variables.
+    """
+
+    field_mapping: dict[str, str]
+    date_format: str
+    sign_convention: SignConventionType
+    number_format: NumberFormatType
+    is_multi_account: bool
+    confidence: str
+```
+
+- [ ] **Step 4.4: Refactor the two branches in `_import_tabular`**
+
+In `_import_tabular`, replace the block at lines 355-386 (matched-format vs auto-detect) with:
+
+```python
+    if matched_format:
+        resolved = ResolvedMapping(
+            field_mapping=matched_format.field_mapping,
+            date_format=matched_format.date_format,
+            sign_convention=matched_format.sign_convention,
+            number_format=matched_format.number_format,
+            is_multi_account=matched_format.multi_account,
+            confidence="high",
+        )
+        format_source = (
+            "built-in" if matched_format.name in builtin_formats else "saved"
+        )
+    else:
+        mapping_result = map_columns(df, overrides=overrides)
+        resolved = ResolvedMapping(
+            field_mapping=mapping_result.field_mapping,
+            date_format=mapping_result.date_format or "%Y-%m-%d",
+            sign_convention=mapping_result.sign_convention,
+            number_format=mapping_result.number_format,
+            is_multi_account=mapping_result.is_multi_account,
+            confidence=mapping_result.confidence,
+        )
+        format_source = "detected"
+
+        if mapping_result.sign_needs_confirmation and not sign:
+            logger.warning(
+                "⚠️  Sign convention is ambiguous (all amounts appear positive). "
+                f"Proceeding with '{resolved.sign_convention}' — "
+                "use --sign to override if expense amounts look wrong."
+            )
+
+        if mapping_result.confidence == "low":
+            raise ValueError(
+                f"Could not reliably detect column mapping for "
+                f"{file_path.name}. Use --override to specify columns manually."
+            )
+```
+
+The CLI overrides block (currently around lines 395-401) becomes:
+
+```python
+    # Apply CLI overrides — rebuild a new ResolvedMapping (frozen)
+    if sign or date_format_override or number_format_override:
+        resolved = dataclasses.replace(
+            resolved,
+            sign_convention=sign or resolved.sign_convention,  # type: ignore[arg-type]  # CLI validates against the literal set
+            date_format=date_format_override or resolved.date_format,
+            number_format=number_format_override or resolved.number_format,  # type: ignore[arg-type]  # CLI validates against the literal set
+        )
+```
+
+Add `import dataclasses` to the top-level imports if not already present.
+
+Replace every remaining reference to `mapping_result_mapping`, `mapping_result_date_format`, `mapping_result_sign_convention`, `mapping_result_number_format`, `mapping_result_is_multi_account`, `mapping_result_confidence` with `resolved.field_mapping`, `resolved.date_format`, `resolved.sign_convention`, `resolved.number_format`, `resolved.is_multi_account`, `resolved.confidence`. Pay attention to:
+
+- `TABULAR_DETECTION_CONFIDENCE.labels(...)` (around line 393)
+- `acct_name_col = mapping_result_mapping.get("account_name")` (around line 409)
+- the `mapping_result_is_multi_account` check (around line 420)
+- the `transform_dataframe(...)` keyword arguments (around lines 451-463)
+- the `loader.finalize_import_batch(...)` call (around lines 496-512)
+- the `auto-save format` block (around lines 530-551) — including the `confidence in ("high", "medium")` check and `field_mapping=resolved.field_mapping`, etc.
+
+The `# type: ignore[reportArgumentType]` comments on `sign_convention` and `number_format` in the `TabularFormat(...)` construction (around lines 545, 547) can now be removed — both are already `SignConventionType` / `NumberFormatType`.
+
+- [ ] **Step 4.5: Run the failing test to verify it passes**
+
+Run: `uv run pytest tests/moneybin/test_services/test_tabular_import_service.py::test_resolved_mapping_round_trip -v`
+Expected: PASS
+
+- [ ] **Step 4.6: Run the full tabular test suite**
+
+Run: `uv run pytest tests/moneybin/test_services/test_tabular_import_service.py tests/moneybin/test_extractors/test_tabular/ tests/moneybin/test_loaders/ -v`
+Expected: all green.
+
+- [ ] **Step 4.7: Run pyright on the modified file**
+
+Run: `uv run pyright src/moneybin/services/import_service.py`
+Expected: 0 errors.
+
+- [ ] **Step 4.8: Run the E2E import workflow as a smoke test**
+
+Run: `uv run pytest tests/e2e/test_e2e_workflows.py -v -k tabular`
+Expected: all green. (If no tabular E2E test exists, run `tests/e2e/test_e2e_workflows.py -v` and confirm nothing regresses.)
+
+- [ ] **Step 4.9: Commit**
+
+```bash
+git add src/moneybin/services/import_service.py \
+        tests/moneybin/test_services/test_tabular_import_service.py
+git commit -m "Extract ResolvedMapping dataclass in _import_tabular"
+```
+
+---
+
+## Task 5: Extract `handle_database_errors` context manager
+
+**Files:**
+- Create: `src/moneybin/cli/utils.py`
+- Test: `tests/moneybin/test_cli/test_handle_database_errors.py` (create)
+- Modify (call sites — see step 5.4 for the full list): `src/moneybin/cli/commands/{import_cmd,stats,matches,categorize,synthetic,mcp,db,migrate,transform}.py`
+
+The existing pattern (verified via grep) is repeated **30+ times** across 9 CLI command modules. Each occurrence is the same 5-line block:
+
+```python
+    except DatabaseKeyError as e:
+        from moneybin.database import database_key_error_hint
+
+        logger.error(f"❌ {e}")
+        logger.info(database_key_error_hint())
+        raise typer.Exit(1) from e
+```
+
+Per `.claude/rules/cli.md`: "Recovery messages containing keys, tokens, or credentials must go to stderr via `typer.echo(..., err=True)` — **never through `logger.*()`**." But `database_key_error_hint()` returns a generic instructional message ("run `moneybin db unlock`") with no secret values, so the existing `logger.info` is acceptable. Keep that behavior — refactor only the structure, not the channel. Verify by reading `database_key_error_hint()` in `src/moneybin/database.py` before continuing.
+
+- [ ] **Step 5.1: Write the failing tests**
+
+Create `tests/moneybin/test_cli/test_handle_database_errors.py`:
+
+```python
+"""Tests for the shared CLI database-error handler."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+
+from moneybin.database import DatabaseKeyError
+
+
+def test_handle_database_errors_yields_database() -> None:
+    """When get_database succeeds, the context manager yields the Database."""
+    from moneybin.cli.utils import handle_database_errors
+
+    fake_db = MagicMock()
+    with patch("moneybin.cli.utils.get_database", return_value=fake_db):
+        with handle_database_errors() as db:
+            assert db is fake_db
+
+
+def test_handle_database_errors_translates_key_error_to_exit(caplog) -> None:
+    """DatabaseKeyError is caught, logged, and converted to typer.Exit(1)."""
+    from moneybin.cli.utils import handle_database_errors
+
+    with patch(
+        "moneybin.cli.utils.get_database",
+        side_effect=DatabaseKeyError("locked"),
+    ):
+        with caplog.at_level("ERROR"), pytest.raises(typer.Exit) as exc_info:
+            with handle_database_errors():
+                pass
+    assert exc_info.value.exit_code == 1
+    assert "locked" in caplog.text
+
+
+def test_handle_database_errors_lets_other_exceptions_propagate() -> None:
+    """Non-DatabaseKeyError exceptions raised inside the block pass through."""
+    from moneybin.cli.utils import handle_database_errors
+
+    fake_db = MagicMock()
+    with patch("moneybin.cli.utils.get_database", return_value=fake_db):
+        with pytest.raises(RuntimeError, match="boom"):
+            with handle_database_errors():
+                raise RuntimeError("boom")
+```
+
+- [ ] **Step 5.2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/moneybin/test_cli/test_handle_database_errors.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'moneybin.cli.utils'`
+
+- [ ] **Step 5.3: Create `src/moneybin/cli/utils.py`**
+
+```python
+"""Shared helpers for CLI commands."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import typer
+
+from moneybin.database import (
+    Database,
+    DatabaseKeyError,
+    database_key_error_hint,
+    get_database,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def handle_database_errors() -> Iterator[Database]:
+    """Get the active database with standard CLI error handling.
+
+    Catches ``DatabaseKeyError`` (raised when the encryption key is not
+    available — e.g. database is locked), logs a user-facing error and the
+    standard ``moneybin db unlock`` hint, and exits with code 1. All other
+    exceptions propagate unchanged so callers can handle them.
+    """
+    try:
+        db = get_database()
+    except DatabaseKeyError as e:
+        logger.error(f"❌ {e}")
+        logger.info(database_key_error_hint())
+        raise typer.Exit(1) from e
+
+    yield db
+```
+
+- [ ] **Step 5.4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/moneybin/test_cli/test_handle_database_errors.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 5.5: Run pyright**
+
+Run: `uv run pyright src/moneybin/cli/utils.py`
+Expected: 0 errors.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add src/moneybin/cli/utils.py tests/moneybin/test_cli/test_handle_database_errors.py
+git commit -m "Add handle_database_errors context manager for CLI commands"
+```
+
+---
+
+## Task 6: Migrate CLI command call sites to `handle_database_errors`
+
+**Files (call sites to refactor — verify each line range against the current file before editing):**
+
+Use grep to enumerate every match before editing:
+
+```bash
+grep -rn "except DatabaseKeyError" src/moneybin/cli/commands/
+```
+
+Expect ~30 occurrences across these modules:
+
+- `src/moneybin/cli/commands/import_cmd.py` (5 sites: lines ~219, ~260, ~330, ~604, ~639)
+- `src/moneybin/cli/commands/stats.py` (1 site)
+- `src/moneybin/cli/commands/matches.py` (5 sites)
+- `src/moneybin/cli/commands/categorize.py` (4 sites)
+- `src/moneybin/cli/commands/synthetic.py` — check
+- `src/moneybin/cli/commands/mcp.py` — check
+- `src/moneybin/cli/commands/db.py` — check
+- `src/moneybin/cli/commands/migrate.py` — check
+- `src/moneybin/cli/commands/transform.py` — check
+
+For each call site, the typical *before* shape is:
+
+```python
+def some_command(...) -> None:
+    setup_logging(cli_mode=True)
+    try:
+        db = get_database()
+        # ... work using db ...
+    except DatabaseKeyError as e:
+        from moneybin.database import database_key_error_hint
+
+        logger.error(f"❌ {e}")
+        logger.info(database_key_error_hint())
+        raise typer.Exit(1) from e
+    except ValueError as e:
+        ...
+```
+
+The *after* shape:
+
+```python
+def some_command(...) -> None:
+    setup_logging(cli_mode=True)
+    try:
+        with handle_database_errors() as db:
+            # ... work using db ...
+    except ValueError as e:
+        ...
+```
+
+Subtleties:
+
+1. The original handler runs *before* other excepts because `get_database()` is the first call inside `try`. The new shape puts `handle_database_errors()` *outside* the rest of the try, so other excepts must remain at the outer level. The shape above (outer `try` wrapping `with handle_database_errors() as db:`) preserves that order.
+2. If a function only catches `DatabaseKeyError` (no other excepts), the shape simplifies to just `with handle_database_errors() as db: ...` — no outer try needed.
+3. Remove the now-unused `from moneybin.database import DatabaseKeyError, get_database` import — replace with `from moneybin.cli.utils import handle_database_errors`. If `get_database` is still used elsewhere in the same file (e.g., outside any handler), keep that part of the import.
+4. Remove the inline `from moneybin.database import database_key_error_hint` — it's unused after the refactor.
+
+- [ ] **Step 6.1: Refactor `src/moneybin/cli/commands/import_cmd.py`**
+
+Read the file to confirm the exact shape of each of the 5 sites at lines ~170, ~219, ~253, ~314, ~330, ~583, ~604, ~627, ~639. For each command (`import_file`, `import_history`, `import_revert`, `delete_format`, `import_status`), apply the *before*/*after* transformation above.
+
+Verify after edits: `grep -n "except DatabaseKeyError\|database_key_error_hint" src/moneybin/cli/commands/import_cmd.py` — expect zero matches.
+
+Run the relevant tests:
+
+```bash
+uv run pytest tests/moneybin/test_cli/ -v -k import
+uv run pyright src/moneybin/cli/commands/import_cmd.py
+```
+
+Expected: green.
+
+- [ ] **Step 6.2: Refactor `src/moneybin/cli/commands/stats.py`**
+
+Apply the same pattern to the single site at line ~42.
+
+Verify: `grep -n "except DatabaseKeyError" src/moneybin/cli/commands/stats.py` — expect zero matches.
+
+Run: `uv run pytest tests/moneybin/test_stats_command.py -v && uv run pyright src/moneybin/cli/commands/stats.py`
+Expected: green.
+
+- [ ] **Step 6.3: Refactor `src/moneybin/cli/commands/matches.py`**
+
+Apply the same pattern to the 5 sites at lines ~52, ~214, ~260, ~287, ~330. Verify and run:
+
+```bash
+grep -n "except DatabaseKeyError" src/moneybin/cli/commands/matches.py  # expect 0
+uv run pytest tests/moneybin/test_cli/ -v -k matches
+uv run pyright src/moneybin/cli/commands/matches.py
+```
+
+- [ ] **Step 6.4: Refactor `src/moneybin/cli/commands/categorize.py`**
+
+Apply to the 4 sites at lines ~42, ~67, ~87, ~131. Verify and run:
+
+```bash
+grep -n "except DatabaseKeyError" src/moneybin/cli/commands/categorize.py  # expect 0
+uv run pytest tests/moneybin/test_cli/ -v -k categorize
+uv run pyright src/moneybin/cli/commands/categorize.py
+```
+
+- [ ] **Step 6.5: Refactor `src/moneybin/cli/commands/{synthetic,mcp,db,migrate,transform}.py`**
+
+For each file in `synthetic.py mcp.py db.py migrate.py transform.py`:
+
+```bash
+grep -n "except DatabaseKeyError" src/moneybin/cli/commands/<file>
+```
+
+Apply the same transformation to each site. After editing each file, verify there are no remaining matches and run pyright on the file.
+
+- [ ] **Step 6.6: Final verification — no regressions in repo-wide grep**
+
+Run: `grep -rn "except DatabaseKeyError" src/moneybin/cli/`
+Expected: no matches.
+
+Run: `grep -rn "database_key_error_hint" src/moneybin/cli/`
+Expected: no matches in `cli/commands/`. (Matches inside `cli/utils.py` and `database.py` are fine.)
+
+- [ ] **Step 6.7: Full unit-test run**
+
+Run: `make test`
+Expected: green.
+
+- [ ] **Step 6.8: Full E2E run**
+
+Run: `uv run pytest tests/e2e/ -v -m "e2e and not slow"`
+Expected: green. (Lock/unlock paths are exercised — verify especially `tests/e2e/test_e2e_mutating.py` and `test_e2e_workflows.py` still pass.)
+
+- [ ] **Step 6.9: Commit**
+
+```bash
+git add src/moneybin/cli/commands/
+git commit -m "Migrate CLI commands to handle_database_errors context manager"
+```
+
+---
+
+## Task 7: Pre-push quality pass
+
+- [ ] **Step 7.1: Run `make check test`**
+
+Run: `make check test`
+Expected: format clean, lint clean, pyright clean, all tests green.
+
+- [ ] **Step 7.2: Self-review the diff**
+
+Run: `git diff main..HEAD --stat`
+Confirm: only the files listed in this plan changed. No drive-by edits.
+
+- [ ] **Step 7.3: Push and open PR**
+
+```bash
+git push -u origin refactor/tabular-import-cleanup-stream-a
+gh pr create --title "Refactor tabular import internals" --body "$(cat <<'EOF'
+## Summary
+- Extract `ResolvedMapping` dataclass in `_import_tabular` (Stream A1)
+- Thread `SignConventionType` / `NumberFormatType` through `column_mapper` and `transforms` (A2)
+- Move `balance_pass_threshold` and `balance_tolerance_cents` to `TabularConfig` (A3)
+- Extract `handle_database_errors` context manager and adopt across 9 CLI command modules (A4)
+
+No behavior change. Spec: docs/specs/tabular-import-cleanup.md (Stream A).
+
+## Test plan
+- [x] `make check test`
+- [x] `uv run pytest tests/e2e/ -m "e2e and not slow"`
+- [ ] Manual smoke: `moneybin import file <fixture.csv>` succeeds
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-04-25-tabular-cleanup-stream-a-refactor.md
+++ b/docs/superpowers/plans/2026-04-25-tabular-cleanup-stream-a-refactor.md
@@ -265,10 +265,8 @@ Inside the function body, replace:
 with:
 
 ```python
-    _balance_tolerance = (Decimal(tolerance_cents) / Decimal(100)).quantize(
-        Decimal("0.01")
-    )
-    _pass_threshold = pass_threshold
+_balance_tolerance = (Decimal(tolerance_cents) / Decimal(100)).quantize(Decimal("0.01"))
+_pass_threshold = pass_threshold
 ```
 
 Leave the rest of the function unchanged — `_balance_tolerance` and `_pass_threshold` are still referenced below.
@@ -527,42 +525,40 @@ class ResolvedMapping:
 In `_import_tabular`, replace the block at lines 355-386 (matched-format vs auto-detect) with:
 
 ```python
-    if matched_format:
-        resolved = ResolvedMapping(
-            field_mapping=matched_format.field_mapping,
-            date_format=matched_format.date_format,
-            sign_convention=matched_format.sign_convention,
-            number_format=matched_format.number_format,
-            is_multi_account=matched_format.multi_account,
-            confidence="high",
-        )
-        format_source = (
-            "built-in" if matched_format.name in builtin_formats else "saved"
-        )
-    else:
-        mapping_result = map_columns(df, overrides=overrides)
-        resolved = ResolvedMapping(
-            field_mapping=mapping_result.field_mapping,
-            date_format=mapping_result.date_format or "%Y-%m-%d",
-            sign_convention=mapping_result.sign_convention,
-            number_format=mapping_result.number_format,
-            is_multi_account=mapping_result.is_multi_account,
-            confidence=mapping_result.confidence,
-        )
-        format_source = "detected"
+if matched_format:
+    resolved = ResolvedMapping(
+        field_mapping=matched_format.field_mapping,
+        date_format=matched_format.date_format,
+        sign_convention=matched_format.sign_convention,
+        number_format=matched_format.number_format,
+        is_multi_account=matched_format.multi_account,
+        confidence="high",
+    )
+    format_source = "built-in" if matched_format.name in builtin_formats else "saved"
+else:
+    mapping_result = map_columns(df, overrides=overrides)
+    resolved = ResolvedMapping(
+        field_mapping=mapping_result.field_mapping,
+        date_format=mapping_result.date_format or "%Y-%m-%d",
+        sign_convention=mapping_result.sign_convention,
+        number_format=mapping_result.number_format,
+        is_multi_account=mapping_result.is_multi_account,
+        confidence=mapping_result.confidence,
+    )
+    format_source = "detected"
 
-        if mapping_result.sign_needs_confirmation and not sign:
-            logger.warning(
-                "⚠️  Sign convention is ambiguous (all amounts appear positive). "
-                f"Proceeding with '{resolved.sign_convention}' — "
-                "use --sign to override if expense amounts look wrong."
-            )
+    if mapping_result.sign_needs_confirmation and not sign:
+        logger.warning(
+            "⚠️  Sign convention is ambiguous (all amounts appear positive). "
+            f"Proceeding with '{resolved.sign_convention}' — "
+            "use --sign to override if expense amounts look wrong."
+        )
 
-        if mapping_result.confidence == "low":
-            raise ValueError(
-                f"Could not reliably detect column mapping for "
-                f"{file_path.name}. Use --override to specify columns manually."
-            )
+    if mapping_result.confidence == "low":
+        raise ValueError(
+            f"Could not reliably detect column mapping for "
+            f"{file_path.name}. Use --override to specify columns manually."
+        )
 ```
 
 The CLI overrides block (currently around lines 395-401) becomes:

--- a/docs/superpowers/plans/2026-04-25-tabular-cleanup-stream-b1-decimal.md
+++ b/docs/superpowers/plans/2026-04-25-tabular-cleanup-stream-b1-decimal.md
@@ -158,6 +158,7 @@ Re-read `tests/moneybin/test_extractors/test_ofx_extractor.py`. For any assertio
 
 ```python
 from decimal import Decimal
+
 assert df["amount"][0] == Decimal("12.34")
 ```
 

--- a/docs/superpowers/plans/2026-04-25-tabular-cleanup-stream-b1-decimal.md
+++ b/docs/superpowers/plans/2026-04-25-tabular-cleanup-stream-b1-decimal.md
@@ -1,0 +1,450 @@
+# Tabular Import Cleanup — Stream B1 (Decimal Correctness) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `float` with `Decimal` for all monetary values that currently leak through `float` on the way to DuckDB `DECIMAL(18,2)` columns. Tabular pipeline was fixed; this plan covers OFX, W-2, and the synthetic data writer.
+
+**Architecture:** Each module already gets a `Decimal` from upstream (OFX library, Pydantic schema) and then *casts to `float`* before handing off to Polars. The fix is to keep the value as `Decimal` end-to-end and use `pl.Decimal(precision=18, scale=2)` in the Polars schemas instead of `pl.Float64`. The DuckDB tables are already `DECIMAL(18,2)`.
+
+**Tech Stack:** Python 3.12, Polars, DuckDB, Pydantic v2, ofxparse.
+
+**Branch:** `fix/decimal-correctness-extractors`
+
+**Spec:** [docs/specs/tabular-import-cleanup.md](../../specs/tabular-import-cleanup.md) §Stream B1
+
+---
+
+## Pre-Plan Verification
+
+The spec lists four locations that *may* still use `float`. Two were verified during plan-writing — they do, and are fixed below:
+
+- `src/moneybin/extractors/ofx_extractor.py:337,358,384,390` — calls `float(...)` on Decimal values, declares `pl.Float64` in schema. **CONFIRMED.**
+- `src/moneybin/extractors/w2_extractor.py:997-1020` — calls `float(...)` on every Decimal Box value before building the dict. **CONFIRMED.**
+- `src/moneybin/testing/synthetic/writer.py:155,180,238,241` — calls `float(...)` on amounts/balances when building dicts. **CONFIRMED.** (Spec wrongly pointed at `tests/moneybin/test_services/test_synthetic_data.py` — the source code is in `src/moneybin/testing/synthetic/writer.py`. Tests live in `tests/moneybin/test_synthetic/`.)
+- `src/moneybin/mcp/` — spec says "MCP tool responses with float amounts." A grep for `float(` and `: float` across `src/moneybin/mcp/` returned **no matches** for monetary fields. The MCP tools read amounts from DuckDB `DECIMAL(18,2)` and return them as-is. **NO ACTION REQUIRED** — but verify in Task 4 below before closing the plan.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/moneybin/extractors/ofx_extractor.py` | OFX → Polars DataFrame builder | Modify — drop `float(...)` casts on `amount`, `ledger_balance`, `available_balance`; switch `pl.Float64` to `pl.Decimal(18, 2)` in the empty-frame schema |
+| `src/moneybin/extractors/w2_extractor.py` | W-2 → dict builder | Modify — drop `float(...)` casts on every Box value |
+| `src/moneybin/testing/synthetic/writer.py` | Synthetic data → CSV/Parquet writer | Modify — drop `float(...)` casts on `amount` / `balance` / `ledger_balance` |
+| `src/moneybin/loaders/ofx_loader.py` | DuckDB ingest from OFX DataFrames | Read & adjust if it casts to/from float on the boundary |
+| `src/moneybin/loaders/w2_loader.py` | DuckDB ingest from W-2 dicts | Read & adjust if it casts to/from float on the boundary |
+| `tests/moneybin/test_extractors/test_ofx_extractor.py` | Existing OFX extractor tests | Update assertions from `float` literals to `Decimal("...")` |
+| `tests/moneybin/test_extractors/test_w2_extractor.py` | Existing W-2 extractor tests | Update assertions from `float` literals to `Decimal("...")` |
+| `tests/moneybin/test_synthetic/test_writer.py` | Existing synthetic writer tests | Update assertions to `Decimal("...")` |
+
+---
+
+## Task 1: Fix OFX extractor — keep `Decimal` to the DataFrame boundary
+
+**Files:**
+- Modify: `src/moneybin/extractors/ofx_extractor.py:320-365` (transactions DataFrame builder)
+- Modify: `src/moneybin/extractors/ofx_extractor.py:367-405` (balances dict builder)
+- Test: `tests/moneybin/test_extractors/test_ofx_extractor.py` (existing)
+
+The schema already uses `Decimal` (`OFXTransactionSchema.amount: Decimal` at line 53). The extractor converts to `float` for the dict, then declares the empty-frame schema as `pl.Float64`. Both must change.
+
+- [ ] **Step 1.1: Read the existing test to understand current assertions**
+
+Run: `Read tests/moneybin/test_extractors/test_ofx_extractor.py` and note any assertion that uses `float` literals on amount/balance — those will need updating.
+
+- [ ] **Step 1.2: Write a failing test asserting Decimal preservation**
+
+Append to `tests/moneybin/test_extractors/test_ofx_extractor.py`:
+
+```python
+def test_extracted_transaction_amount_is_decimal(tmp_path) -> None:
+    """OFX transactions DataFrame uses Decimal, not Float64, for amount."""
+    import polars as pl
+
+    from moneybin.extractors.ofx_extractor import OFXExtractor
+
+    # Reuse any existing OFX fixture in this test file. If a fixture path
+    # constant exists (e.g. SAMPLE_OFX), use it. Otherwise, copy the smallest
+    # existing OFX-from-file test setup here.
+    ofx_path = SAMPLE_OFX  # noqa: F821 — replace with the file's existing fixture
+    extractor = OFXExtractor()
+    data = extractor.extract_from_file(ofx_path)
+
+    txn_df: pl.DataFrame = data.transactions
+    assert txn_df.schema["amount"] == pl.Decimal(precision=18, scale=2)
+```
+
+If `SAMPLE_OFX` doesn't exist in the file, replace with whatever fixture path/constant the existing tests already use.
+
+- [ ] **Step 1.3: Run the test to verify it fails**
+
+Run: `uv run pytest tests/moneybin/test_extractors/test_ofx_extractor.py::test_extracted_transaction_amount_is_decimal -v`
+Expected: FAIL with an `AssertionError` reporting `pl.Float64` ≠ `pl.Decimal(...)`.
+
+- [ ] **Step 1.4: Update the transactions DataFrame builder**
+
+Edit `src/moneybin/extractors/ofx_extractor.py`. At line 337, change:
+
+```python
+                    "amount": float(tx_schema.amount),
+```
+
+to:
+
+```python
+                    "amount": tx_schema.amount,
+```
+
+At line 358 (inside `_build_empty_transactions_df`), change:
+
+```python
+                "amount": pl.Float64,
+```
+
+to:
+
+```python
+                "amount": pl.Decimal(precision=18, scale=2),
+```
+
+If `pl.DataFrame(transactions_data)` later in the same function infers a non-Decimal dtype because the inferred Python type is `Decimal`, force the schema explicitly:
+
+```python
+        if transactions_data:
+            return pl.DataFrame(
+                transactions_data,
+                schema_overrides={"amount": pl.Decimal(precision=18, scale=2)},
+            )
+```
+
+- [ ] **Step 1.5: Update the balances builder**
+
+At line 384, change:
+
+```python
+                    "ledger_balance": float(statement.balance)
+```
+
+to:
+
+```python
+                    "ledger_balance": statement.balance
+```
+
+(Note: `statement.balance` from `ofxparse` is already a `Decimal`. If pyright complains, add a type-narrowing `Decimal(...)` wrapper.)
+
+At line 390, change:
+
+```python
+                    "available_balance": float(statement.available_balance)
+```
+
+to:
+
+```python
+                    "available_balance": statement.available_balance
+```
+
+If the file builds an empty balances DataFrame with `pl.Float64` for those columns, switch them to `pl.Decimal(precision=18, scale=2)` too. Use Read on lines ~400-440 to find that constructor and update its schema.
+
+- [ ] **Step 1.6: Update the loader if necessary**
+
+Read `src/moneybin/loaders/ofx_loader.py`. Look for any `pl.Float64` in schema declarations or `.cast(pl.Float64)` calls touching `amount`, `ledger_balance`, or `available_balance`. Replace with `pl.Decimal(precision=18, scale=2)`. If the loader simply forwards the DataFrame to `db.ingest_dataframe(...)`, no change is needed — DuckDB will cast `Decimal` → `DECIMAL(18,2)` directly.
+
+- [ ] **Step 1.7: Update existing test assertions**
+
+Re-read `tests/moneybin/test_extractors/test_ofx_extractor.py`. For any assertion of the form `assert df["amount"][0] == 12.34` or `pytest.approx(12.34)`, change to:
+
+```python
+from decimal import Decimal
+assert df["amount"][0] == Decimal("12.34")
+```
+
+Use exact string literals — never `Decimal(12.34)` (captures float imprecision per `.claude/rules/database.md`).
+
+- [ ] **Step 1.8: Run the OFX extractor tests**
+
+Run: `uv run pytest tests/moneybin/test_extractors/test_ofx_extractor.py -v`
+Expected: all green.
+
+- [ ] **Step 1.9: Run the OFX loader and end-to-end OFX tests**
+
+Run: `uv run pytest tests/moneybin/test_loaders/ -v -k ofx && uv run pytest tests/e2e/ -v -k ofx`
+Expected: all green. (If the loader tests check schema, they should now expect `Decimal` too — update accordingly.)
+
+- [ ] **Step 1.10: Run pyright**
+
+Run: `uv run pyright src/moneybin/extractors/ofx_extractor.py src/moneybin/loaders/ofx_loader.py`
+Expected: 0 errors.
+
+- [ ] **Step 1.11: Commit**
+
+```bash
+git add src/moneybin/extractors/ofx_extractor.py \
+        src/moneybin/loaders/ofx_loader.py \
+        tests/moneybin/test_extractors/test_ofx_extractor.py \
+        tests/moneybin/test_loaders/
+git commit -m "Use Decimal end-to-end in OFX extractor and loader"
+```
+
+---
+
+## Task 2: Fix W-2 extractor — keep `Decimal` for all Box values
+
+**Files:**
+- Modify: `src/moneybin/extractors/w2_extractor.py:990-1025` (final dict builder — adjust line range after reading)
+- Modify (if needed): `src/moneybin/loaders/w2_loader.py`
+- Test: `tests/moneybin/test_extractors/test_w2_extractor.py` (existing)
+
+W-2 boxes are stored in `raw_w2_forms` as `DECIMAL(18,2)`. The extractor casts every box value to `float` when building its return dict. Drop those casts.
+
+- [ ] **Step 2.1: Read the W-2 extractor return dict**
+
+Read `src/moneybin/extractors/w2_extractor.py:980-1030` to confirm the exact line numbers and the structure. There are at least 11 `float(...)` calls in this region — list them.
+
+- [ ] **Step 2.2: Write a failing test**
+
+Append to `tests/moneybin/test_extractors/test_w2_extractor.py`:
+
+```python
+def test_extracted_w2_wages_are_decimal() -> None:
+    """W-2 extractor returns Decimal — never float — for monetary fields."""
+    from decimal import Decimal
+
+    # Use whatever extractor fixture the file already uses.
+    extractor = W2Extractor()  # noqa: F821 — already imported in this file
+    data = extractor.extract_from_file(SAMPLE_W2_PDF)  # noqa: F821 — replace with file's fixture
+    record = data[0] if isinstance(data, list) else data
+
+    for field in (
+        "wages",
+        "federal_income_tax",
+        "social_security_wages",
+        "social_security_tax",
+        "medicare_wages",
+        "medicare_tax",
+    ):
+        if record.get(field) is not None:
+            assert isinstance(record[field], Decimal), (
+                f"{field} should be Decimal, got {type(record[field]).__name__}"
+            )
+```
+
+If the extractor returns a Pydantic model rather than a dict, adapt the indexing.
+
+- [ ] **Step 2.3: Run the test to verify it fails**
+
+Run: `uv run pytest tests/moneybin/test_extractors/test_w2_extractor.py::test_extracted_w2_wages_are_decimal -v`
+Expected: FAIL on the first field (`wages`) — gets `float` not `Decimal`.
+
+- [ ] **Step 2.4: Drop every `float(...)` cast in the extractor return dict**
+
+Edit `src/moneybin/extractors/w2_extractor.py`. For each line in the 990-1025 block, change `float(w2_schema.<box>)` to `w2_schema.<box>`. Example:
+
+```python
+            "wages": w2_schema.wages,
+            "federal_income_tax": w2_schema.federal_income_tax,
+            "social_security_wages": w2_schema.social_security_wages
+            ...,
+```
+
+(Keep any surrounding `if X is not None else None` ternaries intact.)
+
+- [ ] **Step 2.5: Update existing test assertions**
+
+Find any assertion in `test_w2_extractor.py` that compares to a bare float literal. Convert to `Decimal("…")`. Example: `assert record["wages"] == 50000.00` → `assert record["wages"] == Decimal("50000.00")`.
+
+- [ ] **Step 2.6: Update the loader if necessary**
+
+Read `src/moneybin/loaders/w2_loader.py`. If it casts to/from float anywhere, switch to `Decimal` (or remove the cast — the values are already Decimal). If it builds a Polars DataFrame internally with `pl.Float64`, switch to `pl.Decimal(precision=18, scale=2)`.
+
+- [ ] **Step 2.7: Run the W-2 test suite**
+
+Run: `uv run pytest tests/moneybin/test_extractors/test_w2_extractor.py tests/moneybin/test_loaders/ -v -k w2 && uv run pytest tests/e2e/ -v -k w2`
+Expected: all green.
+
+- [ ] **Step 2.8: Run pyright**
+
+Run: `uv run pyright src/moneybin/extractors/w2_extractor.py src/moneybin/loaders/w2_loader.py`
+Expected: 0 errors.
+
+- [ ] **Step 2.9: Commit**
+
+```bash
+git add src/moneybin/extractors/w2_extractor.py \
+        src/moneybin/loaders/w2_loader.py \
+        tests/moneybin/test_extractors/test_w2_extractor.py \
+        tests/moneybin/test_loaders/
+git commit -m "Use Decimal end-to-end in W-2 extractor and loader"
+```
+
+---
+
+## Task 3: Fix synthetic-data writer — keep `Decimal` end-to-end
+
+**Files:**
+- Modify: `src/moneybin/testing/synthetic/writer.py:150-250` (read first, then patch the four `float(...)` sites at ~155, ~180, ~238, ~241)
+- Modify: `src/moneybin/testing/synthetic/models.py:29-134` (consider whether `amount: float` and `opening_balance: float` should become `Decimal`)
+- Test: `tests/moneybin/test_synthetic/test_writer.py` (existing)
+
+This is the most invasive sub-task. Synthetic *generation* happens in `float` space (random distributions, raise calculations) but *output* must be `Decimal` to round-trip cleanly through the import pipeline. Decision: keep generators in `float`, convert at the writer boundary using `Decimal(str(value))` (per `.claude/rules/database.md`).
+
+- [ ] **Step 3.1: Read the writer to confirm the four sites**
+
+Read `src/moneybin/testing/synthetic/writer.py:140-260`. Confirm the four `float(...)` casts are at the lines noted in the spec, and identify the surrounding dict structures.
+
+- [ ] **Step 3.2: Write a failing test**
+
+Append to `tests/moneybin/test_synthetic/test_writer.py`:
+
+```python
+def test_writer_emits_decimal_amounts(tmp_path) -> None:
+    """Synthetic writer outputs Decimal amounts in the produced DataFrames."""
+    from decimal import Decimal
+
+    import polars as pl
+
+    # Use whatever the existing tests use to build a small ledger and run
+    # the writer. Adapt this skeleton to the file's existing helpers.
+    ledger = _build_minimal_ledger()  # noqa: F821 — implement using the file's existing test helpers
+
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    writer = SyntheticWriter(output_dir)  # noqa: F821 — already imported in this test file
+    writer.write(ledger)
+
+    # Read back one of the produced CSVs and assert amount column is Decimal-coercible
+    csv_path = next(output_dir.rglob("*.csv"))
+    df = pl.read_csv(csv_path)
+    if "amount" in df.columns:
+        # Polars read_csv infers Float — what matters is the on-disk value
+        # round-trips through Decimal without precision loss.
+        for raw in df["amount"].to_list():
+            assert Decimal(str(raw)) == Decimal(f"{raw:.2f}"), (
+                f"Amount {raw!r} would lose precision in a Decimal round-trip"
+            )
+```
+
+If the synthetic writer returns DataFrames in-memory rather than writing files, adapt the test accordingly.
+
+- [ ] **Step 3.3: Run the test to verify it fails**
+
+Run: `uv run pytest tests/moneybin/test_synthetic/test_writer.py::test_writer_emits_decimal_amounts -v`
+Expected: FAIL — values currently round-trip as floats with imprecision (e.g. `123.4500000001`).
+
+- [ ] **Step 3.4: Convert at the writer boundary**
+
+Edit `src/moneybin/testing/synthetic/writer.py`. At each of the four sites:
+
+```python
+                "ledger_balance": float(acct.opening_balance),
+```
+
+becomes:
+
+```python
+                "ledger_balance": Decimal(str(round(acct.opening_balance, 2))),
+```
+
+And:
+
+```python
+                "amount": float(txn.amount),
+```
+
+becomes:
+
+```python
+                "amount": Decimal(str(round(txn.amount, 2))),
+```
+
+The `round(..., 2)` ensures the random-generator floats are quantized to two decimals before string-conversion. `Decimal(str(...))` is the only safe constructor (per `.claude/rules/database.md`).
+
+Add `from decimal import Decimal` to the file's imports if not already present.
+
+If any DataFrame in this file declares a schema with `pl.Float64` for these columns, switch to `pl.Decimal(precision=18, scale=2)`. Use Grep to find them.
+
+- [ ] **Step 3.5: Run the synthetic writer tests**
+
+Run: `uv run pytest tests/moneybin/test_synthetic/ -v`
+Expected: all green.
+
+- [ ] **Step 3.6: Run the synthetic E2E test**
+
+Run: `uv run pytest tests/e2e/ -v -k synthetic`
+Expected: all green.
+
+- [ ] **Step 3.7: Run pyright**
+
+Run: `uv run pyright src/moneybin/testing/synthetic/`
+Expected: 0 errors.
+
+- [ ] **Step 3.8: Commit**
+
+```bash
+git add src/moneybin/testing/synthetic/ tests/moneybin/test_synthetic/
+git commit -m "Convert synthetic writer amounts to Decimal at the output boundary"
+```
+
+---
+
+## Task 4: Verify MCP layer is already Decimal-clean
+
+**Files:**
+- Inspect: `src/moneybin/mcp/tools/` (no edits expected)
+
+Pre-plan grep showed no `float(` casts on amount fields in the MCP layer. Confirm before closing the plan.
+
+- [ ] **Step 4.1: Repo-wide grep for monetary float casts**
+
+Run:
+
+```bash
+grep -rn "float(.*amount\|float(.*balance\|float(.*wage" src/moneybin/mcp/
+```
+
+Expected: no matches. If matches appear, file a follow-up issue rather than expanding this PR's scope.
+
+- [ ] **Step 4.2: Spot-check `spending.py`, `accounts.py`, `transactions.py`**
+
+For each, scan the response builder. The amount/balance values should be passed through unchanged from the DuckDB query result. If you see `float(...)` or `: float` annotations on monetary columns, file a follow-up.
+
+- [ ] **Step 4.3: No commit needed if no edits**
+
+Document the verification in the PR description.
+
+---
+
+## Task 5: Pre-push quality pass
+
+- [ ] **Step 5.1: Run the broader test surface**
+
+Run: `make check test`
+Expected: all green.
+
+- [ ] **Step 5.2: Run all E2E tests**
+
+Run: `uv run pytest tests/e2e/ -v -m "e2e and not slow"`
+Expected: all green.
+
+- [ ] **Step 5.3: Push and open PR**
+
+```bash
+git push -u origin fix/decimal-correctness-extractors
+gh pr create --title "Use Decimal end-to-end for monetary values" --body "$(cat <<'EOF'
+## Summary
+- OFX extractor and loader: keep `Decimal` from Pydantic schema to Polars DataFrame
+- W-2 extractor: drop all `float(...)` casts on Box monetary fields
+- Synthetic writer: quantize generator floats with `Decimal(str(round(x, 2)))` at the output boundary
+- MCP layer verified clean — no float casts on amount/balance/wage fields
+
+Spec: docs/specs/tabular-import-cleanup.md (Stream B1).
+
+## Test plan
+- [x] `make check test`
+- [x] `uv run pytest tests/e2e/ -m "e2e and not slow"`
+- [x] Round-trip a real OFX file through `moneybin import file` and confirm `raw.ofx_transactions.amount` matches the source to the cent
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-04-25-tabular-cleanup-stream-b2-merchant-batch.md
+++ b/docs/superpowers/plans/2026-04-25-tabular-cleanup-stream-b2-merchant-batch.md
@@ -95,8 +95,7 @@ def test_bulk_categorize_uses_constant_number_of_db_calls(
     # Expected reads: 1 batch description fetch + 1 merchant fetch +
     # any small bookkeeping. Generous upper bound = 5; previous impl was 50+.
     assert len(select_calls) <= 5, (
-        f"Expected ≤5 SELECTs, got {len(select_calls)}:\n"
-        + "\n".join(select_calls)
+        f"Expected ≤5 SELECTs, got {len(select_calls)}:\n" + "\n".join(select_calls)
     )
 ```
 

--- a/docs/superpowers/plans/2026-04-25-tabular-cleanup-stream-b2-merchant-batch.md
+++ b/docs/superpowers/plans/2026-04-25-tabular-cleanup-stream-b2-merchant-batch.md
@@ -1,0 +1,403 @@
+# Tabular Import Cleanup — Stream B2 (Batch Merchant Resolution) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the N+1 merchant lookup in `bulk_categorize`. Today every item triggers an individual `SELECT description` and an individual `match_merchant` (which itself queries `MERCHANTS` once per call). After this plan, those queries collapse to two batch queries plus an in-memory match.
+
+**Architecture:** `bulk_categorize` already calls `match_merchant(db, description)` per item. `match_merchant` is a thin wrapper over `_fetch_merchants(db)` (one query) + `_match_description(...)` (in-memory). The fix is to:
+
+1. Batch-fetch all `(transaction_id, description)` pairs once.
+2. Cache `_fetch_merchants(db)` once.
+3. Reuse `_match_description(...)` per item against the cached list.
+4. Batch-insert new merchants and category assignments at the end.
+
+**Tech Stack:** Python 3.12, DuckDB, Polars (not strictly needed here).
+
+**Branch:** `perf/categorize-bulk-batch-merchants`
+
+**Spec:** [docs/specs/tabular-import-cleanup.md](../../specs/tabular-import-cleanup.md) §Stream B2
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/moneybin/services/categorization_service.py:307-401` | `bulk_categorize()` — per-item resolution loop | **Modify** — replace per-item DB calls with two batch queries + in-memory match |
+| `src/moneybin/services/categorization_service.py:181-258` | `_fetch_merchants` / `_match_description` / `match_merchant` | **No change** — already factored, just reused |
+| `tests/moneybin/test_services/test_categorization_service.py` | Existing categorization service tests | **Modify** — add a perf-shape test (counts DB calls) and a behavior test (auto-creation still happens) |
+
+The batch path is local to `bulk_categorize`. No other callers need to change. The MCP tool `categorize_bulk` (`src/moneybin/mcp/tools/categorize.py:286-309`) already delegates here and stays a one-liner.
+
+---
+
+## Task 1: Write the perf-shape test
+
+**Files:**
+- Test: `tests/moneybin/test_services/test_categorization_service.py` (existing — append)
+
+The motivating concern is round-trip count, not wall time. Asserting wall-time bounds is flaky; instead, count `db.execute` calls.
+
+- [ ] **Step 1.1: Read the existing test to find a fixture pattern**
+
+Run: `Read tests/moneybin/test_services/test_categorization_service.py` and locate any existing `bulk_categorize` test. Note the fixture used to set up a Database with seeded transactions — most likely a `tmp_path` + `Database(..., no_auto_upgrade=True)` pattern with helper inserts. Reuse that scaffolding.
+
+- [ ] **Step 1.2: Append the perf-shape test**
+
+```python
+def test_bulk_categorize_uses_constant_number_of_db_calls(
+    monkeypatch, mock_secret_store, tmp_path
+) -> None:
+    """bulk_categorize should not scale DB round-trips with item count.
+
+    With N items, the number of read queries (description fetch + merchant
+    fetch) must be O(1), not O(N).
+    """
+    from moneybin.database import Database
+    from moneybin.services.categorization_service import bulk_categorize
+    from moneybin.tables import FCT_TRANSACTIONS
+
+    db = Database(
+        tmp_path / "perf.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+    )
+    # Seed 25 transactions and 25 corresponding category items.
+    db.execute(f"""
+        CREATE OR REPLACE TABLE {FCT_TRANSACTIONS.full_name} AS
+        SELECT
+            'txn_' || i AS transaction_id,
+            CAST('2025-01-01' AS DATE) AS transaction_date,
+            CAST(-10.00 AS DECIMAL(18,2)) AS amount,
+            'Coffee shop ' || i AS description,
+            CAST(NULL AS VARCHAR) AS memo,
+            'acct1' AS account_id
+        FROM range(25) t(i)
+    """)
+    items = [
+        {"transaction_id": f"txn_{i}", "category": "Food", "subcategory": "Coffee"}
+        for i in range(25)
+    ]
+
+    real_execute = db.execute
+    select_calls: list[str] = []
+
+    def counting_execute(query, *args, **kwargs):
+        if query.strip().upper().startswith("SELECT"):
+            select_calls.append(query)
+        return real_execute(query, *args, **kwargs)
+
+    monkeypatch.setattr(db, "execute", counting_execute)
+
+    result = bulk_categorize(db, items)
+
+    assert result.applied == 25
+    # Expected reads: 1 batch description fetch + 1 merchant fetch +
+    # any small bookkeeping. Generous upper bound = 5; previous impl was 50+.
+    assert len(select_calls) <= 5, (
+        f"Expected ≤5 SELECTs, got {len(select_calls)}:\n"
+        + "\n".join(select_calls)
+    )
+```
+
+- [ ] **Step 1.3: Run the test to verify it fails**
+
+Run: `uv run pytest tests/moneybin/test_services/test_categorization_service.py::test_bulk_categorize_uses_constant_number_of_db_calls -v`
+Expected: FAIL — current implementation issues 25+ SELECTs (one per item plus one merchants fetch per `match_merchant` call).
+
+---
+
+## Task 2: Refactor `bulk_categorize` to batch reads and reuse merchant cache
+
+**Files:**
+- Modify: `src/moneybin/services/categorization_service.py:307-401`
+
+The new flow:
+
+1. Filter items to those with non-empty `transaction_id` and `category`. Stash the rest in `error_details` with `skipped += 1`.
+2. Single batch query: `SELECT transaction_id, description FROM fct_transactions WHERE transaction_id IN (?, ?, ...)` — build a `dict[txn_id, description]`.
+3. Single `_fetch_merchants(db)` call → cached merchant list (may be `None` if table missing).
+4. Per item, call `_match_description(description, cached_merchants)` for resolution. If no match and `normalized` is non-empty, queue a `create_merchant` **inside the loop** (still single-row INSERTs — DuckDB's overhead is per-statement, not per-round-trip; further batching is overkill until profiled).
+5. Per item, perform the existing `INSERT OR REPLACE INTO transaction_categories` — this is unavoidable per-item but is a write, not a read, and is what the user is paying for.
+
+The behavior must not change: `merchants_created` count, `applied` count, `error_details` content, and the relative ordering of error reporting must all match.
+
+- [ ] **Step 2.1: Replace the function body**
+
+Read `src/moneybin/services/categorization_service.py:307-401` first to confirm the exact current implementation. Then replace the body of `bulk_categorize` with:
+
+```python
+def bulk_categorize(
+    db: Database,
+    items: list[dict[str, str]],
+) -> BulkCategorizationResult:
+    """Assign categories to multiple transactions with merchant auto-creation.
+
+    For each item, looks up the transaction description, resolves or creates
+    a merchant mapping, then inserts/replaces the category assignment.
+    Merchant resolution is best-effort — failures do not prevent categorization.
+
+    Read-side cost is O(1) in the number of items: one batch description
+    fetch and one merchant-table fetch, regardless of input size.
+
+    Args:
+        db: Database instance (read-write).
+        items: List of dicts with transaction_id, category, and optional subcategory.
+
+    Returns:
+        BulkCategorizationResult with applied/skipped/error counts.
+    """
+    applied = 0
+    skipped = 0
+    errors = 0
+    merchants_created = 0
+    error_details: list[dict[str, str]] = []
+
+    # Phase 1 — validate and partition input
+    valid_items: list[tuple[str, str, str | None]] = []
+    for item in items:
+        txn_id = item.get("transaction_id", "").strip()
+        category = item.get("category", "").strip()
+        if not txn_id or not category:
+            skipped += 1
+            error_details.append({
+                "transaction_id": txn_id or "(missing)",
+                "reason": "Missing transaction_id or category",
+            })
+            continue
+        subcategory = item.get("subcategory", "").strip() or None
+        valid_items.append((txn_id, category, subcategory))
+
+    if not valid_items:
+        return BulkCategorizationResult(
+            applied=applied,
+            skipped=skipped,
+            errors=errors,
+            error_details=error_details,
+            merchants_created=merchants_created,
+        )
+
+    # Phase 2 — batch-fetch descriptions
+    txn_ids = [v[0] for v in valid_items]
+    placeholders = ",".join(["?"] * len(txn_ids))
+    descriptions: dict[str, str | None] = {}
+    try:
+        rows = db.execute(
+            f"""
+            SELECT transaction_id, description
+            FROM {FCT_TRANSACTIONS.full_name}
+            WHERE transaction_id IN ({placeholders})
+            """,  # noqa: S608 — placeholders count is bounded by len(valid_items); values are parameterized
+            txn_ids,
+        ).fetchall()
+        descriptions = {row[0]: row[1] for row in rows}
+    except Exception:  # noqa: BLE001 — best-effort; missing table → all merchants resolve to None
+        logger.debug("Could not batch-fetch descriptions", exc_info=True)
+
+    # Phase 3 — fetch merchants once, then match in memory
+    cached_merchants = _fetch_merchants(db)
+
+    # Phase 4 — per-item categorization (writes only)
+    for txn_id, category, subcategory in valid_items:
+        merchant_id: str | None = None
+        description = descriptions.get(txn_id)
+        if description and cached_merchants is not None:
+            try:
+                existing = _match_description(description, cached_merchants)
+                if existing:
+                    merchant_id = existing["merchant_id"]
+                else:
+                    normalized = normalize_description(description)
+                    if normalized:
+                        merchant_id = create_merchant(
+                            db,
+                            normalized,
+                            normalized,
+                            match_type="contains",
+                            category=category,
+                            subcategory=subcategory,
+                            created_by="ai",
+                        )
+                        merchants_created += 1
+                        # Append to cache so subsequent items in this batch
+                        # find the just-created merchant instead of re-creating.
+                        cached_merchants.append((
+                            merchant_id,
+                            normalized,
+                            "contains",
+                            normalized,
+                            category,
+                            subcategory,
+                        ))
+            except Exception:  # noqa: BLE001 — merchant resolution is best-effort; categorization proceeds without it
+                logger.debug(
+                    f"Could not resolve merchant for {txn_id}",
+                    exc_info=True,
+                )
+
+        try:
+            db.execute(
+                f"""
+                INSERT OR REPLACE INTO {TRANSACTION_CATEGORIES.full_name}
+                (transaction_id, category, subcategory,
+                 categorized_at, categorized_by, merchant_id)
+                VALUES (?, ?, ?, CURRENT_TIMESTAMP, 'ai', ?)
+                """,
+                [txn_id, category, subcategory, merchant_id],
+            )
+            applied += 1
+        except Exception:  # noqa: BLE001 — DuckDB raises untyped errors on constraint violations
+            errors += 1
+            logger.exception(f"bulk_categorize failed for transaction {txn_id!r}")
+            error_details.append({
+                "transaction_id": txn_id,
+                "reason": "Failed to apply category — check logs for details.",
+            })
+
+    return BulkCategorizationResult(
+        applied=applied,
+        skipped=skipped,
+        errors=errors,
+        error_details=error_details,
+        merchants_created=merchants_created,
+    )
+```
+
+Behavior preserved:
+
+- Validation order and `error_details` content for missing `transaction_id`/`category` — unchanged.
+- For valid items where the description fetch failed or returned nothing → `merchant_id = None`, category still applied (matches existing best-effort behavior).
+- Merchant auto-create still happens with the same `match_type="contains"`, `created_by="ai"`, and `category`/`subcategory` from the item.
+- Insert-cache trick prevents creating the same merchant twice when two items in the same batch share a normalized description.
+
+- [ ] **Step 2.2: Run the perf-shape test**
+
+Run: `uv run pytest tests/moneybin/test_services/test_categorization_service.py::test_bulk_categorize_uses_constant_number_of_db_calls -v`
+Expected: PASS.
+
+- [ ] **Step 2.3: Run the full categorization test suite**
+
+Run: `uv run pytest tests/moneybin/test_services/test_categorization_service.py -v`
+Expected: all green. Pay special attention to any test that asserts `merchants_created == N` — the in-batch dedup might change a count if two test items share a description (unlikely in existing tests, but verify).
+
+- [ ] **Step 2.4: Run the MCP categorize tests**
+
+Run: `uv run pytest tests/moneybin/test_mcp/ -v -k categorize`
+Expected: all green.
+
+- [ ] **Step 2.5: Run pyright**
+
+Run: `uv run pyright src/moneybin/services/categorization_service.py`
+Expected: 0 errors.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add src/moneybin/services/categorization_service.py \
+        tests/moneybin/test_services/test_categorization_service.py
+git commit -m "Batch description and merchant lookups in bulk_categorize"
+```
+
+---
+
+## Task 3: Add a behavior test for in-batch merchant dedup
+
+**Files:**
+- Test: `tests/moneybin/test_services/test_categorization_service.py` (append)
+
+This guards against a subtle regression: if a future change drops the cache-append in Phase 4, two items with the same normalized description would create the merchant twice (or, worse, fail on a uniqueness constraint).
+
+- [ ] **Step 3.1: Write the test**
+
+```python
+def test_bulk_categorize_dedupes_merchant_creation_within_batch(
+    mock_secret_store, tmp_path
+) -> None:
+    """Two items with the same description create exactly one merchant."""
+    from moneybin.database import Database
+    from moneybin.services.categorization_service import bulk_categorize
+    from moneybin.tables import FCT_TRANSACTIONS, MERCHANTS
+
+    db = Database(
+        tmp_path / "dedup.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+    )
+    db.execute(f"""
+        CREATE OR REPLACE TABLE {FCT_TRANSACTIONS.full_name} AS
+        SELECT
+            'txn_' || i AS transaction_id,
+            CAST('2025-01-01' AS DATE) AS transaction_date,
+            CAST(-10.00 AS DECIMAL(18,2)) AS amount,
+            'IDENTICAL VENDOR' AS description,
+            CAST(NULL AS VARCHAR) AS memo,
+            'acct1' AS account_id
+        FROM range(3) t(i)
+    """)
+
+    items = [
+        {"transaction_id": f"txn_{i}", "category": "Food", "subcategory": "Coffee"}
+        for i in range(3)
+    ]
+
+    result = bulk_categorize(db, items)
+
+    assert result.applied == 3
+    assert result.merchants_created == 1, (
+        f"Expected 1 merchant created across 3 identical-description items, "
+        f"got {result.merchants_created}"
+    )
+
+    merchant_count = db.execute(
+        f"SELECT COUNT(*) FROM {MERCHANTS.full_name}"
+    ).fetchone()
+    assert merchant_count is not None
+    assert merchant_count[0] == 1
+```
+
+- [ ] **Step 3.2: Run the test**
+
+Run: `uv run pytest tests/moneybin/test_services/test_categorization_service.py::test_bulk_categorize_dedupes_merchant_creation_within_batch -v`
+Expected: PASS (the cache-append in Phase 4 already ensures this).
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add tests/moneybin/test_services/test_categorization_service.py
+git commit -m "Test in-batch merchant dedup in bulk_categorize"
+```
+
+---
+
+## Task 4: Pre-push quality pass
+
+- [ ] **Step 4.1: Full check**
+
+Run: `make check test`
+Expected: green.
+
+- [ ] **Step 4.2: E2E**
+
+Run: `uv run pytest tests/e2e/ -v -m "e2e and not slow"`
+Expected: green.
+
+- [ ] **Step 4.3: Push and open PR**
+
+```bash
+git push -u origin perf/categorize-bulk-batch-merchants
+gh pr create --title "Batch merchant resolution in categorize.bulk" --body "$(cat <<'EOF'
+## Summary
+- Replace per-item description fetch with a single `IN (...)` batch query
+- Cache `_fetch_merchants(db)` once per call, reuse `_match_description` in memory
+- Append newly-created merchants to the cache so duplicate descriptions in a batch don't double-create
+- Drops read round-trips from O(N) to O(1) per `bulk_categorize` call
+
+Spec: docs/specs/tabular-import-cleanup.md (Stream B2). No behavior change beyond perf and within-batch dedup (which existed by accident before — now explicit and tested).
+
+## Test plan
+- [x] `make check test`
+- [x] New perf-shape test asserts ≤5 SELECTs for 25 items
+- [x] New dedup test asserts 1 merchant created for 3 identical-description items
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-04-25-tabular-cleanup-stream-c-account-matching.md
+++ b/docs/superpowers/plans/2026-04-25-tabular-cleanup-stream-c-account-matching.md
@@ -217,17 +217,17 @@ git commit -m "Make account_matching threshold configurable"
 This is the behavior change. The current single-account path (around lines 412-433) does:
 
 ```python
-    if account_id:
-        account_ids: str | list[str] = account_id
-        ...
-    elif account_name:
-        aid = slugify(account_name)
-        account_ids = aid
-        ...
-    elif (mapping_result_is_multi_account and ...):
-        ...
-    else:
-        raise ValueError(...)
+if account_id:
+    account_ids: str | list[str] = account_id
+    ...
+elif account_name:
+    aid = slugify(account_name)
+    account_ids = aid
+    ...
+elif mapping_result_is_multi_account and ...:
+    ...
+else:
+    raise ValueError(...)
 ```
 
 After this task, the `elif account_name:` branch routes through `match_account()`. The multi-account branch (per-row) and the explicit `account_id` branch are unchanged — both already bypass the matcher correctly.
@@ -412,8 +412,7 @@ def _resolve_account_via_matcher(
         return slugify(account_name)
 
     existing = [
-        {"account_id": r[0], "account_name": r[1], "account_number": r[2]}
-        for r in rows
+        {"account_id": r[0], "account_name": r[1], "account_number": r[2]} for r in rows
     ]
 
     result = match_account(
@@ -440,8 +439,7 @@ def _resolve_account_via_matcher(
         logger.warning(
             f"⚠️  Account {account_name!r} did not match exactly. Fuzzy candidates: "
             + ", ".join(
-                f"{c['account_name']!r} ({c['account_id']})"
-                for c in result.candidates
+                f"{c['account_name']!r} ({c['account_id']})" for c in result.candidates
             )
             + ". Use --yes to auto-accept the top candidate, "
             "or --account-id to pick explicitly."
@@ -614,6 +612,7 @@ def test_import_file_passes_yes_flag_through(monkeypatch, tmp_path) -> None:
     def fake_import_file(*, db, file_path, **kwargs):
         captured.update(kwargs)
         from moneybin.services.import_service import ImportResult
+
         return ImportResult(file_path=str(file_path), file_type="tabular")
 
     monkeypatch.setattr(
@@ -649,18 +648,20 @@ Expected: FAIL — either CLI rejects `--yes` (no such option) or `captured["aut
 Edit `src/moneybin/cli/commands/import_cmd.py`. In the `import_file` function signature (after line 152, before the closing `)`):
 
 ```python
-    yes: bool = typer.Option(
+yes: bool = (
+    typer.Option(
         False,
         "--yes",
         "-y",
         help="Auto-accept the top fuzzy account match without prompting",
     ),
+)
 ```
 
 In the call to `run_import(...)` (around line 199), append:
 
 ```python
-            auto_accept=yes,
+auto_accept = (yes,)
 ```
 
 - [ ] **Step 4.5: Run the test to verify it passes**

--- a/docs/superpowers/plans/2026-04-25-tabular-cleanup-stream-c-account-matching.md
+++ b/docs/superpowers/plans/2026-04-25-tabular-cleanup-stream-c-account-matching.md
@@ -1,0 +1,775 @@
+# Tabular Import Cleanup — Stream C (Wire Account Matching) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the existing `match_account()` (in `extractors/tabular/account_matching.py`) into `_import_tabular()` so re-imports under varying account names ("Chase Checking" vs "CHASE CHECKING ACCT") map to the same account ID instead of creating duplicates. Surface the fuzzy threshold via `TabularConfig` and add a non-interactive `--yes` flag to auto-accept fuzzy matches.
+
+**Architecture:** `_import_tabular()` currently does `slugify(account_name)` to derive an account ID. The new path queries existing accounts from `raw.tabular_accounts`, calls `match_account()`, and branches on its outcome (matched / fuzzy candidates / no candidates). The fuzzy threshold (currently hardcoded `0.6`) becomes `TabularConfig.account_match_threshold`. Interactive prompts are gated by `sys.stdin.isatty()` and an explicit `--yes` flag for non-interactive parity (per `.claude/rules/cli.md`).
+
+**Tech Stack:** Python 3.12, DuckDB, Typer, Polars.
+
+**Branch:** `feat/tabular-account-matching`
+
+**Spec:** [docs/specs/tabular-import-cleanup.md](../../specs/tabular-import-cleanup.md) §Stream C
+
+**Depends on:** Stream A (Task 1 — `TabularConfig` lives there). If Stream A has not landed, the `account_match_threshold` config addition in Task 1 here can stand alone — it just adds one more field to the same model.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/moneybin/config.py` | `TabularConfig` Pydantic model | **Modify** — add `account_match_threshold: float = 0.6` |
+| `src/moneybin/extractors/tabular/account_matching.py` | `match_account()` and threshold | **Modify** — accept `threshold` kwarg; remove the TODO comment |
+| `src/moneybin/services/import_service.py` | `_import_tabular()` account ID assignment | **Modify** — query existing accounts, call `match_account`, branch on outcome |
+| `src/moneybin/cli/commands/import_cmd.py` | `import_file` Typer command | **Modify** — add `--yes` / `-y` flag, pipe through |
+| `tests/moneybin/test_extractors/test_tabular/test_account_matching.py` | Existing matcher tests | **Modify** — assert configurable threshold |
+| `tests/moneybin/test_services/test_tabular_import_service.py` | Existing import-service tests | **Modify** — add 3 tests for the three matching outcomes |
+| `tests/moneybin/test_cli/test_import_command.py` (or existing) | CLI tests | **Modify** — assert `--yes` is accepted and forwarded |
+
+The matching logic lives in the existing extractor module. The branching policy (interactive vs auto-accept vs new-account) lives in `_import_tabular` because it depends on CLI state (`auto_accept`, `sys.stdin.isatty()`).
+
+---
+
+## Task 1: Add `account_match_threshold` to `TabularConfig`
+
+**Files:**
+- Modify: `src/moneybin/config.py:119-139`
+- Test: `tests/moneybin/test_config_profiles.py`
+
+If Stream A landed first, this slots between `balance_tolerance_cents` and the closing of `TabularConfig`. If Stream A did not land, just add the field.
+
+- [ ] **Step 1.1: Write the failing test**
+
+Append to `tests/moneybin/test_config_profiles.py`:
+
+```python
+def test_tabular_config_account_match_threshold_default() -> None:
+    """TabularConfig exposes the fuzzy account-match threshold with default 0.6."""
+    from moneybin.config import TabularConfig
+
+    cfg = TabularConfig()
+    assert cfg.account_match_threshold == 0.6
+
+
+def test_tabular_config_account_match_threshold_override() -> None:
+    """Caller can tighten or loosen the fuzzy match threshold."""
+    from moneybin.config import TabularConfig
+
+    cfg = TabularConfig(account_match_threshold=0.85)
+    assert cfg.account_match_threshold == 0.85
+```
+
+- [ ] **Step 1.2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/moneybin/test_config_profiles.py -v -k account_match_threshold`
+Expected: FAIL — `account_match_threshold` does not exist.
+
+- [ ] **Step 1.3: Add the field**
+
+Edit `src/moneybin/config.py`. Inside `TabularConfig`, after `row_refuse_threshold` (or, if Stream A landed, after `balance_tolerance_cents`):
+
+```python
+    account_match_threshold: float = Field(
+        default=0.6,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Fuzzy-match similarity threshold (difflib.SequenceMatcher.ratio) "
+            "for account-name matching. Below this threshold, candidates are "
+            "treated as 'no match'."
+        ),
+    )
+```
+
+- [ ] **Step 1.4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/moneybin/test_config_profiles.py -v -k account_match_threshold`
+Expected: 2 passed.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/moneybin/config.py tests/moneybin/test_config_profiles.py
+git commit -m "Add account_match_threshold to TabularConfig"
+```
+
+---
+
+## Task 2: Make `match_account` accept a configurable threshold
+
+**Files:**
+- Modify: `src/moneybin/extractors/tabular/account_matching.py:31-99`
+- Test: `tests/moneybin/test_extractors/test_tabular/test_account_matching.py` (existing — read first)
+
+The current implementation hardcodes `0.6` at line 81. After this task, the threshold is a keyword argument with the same default.
+
+- [ ] **Step 2.1: Read the existing test file**
+
+Run: `Read tests/moneybin/test_extractors/test_tabular/test_account_matching.py` (path may differ — Glob if needed). Note the existing test fixtures so the new tests reuse the same `existing_accounts` shape.
+
+- [ ] **Step 2.2: Write the failing tests**
+
+Append to the existing test file (or create one if missing):
+
+```python
+def test_match_account_respects_custom_threshold() -> None:
+    """A high threshold rejects fuzzy candidates that the default would accept."""
+    from moneybin.extractors.tabular.account_matching import match_account
+
+    existing = [{"account_id": "acct1", "account_name": "Chase Checking"}]
+    # "Chase Visa" vs "Chase Checking" — SequenceMatcher.ratio ≈ 0.65
+    result = match_account(
+        "Chase Visa",
+        existing_accounts=existing,
+        threshold=0.95,
+    )
+    assert result.matched is False
+    assert result.candidates == []  # below threshold → no candidates
+
+
+def test_match_account_default_threshold_returns_candidates() -> None:
+    """The default 0.6 threshold surfaces near-misses as candidates."""
+    from moneybin.extractors.tabular.account_matching import match_account
+
+    existing = [{"account_id": "acct1", "account_name": "Chase Checking"}]
+    result = match_account("Chase Visa", existing_accounts=existing)
+    assert result.matched is False
+    assert any(c["account_id"] == "acct1" for c in result.candidates)
+```
+
+- [ ] **Step 2.3: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/moneybin/test_extractors/test_tabular/test_account_matching.py -v -k threshold`
+Expected: FAIL with `TypeError: match_account() got an unexpected keyword argument 'threshold'`.
+
+- [ ] **Step 2.4: Patch `match_account`**
+
+Edit `src/moneybin/extractors/tabular/account_matching.py`. Remove the TODO comment at lines 31-33 (the work is done by this PR). Update the signature and the fuzzy block:
+
+```python
+def match_account(
+    account_name: str,
+    *,
+    account_number: str | None = None,
+    explicit_account_id: str | None = None,
+    existing_accounts: Sequence[Mapping[str, str | None]] | None = None,
+    threshold: float = 0.6,
+) -> AccountMatch:
+    """Match an account against the existing account registry.
+
+    Args:
+        account_name: Account name to match.
+        account_number: Account number for strongest match.
+        explicit_account_id: Explicit ID (bypasses matching).
+        existing_accounts: List of existing account dicts with
+            account_id, account_name, and optionally account_number.
+        threshold: Minimum SequenceMatcher.ratio for a name to count as a
+            fuzzy candidate. Defaults to 0.6.
+
+    Returns:
+        AccountMatch with match result and candidates.
+    """
+```
+
+In the fuzzy section (around line 81), change:
+
+```python
+        if ratio >= 0.6:
+```
+
+to:
+
+```python
+        if ratio >= threshold:
+```
+
+Update the docstring above the function — it can also lose the "TODO: wire into import pipeline" comment block (lines 31-33).
+
+- [ ] **Step 2.5: Run the tests**
+
+Run: `uv run pytest tests/moneybin/test_extractors/test_tabular/test_account_matching.py -v`
+Expected: all green (existing tests still pass with the default).
+
+- [ ] **Step 2.6: Run pyright**
+
+Run: `uv run pyright src/moneybin/extractors/tabular/account_matching.py`
+Expected: 0 errors.
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add src/moneybin/extractors/tabular/account_matching.py \
+        tests/moneybin/test_extractors/test_tabular/test_account_matching.py
+git commit -m "Make account_matching threshold configurable"
+```
+
+---
+
+## Task 3: Wire `match_account` into `_import_tabular`
+
+**Files:**
+- Modify: `src/moneybin/services/import_service.py:239-557` (`_import_tabular`)
+- Modify: `src/moneybin/services/import_service.py:560-660` (`import_file` — accept and forward `auto_accept`)
+- Test: `tests/moneybin/test_services/test_tabular_import_service.py`
+
+This is the behavior change. The current single-account path (around lines 412-433) does:
+
+```python
+    if account_id:
+        account_ids: str | list[str] = account_id
+        ...
+    elif account_name:
+        aid = slugify(account_name)
+        account_ids = aid
+        ...
+    elif (mapping_result_is_multi_account and ...):
+        ...
+    else:
+        raise ValueError(...)
+```
+
+After this task, the `elif account_name:` branch routes through `match_account()`. The multi-account branch (per-row) and the explicit `account_id` branch are unchanged — both already bypass the matcher correctly.
+
+**Important:** the new query reads from `raw.tabular_accounts`. That table includes `account_id`, `account_name`, `account_number`, `account_number_masked` (per `src/moneybin/sql/schema/raw_tabular_accounts.sql:5-19`). The PRIMARY KEY is `(account_id, source_file)` — meaning the same account can appear under multiple files. Dedup with `SELECT DISTINCT` on `(account_id, account_name, account_number)`.
+
+- [ ] **Step 3.1: Write the three behavior tests**
+
+Append to `tests/moneybin/test_services/test_tabular_import_service.py`. These are unit-shape tests against the helper introduced in step 3.2 (`_resolve_account_via_matcher`), which keeps the test surface narrow.
+
+```python
+def test_resolve_account_via_matcher_uses_existing_id_on_match(
+    mock_secret_store, tmp_path
+) -> None:
+    """Matched account name → reuses the existing account_id."""
+    from moneybin.database import Database
+    from moneybin.services.import_service import _resolve_account_via_matcher
+
+    db = Database(
+        tmp_path / "match.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+    )
+    db.execute("""
+        INSERT INTO raw.tabular_accounts
+        (account_id, account_name, account_number, account_number_masked,
+         account_type, institution_name, currency, source_file, source_type,
+         source_origin, import_id)
+        VALUES
+        ('chase-checking', 'Chase Checking', NULL, NULL, NULL, NULL, NULL,
+         'old.csv', 'csv', 'chase', 'imp1')
+    """)
+    aid = _resolve_account_via_matcher(
+        db,
+        account_name="Chase Checking",
+        account_number=None,
+        threshold=0.6,
+        auto_accept=False,
+    )
+    assert aid == "chase-checking"
+
+
+def test_resolve_account_via_matcher_creates_new_when_no_candidates(
+    mock_secret_store, tmp_path
+) -> None:
+    """No fuzzy candidates → fall back to slugify (creates a new account)."""
+    from moneybin.database import Database
+    from moneybin.services.import_service import _resolve_account_via_matcher
+
+    db = Database(
+        tmp_path / "new.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+    )
+    aid = _resolve_account_via_matcher(
+        db,
+        account_name="Brand New Account",
+        account_number=None,
+        threshold=0.6,
+        auto_accept=False,
+    )
+    assert aid == "brand-new-account"
+
+
+def test_resolve_account_via_matcher_auto_accepts_top_candidate(
+    mock_secret_store, tmp_path, caplog
+) -> None:
+    """With auto_accept=True, a fuzzy candidate is taken without prompting."""
+    from moneybin.database import Database
+    from moneybin.services.import_service import _resolve_account_via_matcher
+
+    db = Database(
+        tmp_path / "fuzzy.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+    )
+    db.execute("""
+        INSERT INTO raw.tabular_accounts
+        (account_id, account_name, account_number, account_number_masked,
+         account_type, institution_name, currency, source_file, source_type,
+         source_origin, import_id)
+        VALUES
+        ('chase-checking', 'Chase Checking Acct', NULL, NULL, NULL, NULL, NULL,
+         'old.csv', 'csv', 'chase', 'imp1')
+    """)
+    with caplog.at_level("INFO"):
+        aid = _resolve_account_via_matcher(
+            db,
+            account_name="Chase Checking",
+            account_number=None,
+            threshold=0.6,
+            auto_accept=True,
+        )
+    assert aid == "chase-checking"
+    assert "auto-accepting" in caplog.text.lower()
+
+
+def test_resolve_account_via_matcher_warns_and_falls_back_when_not_auto(
+    mock_secret_store, tmp_path, caplog
+) -> None:
+    """Without auto_accept, fuzzy candidates trigger a warning + slugify fallback."""
+    from moneybin.database import Database
+    from moneybin.services.import_service import _resolve_account_via_matcher
+
+    db = Database(
+        tmp_path / "fuzzy.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+    )
+    db.execute("""
+        INSERT INTO raw.tabular_accounts
+        (account_id, account_name, account_number, account_number_masked,
+         account_type, institution_name, currency, source_file, source_type,
+         source_origin, import_id)
+        VALUES
+        ('chase-checking', 'Chase Checking Acct', NULL, NULL, NULL, NULL, NULL,
+         'old.csv', 'csv', 'chase', 'imp1')
+    """)
+    with caplog.at_level("WARNING"):
+        aid = _resolve_account_via_matcher(
+            db,
+            account_name="Chase Checking",
+            account_number=None,
+            threshold=0.6,
+            auto_accept=False,
+        )
+    assert aid == "chase-checking"  # slugify("Chase Checking") happens to match
+    assert "fuzzy" in caplog.text.lower() or "candidate" in caplog.text.lower()
+```
+
+The fourth test exists to prove the *non-auto-accept* path still completes (warning + slug fallback) — important because it's the default path and must not block import.
+
+- [ ] **Step 3.2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/moneybin/test_services/test_tabular_import_service.py -v -k resolve_account_via_matcher`
+Expected: FAIL with `ImportError: cannot import name '_resolve_account_via_matcher'`.
+
+- [ ] **Step 3.3: Add the helper to `import_service.py`**
+
+Edit `src/moneybin/services/import_service.py`. After the existing helpers (after `_detect_file_type` around line 142), add:
+
+```python
+def _resolve_account_via_matcher(
+    db: Database,
+    *,
+    account_name: str,
+    account_number: str | None,
+    threshold: float,
+    auto_accept: bool,
+) -> str:
+    """Resolve an account name to an account_id using match_account().
+
+    Three outcomes:
+      1. Matched (number or exact slug) → return the existing account_id.
+      2. Fuzzy candidates and auto_accept=True → take the top candidate, log it.
+      3. Fuzzy candidates and auto_accept=False → log a warning listing
+         candidates, fall back to slugify(account_name).
+      4. No candidates → fall back to slugify(account_name) (creates new).
+
+    Args:
+        db: Database instance.
+        account_name: Account name from CLI/file.
+        account_number: Account number if available, for strongest match.
+        threshold: Minimum SequenceMatcher.ratio for a fuzzy candidate.
+        auto_accept: True if the user passed --yes (or stdin is non-interactive).
+
+    Returns:
+        The resolved account_id (existing or freshly slugified).
+    """
+    from moneybin.extractors.tabular.account_matching import match_account
+    from moneybin.utils import slugify
+
+    try:
+        rows = db.execute(
+            """
+            SELECT DISTINCT account_id, account_name, account_number
+            FROM raw.tabular_accounts
+            """
+        ).fetchall()
+    except Exception:  # noqa: BLE001 — table missing on first import; fall back cleanly
+        logger.debug("raw.tabular_accounts unavailable; skipping account match")
+        return slugify(account_name)
+
+    existing = [
+        {"account_id": r[0], "account_name": r[1], "account_number": r[2]}
+        for r in rows
+    ]
+
+    result = match_account(
+        account_name,
+        account_number=account_number,
+        existing_accounts=existing,
+        threshold=threshold,
+    )
+
+    if result.matched and result.account_id:
+        logger.info(
+            f"Matched account {account_name!r} → existing id {result.account_id!r}"
+        )
+        return result.account_id
+
+    if result.candidates:
+        if auto_accept:
+            top = result.candidates[0]
+            logger.info(
+                f"⚙️  Auto-accepting fuzzy match for {account_name!r}: "
+                f"{top['account_name']!r} → {top['account_id']!r}"
+            )
+            return top["account_id"]
+        logger.warning(
+            f"⚠️  Account {account_name!r} did not match exactly. Fuzzy candidates: "
+            + ", ".join(
+                f"{c['account_name']!r} ({c['account_id']})"
+                for c in result.candidates
+            )
+            + ". Use --yes to auto-accept the top candidate, "
+            "or --account-id to pick explicitly."
+        )
+
+    return slugify(account_name)
+```
+
+- [ ] **Step 3.4: Wire the helper into `_import_tabular`**
+
+Still in `src/moneybin/services/import_service.py`. Update the `_import_tabular` signature to accept `auto_accept` (around line 256):
+
+```python
+def _import_tabular(
+    db: Database,
+    file_path: Path,
+    *,
+    account_name: str | None = None,
+    account_id: str | None = None,
+    format_name: str | None = None,
+    overrides: dict[str, str] | None = None,
+    sign: str | None = None,
+    date_format_override: str | None = None,
+    number_format_override: str | None = None,
+    save_format: bool = True,
+    sheet: str | None = None,
+    delimiter: str | None = None,
+    encoding: str | None = None,
+    no_row_limit: bool = False,
+    no_size_limit: bool = False,
+    auto_accept: bool = False,
+) -> ImportResult:
+```
+
+In the account-resolution block (currently around lines 412-433), change the `elif account_name:` branch from:
+
+```python
+    elif account_name:
+        aid = slugify(account_name)
+        account_ids = aid
+        acct_id_to_name[aid] = account_name
+```
+
+to:
+
+```python
+    elif account_name:
+        from moneybin.config import get_settings
+
+        threshold = get_settings().data.tabular.account_match_threshold
+        aid = _resolve_account_via_matcher(
+            db,
+            account_name=account_name,
+            account_number=None,
+            threshold=threshold,
+            auto_accept=auto_accept,
+        )
+        account_ids = aid
+        acct_id_to_name[aid] = account_name
+```
+
+(`account_number=None` for now — when Stream-D-style account-number extraction lands, the matcher already accepts it and will tighten the match.)
+
+Update `import_file` (around line 560) to accept and forward `auto_accept`. Add the parameter at the end of the keyword-args:
+
+```python
+def import_file(
+    db: Database,
+    file_path: str | Path,
+    *,
+    apply_transforms: bool = True,
+    institution: str | None = None,
+    account_id: str | None = None,
+    account_name: str | None = None,
+    format_name: str | None = None,
+    overrides: dict[str, str] | None = None,
+    sign: str | None = None,
+    date_format: str | None = None,
+    number_format: str | None = None,
+    save_format: bool = True,
+    sheet: str | None = None,
+    delimiter: str | None = None,
+    encoding: str | None = None,
+    no_row_limit: bool = False,
+    no_size_limit: bool = False,
+    auto_accept: bool = False,
+) -> ImportResult:
+```
+
+In the `_import_tabular(...)` call inside `import_file` (around lines 627-644), pass `auto_accept=auto_accept`:
+
+```python
+        result = _import_tabular(
+            db,
+            path,
+            account_name=account_name,
+            account_id=account_id,
+            format_name=format_name,
+            overrides=overrides,
+            sign=sign,
+            date_format_override=date_format,
+            number_format_override=number_format,
+            save_format=save_format,
+            sheet=sheet,
+            delimiter=delimiter,
+            encoding=encoding,
+            no_row_limit=no_row_limit,
+            no_size_limit=no_size_limit,
+            auto_accept=auto_accept,
+        )
+```
+
+Update the `import_file` docstring's Args section to mention `auto_accept`:
+
+```python
+        auto_accept: Auto-accept the top fuzzy account match without prompting
+            (CLI: --yes / -y). Defaults to False.
+```
+
+- [ ] **Step 3.5: Run the new tests to verify they pass**
+
+Run: `uv run pytest tests/moneybin/test_services/test_tabular_import_service.py -v -k resolve_account_via_matcher`
+Expected: 4 passed.
+
+- [ ] **Step 3.6: Run the broader tabular suites**
+
+Run: `uv run pytest tests/moneybin/test_services/ tests/moneybin/test_extractors/test_tabular/ -v`
+Expected: all green.
+
+- [ ] **Step 3.7: Run pyright**
+
+Run: `uv run pyright src/moneybin/services/import_service.py`
+Expected: 0 errors.
+
+- [ ] **Step 3.8: Commit**
+
+```bash
+git add src/moneybin/services/import_service.py \
+        tests/moneybin/test_services/test_tabular_import_service.py
+git commit -m "Wire match_account() into tabular import pipeline"
+```
+
+---
+
+## Task 4: Add `--yes` / `-y` flag to `import file` CLI
+
+**Files:**
+- Modify: `src/moneybin/cli/commands/import_cmd.py:76-234` (`import_file`)
+- Test: `tests/moneybin/test_cli/test_import_command.py` (or wherever the import-CLI tests live — Glob first)
+
+Per `.claude/rules/cli.md`, every interactive choice must have a single-flag equivalent. `--yes` / `-y` is the standard auto-accept flag.
+
+- [ ] **Step 4.1: Find the existing CLI test file**
+
+Run: `Glob tests/**/test_import*.py` and `Glob tests/moneybin/test_cli/*.py`. Identify the test that exercises `import_file` via the Typer `CliRunner`.
+
+- [ ] **Step 4.2: Write a failing test**
+
+Append (to whichever file holds the import CLI tests):
+
+```python
+def test_import_file_passes_yes_flag_through(monkeypatch, tmp_path) -> None:
+    """--yes is parsed and forwarded as auto_accept=True to import_file()."""
+    from typer.testing import CliRunner
+
+    from moneybin.cli.commands.import_cmd import app
+
+    captured: dict[str, object] = {}
+
+    def fake_import_file(*, db, file_path, **kwargs):
+        captured.update(kwargs)
+        from moneybin.services.import_service import ImportResult
+        return ImportResult(file_path=str(file_path), file_type="tabular")
+
+    monkeypatch.setattr(
+        "moneybin.services.import_service.import_file", fake_import_file
+    )
+    monkeypatch.setattr(
+        "moneybin.cli.commands.import_cmd.get_database",
+        lambda: object(),
+        raising=False,
+    )
+
+    csv = tmp_path / "x.csv"
+    csv.write_text("Date,Amount,Description\n2025-01-01,1.00,X\n")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["file", str(csv), "--account-name", "Test", "--yes"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured.get("auto_accept") is True
+```
+
+If the existing tests use a different mocking pattern (e.g., patching `run_import` aliased inside `import_cmd.py`), adapt the monkeypatch target. The check that matters is `captured["auto_accept"] is True` after `--yes`.
+
+- [ ] **Step 4.3: Run the test to verify it fails**
+
+Run: `uv run pytest tests/moneybin/test_cli/test_import_command.py -v -k yes_flag`
+Expected: FAIL — either CLI rejects `--yes` (no such option) or `captured["auto_accept"]` is missing.
+
+- [ ] **Step 4.4: Add the flag**
+
+Edit `src/moneybin/cli/commands/import_cmd.py`. In the `import_file` function signature (after line 152, before the closing `)`):
+
+```python
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Auto-accept the top fuzzy account match without prompting",
+    ),
+```
+
+In the call to `run_import(...)` (around line 199), append:
+
+```python
+            auto_accept=yes,
+```
+
+- [ ] **Step 4.5: Run the test to verify it passes**
+
+Run: `uv run pytest tests/moneybin/test_cli/test_import_command.py -v -k yes_flag`
+Expected: PASS.
+
+- [ ] **Step 4.6: Run the full CLI test suite**
+
+Run: `uv run pytest tests/moneybin/test_cli/ -v -k import`
+Expected: all green.
+
+- [ ] **Step 4.7: Run E2E import help and workflow**
+
+Run: `uv run pytest tests/e2e/test_e2e_help.py tests/e2e/test_e2e_workflows.py -v -k import`
+Expected: all green. (`test_e2e_help.py` calls `--help` for every command — the new `--yes` flag will appear there automatically.)
+
+- [ ] **Step 4.8: Run pyright**
+
+Run: `uv run pyright src/moneybin/cli/commands/import_cmd.py`
+Expected: 0 errors.
+
+- [ ] **Step 4.9: Commit**
+
+```bash
+git add src/moneybin/cli/commands/import_cmd.py \
+        tests/moneybin/test_cli/test_import_command.py
+git commit -m "Add --yes/-y flag to import file for auto-accepting fuzzy matches"
+```
+
+---
+
+## Task 5: Update spec status and roadmap
+
+Per `.claude/rules/shipping.md`, when a feature ships:
+
+- [ ] **Step 5.1: Update spec status**
+
+Edit `docs/specs/tabular-import-cleanup.md`. Change the `**Status**: draft` line at the top to `**Status**: implemented` (only after all Stream A/B1/B2/C PRs land — for this PR alone, leave at `draft` and update only the §Stream C heading status if a sub-status convention exists in the file).
+
+Edit `docs/specs/INDEX.md`. Bump the `tabular-import-cleanup` row's status accordingly.
+
+- [ ] **Step 5.2: Update README roadmap**
+
+Read `README.md`. If a roadmap row mentions "account matching" with a 📐 or 🗓️ icon, change to ✅. If the "What Works Today" section mentions tabular import, add a sentence: "Re-importing the same account under a different name now matches against the existing account ID (with `--yes` to auto-accept fuzzy matches non-interactively)."
+
+- [ ] **Step 5.3: Commit docs**
+
+```bash
+git add docs/specs/tabular-import-cleanup.md docs/specs/INDEX.md README.md
+git commit -m "Mark account matching shipped; update README"
+```
+
+---
+
+## Task 6: Pre-push quality pass
+
+- [ ] **Step 6.1: Run `/simplify` on changed code**
+
+Per `.claude/rules/shipping.md`, run a simplification pass before the final commit. Focus areas:
+- Is `_resolve_account_via_matcher` doing more than one thing? (DB read + matcher call + branching + logging — this is intentional; one helper, one caller.)
+- Could the `slugify` fallback in 3 of the 4 paths factor out? (No — each fallback path has a different log message; collapsing would lose user feedback.)
+
+Make any small simplifications and commit them as a separate "Simplify" commit if non-trivial.
+
+- [ ] **Step 6.2: Run `make check test`**
+
+Run: `make check test`
+Expected: green.
+
+- [ ] **Step 6.3: Run all E2E**
+
+Run: `uv run pytest tests/e2e/ -v -m "e2e and not slow"`
+Expected: green.
+
+- [ ] **Step 6.4: Manual smoke test**
+
+```bash
+# 1. First import — creates account
+uv run moneybin import file <fixture.csv> --account-name "Chase Checking"
+
+# 2. Re-import under a slightly different name — should match
+uv run moneybin import file <fixture2.csv> --account-name "Chase Checking Acct" --yes
+
+# 3. Verify both imports landed under the same account_id
+uv run moneybin data sql "SELECT account_id, account_name FROM raw.tabular_accounts ORDER BY account_id"
+```
+
+Expected: both imports use `account_id = 'chase-checking'`. Without `--yes`, step 2 would warn and create a new `chase-checking-acct` account.
+
+- [ ] **Step 6.5: Push and open PR**
+
+```bash
+git push -u origin feat/tabular-account-matching
+gh pr create --title "Wire account matching into tabular import pipeline" --body "$(cat <<'EOF'
+## Summary
+- `match_account()` is now called from `_import_tabular()` for single-account files
+- Three outcomes handled: exact match (reuse id), fuzzy candidates (auto-accept with `--yes` or warn + fallback), no candidates (slugify a new id)
+- Fuzzy threshold moved to `TabularConfig.account_match_threshold` (default 0.6)
+- New CLI flag: `--yes` / `-y` for non-interactive auto-accept (per cli.md non-interactive parity rule)
+
+User-visible behavior change: re-importing the same account under varying names no longer creates duplicate account records. Spec: docs/specs/tabular-import-cleanup.md (Stream C).
+
+## Test plan
+- [x] `make check test`
+- [x] 4 new unit tests on `_resolve_account_via_matcher` (matched / no-match / auto-accept / warn-and-fallback)
+- [x] CLI test asserts `--yes` propagates as `auto_accept=True`
+- [x] E2E `test_e2e_help.py` picks up the new flag automatically
+- [x] Manual smoke: re-import under varying name reuses account_id
+EOF
+)"
+```

--- a/src/moneybin/cli/commands/categorize.py
+++ b/src/moneybin/cli/commands/categorize.py
@@ -8,6 +8,8 @@ import logging
 
 import typer
 
+from moneybin.cli.utils import handle_database_errors
+
 logger = logging.getLogger(__name__)
 
 app = typer.Typer(
@@ -19,31 +21,24 @@ app = typer.Typer(
 @app.command("apply-rules")
 def apply_rules_cmd() -> None:
     """Run all active rules and merchant mappings against uncategorized transactions."""
-    from moneybin.database import DatabaseKeyError, get_database
     from moneybin.services.categorization_service import (
         apply_deterministic_categorization,
     )
 
     try:
-        db = get_database()
-        stats = apply_deterministic_categorization(db)
-        if stats["total"] > 0:
-            logger.info(
-                f"\u2705 Categorized {stats['total']} transactions "
-                f"({stats['merchant']} merchant, {stats['rule']} rule)"
-            )
-        else:
-            logger.info(
-                "\u2705 No uncategorized transactions matched rules or merchants"
-            )
+        with handle_database_errors() as db:
+            stats = apply_deterministic_categorization(db)
+            if stats["total"] > 0:
+                logger.info(
+                    f"\u2705 Categorized {stats['total']} transactions "
+                    f"({stats['merchant']} merchant, {stats['rule']} rule)"
+                )
+            else:
+                logger.info(
+                    "\u2705 No uncategorized transactions matched rules or merchants"
+                )
     except FileNotFoundError as e:
         logger.error(f"{e}")
-        raise typer.Exit(1) from e
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
-
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
         raise typer.Exit(1) from e
 
 
@@ -54,41 +49,27 @@ def seed_cmd() -> None:
     Requires SQLMesh transforms to have been run at least once.
     Safe to run multiple times — existing categories are not overwritten.
     """
-    from moneybin.database import DatabaseKeyError, get_database
     from moneybin.services.categorization_service import seed_categories
 
     try:
-        db = get_database()
-        count = seed_categories(db)
-        logger.info(f"\u2705 Seeded {count} new categories")
+        with handle_database_errors() as db:
+            count = seed_categories(db)
+            logger.info(f"\u2705 Seeded {count} new categories")
     except FileNotFoundError as e:
         logger.error(f"{e}")
-        raise typer.Exit(1) from e
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
-
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
         raise typer.Exit(1) from e
 
 
 @app.command("stats")
 def stats_cmd() -> None:
     """Show categorization coverage statistics."""
-    from moneybin.database import DatabaseKeyError, get_database
     from moneybin.services.categorization_service import get_categorization_stats
 
     try:
-        db = get_database()
-        stats = get_categorization_stats(db)
+        with handle_database_errors() as db:
+            stats = get_categorization_stats(db)
     except FileNotFoundError as e:
         logger.error(f"{e}")
-        raise typer.Exit(1) from e
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
-
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
         raise typer.Exit(1) from e
 
     total = stats["total"]
@@ -111,28 +92,21 @@ def stats_cmd() -> None:
 @app.command("list-rules")
 def list_rules_cmd() -> None:
     """Display all active categorization rules."""
-    from moneybin.database import DatabaseKeyError, get_database
     from moneybin.tables import CATEGORIZATION_RULES
 
     try:
-        db = get_database()
-        rows = db.execute(
-            f"""
-            SELECT rule_id, name, merchant_pattern, match_type,
-                   category, subcategory, priority
-            FROM {CATEGORIZATION_RULES.full_name}
-            WHERE is_active = true
-            ORDER BY priority ASC, name
-            """
-        ).fetchall()
+        with handle_database_errors() as db:
+            rows = db.execute(
+                f"""
+                SELECT rule_id, name, merchant_pattern, match_type,
+                       category, subcategory, priority
+                FROM {CATEGORIZATION_RULES.full_name}
+                WHERE is_active = true
+                ORDER BY priority ASC, name
+                """
+            ).fetchall()
     except FileNotFoundError as e:
         logger.error(f"{e}")
-        raise typer.Exit(1) from e
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
-
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
         raise typer.Exit(1) from e
 
     if not rows:

--- a/src/moneybin/cli/commands/import_cmd.py
+++ b/src/moneybin/cli/commands/import_cmd.py
@@ -167,7 +167,7 @@ def import_file(
         moneybin import file statement.ofx --institution "Wells Fargo"
         moneybin import file export.csv --override date=Date --override amount=Amount
     """
-    from moneybin.database import DatabaseKeyError, get_database
+    from moneybin.cli.utils import handle_database_errors
     from moneybin.services.import_service import import_file as run_import
 
     source = Path(file_path)
@@ -195,33 +195,27 @@ def import_file(
         raise typer.Exit(1)
 
     try:
-        db = get_database()
-        result = run_import(
-            db=db,
-            file_path=source,
-            apply_transforms=not skip_transform,
-            institution=institution,
-            account_id=account_id,
-            account_name=account_name,
-            format_name=format_name,
-            overrides=overrides,
-            sign=sign or None,
-            date_format=date_format or None,
-            number_format=number_format or None,
-            save_format=save_format,
-            sheet=sheet,
-            delimiter=delimiter,
-            encoding=encoding,
-            no_row_limit=no_row_limit,
-            no_size_limit=no_size_limit,
-        )
-        logger.info(f"✅ {result.summary()}")
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
-
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
+        with handle_database_errors() as db:
+            result = run_import(
+                db=db,
+                file_path=source,
+                apply_transforms=not skip_transform,
+                institution=institution,
+                account_id=account_id,
+                account_name=account_name,
+                format_name=format_name,
+                overrides=overrides,
+                sign=sign or None,
+                date_format=date_format or None,
+                number_format=number_format or None,
+                save_format=save_format,
+                sheet=sheet,
+                delimiter=delimiter,
+                encoding=encoding,
+                no_row_limit=no_row_limit,
+                no_size_limit=no_size_limit,
+            )
+            logger.info(f"✅ {result.summary()}")
     except ValueError as e:
         logger.error(f"❌ {e}")
         raise typer.Exit(1) from e
@@ -250,19 +244,12 @@ def import_history(
         moneybin import history --limit 50
         moneybin import history --import-id abc123
     """
-    from moneybin.database import DatabaseKeyError, get_database
+    from moneybin.cli.utils import handle_database_errors
     from moneybin.loaders.tabular_loader import TabularLoader
 
-    try:
-        db = get_database()
+    with handle_database_errors() as db:
         loader = TabularLoader(db)
         records = loader.get_import_history(limit=limit, import_id=import_id)
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
-
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
 
     if not records:
         if import_id:
@@ -311,7 +298,7 @@ def import_revert(
         moneybin import revert abc123-...
         moneybin import revert abc123-... --yes
     """
-    from moneybin.database import DatabaseKeyError, get_database
+    from moneybin.cli.utils import handle_database_errors
     from moneybin.loaders.tabular_loader import TabularLoader
 
     if not yes:
@@ -323,16 +310,9 @@ def import_revert(
             logger.info("Revert cancelled")
             raise typer.Exit(0)
 
-    try:
-        db = get_database()
+    with handle_database_errors() as db:
         loader = TabularLoader(db)
         result = loader.revert_import(import_id)
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
-
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
 
     status = result.get("status")
     if status == "not_found":
@@ -580,7 +560,7 @@ def delete_format(
         moneybin import delete-format my_custom_format
         moneybin import delete-format my_custom_format --yes
     """
-    from moneybin.database import DatabaseKeyError, get_database
+    from moneybin.cli.utils import handle_database_errors
     from moneybin.extractors.tabular.formats import (
         delete_format_from_db,
         load_builtin_formats,
@@ -598,15 +578,8 @@ def delete_format(
             logger.info("Delete cancelled")
             raise typer.Exit(0)
 
-    try:
-        db = get_database()
+    with handle_database_errors() as db:
         deleted = delete_format_from_db(db, name)
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
-
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
 
     if not deleted:
         logger.error(f"❌ Format {name!r} not found")
@@ -623,8 +596,8 @@ def import_status() -> None:
     Example:
         moneybin import status
     """
+    from moneybin.cli.utils import handle_database_errors
     from moneybin.config import get_settings
-    from moneybin.database import DatabaseKeyError, get_database
 
     db_path = get_settings().database.path
 
@@ -634,14 +607,8 @@ def import_status() -> None:
         raise typer.Exit(1)
 
     try:
-        db = get_database()
-        _print_import_status(db)
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
-
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
+        with handle_database_errors() as db:
+            _print_import_status(db)
     except Exception as e:  # noqa: BLE001 — surface connection errors generically
         logger.error(f"❌ Could not open database: {e}")
         raise typer.Exit(1) from e

--- a/src/moneybin/cli/commands/matches.py
+++ b/src/moneybin/cli/commands/matches.py
@@ -7,7 +7,7 @@ from typing import Any
 import duckdb as duckdb_mod
 import typer
 
-from moneybin.database import DatabaseKeyError, get_database
+from moneybin.cli.utils import handle_database_errors
 from moneybin.matching.engine import TransactionMatcher
 from moneybin.matching.persistence import VALID_MATCH_TYPES, get_match_log, undo_match
 
@@ -33,28 +33,22 @@ def matches_run(
     from moneybin.matching.priority import seed_source_priority
 
     try:
-        db = get_database()
-        settings = get_settings().matching
-        seed_source_priority(db, settings)
-        matcher = TransactionMatcher(db, settings)
-        result = matcher.run()
-        if result.has_matches:
-            logger.info(f"Matching: {result.summary()}")
-            if result.has_pending:
-                logger.info("Run 'moneybin matches review' when ready")
-        else:
-            logger.info("No new matches found")
+        with handle_database_errors() as db:
+            settings = get_settings().matching
+            seed_source_priority(db, settings)
+            matcher = TransactionMatcher(db, settings)
+            result = matcher.run()
+            if result.has_matches:
+                logger.info(f"Matching: {result.summary()}")
+                if result.has_pending:
+                    logger.info("Run 'moneybin matches review' when ready")
+            else:
+                logger.info("No new matches found")
 
-        if not skip_transform and result.auto_merged:
-            from moneybin.services.import_service import run_transforms
+            if not skip_transform and result.auto_merged:
+                from moneybin.services.import_service import run_transforms
 
-            run_transforms()
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
-
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
+                run_transforms()
     except duckdb_mod.CatalogException:
         logger.error(_NO_TRANSFORMS_MSG)
         raise typer.Exit(1) from None
@@ -134,8 +128,7 @@ def matches_review(
         logger.error("❌ --type must be 'dedup' or 'transfer'")
         raise typer.Exit(2)
 
-    try:
-        db = get_database()
+    with handle_database_errors() as db:
         accepted_any = False
 
         # Non-interactive: single match decision
@@ -211,13 +204,6 @@ def matches_review(
 
             run_transforms()
 
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
-
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
-
 
 @app.command("history")
 def matches_history_cmd(
@@ -231,8 +217,7 @@ def matches_history_cmd(
         logger.error("❌ --type must be 'dedup' or 'transfer'")
         raise typer.Exit(2)
 
-    try:
-        db = get_database()
+    with handle_database_errors() as db:
         entries = get_match_log(db, limit=limit, match_type=match_type)
 
         if not entries:
@@ -257,13 +242,6 @@ def matches_history_cmd(
             )
         typer.echo()
 
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
-
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
-
 
 @app.command("undo")
 def matches_undo_cmd(
@@ -278,17 +256,11 @@ def matches_undo_cmd(
             raise typer.Exit(0)
 
     try:
-        db = get_database()
-        undo_match(db, match_id, reversed_by="user")
-        logger.info(f"Reversed match {match_id[:8]}...")
+        with handle_database_errors() as db:
+            undo_match(db, match_id, reversed_by="user")
+            logger.info(f"Reversed match {match_id[:8]}...")
     except ValueError as e:
         logger.error(f"❌ {e}")
-        raise typer.Exit(1) from e
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
-
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
         raise typer.Exit(1) from e
 
 
@@ -303,36 +275,29 @@ def matches_backfill(
     from moneybin.matching.priority import seed_source_priority
 
     try:
-        db = get_database()
-        settings = get_settings().matching
+        with handle_database_errors() as db:
+            settings = get_settings().matching
 
-        count = db.execute(
-            "SELECT COUNT(*) FROM prep.int_transactions__unioned"
-        ).fetchone()
-        total = count[0] if count else 0
-        logger.info(
-            f"Scanning {total:,} existing transactions for duplicates and transfers..."
-        )
+            count = db.execute(
+                "SELECT COUNT(*) FROM prep.int_transactions__unioned"
+            ).fetchone()
+            total = count[0] if count else 0
+            logger.info(
+                f"Scanning {total:,} existing transactions for duplicates and transfers..."
+            )
 
-        seed_source_priority(db, settings)
-        matcher = TransactionMatcher(db, settings)
-        result = matcher.run()
+            seed_source_priority(db, settings)
+            matcher = TransactionMatcher(db, settings)
+            result = matcher.run()
 
-        logger.info(f"Backfill complete: {result.summary()}")
-        if result.has_pending:
-            logger.info("Run 'moneybin matches review' when ready")
+            logger.info(f"Backfill complete: {result.summary()}")
+            if result.has_pending:
+                logger.info("Run 'moneybin matches review' when ready")
 
-        if not skip_transform and result.auto_merged:
-            from moneybin.services.import_service import run_transforms
+            if not skip_transform and result.auto_merged:
+                from moneybin.services.import_service import run_transforms
 
-            run_transforms()
-
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
-
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
+                run_transforms()
     except duckdb_mod.CatalogException:
         logger.error(_NO_TRANSFORMS_MSG)
         raise typer.Exit(1) from None

--- a/src/moneybin/cli/commands/mcp.py
+++ b/src/moneybin/cli/commands/mcp.py
@@ -306,8 +306,8 @@ def serve(
 
         # Typically invoked by AI clients, not run manually
     """
+    from moneybin.cli.utils import handle_database_errors
     from moneybin.config import get_database_path
-    from moneybin.database import DatabaseKeyError
     from moneybin.mcp.server import close_db, init_db, mcp
 
     # Import resources/prompts to register their decorators with the server.
@@ -337,15 +337,10 @@ def serve(
     validated_transport: TransportType = transport  # type: ignore[assignment] — validated above
 
     try:
-        init_db()
+        with handle_database_errors():
+            init_db()
         logger.info(f"MCP server starting (transport={transport}, db={db_path})")
         mcp.run(transport=validated_transport)
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
-
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
     except FileNotFoundError as e:
         logger.error(f"Database not found: {e}")
         raise typer.Exit(1) from e

--- a/src/moneybin/cli/commands/migrate.py
+++ b/src/moneybin/cli/commands/migrate.py
@@ -10,7 +10,7 @@ from typing import Annotated
 
 import typer
 
-from moneybin.database import DatabaseKeyError, get_database
+from moneybin.cli.utils import handle_database_errors
 from moneybin.migrations import MigrationRunner, get_current_versions
 
 logger = logging.getLogger(__name__)
@@ -26,90 +26,76 @@ def migrate_apply(
     ] = False,
 ) -> None:
     """Apply pending database migrations."""
-    try:
-        db = get_database()
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
+    with handle_database_errors() as db:
+        runner = MigrationRunner(db)
 
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
-
-    runner = MigrationRunner(db)
-
-    if dry_run:
-        pending = runner.pending()
-        if not pending:
-            logger.info("No pending migrations")
+        if dry_run:
+            pending = runner.pending()
+            if not pending:
+                logger.info("No pending migrations")
+                raise typer.Exit(0) from None
+            logger.info(f"{len(pending)} pending migration(s):")
+            for m in pending:
+                logger.info(f"  {m.filename} ({m.file_type})")
             raise typer.Exit(0) from None
-        logger.info(f"{len(pending)} pending migration(s):")
-        for m in pending:
-            logger.info(f"  {m.filename} ({m.file_type})")
-        raise typer.Exit(0) from None
 
-    result = runner.apply_all()
+        result = runner.apply_all()
 
-    # Show drift warnings
-    for warning in runner.check_drift():
-        logger.warning(f"⚠️  {warning.reason}")
+        # Show drift warnings
+        for warning in runner.check_drift():
+            logger.warning(f"⚠️  {warning.reason}")
 
-    if result.failed:
-        result.log_failure()
-        raise typer.Exit(1) from None
+        if result.failed:
+            result.log_failure()
+            raise typer.Exit(1) from None
 
-    if result.applied_count > 0:
-        logger.info(f"✅ {result.applied_count} migration(s) applied")
-    else:
-        logger.info("No pending migrations")
+        if result.applied_count > 0:
+            logger.info(f"✅ {result.applied_count} migration(s) applied")
+        else:
+            logger.info("No pending migrations")
 
 
 @app.command("status")
 def migrate_status() -> None:
     """Show migration state — applied, pending, and drift warnings."""
-    try:
-        db = get_database()
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
+    with handle_database_errors() as db:
+        runner = MigrationRunner(db)
 
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
+        # Applied migrations
+        applied = runner.applied_details()
 
-    runner = MigrationRunner(db)
+        if applied:
+            logger.info("Applied migrations:")
+            for m in applied:
+                status = "✅" if m.success else "❌"
+                time_str = (
+                    f" ({m.execution_ms}ms)" if m.execution_ms is not None else ""
+                )
+                logger.info(
+                    f"  {status} V{m.version:03d} {m.filename}{time_str} — {m.applied_at}"
+                )
+        else:
+            logger.info("No applied migrations")
 
-    # Applied migrations
-    applied = runner.applied_details()
+        # Pending
+        pending = runner.pending()
+        if pending:
+            logger.info(f"\nPending migrations ({len(pending)}):")
+            for m in pending:
+                logger.info(f"  ⚙️  {m.filename}")
+        else:
+            logger.info("\nNo pending migrations")
 
-    if applied:
-        logger.info("Applied migrations:")
-        for m in applied:
-            status = "✅" if m.success else "❌"
-            time_str = f" ({m.execution_ms}ms)" if m.execution_ms is not None else ""
-            logger.info(
-                f"  {status} V{m.version:03d} {m.filename}{time_str} — {m.applied_at}"
-            )
-    else:
-        logger.info("No applied migrations")
+        # Drift warnings
+        drift = runner.check_drift()
+        if drift:
+            logger.info("\nDrift warnings:")
+            for w in drift:
+                logger.warning(f"  ⚠️  {w.reason}")
 
-    # Pending
-    pending = runner.pending()
-    if pending:
-        logger.info(f"\nPending migrations ({len(pending)}):")
-        for m in pending:
-            logger.info(f"  ⚙️  {m.filename}")
-    else:
-        logger.info("\nNo pending migrations")
-
-    # Drift warnings
-    drift = runner.check_drift()
-    if drift:
-        logger.info("\nDrift warnings:")
-        for w in drift:
-            logger.warning(f"  ⚠️  {w.reason}")
-
-    # Version state
-    versions = get_current_versions(db)
-    if versions:
-        logger.info("\nComponent versions:")
-        for component, version in sorted(versions.items()):
-            logger.info(f"  {component}: {version}")
+        # Version state
+        versions = get_current_versions(db)
+        if versions:
+            logger.info("\nComponent versions:")
+            for component, version in sorted(versions.items()):
+                logger.info(f"  {component}: {version}")

--- a/src/moneybin/cli/commands/stats.py
+++ b/src/moneybin/cli/commands/stats.py
@@ -10,7 +10,7 @@ from typing import Annotated, Literal
 
 import typer
 
-from moneybin.database import DatabaseKeyError, get_database
+from moneybin.cli.utils import handle_database_errors
 from moneybin.utils.parsing import parse_duration
 
 logger = logging.getLogger(__name__)
@@ -37,99 +37,91 @@ def stats_show(
     ] = "text",
 ) -> None:
     """Display lifetime metric aggregates."""
-    try:
-        db = get_database()
-    except DatabaseKeyError as e:
-        from moneybin.database import database_key_error_hint
+    with handle_database_errors() as db:
+        # Build query with optional filters
+        where_clauses: list[str] = []
+        params: list[str | datetime] = []
 
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
+        if since:
+            try:
+                delta = parse_duration(since)
+            except ValueError as e:
+                logger.error(f"❌ {e}")
+                raise typer.Exit(1) from e
+            cutoff = datetime.now(tz=UTC) - delta
+            where_clauses.append("recorded_at >= ?")
+            params.append(cutoff)
 
-    # Build query with optional filters
-    where_clauses: list[str] = []
-    params: list[str | datetime] = []
+        if metric:
+            # Escape LIKE metacharacters so _ and % match literally
+            escaped = metric.replace("!", "!!").replace("%", "!%").replace("_", "!_")
+            where_clauses.append("metric_name LIKE ? ESCAPE '!'")
+            params.append(f"%{escaped}%")
 
-    if since:
+        where_sql = ""
+        if where_clauses:
+            where_sql = "WHERE " + " AND ".join(where_clauses)
+
         try:
-            delta = parse_duration(since)
-        except ValueError as e:
-            logger.error(f"❌ {e}")
-            raise typer.Exit(1) from e
-        cutoff = datetime.now(tz=UTC) - delta
-        where_clauses.append("recorded_at >= ?")
-        params.append(cutoff)
+            # Use latest snapshot per metric+labels (not SUM — values are cumulative)
+            rows = db.execute(
+                f"""
+                SELECT metric_name, metric_type, labels,
+                       value AS current_value,
+                       snapshot_count,
+                       last_recorded
+                FROM (
+                    SELECT metric_name, metric_type, labels, value,
+                           COUNT(*) OVER (
+                               PARTITION BY metric_name, metric_type, labels
+                           ) AS snapshot_count,
+                           MAX(recorded_at) OVER (
+                               PARTITION BY metric_name, metric_type, labels
+                           ) AS last_recorded,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY metric_name, metric_type, labels
+                               ORDER BY recorded_at DESC
+                           ) AS rn
+                    FROM app.metrics
+                    {where_sql}
+                )
+                WHERE rn = 1
+                ORDER BY metric_name
+                """,  # noqa: S608 — where_sql is built from validated fragments, not user input
+                params if params else None,
+            ).fetchall()
+        except Exception:  # noqa: BLE001 — app.metrics table may not exist yet
+            logger.debug("Failed to query app.metrics", exc_info=True)
+            rows = []
 
-    if metric:
-        # Escape LIKE metacharacters so _ and % match literally
-        escaped = metric.replace("!", "!!").replace("%", "!%").replace("_", "!_")
-        where_clauses.append("metric_name LIKE ? ESCAPE '!'")
-        params.append(f"%{escaped}%")
+        if output == "json":
+            result = {
+                "metrics": [
+                    {
+                        "name": row[0],
+                        "type": row[1],
+                        "labels": row[2],
+                        "value": row[3],
+                        "snapshots": row[4],
+                        "last_recorded": row[5].isoformat() if row[5] else None,
+                    }
+                    for row in rows
+                ]
+            }
+            typer.echo(json.dumps(result, indent=2))
+            return
 
-    where_sql = ""
-    if where_clauses:
-        where_sql = "WHERE " + " AND ".join(where_clauses)
+        if not rows:
+            typer.echo("No metrics recorded yet. Run some operations first.")
+            return
 
-    try:
-        # Use latest snapshot per metric+labels (not SUM — values are cumulative)
-        rows = db.execute(
-            f"""
-            SELECT metric_name, metric_type, labels,
-                   value AS current_value,
-                   snapshot_count,
-                   last_recorded
-            FROM (
-                SELECT metric_name, metric_type, labels, value,
-                       COUNT(*) OVER (
-                           PARTITION BY metric_name, metric_type, labels
-                       ) AS snapshot_count,
-                       MAX(recorded_at) OVER (
-                           PARTITION BY metric_name, metric_type, labels
-                       ) AS last_recorded,
-                       ROW_NUMBER() OVER (
-                           PARTITION BY metric_name, metric_type, labels
-                           ORDER BY recorded_at DESC
-                       ) AS rn
-                FROM app.metrics
-                {where_sql}
-            )
-            WHERE rn = 1
-            ORDER BY metric_name
-            """,  # noqa: S608 — where_sql is built from validated fragments, not user input
-            params if params else None,
-        ).fetchall()
-    except Exception:  # noqa: BLE001 — app.metrics table may not exist yet
-        logger.debug("Failed to query app.metrics", exc_info=True)
-        rows = []
-
-    if output == "json":
-        result = {
-            "metrics": [
-                {
-                    "name": row[0],
-                    "type": row[1],
-                    "labels": row[2],
-                    "value": row[3],
-                    "snapshots": row[4],
-                    "last_recorded": row[5].isoformat() if row[5] else None,
-                }
-                for row in rows
-            ]
-        }
-        typer.echo(json.dumps(result, indent=2))
-        return
-
-    if not rows:
-        typer.echo("No metrics recorded yet. Run some operations first.")
-        return
-
-    # Human-readable output
-    for row in rows:
-        name, metric_type, _labels, value, count, _last = row
-        display_name = name.replace("moneybin_", "").replace("_", " ").title()
-        if metric_type == "counter":
-            typer.echo(f"{display_name}: {value:,.0f} total")
-        elif metric_type == "gauge":
-            typer.echo(f"{display_name}: {value:.2f}")
-        elif metric_type == "histogram":
-            typer.echo(f"{display_name}: {count} observations (sum={value:.2f}s)")
+        # Human-readable output
+        for row in rows:
+            name, metric_type, _labels, value, count, _last = row
+            display_name = name.replace("moneybin_", "").replace("_", " ").title()
+            if metric_type == "counter":
+                typer.echo(f"{display_name}: {value:,.0f} total")
+            elif metric_type == "gauge":
+                typer.echo(f"{display_name}: {value:.2f}")
+            elif metric_type == "histogram":
+                typer.echo(f"{display_name}: {count} observations (sum={value:.2f}s)")

--- a/src/moneybin/cli/commands/synthetic.py
+++ b/src/moneybin/cli/commands/synthetic.py
@@ -51,8 +51,9 @@ def _run_generate(
         seed: Deterministic seed (None for random).
         skip_transform: If True, skip running SQLMesh after generation.
     """
+    from moneybin.cli.utils import handle_database_errors
     from moneybin.config import get_current_profile, set_current_profile
-    from moneybin.database import DatabaseKeyError, close_database, get_database
+    from moneybin.database import close_database
     from moneybin.services.import_service import run_transforms
     from moneybin.testing.synthetic.engine import GeneratorEngine
     from moneybin.testing.synthetic.writer import SyntheticWriter
@@ -69,78 +70,74 @@ def _run_generate(
     set_current_profile(profile)
 
     try:
-        try:
-            db = get_database()
-        except DatabaseKeyError as e:
-            from moneybin.database import database_key_error_hint
+        with handle_database_errors() as db:
+            # Check if profile already has data
+            try:
+                row = db.execute(
+                    """SELECT (SELECT COUNT(*) FROM raw.ofx_transactions)
+                            + (SELECT COUNT(*) FROM raw.tabular_transactions)"""
+                ).fetchone()
+                existing_count = row[0] if row else 0
+            except Exception:  # noqa: BLE001,S110 — tables may not exist in a fresh DB
+                existing_count = 0
 
-            logger.error(f"❌ {e}")
-            logger.info(database_key_error_hint())
-            raise typer.Exit(1) from e
+            if existing_count > 0:
+                logger.error(
+                    f"❌ Profile {profile!r} already has data ({existing_count} transactions)"
+                )
+                logger.info(
+                    f"💡 Use 'moneybin synthetic reset --persona={persona}' "
+                    f"to wipe and regenerate"
+                )
+                raise typer.Exit(1) from None
 
-        # Check if profile already has data
-        try:
-            row = db.execute(
-                """SELECT (SELECT COUNT(*) FROM raw.ofx_transactions)
-                        + (SELECT COUNT(*) FROM raw.tabular_transactions)"""
-            ).fetchone()
-            existing_count = row[0] if row else 0
-        except Exception:  # noqa: BLE001,S110 — tables may not exist in a fresh DB
-            existing_count = 0
+            # Generate
+            try:
+                engine = GeneratorEngine(persona, seed=actual_seed, years=years)
+                result = engine.generate()
+            except FileNotFoundError as e:
+                logger.error(f"❌ {e}")
+                raise typer.Exit(1) from None
 
-        if existing_count > 0:
-            logger.error(
-                f"❌ Profile {profile!r} already has data ({existing_count} transactions)"
+            # Write to database
+            writer = SyntheticWriter(db)
+            counts = writer.write(result)
+
+            acct_count = counts.get("ofx_accounts", 0) + counts.get(
+                "tabular_accounts", 0
+            )
+            txn_count = counts.get("ofx_transactions", 0) + counts.get(
+                "tabular_transactions", 0
+            )
+            gt_count = counts.get("ground_truth", 0)
+            transfer_count = (
+                sum(1 for t in result.transactions if t.transfer_pair_id) // 2
+            )
+
+            logger.info(f"  Created {acct_count} accounts")
+            logger.info(
+                f"  Generated {txn_count} transactions "
+                f"({result.start_date} to {result.end_date})"
             )
             logger.info(
-                f"💡 Use 'moneybin synthetic reset --persona={persona}' "
-                f"to wipe and regenerate"
+                f"  Wrote ground truth: {gt_count} labels, {transfer_count} transfer pairs"
             )
-            raise typer.Exit(1) from None
 
-        # Generate
-        try:
-            engine = GeneratorEngine(persona, seed=actual_seed, years=years)
-            result = engine.generate()
-        except FileNotFoundError as e:
-            logger.error(f"❌ {e}")
-            raise typer.Exit(1) from None
+            # Run SQLMesh transforms
+            if not skip_transform:
+                logger.info("⚙️  Running SQLMesh to materialize pipeline...")
+                try:
+                    run_transforms()
+                except Exception:  # noqa: BLE001 — SQLMesh failures are non-fatal here
+                    logger.warning(
+                        "⚠️  SQLMesh transforms failed — raw data is intact, "
+                        "run 'moneybin transform apply' manually"
+                    )
 
-        # Write to database
-        writer = SyntheticWriter(db)
-        counts = writer.write(result)
-
-        acct_count = counts.get("ofx_accounts", 0) + counts.get("tabular_accounts", 0)
-        txn_count = counts.get("ofx_transactions", 0) + counts.get(
-            "tabular_transactions", 0
-        )
-        gt_count = counts.get("ground_truth", 0)
-        transfer_count = sum(1 for t in result.transactions if t.transfer_pair_id) // 2
-
-        logger.info(f"  Created {acct_count} accounts")
-        logger.info(
-            f"  Generated {txn_count} transactions "
-            f"({result.start_date} to {result.end_date})"
-        )
-        logger.info(
-            f"  Wrote ground truth: {gt_count} labels, {transfer_count} transfer pairs"
-        )
-
-        # Run SQLMesh transforms
-        if not skip_transform:
-            logger.info("⚙️  Running SQLMesh to materialize pipeline...")
-            try:
-                run_transforms()
-            except Exception:  # noqa: BLE001 — SQLMesh failures are non-fatal here
-                logger.warning(
-                    "⚠️  SQLMesh transforms failed — raw data is intact, "
-                    "run 'moneybin transform apply' manually"
-                )
-
-        logger.info(
-            f"✅ Profile {profile!r} ready (seed={actual_seed}). "
-            f"Use --profile={profile} with any moneybin command."
-        )
+            logger.info(
+                f"✅ Profile {profile!r} ready (seed={actual_seed}). "
+                f"Use --profile={profile} with any moneybin command."
+            )
     finally:
         close_database()
         # When called from reset(), original_profile == profile (reset already
@@ -192,8 +189,9 @@ def reset(
     ),
 ) -> None:
     """Wipe a generated profile and regenerate from scratch."""
+    from moneybin.cli.utils import handle_database_errors
     from moneybin.config import get_current_profile, set_current_profile
-    from moneybin.database import DatabaseKeyError, close_database, get_database
+    from moneybin.database import close_database
 
     target_profile = profile or _PERSONA_PROFILES.get(persona, persona)
 
@@ -202,57 +200,49 @@ def reset(
     set_current_profile(target_profile)
 
     try:
-        try:
-            db = get_database()
-        except DatabaseKeyError as e:
-            from moneybin.database import database_key_error_hint
-
-            logger.error(f"❌ {e}")
-            logger.info(database_key_error_hint())
-            raise typer.Exit(1) from e
-
-        # Safety check: only reset profiles created by the generator
-        try:
-            gt_row = db.execute(
-                """SELECT COUNT(*) FROM information_schema.tables
-                WHERE table_schema = 'synthetic' AND table_name = 'ground_truth'"""
-            ).fetchone()
-            gt_exists = gt_row[0] if gt_row else 0
-        except Exception:  # noqa: BLE001 — fresh DB with no synthetic schema
-            gt_exists = 0
-
-        if not gt_exists:
-            logger.error(
-                f"❌ Profile {target_profile!r} was not created by the "
-                f"generator. Refusing to reset."
-            )
-            logger.info(
-                f"💡 To destroy a non-generated profile, use "
-                f"'moneybin db destroy --profile={target_profile}'"
-            )
-            raise typer.Exit(1) from None
-
-        if not yes:
-            confirmed = typer.confirm(
-                f"This will destroy all data in profile {target_profile!r} "
-                f"and regenerate. Continue?"
-            )
-            if not confirmed:
-                raise typer.Abort()
-
-        from moneybin.metrics.registry import SYNTHETIC_RESET_TOTAL
-
-        SYNTHETIC_RESET_TOTAL.labels(persona=persona).inc()
-        logger.info(f"⚙️  Resetting profile {target_profile!r}...")
-        for table, where in _RESET_DELETIONS.items():
+        with handle_database_errors() as db:
+            # Safety check: only reset profiles created by the generator
             try:
-                db.execute(f"DELETE FROM {table} {where}")  # noqa: S608 — allowlisted table names + literal WHERE clauses
-            except Exception:  # noqa: BLE001,S110 — table may not exist
-                pass
+                gt_row = db.execute(
+                    """SELECT COUNT(*) FROM information_schema.tables
+                    WHERE table_schema = 'synthetic' AND table_name = 'ground_truth'"""
+                ).fetchone()
+                gt_exists = gt_row[0] if gt_row else 0
+            except Exception:  # noqa: BLE001 — fresh DB with no synthetic schema
+                gt_exists = 0
 
-        db.close()
-        # Close the singleton so _run_generate gets a fresh connection
-        close_database()
+            if not gt_exists:
+                logger.error(
+                    f"❌ Profile {target_profile!r} was not created by the "
+                    f"generator. Refusing to reset."
+                )
+                logger.info(
+                    f"💡 To destroy a non-generated profile, use "
+                    f"'moneybin db destroy --profile={target_profile}'"
+                )
+                raise typer.Exit(1) from None
+
+            if not yes:
+                confirmed = typer.confirm(
+                    f"This will destroy all data in profile {target_profile!r} "
+                    f"and regenerate. Continue?"
+                )
+                if not confirmed:
+                    raise typer.Abort()
+
+            from moneybin.metrics.registry import SYNTHETIC_RESET_TOTAL
+
+            SYNTHETIC_RESET_TOTAL.labels(persona=persona).inc()
+            logger.info(f"⚙️  Resetting profile {target_profile!r}...")
+            for table, where in _RESET_DELETIONS.items():
+                try:
+                    db.execute(f"DELETE FROM {table} {where}")  # noqa: S608 — allowlisted table names + literal WHERE clauses
+                except Exception:  # noqa: BLE001,S110 — table may not exist
+                    pass
+
+            db.close()
+            # Close the singleton so _run_generate gets a fresh connection
+            close_database()
 
         # Regenerate
         _run_generate(

--- a/src/moneybin/cli/commands/transform.py
+++ b/src/moneybin/cli/commands/transform.py
@@ -8,12 +8,8 @@ import logging
 
 import typer
 
-from moneybin.database import (
-    DatabaseKeyError,
-    database_key_error_hint,
-    get_database,
-    sqlmesh_context,
-)
+from moneybin.cli.utils import handle_database_errors
+from moneybin.database import sqlmesh_context
 
 app = typer.Typer(help="Run data transformations using SQLMesh", no_args_is_help=True)
 logger = logging.getLogger(__name__)
@@ -33,14 +29,10 @@ def plan_transforms(
     logger.info("⚙️  Running SQLMesh plan...")
 
     try:
-        get_database()
-        with sqlmesh_context() as ctx:
-            ctx.plan(auto_apply=auto_apply, no_prompts=auto_apply)
+        with handle_database_errors():
+            with sqlmesh_context() as ctx:
+                ctx.plan(auto_apply=auto_apply, no_prompts=auto_apply)
         logger.info("✅ SQLMesh plan completed")
-    except DatabaseKeyError as e:
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
     except Exception as e:  # noqa: BLE001 — SQLMesh raises broad exceptions
         logger.error(f"❌ SQLMesh plan failed: {e}")
         raise typer.Exit(1) from e
@@ -56,14 +48,10 @@ def apply_transforms() -> None:
     logger.info("⚙️  Applying SQLMesh transforms...")
 
     try:
-        get_database()
-        with sqlmesh_context() as ctx:
-            ctx.plan(auto_apply=True, no_prompts=True)
+        with handle_database_errors():
+            with sqlmesh_context() as ctx:
+                ctx.plan(auto_apply=True, no_prompts=True)
         logger.info("✅ SQLMesh transforms applied")
-    except DatabaseKeyError as e:
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
     except Exception as e:  # noqa: BLE001 — SQLMesh raises broad exceptions
         logger.error(f"❌ SQLMesh apply failed: {e}")
         raise typer.Exit(1) from e
@@ -74,19 +62,15 @@ def transform_status() -> None:
     """Show current model state and environment."""
     logger.info("⚙️  Checking SQLMesh status...")
     try:
-        get_database()
-        with sqlmesh_context() as ctx:
-            env = ctx.state_reader.get_environment("prod")
-            if env:
-                logger.info("Environment: prod")
-                logger.info(f"  Last updated: {env.expiration_ts}")
-            else:
-                logger.info("No SQLMesh environment initialized yet")
-                logger.info("💡 Run 'moneybin transform apply' to initialize")
-    except DatabaseKeyError as e:
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
+        with handle_database_errors():
+            with sqlmesh_context() as ctx:
+                env = ctx.state_reader.get_environment("prod")
+                if env:
+                    logger.info("Environment: prod")
+                    logger.info(f"  Last updated: {env.expiration_ts}")
+                else:
+                    logger.info("No SQLMesh environment initialized yet")
+                    logger.info("💡 Run 'moneybin transform apply' to initialize")
     except Exception as e:  # noqa: BLE001 — SQLMesh raises broad exceptions
         logger.error(f"❌ SQLMesh status failed: {e}")
         raise typer.Exit(1) from e
@@ -97,14 +81,10 @@ def transform_validate() -> None:
     """Check that model SQL parses and resolves without errors."""
     logger.info("⚙️  Validating SQLMesh models...")
     try:
-        get_database()
-        with sqlmesh_context() as ctx:
-            ctx.plan(no_prompts=True, auto_apply=False)
+        with handle_database_errors():
+            with sqlmesh_context() as ctx:
+                ctx.plan(no_prompts=True, auto_apply=False)
         logger.info("✅ All models valid")
-    except DatabaseKeyError as e:
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
     except Exception as e:  # noqa: BLE001 — SQLMesh raises broad exceptions
         logger.error(f"❌ Validation failed: {e}")
         raise typer.Exit(1) from e
@@ -122,14 +102,10 @@ def transform_audit(
     """Run data quality assertions defined in SQLMesh models."""
     logger.info("⚙️  Running SQLMesh audits...")
     try:
-        get_database()
-        with sqlmesh_context() as ctx:
-            ctx.audit(start=start, end=end)
+        with handle_database_errors():
+            with sqlmesh_context() as ctx:
+                ctx.audit(start=start, end=end)
         logger.info("✅ All audits passed")
-    except DatabaseKeyError as e:
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
     except Exception as e:  # noqa: BLE001 — SQLMesh raises broad exceptions
         logger.error(f"❌ Audit failed: {e}")
         raise typer.Exit(1) from e
@@ -155,20 +131,16 @@ def transform_restate(
             return
     logger.info(f"⚙️  Restating {model} from {start}...")
     try:
-        get_database()
-        with sqlmesh_context() as ctx:
-            ctx.plan(
-                restate_models=[model],
-                start=start,
-                end=end,
-                auto_apply=True,
-                no_prompts=True,
-            )
+        with handle_database_errors():
+            with sqlmesh_context() as ctx:
+                ctx.plan(
+                    restate_models=[model],
+                    start=start,
+                    end=end,
+                    auto_apply=True,
+                    no_prompts=True,
+                )
         logger.info(f"✅ Restated {model}")
-    except DatabaseKeyError as e:
-        logger.error(f"❌ {e}")
-        logger.info(database_key_error_hint())
-        raise typer.Exit(1) from e
     except Exception as e:  # noqa: BLE001 — SQLMesh raises broad exceptions
         logger.error(f"❌ Restatement failed: {e}")
         raise typer.Exit(1) from e

--- a/src/moneybin/cli/commands/transform.py
+++ b/src/moneybin/cli/commands/transform.py
@@ -34,6 +34,8 @@ def plan_transforms(
             with sqlmesh_context() as ctx:
                 ctx.plan(auto_apply=auto_apply, no_prompts=auto_apply)
         logger.info("✅ SQLMesh plan completed")
+    except typer.Exit:
+        raise
     except Exception as e:  # noqa: BLE001 — SQLMesh raises broad exceptions
         logger.error(f"❌ SQLMesh plan failed: {e}")
         raise typer.Exit(1) from e
@@ -53,6 +55,8 @@ def apply_transforms() -> None:
             with sqlmesh_context() as ctx:
                 ctx.plan(auto_apply=True, no_prompts=True)
         logger.info("✅ SQLMesh transforms applied")
+    except typer.Exit:
+        raise
     except Exception as e:  # noqa: BLE001 — SQLMesh raises broad exceptions
         logger.error(f"❌ SQLMesh apply failed: {e}")
         raise typer.Exit(1) from e
@@ -78,6 +82,8 @@ def transform_status() -> None:
                 else:
                     logger.info("No SQLMesh environment initialized yet")
                     logger.info("💡 Run 'moneybin transform apply' to initialize")
+    except typer.Exit:
+        raise
     except Exception as e:  # noqa: BLE001 — SQLMesh raises broad exceptions
         logger.error(f"❌ SQLMesh status failed: {e}")
         raise typer.Exit(1) from e
@@ -92,6 +98,8 @@ def transform_validate() -> None:
             with sqlmesh_context() as ctx:
                 ctx.plan(no_prompts=True, auto_apply=False)
         logger.info("✅ All models valid")
+    except typer.Exit:
+        raise
     except Exception as e:  # noqa: BLE001 — SQLMesh raises broad exceptions
         logger.error(f"❌ Validation failed: {e}")
         raise typer.Exit(1) from e
@@ -113,6 +121,8 @@ def transform_audit(
             with sqlmesh_context() as ctx:
                 ctx.audit(start=start, end=end)
         logger.info("✅ All audits passed")
+    except typer.Exit:
+        raise
     except Exception as e:  # noqa: BLE001 — SQLMesh raises broad exceptions
         logger.error(f"❌ Audit failed: {e}")
         raise typer.Exit(1) from e
@@ -148,6 +158,8 @@ def transform_restate(
                     no_prompts=True,
                 )
         logger.info(f"✅ Restated {model}")
+    except typer.Exit:
+        raise
     except Exception as e:  # noqa: BLE001 — SQLMesh raises broad exceptions
         logger.error(f"❌ Restatement failed: {e}")
         raise typer.Exit(1) from e

--- a/src/moneybin/cli/utils.py
+++ b/src/moneybin/cli/utils.py
@@ -1,0 +1,37 @@
+"""Shared helpers for CLI commands."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Generator
+from contextlib import contextmanager
+
+import typer
+
+from moneybin.database import (
+    Database,
+    DatabaseKeyError,
+    database_key_error_hint,
+    get_database,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def handle_database_errors() -> Generator[Database, None, None]:
+    """Get the active database with standard CLI error handling.
+
+    Catches ``DatabaseKeyError`` (raised when the encryption key is not
+    available — e.g. database is locked), logs a user-facing error and the
+    standard ``moneybin db unlock`` hint, and exits with code 1. All other
+    exceptions propagate unchanged so callers can handle them.
+    """
+    try:
+        db = get_database()
+    except DatabaseKeyError as e:
+        logger.error(f"❌ {e}")
+        logger.info(database_key_error_hint())
+        raise typer.Exit(1) from e
+
+    yield db

--- a/src/moneybin/config.py
+++ b/src/moneybin/config.py
@@ -137,6 +137,20 @@ class TabularConfig(BaseModel):
         default=50_000,
         description="Row count above which import is refused (use --no-row-limit to override)",
     )
+    balance_pass_threshold: float = Field(
+        default=0.90,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Minimum fraction of balance deltas that must match "
+            "for balance validation to pass"
+        ),
+    )
+    balance_tolerance_cents: int = Field(
+        default=1,
+        ge=0,
+        description="Per-delta tolerance in cents for balance validation",
+    )
 
 
 class DataConfig(BaseModel):

--- a/src/moneybin/extractors/tabular/column_mapper.py
+++ b/src/moneybin/extractors/tabular/column_mapper.py
@@ -18,6 +18,10 @@ from moneybin.extractors.tabular.field_aliases import (
     ACCOUNT_IDENTIFYING_FIELDS,
     match_header_to_field,
 )
+from moneybin.extractors.tabular.formats import (
+    NumberFormatType,
+    SignConventionType,
+)
 from moneybin.extractors.tabular.sign_convention import (
     infer_sign_convention,
 )
@@ -54,10 +58,10 @@ class MappingResult:
     date_format: str | None = None
     """Detected date format string."""
 
-    number_format: str = "us"
+    number_format: NumberFormatType = "us"
     """Detected number format convention."""
 
-    sign_convention: str = "negative_is_expense"
+    sign_convention: SignConventionType = "negative_is_expense"
     """Detected sign convention."""
 
     sign_needs_confirmation: bool = False

--- a/src/moneybin/extractors/tabular/date_detection.py
+++ b/src/moneybin/extractors/tabular/date_detection.py
@@ -8,6 +8,10 @@ disambiguation and convention scoring for number format detection.
 import re
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from moneybin.extractors.tabular.formats import NumberFormatType
 
 _CURRENCY_SYMBOLS = re.compile(
     r"[$€£¥₩₹₽₺₫kr\s]|CHF|R\$|kr\b|SEK|NOK|DKK", re.IGNORECASE
@@ -137,14 +141,16 @@ def _disambiguate_dd_mm(
     return "%m/%d/%Y", "medium"
 
 
-def detect_number_format(values: list[str | None]) -> str:
+def detect_number_format(
+    values: list[str | None],
+) -> "NumberFormatType":
     """Detect the number format convention from sample values.
 
     Args:
         values: Sample amount strings.
 
     Returns:
-        One of: "us", "european", "swiss_french", "zero_decimal".
+        One of NumberFormatType literal values.
     """
     clean = [v.strip() for v in values if v and v.strip()]
     if not clean:
@@ -204,14 +210,14 @@ def detect_number_format(values: list[str | None]) -> str:
     return best
 
 
-def parse_amount_str(value: str, number_format: str) -> Decimal | None:
+def parse_amount_str(value: str, number_format: "NumberFormatType") -> Decimal | None:
     """Parse an amount string using the specified number format convention.
 
     Handles currency symbols, parentheses-as-negative, DR/CR suffixes.
 
     Args:
         value: Raw amount string.
-        number_format: Convention: us, european, swiss_french, zero_decimal.
+        number_format: One of NumberFormatType literal values.
 
     Returns:
         Parsed Decimal, or None if the string is empty/unparseable.

--- a/src/moneybin/extractors/tabular/date_detection.py
+++ b/src/moneybin/extractors/tabular/date_detection.py
@@ -8,7 +8,7 @@ disambiguation and convention scoring for number format detection.
 import re
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from moneybin.extractors.tabular.formats import NumberFormatType
@@ -207,7 +207,7 @@ def detect_number_format(
     best = max(convention_scores, key=lambda k: convention_scores[k])
     if convention_scores[best] == 0:
         return "us"
-    return best
+    return cast("NumberFormatType", best)
 
 
 def parse_amount_str(value: str, number_format: "NumberFormatType") -> Decimal | None:

--- a/src/moneybin/extractors/tabular/sign_convention.py
+++ b/src/moneybin/extractors/tabular/sign_convention.py
@@ -8,12 +8,14 @@ Determines how the source represents expenses vs income:
 
 from dataclasses import dataclass
 
+from moneybin.extractors.tabular.formats import SignConventionType
+
 
 @dataclass(frozen=True)
 class SignConventionResult:
     """Result of sign convention inference."""
 
-    convention: str
+    convention: SignConventionType
     """One of: negative_is_expense, negative_is_income, split_debit_credit."""
 
     needs_confirmation: bool = False

--- a/src/moneybin/extractors/tabular/transforms.py
+++ b/src/moneybin/extractors/tabular/transforms.py
@@ -103,6 +103,8 @@ def transform_dataframe(
     source_type: str,
     source_origin: str,
     import_id: str,
+    balance_pass_threshold: float = 0.90,
+    balance_tolerance_cents: int = 1,
 ) -> TransformResult:
     """Transform a mapped DataFrame into the raw.tabular_transactions shape.
 
@@ -119,6 +121,10 @@ def transform_dataframe(
         source_type: File format type (csv, tsv, excel, parquet, etc.).
         source_origin: Institution or source name (e.g. "chase_credit").
         import_id: Unique ID for this import run.
+        balance_pass_threshold: Fraction of balance deltas that must match for
+            validation to pass (default 0.90).
+        balance_tolerance_cents: Maximum allowed delta mismatch in cents
+            (default 1, i.e. ±$0.01).
 
     Returns:
         TransformResult with validated transactions DataFrame and rejection stats.
@@ -321,7 +327,13 @@ def transform_dataframe(
                 str(v) if v is not None else ""
                 for v in df[balance_col].cast(pl.Utf8).to_list()
             ]
-            result = _validate_running_balance(result, balance_strs, number_format)
+            result = _validate_running_balance(
+                result,
+                balance_strs,
+                number_format,
+                pass_threshold=balance_pass_threshold,
+                tolerance_cents=balance_tolerance_cents,
+            )
 
     return result
 
@@ -464,6 +476,9 @@ def _validate_running_balance(
     result: TransformResult,
     balance_strs: list[str],
     number_format: str,
+    *,
+    pass_threshold: float = 0.90,
+    tolerance_cents: int = 1,
 ) -> TransformResult:
     """Validate running balance consistency against transaction amounts.
 
@@ -479,13 +494,19 @@ def _validate_running_balance(
         balance_strs: Raw balance strings from the source file, one per source row.
             May be longer than ``result.transactions`` if rows were rejected.
         number_format: Number format used by ``parse_amount_str`` for balances.
+        pass_threshold: Fraction of balance deltas that must match for validation
+            to pass (default 0.90).
+        tolerance_cents: Maximum allowed delta mismatch in cents (default 1,
+            i.e. ±$0.01).
 
     Returns:
         Updated TransformResult with ``balance_validated`` set and, when
         auto-correction fires, negated amounts in ``transactions``.
     """
-    _balance_tolerance = Decimal("0.01")
-    _pass_threshold = 0.90
+    _balance_tolerance = (Decimal(tolerance_cents) / Decimal(100)).quantize(
+        Decimal("0.01")
+    )
+    _pass_threshold = pass_threshold
 
     amounts: list[Decimal] = result.transactions["amount"].to_list()
     row_numbers: list[int] = result.transactions["row_number"].to_list()

--- a/src/moneybin/extractors/tabular/transforms.py
+++ b/src/moneybin/extractors/tabular/transforms.py
@@ -19,6 +19,10 @@ from decimal import Decimal
 import polars as pl
 
 from moneybin.extractors.tabular.date_detection import parse_amount_str
+from moneybin.extractors.tabular.formats import (
+    NumberFormatType,
+    SignConventionType,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -96,8 +100,8 @@ def transform_dataframe(
     df: pl.DataFrame,
     field_mapping: dict[str, str],
     date_format: str,
-    sign_convention: str,
-    number_format: str,
+    sign_convention: SignConventionType,
+    number_format: NumberFormatType,
     account_id: str | list[str],
     source_file: str,
     source_type: str,
@@ -112,9 +116,8 @@ def transform_dataframe(
         df: Source DataFrame with original column names.
         field_mapping: Destination field → source column mapping from Stage 3.
         date_format: strptime format string for parsing dates.
-        sign_convention: One of: negative_is_expense, negative_is_income,
-            split_debit_credit.
-        number_format: One of: us, european, swiss_french, zero_decimal.
+        sign_convention: One of SignConventionType literal values.
+        number_format: One of NumberFormatType literal values.
         account_id: Account identifier — single string (broadcast to all rows)
             or list of per-row IDs (for multi-account files).
         source_file: Path to the source file (for provenance).
@@ -375,8 +378,8 @@ def _extract_amounts(
     *,
     df: pl.DataFrame,
     field_mapping: dict[str, str],
-    sign_convention: str,
-    number_format: str,
+    sign_convention: SignConventionType,
+    number_format: NumberFormatType,
 ) -> tuple[list[Decimal | None], dict[int, str]]:
     """Extract and normalize amounts from the DataFrame.
 
@@ -385,9 +388,8 @@ def _extract_amounts(
     Args:
         df: Source DataFrame.
         field_mapping: Destination field → source column mapping.
-        sign_convention: One of: negative_is_expense, negative_is_income,
-            split_debit_credit.
-        number_format: Number format convention.
+        sign_convention: One of SignConventionType literal values.
+        number_format: One of NumberFormatType literal values.
 
     Returns:
         Tuple of (amounts list, rejection map {idx: reason}).
@@ -475,7 +477,7 @@ def _combine_original_debit_credit(
 def _validate_running_balance(
     result: TransformResult,
     balance_strs: list[str],
-    number_format: str,
+    number_format: NumberFormatType,
     *,
     pass_threshold: float = 0.90,
     tolerance_cents: int = 1,
@@ -493,7 +495,7 @@ def _validate_running_balance(
         result: Current TransformResult with a parsed ``transactions`` DataFrame.
         balance_strs: Raw balance strings from the source file, one per source row.
             May be longer than ``result.transactions`` if rows were rejected.
-        number_format: Number format used by ``parse_amount_str`` for balances.
+        number_format: One of NumberFormatType literal values.
         pass_threshold: Fraction of balance deltas that must match for validation
             to pass (default 0.90).
         tolerance_cents: Maximum allowed delta mismatch in cents (default 1,

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -448,6 +448,9 @@ def _import_tabular(
     )
 
     # Stage 4: Transform
+    from moneybin.config import get_settings
+
+    tabular_cfg = get_settings().data.tabular
     try:
         transform_result = transform_dataframe(
             df=df,
@@ -460,6 +463,8 @@ def _import_tabular(
             source_type=source_type,
             source_origin=source_origin,
             import_id=import_id,
+            balance_pass_threshold=tabular_cfg.balance_pass_threshold,
+            balance_tolerance_cents=tabular_cfg.balance_tolerance_cents,
         )
     except Exception as e:  # noqa: BLE001  # re-raised as ValueError after recording rejection in DB
         loader.finalize_import_batch(

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -5,6 +5,7 @@ data, load to raw tables, and run SQLMesh transforms. Both CLI commands and
 MCP tools call this same service — no duplication.
 """
 
+import dataclasses
 import logging
 import time
 from dataclasses import dataclass, field
@@ -63,6 +64,23 @@ class ImportResult:
             lines.append("  Core tables rebuilt (dim_accounts, fct_transactions)")
 
         return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class ResolvedMapping:
+    """Final per-import mapping from the matched format or auto-detection.
+
+    Both the matched-format branch and the auto-detect branch in
+    ``_import_tabular`` produce one of these. Downstream code reads from
+    the instance instead of six unpacked local variables.
+    """
+
+    field_mapping: dict[str, str]
+    date_format: str
+    sign_convention: SignConventionType
+    number_format: NumberFormatType
+    is_multi_account: bool
+    confidence: str
 
 
 def _query_date_range(
@@ -358,29 +376,33 @@ def _import_tabular(
                 break
 
     if matched_format:
-        mapping_result_mapping = matched_format.field_mapping
-        mapping_result_date_format = matched_format.date_format
-        mapping_result_sign_convention = matched_format.sign_convention
-        mapping_result_number_format = matched_format.number_format
-        mapping_result_is_multi_account = matched_format.multi_account
-        mapping_result_confidence = "high"
+        resolved = ResolvedMapping(
+            field_mapping=matched_format.field_mapping,
+            date_format=matched_format.date_format,
+            sign_convention=matched_format.sign_convention,
+            number_format=matched_format.number_format,
+            is_multi_account=matched_format.multi_account,
+            confidence="high",
+        )
         format_source = (
             "built-in" if matched_format.name in builtin_formats else "saved"
         )
     else:
         mapping_result = map_columns(df, overrides=overrides)
-        mapping_result_mapping = mapping_result.field_mapping
-        mapping_result_date_format = mapping_result.date_format or "%Y-%m-%d"
-        mapping_result_sign_convention = mapping_result.sign_convention
-        mapping_result_number_format = mapping_result.number_format
-        mapping_result_is_multi_account = mapping_result.is_multi_account
-        mapping_result_confidence = mapping_result.confidence
+        resolved = ResolvedMapping(
+            field_mapping=mapping_result.field_mapping,
+            date_format=mapping_result.date_format or "%Y-%m-%d",
+            sign_convention=mapping_result.sign_convention,
+            number_format=mapping_result.number_format,
+            is_multi_account=mapping_result.is_multi_account,
+            confidence=mapping_result.confidence,
+        )
         format_source = "detected"
 
         if mapping_result.sign_needs_confirmation and not sign:
             logger.warning(
                 "⚠️  Sign convention is ambiguous (all amounts appear positive). "
-                f"Proceeding with '{mapping_result_sign_convention}' — "
+                f"Proceeding with '{resolved.sign_convention}' — "
                 "use --sign to override if expense amounts look wrong."
             )
 
@@ -395,15 +417,20 @@ def _import_tabular(
         TABULAR_FORMAT_MATCHES.labels(
             format_name=matched_format.name, format_source=format_source
         ).inc()
-    TABULAR_DETECTION_CONFIDENCE.labels(confidence=mapping_result_confidence).inc()
+    TABULAR_DETECTION_CONFIDENCE.labels(confidence=resolved.confidence).inc()
 
-    # Apply CLI overrides (take precedence over detected/built-in values)
-    if sign:
-        mapping_result_sign_convention = cast(SignConventionType, sign)
-    if date_format_override:
-        mapping_result_date_format = date_format_override
-    if number_format_override:
-        mapping_result_number_format = cast(NumberFormatType, number_format_override)
+    # Apply CLI overrides — rebuild a new ResolvedMapping (frozen)
+    if sign or date_format_override or number_format_override:
+        resolved = dataclasses.replace(
+            resolved,
+            sign_convention=cast(SignConventionType, sign)
+            if sign
+            else resolved.sign_convention,
+            date_format=date_format_override or resolved.date_format,
+            number_format=cast(NumberFormatType, number_format_override)
+            if number_format_override
+            else resolved.number_format,
+        )
 
     # Determine account info
     source_type = format_info.file_type
@@ -411,7 +438,7 @@ def _import_tabular(
         source_type = "csv"
 
     # Build per-row account_ids and a name→id mapping for the accounts table
-    acct_name_col = mapping_result_mapping.get("account_name")
+    acct_name_col = resolved.field_mapping.get("account_name")
     acct_id_to_name: dict[str, str] = {}
 
     if account_id:
@@ -421,11 +448,7 @@ def _import_tabular(
         aid = slugify(account_name)
         account_ids = aid
         acct_id_to_name[aid] = account_name
-    elif (
-        mapping_result_is_multi_account
-        and acct_name_col
-        and acct_name_col in df.columns
-    ):
+    elif resolved.is_multi_account and acct_name_col and acct_name_col in df.columns:
         # Per-row account assignment from the DataFrame column
         raw_names = [
             str(v) if v is not None else "unknown" for v in df[acct_name_col].to_list()
@@ -459,10 +482,10 @@ def _import_tabular(
     try:
         transform_result = transform_dataframe(
             df=df,
-            field_mapping=mapping_result_mapping,
-            date_format=mapping_result_date_format,
-            sign_convention=mapping_result_sign_convention,
-            number_format=mapping_result_number_format,
+            field_mapping=resolved.field_mapping,
+            date_format=resolved.date_format,
+            sign_convention=resolved.sign_convention,
+            number_format=resolved.number_format,
             account_id=account_ids,
             source_file=str(file_path),
             source_type=source_type,
@@ -514,10 +537,10 @@ def _import_tabular(
             for r in transform_result.rejection_details
         ]
         or None,
-        detection_confidence=mapping_result_confidence,
-        number_format=mapping_result_number_format,
-        date_format=mapping_result_date_format,
-        sign_convention=mapping_result_sign_convention,
+        detection_confidence=resolved.confidence,
+        number_format=resolved.number_format,
+        date_format=resolved.date_format,
+        sign_convention=resolved.sign_convention,
         balance_validated=transform_result.balance_validated,
     )
 
@@ -540,7 +563,7 @@ def _import_tabular(
     if (
         save_format
         and not matched_format
-        and mapping_result_confidence in ("high", "medium")
+        and resolved.confidence in ("high", "medium")
         and rows_imported > 0
     ):
         try:
@@ -551,11 +574,11 @@ def _import_tabular(
                 delimiter=format_info.delimiter,
                 encoding=format_info.encoding,
                 header_signature=list(df.columns),
-                field_mapping=mapping_result_mapping,
-                sign_convention=mapping_result_sign_convention,  # type: ignore[reportArgumentType]  # validated by CLI and Pydantic validator
-                date_format=mapping_result_date_format,
-                number_format=mapping_result_number_format,  # type: ignore[reportArgumentType]  # validated by CLI and Pydantic validator
-                multi_account=mapping_result_is_multi_account,
+                field_mapping=resolved.field_mapping,
+                sign_convention=resolved.sign_convention,
+                date_format=resolved.date_format,
+                number_format=resolved.number_format,
+                multi_account=resolved.is_multi_account,
                 source="detected",
                 times_used=1,
             )

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -9,8 +9,13 @@ import logging
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import cast
 
 from moneybin.database import Database, sqlmesh_context
+from moneybin.extractors.tabular.formats import (
+    NumberFormatType,
+    SignConventionType,
+)
 from moneybin.metrics.registry import (
     IMPORT_DURATION_SECONDS,
     IMPORT_ERRORS_TOTAL,
@@ -394,11 +399,11 @@ def _import_tabular(
 
     # Apply CLI overrides (take precedence over detected/built-in values)
     if sign:
-        mapping_result_sign_convention = sign
+        mapping_result_sign_convention = cast(SignConventionType, sign)
     if date_format_override:
         mapping_result_date_format = date_format_override
     if number_format_override:
-        mapping_result_number_format = number_format_override
+        mapping_result_number_format = cast(NumberFormatType, number_format_override)
 
     # Determine account info
     source_type = format_info.file_type

--- a/tests/moneybin/test_cli/test_cli_transform.py
+++ b/tests/moneybin/test_cli/test_cli_transform.py
@@ -27,7 +27,7 @@ def _mock_sqlmesh_context() -> tuple[Any, MagicMock]:
 class TestTransformStatus:
     """Test transform status command."""
 
-    @patch("moneybin.cli.commands.transform.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.cli.commands.transform.sqlmesh_context")
     def test_status_succeeds(
         self, mock_ctx_factory: MagicMock, _mock_get_db: MagicMock
@@ -42,7 +42,7 @@ class TestTransformStatus:
 class TestTransformValidate:
     """Test transform validate command."""
 
-    @patch("moneybin.cli.commands.transform.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.cli.commands.transform.sqlmesh_context")
     def test_validate_succeeds(
         self, mock_ctx_factory: MagicMock, _mock_get_db: MagicMock
@@ -58,7 +58,7 @@ class TestTransformValidate:
 class TestTransformAudit:
     """Test transform audit command."""
 
-    @patch("moneybin.cli.commands.transform.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.cli.commands.transform.sqlmesh_context")
     def test_audit_succeeds(
         self, mock_ctx_factory: MagicMock, _mock_get_db: MagicMock
@@ -76,7 +76,7 @@ class TestTransformAudit:
 class TestTransformRestate:
     """Test transform restate command."""
 
-    @patch("moneybin.cli.commands.transform.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.cli.commands.transform.sqlmesh_context")
     def test_restate_requires_confirmation(
         self, mock_ctx_factory: MagicMock, _mock_get_db: MagicMock
@@ -92,7 +92,7 @@ class TestTransformRestate:
         assert result.exit_code == 0
         mock_ctx.plan.assert_not_called()
 
-    @patch("moneybin.cli.commands.transform.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.cli.commands.transform.sqlmesh_context")
     def test_restate_with_yes(
         self, mock_ctx_factory: MagicMock, _mock_get_db: MagicMock

--- a/tests/moneybin/test_cli/test_handle_database_errors.py
+++ b/tests/moneybin/test_cli/test_handle_database_errors.py
@@ -1,0 +1,44 @@
+"""Tests for the shared CLI database-error handler."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+
+from moneybin.database import DatabaseKeyError
+
+
+def test_handle_database_errors_yields_database() -> None:
+    """When get_database succeeds, the context manager yields the Database."""
+    from moneybin.cli.utils import handle_database_errors
+
+    fake_db = MagicMock()
+    with patch("moneybin.cli.utils.get_database", return_value=fake_db):
+        with handle_database_errors() as db:
+            assert db is fake_db
+
+
+def test_handle_database_errors_translates_key_error_to_exit(caplog) -> None:
+    """DatabaseKeyError is caught, logged, and converted to typer.Exit(1)."""
+    from moneybin.cli.utils import handle_database_errors
+
+    with patch(
+        "moneybin.cli.utils.get_database",
+        side_effect=DatabaseKeyError("locked"),
+    ):
+        with caplog.at_level("ERROR"), pytest.raises(typer.Exit) as exc_info:
+            with handle_database_errors():
+                pass
+    assert exc_info.value.exit_code == 1
+    assert "locked" in caplog.text
+
+
+def test_handle_database_errors_lets_other_exceptions_propagate() -> None:
+    """Non-DatabaseKeyError exceptions raised inside the block pass through."""
+    from moneybin.cli.utils import handle_database_errors
+
+    fake_db = MagicMock()
+    with patch("moneybin.cli.utils.get_database", return_value=fake_db):
+        with pytest.raises(RuntimeError, match="boom"):
+            with handle_database_errors():
+                raise RuntimeError("boom")

--- a/tests/moneybin/test_cli/test_handle_database_errors.py
+++ b/tests/moneybin/test_cli/test_handle_database_errors.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import typer
+from _pytest.logging import LogCaptureFixture
 
 from moneybin.database import DatabaseKeyError
 
@@ -18,7 +19,9 @@ def test_handle_database_errors_yields_database() -> None:
             assert db is fake_db
 
 
-def test_handle_database_errors_translates_key_error_to_exit(caplog) -> None:
+def test_handle_database_errors_translates_key_error_to_exit(
+    caplog: LogCaptureFixture,
+) -> None:
     """DatabaseKeyError is caught, logged, and converted to typer.Exit(1)."""
     from moneybin.cli.utils import handle_database_errors
 

--- a/tests/moneybin/test_cli/test_import_cmd_tabular.py
+++ b/tests/moneybin/test_cli/test_import_cmd_tabular.py
@@ -39,7 +39,7 @@ class TestImportFileAccountName:
     def mock_get_database(self, mocker: Any) -> MagicMock:
         """Mock get_database to avoid requiring a real encrypted database."""
         return mocker.patch(
-            "moneybin.database.get_database",
+            "moneybin.cli.utils.get_database",
             return_value=MagicMock(),
         )
 
@@ -133,7 +133,7 @@ class TestImportFileValidation:
         csv_file.write_text("a,b,c\n1,2,3\n")
 
         # Mock service so we don't need a real DB.
-        mocker.patch("moneybin.database.get_database", return_value=MagicMock())
+        mocker.patch("moneybin.cli.utils.get_database", return_value=MagicMock())
         mocker.patch(
             "moneybin.services.import_service.import_file",
             return_value=_make_import_result(),
@@ -154,7 +154,7 @@ class TestImportFileValidation:
         csv_file = tmp_path / "test.csv"
         csv_file.write_text("a,b,c\n1,2,3\n")
 
-        mocker.patch("moneybin.database.get_database", return_value=MagicMock())
+        mocker.patch("moneybin.cli.utils.get_database", return_value=MagicMock())
         mocker.patch(
             "moneybin.services.import_service.import_file",
             return_value=_make_import_result(),
@@ -221,7 +221,7 @@ class TestDeleteFormat:
 
     def test_unknown_format_exits_with_error(self, mocker: Any) -> None:
         """Attempting to delete an unknown user format exits 1."""
-        mocker.patch("moneybin.database.get_database", return_value=MagicMock())
+        mocker.patch("moneybin.cli.utils.get_database", return_value=MagicMock())
         mocker.patch(
             "moneybin.extractors.tabular.formats.delete_format_from_db",
             return_value=False,

--- a/tests/moneybin/test_cli/test_import_commands.py
+++ b/tests/moneybin/test_cli/test_import_commands.py
@@ -43,7 +43,7 @@ class TestImportFileCommand:
     def mock_get_database(self, mocker: Any) -> MagicMock:
         """Mock get_database to avoid requiring a real encrypted database."""
         return mocker.patch(
-            "moneybin.database.get_database",
+            "moneybin.cli.utils.get_database",
             return_value=MagicMock(),
         )
 
@@ -215,7 +215,7 @@ class TestImportStatusCommand:
 
         mock_db = MagicMock()
         mock_db.execute.return_value.fetchall.return_value = []
-        mocker.patch("moneybin.database.get_database", return_value=mock_db)
+        mocker.patch("moneybin.cli.utils.get_database", return_value=mock_db)
 
         result = runner.invoke(app, ["status"])
         assert result.exit_code == 0
@@ -244,7 +244,7 @@ class TestImportStatusCommand:
         real_conn = duckdb.connect(str(db_path), read_only=True)
         mock_db = MagicMock()
         mock_db.execute.side_effect = real_conn.execute
-        mocker.patch("moneybin.database.get_database", return_value=mock_db)
+        mocker.patch("moneybin.cli.utils.get_database", return_value=mock_db)
 
         result = runner.invoke(app, ["status"])
         real_conn.close()

--- a/tests/moneybin/test_cli/test_matches.py
+++ b/tests/moneybin/test_cli/test_matches.py
@@ -12,7 +12,7 @@ runner = CliRunner()
 class TestMatchesRun:
     """Tests for the matches run command."""
 
-    @patch("moneybin.cli.commands.matches.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.cli.commands.matches.TransactionMatcher")
     @patch("moneybin.matching.priority.seed_source_priority")
     @patch("moneybin.config.get_settings")
@@ -42,7 +42,7 @@ class TestMatchesReview:
     """Tests for the matches review command."""
 
     @patch("moneybin.services.import_service.run_transforms")
-    @patch("moneybin.cli.commands.matches.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.matching.persistence.update_match_status")
     def test_accept_single_runs_transform(
         self,
@@ -64,7 +64,7 @@ class TestMatchesReview:
         mock_run_transforms.assert_called_once_with()
 
     @patch("moneybin.services.import_service.run_transforms")
-    @patch("moneybin.cli.commands.matches.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.matching.persistence.update_match_status")
     def test_reject_single_does_not_run_transform(
         self,
@@ -86,7 +86,7 @@ class TestMatchesReview:
         mock_run_transforms.assert_not_called()
 
     @patch("moneybin.services.import_service.run_transforms")
-    @patch("moneybin.cli.commands.matches.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.matching.persistence.get_pending_matches")
     @patch("moneybin.matching.persistence.update_match_status")
     def test_accept_all_runs_transform_once(
@@ -109,7 +109,7 @@ class TestMatchesReview:
         mock_run_transforms.assert_called_once_with()
 
     @patch("moneybin.services.import_service.run_transforms")
-    @patch("moneybin.cli.commands.matches.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.matching.persistence.update_match_status")
     def test_accept_single_can_skip_transform(
         self,
@@ -136,7 +136,7 @@ class TestMatchesReview:
         mock_run_transforms.assert_not_called()
 
     @patch("moneybin.services.import_service.run_transforms")
-    @patch("moneybin.cli.commands.matches.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.matching.persistence.get_pending_matches")
     @patch("moneybin.matching.persistence.update_match_status")
     def test_interactive_accept_runs_transform(
@@ -170,7 +170,7 @@ class TestMatchesReview:
 class TestMatchesHistory:
     """Tests for the matches history command."""
 
-    @patch("moneybin.cli.commands.matches.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.cli.commands.matches.get_match_log")
     def test_history_empty(self, mock_log: MagicMock, mock_get_db: MagicMock) -> None:
         mock_get_db.return_value = MagicMock()
@@ -182,7 +182,7 @@ class TestMatchesHistory:
 class TestMatchesUndo:
     """Tests for the matches undo command."""
 
-    @patch("moneybin.cli.commands.matches.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.cli.commands.matches.undo_match")
     def test_undo_calls_persistence(
         self, mock_undo: MagicMock, mock_get_db: MagicMock

--- a/tests/moneybin/test_cli/test_migrate_command.py
+++ b/tests/moneybin/test_cli/test_migrate_command.py
@@ -33,7 +33,7 @@ def _migration(
 class TestMigrateApply:
     """moneybin db migrate apply command."""
 
-    @patch("moneybin.cli.commands.migrate.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.cli.commands.migrate.MigrationRunner")
     def test_apply_runs_pending(
         self, mock_runner_cls: MagicMock, mock_get_db: MagicMock
@@ -49,7 +49,7 @@ class TestMigrateApply:
         assert result.exit_code == 0
         mock_runner.apply_all.assert_called_once()
 
-    @patch("moneybin.cli.commands.migrate.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.cli.commands.migrate.MigrationRunner")
     def test_apply_no_pending_exits_0(
         self, mock_runner_cls: MagicMock, mock_get_db: MagicMock
@@ -64,7 +64,7 @@ class TestMigrateApply:
         result = runner.invoke(app, ["apply"])
         assert result.exit_code == 0
 
-    @patch("moneybin.cli.commands.migrate.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.cli.commands.migrate.MigrationRunner")
     def test_apply_dry_run(
         self, mock_runner_cls: MagicMock, mock_get_db: MagicMock
@@ -77,7 +77,7 @@ class TestMigrateApply:
         assert result.exit_code == 0
         mock_runner.apply_all.assert_not_called()
 
-    @patch("moneybin.cli.commands.migrate.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.cli.commands.migrate.MigrationRunner")
     def test_apply_dry_run_no_pending(
         self, mock_runner_cls: MagicMock, mock_get_db: MagicMock
@@ -90,7 +90,7 @@ class TestMigrateApply:
         assert result.exit_code == 0
         mock_runner.apply_all.assert_not_called()
 
-    @patch("moneybin.cli.commands.migrate.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.cli.commands.migrate.MigrationRunner")
     def test_apply_failure_exits_1(
         self, mock_runner_cls: MagicMock, mock_get_db: MagicMock
@@ -108,7 +108,7 @@ class TestMigrateApply:
         result = runner.invoke(app, ["apply"])
         assert result.exit_code == 1
 
-    @patch("moneybin.cli.commands.migrate.get_database")
+    @patch("moneybin.cli.utils.get_database")
     def test_apply_database_key_error_exits_1(self, mock_get_db: MagicMock) -> None:
         """DatabaseKeyError causes exit 1."""
         from moneybin.database import DatabaseKeyError
@@ -118,7 +118,7 @@ class TestMigrateApply:
         result = runner.invoke(app, ["apply"])
         assert result.exit_code == 1
 
-    @patch("moneybin.cli.commands.migrate.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.cli.commands.migrate.MigrationRunner")
     def test_apply_drift_warnings_shown(
         self,
@@ -149,7 +149,7 @@ class TestMigrateApply:
 class TestMigrateStatus:
     """moneybin db migrate status command."""
 
-    @patch("moneybin.cli.commands.migrate.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.cli.commands.migrate.MigrationRunner")
     @patch("moneybin.cli.commands.migrate.get_current_versions")
     def test_status_shows_applied_and_pending(
@@ -191,7 +191,7 @@ class TestMigrateStatus:
         assert "V001__init.sql" in messages
         assert "V002__new.sql" in messages
 
-    @patch("moneybin.cli.commands.migrate.get_database")
+    @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.cli.commands.migrate.MigrationRunner")
     @patch("moneybin.cli.commands.migrate.get_current_versions")
     def test_status_no_applied(
@@ -216,7 +216,7 @@ class TestMigrateStatus:
         assert result.exit_code == 0
         assert any("No applied migrations" in r.message for r in caplog.records)
 
-    @patch("moneybin.cli.commands.migrate.get_database")
+    @patch("moneybin.cli.utils.get_database")
     def test_status_database_key_error_exits_1(self, mock_get_db: MagicMock) -> None:
         """DatabaseKeyError on status causes exit 1."""
         from moneybin.database import DatabaseKeyError

--- a/tests/moneybin/test_config_profiles.py
+++ b/tests/moneybin/test_config_profiles.py
@@ -377,3 +377,21 @@ class TestProfileDirectoryLayout:
         assert (
             settings.database.backup_path == tmp_path / "profiles" / "alice" / "backups"
         )
+
+
+def test_tabular_config_balance_validation_defaults() -> None:
+    """TabularConfig exposes balance validation tunables with safe defaults."""
+    from moneybin.config import TabularConfig
+
+    cfg = TabularConfig()
+    assert cfg.balance_pass_threshold == 0.90
+    assert cfg.balance_tolerance_cents == 1
+
+
+def test_tabular_config_balance_validation_overrides() -> None:
+    """Caller can override balance validation tunables."""
+    from moneybin.config import TabularConfig
+
+    cfg = TabularConfig(balance_pass_threshold=0.95, balance_tolerance_cents=5)
+    assert cfg.balance_pass_threshold == 0.95
+    assert cfg.balance_tolerance_cents == 5

--- a/tests/moneybin/test_extractors/test_tabular/test_transforms.py
+++ b/tests/moneybin/test_extractors/test_tabular/test_transforms.py
@@ -377,3 +377,63 @@ class TestRunningBalanceValidation:
             import_id="test-123",
         )
         assert result.balance_validated is False
+
+    def test_transform_uses_custom_balance_tolerance_cents(self) -> None:
+        """A high tolerance accepts deltas that the default would reject."""
+        df = pl.DataFrame({
+            "Date": ["2025-01-01", "2025-01-02"],
+            "Description": ["a", "b"],
+            # Amount is off by 10 cents from the balance delta
+            "Amount": ["-10.00", "-19.90"],
+            "Balance": ["100.00", "80.00"],
+        })
+        field_mapping = {
+            "transaction_date": "Date",
+            "description": "Description",
+            "amount": "Amount",
+            "balance": "Balance",
+        }
+        result = transform_dataframe(
+            df=df,
+            field_mapping=field_mapping,
+            date_format="%Y-%m-%d",
+            sign_convention="negative_is_expense",
+            number_format="us",
+            account_id="acct1",
+            source_file="t.csv",
+            source_type="csv",
+            source_origin="t",
+            import_id="imp1",
+            balance_pass_threshold=0.90,
+            balance_tolerance_cents=20,  # 0.20 — accepts the 0.10 mismatch
+        )
+        assert result.balance_validated is True
+
+    def test_transform_default_tolerance_rejects_off_by_ten_cents(self) -> None:
+        """Default 1-cent tolerance rejects a 10-cent delta mismatch."""
+        df = pl.DataFrame({
+            "Date": ["2025-01-01", "2025-01-02"],
+            "Description": ["a", "b"],
+            "Amount": ["-10.00", "-19.90"],
+            "Balance": ["100.00", "80.00"],
+        })
+        field_mapping = {
+            "transaction_date": "Date",
+            "description": "Description",
+            "amount": "Amount",
+            "balance": "Balance",
+        }
+        result = transform_dataframe(
+            df=df,
+            field_mapping=field_mapping,
+            date_format="%Y-%m-%d",
+            sign_convention="negative_is_expense",
+            number_format="us",
+            account_id="acct1",
+            source_file="t.csv",
+            source_type="csv",
+            source_origin="t",
+            import_id="imp1",
+        )
+        # forward 0/1, inverted 0/1 — neither passes
+        assert result.balance_validated is False

--- a/tests/moneybin/test_extractors/test_tabular/test_transforms.py
+++ b/tests/moneybin/test_extractors/test_tabular/test_transforms.py
@@ -5,6 +5,10 @@ from typing import TypedDict
 
 import polars as pl
 
+from moneybin.extractors.tabular.formats import (
+    NumberFormatType,
+    SignConventionType,
+)
 from moneybin.extractors.tabular.transforms import (
     transform_dataframe,
 )
@@ -19,8 +23,8 @@ def _make_df(**columns: list[str]) -> pl.DataFrame:
 class _BaseKwargs(TypedDict):
     field_mapping: dict[str, str]
     date_format: str
-    sign_convention: str
-    number_format: str
+    sign_convention: SignConventionType
+    number_format: NumberFormatType
     account_id: str | list[str]
     source_file: str
     source_type: str

--- a/tests/moneybin/test_services/test_tabular_import_service.py
+++ b/tests/moneybin/test_services/test_tabular_import_service.py
@@ -39,3 +39,28 @@ class TestDetectFileType:
     def test_unsupported_extension_raises(self) -> None:
         with pytest.raises(ValueError, match="Unsupported file type"):
             _detect_file_type(Path("test.jpg"))
+
+
+def test_resolved_mapping_round_trip() -> None:
+    """ResolvedMapping is constructible and exposes the resolved tabular fields."""
+    from moneybin.services.import_service import ResolvedMapping
+
+    rm = ResolvedMapping(
+        field_mapping={"transaction_date": "Date", "amount": "Amt"},
+        date_format="%Y-%m-%d",
+        sign_convention="negative_is_expense",
+        number_format="us",
+        is_multi_account=False,
+        confidence="high",
+    )
+    assert rm.field_mapping["amount"] == "Amt"
+    assert rm.sign_convention == "negative_is_expense"
+    # Frozen — assignment must raise
+    import dataclasses
+
+    try:
+        rm.confidence = "low"  # type: ignore[misc]
+    except dataclasses.FrozenInstanceError:
+        pass
+    else:
+        raise AssertionError("ResolvedMapping must be frozen")

--- a/tests/moneybin/test_stats_command.py
+++ b/tests/moneybin/test_stats_command.py
@@ -34,7 +34,7 @@ class TestTyperSingleCommandCollapse:
         mock_db = MagicMock()
         mock_db.execute.return_value.fetchall.return_value = []
 
-        with patch("moneybin.cli.commands.stats.get_database", return_value=mock_db):
+        with patch("moneybin.cli.utils.get_database", return_value=mock_db):
             result = runner.invoke(stats_app, [])
 
         assert result.exit_code == 0
@@ -47,7 +47,7 @@ class TestTyperSingleCommandCollapse:
         mock_db = MagicMock()
         mock_db.execute.return_value.fetchall.return_value = []
 
-        with patch("moneybin.cli.commands.stats.get_database", return_value=mock_db):
+        with patch("moneybin.cli.utils.get_database", return_value=mock_db):
             result = runner.invoke(stats_app, ["show"])
 
         assert result.exit_code == 2
@@ -63,7 +63,7 @@ class TestStatsShow:
         mock_db = MagicMock()
         mock_db.execute.return_value.fetchall.return_value = []
 
-        with patch("moneybin.cli.commands.stats.get_database", return_value=mock_db):
+        with patch("moneybin.cli.utils.get_database", return_value=mock_db):
             result = runner.invoke(stats_app, [])
 
         assert result.exit_code == 0
@@ -84,7 +84,7 @@ class TestStatsShow:
             ),
         ]
 
-        with patch("moneybin.cli.commands.stats.get_database", return_value=mock_db):
+        with patch("moneybin.cli.utils.get_database", return_value=mock_db):
             result = runner.invoke(stats_app, [])
 
         assert result.exit_code == 0
@@ -96,7 +96,7 @@ class TestStatsShow:
         mock_db = MagicMock()
         mock_db.execute.return_value.fetchall.return_value = []
 
-        with patch("moneybin.cli.commands.stats.get_database", return_value=mock_db):
+        with patch("moneybin.cli.utils.get_database", return_value=mock_db):
             result = runner.invoke(stats_app, ["--output", "json"])
 
         assert result.exit_code == 0
@@ -109,7 +109,7 @@ class TestStatsShow:
         mock_db = MagicMock()
         mock_db.execute.return_value.fetchall.return_value = []
 
-        with patch("moneybin.cli.commands.stats.get_database", return_value=mock_db):
+        with patch("moneybin.cli.utils.get_database", return_value=mock_db):
             result = runner.invoke(stats_app, ["--since", "7d"])
 
         assert result.exit_code == 0
@@ -120,7 +120,7 @@ class TestStatsShow:
         from moneybin.database import DatabaseKeyError
 
         with patch(
-            "moneybin.cli.commands.stats.get_database",
+            "moneybin.cli.utils.get_database",
             side_effect=DatabaseKeyError("locked"),
         ):
             result = runner.invoke(stats_app, [])

--- a/tests/moneybin/test_synthetic/test_cli.py
+++ b/tests/moneybin/test_synthetic/test_cli.py
@@ -33,7 +33,7 @@ class TestGenerateCommand:
         # Make the "already has data" check return 0 rows
         mock_db.execute.return_value.fetchone.return_value = (0,)
         return mocker.patch(
-            "moneybin.database.get_database",
+            "moneybin.cli.utils.get_database",
             return_value=mock_db,
         )
 
@@ -112,7 +112,7 @@ class TestGenerateCommand:
         from moneybin.database import DatabaseKeyError
 
         mocker.patch(
-            "moneybin.database.get_database",
+            "moneybin.cli.utils.get_database",
             side_effect=DatabaseKeyError("no key"),
         )
         result = runner.invoke(app, ["generate", "--persona", "basic"])
@@ -148,7 +148,7 @@ class TestResetCommand:
         # ground_truth table exists
         mock_db.execute.return_value.fetchone.return_value = (1,)
         mock_db.path = Path("/tmp/test.duckdb")
-        mocker.patch("moneybin.database.get_database", return_value=mock_db)
+        mocker.patch("moneybin.cli.utils.get_database", return_value=mock_db)
 
         # Mock _run_generate to avoid the full pipeline
         mock_run = mocker.patch(
@@ -172,7 +172,7 @@ class TestResetCommand:
     def test_reset_requires_yes_or_prompt(self, runner: CliRunner) -> None:
         """Without --yes, reset should prompt for confirmation."""
         # CliRunner sends EOF on stdin by default, so prompt is declined
-        with patch("moneybin.database.get_database") as mock_get_db:
+        with patch("moneybin.cli.utils.get_database") as mock_get_db:
             mock_db = MagicMock()
             # ground_truth table exists check returns 1
             mock_db.execute.return_value.fetchone.return_value = (1,)


### PR DESCRIPTION
## Summary

Stream A of the tabular-import cleanup spec — internal refactors with no behavior changes for end users.

- **Configurable balance validation** — `balance_pass_threshold` and `balance_tolerance_cents` on `TabularConfig`, threaded through `transform_dataframe` and `_validate_running_balance`.
- **Literal types** — `SignConventionType` and `NumberFormatType` replace bare `str` across `column_mapper`, `transforms`, `sign_convention`, and `date_detection`, giving pyright real coverage of the format enums.
- **`ResolvedMapping` dataclass** — replaces the loose `mapping_result_*` locals in `import_service.py`. CLI overrides use `dataclasses.replace`.
- **`handle_database_errors` context manager** — new `src/moneybin/cli/utils.py` centralizes the `get_database()` + `DatabaseKeyError` boilerplate. 26 call sites across 8 CLI command modules migrated.

## Test plan

- [x] `make check test` — all green (1099 passed)
- [x] `uv run pyright` clean
- [x] New unit tests for `handle_database_errors`
- [ ] Manual smoke: `moneybin data transform apply` on a small CSV
- [ ] Manual smoke: `moneybin db unlock` flow still surfaces the standard hint on locked DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)