### PR TITLE
Batch merchant resolution in categorize.bulk

### DIFF
--- a/src/moneybin/services/categorization_service.py
+++ b/src/moneybin/services/categorization_service.py
@@ -178,7 +178,9 @@ def _matches_pattern(text: str, pattern: str, match_type: str) -> bool:
         return False
 
 
-def _fetch_merchants(db: Database) -> list[tuple[str, ...]] | None:
+def _fetch_merchants(
+    db: Database,
+) -> list[tuple[str, str, str, str, str, str | None]] | None:
     """Fetch all merchant mappings ordered by match priority.
 
     Args:
@@ -207,7 +209,7 @@ def _fetch_merchants(db: Database) -> list[tuple[str, ...]] | None:
 
 def _match_description(
     description: str,
-    merchants: list[tuple[str, ...]],
+    merchants: list[tuple[str, str, str, str, str, str | None]],
 ) -> dict[str, str | None] | None:
     """Match a description against a pre-fetched merchant list.
 
@@ -364,15 +366,21 @@ def bulk_categorize(
             SELECT transaction_id, description
             FROM {FCT_TRANSACTIONS.full_name}
             WHERE transaction_id IN ({placeholders})
-            """,  # noqa: S608 — placeholders count is bounded; values are parameterized
+            """,  # noqa: S608 — FCT_TRANSACTIONS is a compile-time TableRef constant; values are parameterized
             txn_ids,
         ).fetchall()
         descriptions = {row[0]: row[1] for row in rows}
-    except Exception:  # noqa: BLE001 — best-effort; missing table → all merchants resolve to None
-        logger.debug("Could not batch-fetch descriptions", exc_info=True)
+    except Exception:  # noqa: BLE001 — best-effort; degrades to no merchant resolution
+        logger.warning("Could not batch-fetch descriptions", exc_info=True)
 
-    # Phase 3 — fetch merchants once, then match in memory
-    cached_merchants = _fetch_merchants(db)
+    # Phase 3 — fetch merchants once, then match in memory.
+    # Guard against any non-CatalogException (schema drift, binder errors, etc.)
+    # so a merchant-table failure doesn't block all category writes for the batch.
+    try:
+        cached_merchants = _fetch_merchants(db)
+    except Exception:  # noqa: BLE001 — best-effort; degrades to no merchant resolution
+        logger.warning("Could not batch-fetch merchants", exc_info=True)
+        cached_merchants = None
 
     # Phase 4 — per-item categorization (writes only)
     for txn_id, category, subcategory in valid_items:
@@ -398,17 +406,14 @@ def bulk_categorize(
                         merchants_created += 1
                         # Append to cache so subsequent items in this batch
                         # find the just-created merchant instead of re-creating.
-                        # Cast — DB rows can hold NULL subcategories, but the
-                        # row tuple type is declared as tuple[str, ...].
-                        new_row: tuple[str, ...] = (
+                        cached_merchants.append((
                             merchant_id,
                             normalized,
                             "contains",
                             normalized,
                             category,
-                            subcategory,  # type: ignore[arg-type]
-                        )
-                        cached_merchants.append(new_row)
+                            subcategory,
+                        ))
             except Exception:  # noqa: BLE001 — merchant resolution is best-effort; categorization proceeds without it
                 logger.debug(
                     f"Could not resolve merchant for {txn_id}",

--- a/src/moneybin/services/categorization_service.py
+++ b/src/moneybin/services/categorization_service.py
@@ -404,16 +404,27 @@ def bulk_categorize(
                             created_by="ai",
                         )
                         merchants_created += 1
-                        # Append to cache so subsequent items in this batch
-                        # find the just-created merchant instead of re-creating.
-                        cached_merchants.append((
+                        # Insert into cache preserving _fetch_merchants() ordering
+                        # (exact → contains → regex) so subsequent items in this
+                        # batch match the just-created contains rule before any
+                        # pre-existing regex rule.
+                        new_row = (
                             merchant_id,
                             normalized,
                             "contains",
                             normalized,
                             category,
                             subcategory,
-                        ))
+                        )
+                        insert_at = next(
+                            (
+                                i
+                                for i, m in enumerate(cached_merchants)
+                                if m[2] == "regex"
+                            ),
+                            len(cached_merchants),
+                        )
+                        cached_merchants.insert(insert_at, new_row)
             except Exception:  # noqa: BLE001 — merchant resolution is best-effort; categorization proceeds without it
                 logger.debug(
                     f"Could not resolve merchant for {txn_id}",

--- a/src/moneybin/services/categorization_service.py
+++ b/src/moneybin/services/categorization_service.py
@@ -314,6 +314,9 @@ def bulk_categorize(
     a merchant mapping, then inserts/replaces the category assignment.
     Merchant resolution is best-effort — failures do not prevent categorization.
 
+    Read-side cost is O(1) in the number of items: one batch description
+    fetch and one merchant-table fetch, regardless of input size.
+
     Args:
         db: Database instance (read-write).
         items: List of dicts with transaction_id, category, and optional subcategory.
@@ -327,6 +330,8 @@ def bulk_categorize(
     merchants_created = 0
     error_details: list[dict[str, str]] = []
 
+    # Phase 1 — validate and partition input
+    valid_items: list[tuple[str, str, str | None]] = []
     for item in items:
         txn_id = item.get("transaction_id", "").strip()
         category = item.get("category", "").strip()
@@ -337,43 +342,80 @@ def bulk_categorize(
                 "reason": "Missing transaction_id or category",
             })
             continue
-
         subcategory = item.get("subcategory", "").strip() or None
+        valid_items.append((txn_id, category, subcategory))
 
-        try:
-            # Resolve merchant_id from description (best-effort)
-            merchant_id = None
+    if not valid_items:
+        return BulkCategorizationResult(
+            applied=applied,
+            skipped=skipped,
+            errors=errors,
+            error_details=error_details,
+            merchants_created=merchants_created,
+        )
+
+    # Phase 2 — batch-fetch descriptions
+    txn_ids = [v[0] for v in valid_items]
+    placeholders = ",".join(["?"] * len(txn_ids))
+    descriptions: dict[str, str | None] = {}
+    try:
+        rows = db.execute(
+            f"""
+            SELECT transaction_id, description
+            FROM {FCT_TRANSACTIONS.full_name}
+            WHERE transaction_id IN ({placeholders})
+            """,  # noqa: S608 — placeholders count is bounded; values are parameterized
+            txn_ids,
+        ).fetchall()
+        descriptions = {row[0]: row[1] for row in rows}
+    except Exception:  # noqa: BLE001 — best-effort; missing table → all merchants resolve to None
+        logger.debug("Could not batch-fetch descriptions", exc_info=True)
+
+    # Phase 3 — fetch merchants once, then match in memory
+    cached_merchants = _fetch_merchants(db)
+
+    # Phase 4 — per-item categorization (writes only)
+    for txn_id, category, subcategory in valid_items:
+        merchant_id: str | None = None
+        description = descriptions.get(txn_id)
+        if description and cached_merchants is not None:
             try:
-                txn = db.execute(
-                    f"""
-                    SELECT description FROM {FCT_TRANSACTIONS.full_name}
-                    WHERE transaction_id = ?
-                    """,
-                    [txn_id],
-                ).fetchone()
-                if txn and txn[0]:
-                    existing = match_merchant(db, txn[0])
-                    if existing:
-                        merchant_id = existing["merchant_id"]
-                    else:
-                        normalized = normalize_description(txn[0])
-                        if normalized:
-                            merchant_id = create_merchant(
-                                db,
-                                normalized,
-                                normalized,
-                                match_type="contains",
-                                category=category,
-                                subcategory=subcategory,
-                                created_by="ai",
-                            )
-                            merchants_created += 1
+                existing = _match_description(description, cached_merchants)
+                if existing:
+                    merchant_id = existing["merchant_id"]
+                else:
+                    normalized = normalize_description(description)
+                    if normalized:
+                        merchant_id = create_merchant(
+                            db,
+                            normalized,
+                            normalized,
+                            match_type="contains",
+                            category=category,
+                            subcategory=subcategory,
+                            created_by="ai",
+                        )
+                        merchants_created += 1
+                        # Append to cache so subsequent items in this batch
+                        # find the just-created merchant instead of re-creating.
+                        # Cast — DB rows can hold NULL subcategories, but the
+                        # row tuple type is declared as tuple[str, ...].
+                        new_row: tuple[str, ...] = (
+                            merchant_id,
+                            normalized,
+                            "contains",
+                            normalized,
+                            category,
+                            subcategory,  # type: ignore[arg-type]
+                        )
+                        cached_merchants.append(new_row)
             except Exception:  # noqa: BLE001 — merchant resolution is best-effort; categorization proceeds without it
                 logger.debug(
                     f"Could not resolve merchant for {txn_id}",
                     exc_info=True,
                 )
 
+        try:
             db.execute(
                 f"""
                 INSERT OR REPLACE INTO {TRANSACTION_CATEGORIES.full_name}

--- a/tests/moneybin/test_services/test_categorization_service.py
+++ b/tests/moneybin/test_services/test_categorization_service.py
@@ -554,3 +554,65 @@ class TestSeedCategories:
         categories = get_active_categories(db)
         assert len(categories) == 2
         assert all(c["category"] == "Food & Drink" for c in categories)
+
+
+# ---------------------------------------------------------------------------
+# bulk_categorize — perf shape and in-batch dedup
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_categorize_uses_constant_number_of_db_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_secret_store: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """bulk_categorize should not scale DB round-trips with item count.
+
+    With N items, the number of read queries (description fetch + merchant
+    fetch) must be O(1), not O(N).
+    """
+    from moneybin.services.categorization_service import bulk_categorize
+    from moneybin.tables import FCT_TRANSACTIONS
+
+    db = Database(
+        tmp_path / "perf.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+    )
+    # Seed 25 transactions and 25 corresponding category items.
+    db.execute(
+        f"""
+        CREATE OR REPLACE TABLE {FCT_TRANSACTIONS.full_name} AS
+        SELECT
+            'txn_' || i AS transaction_id,
+            CAST('2025-01-01' AS DATE) AS transaction_date,
+            CAST(-10.00 AS DECIMAL(18,2)) AS amount,
+            'Coffee shop ' || i AS description,
+            CAST(NULL AS VARCHAR) AS memo,
+            'acct1' AS account_id
+        FROM range(25) t(i)
+        """  # noqa: S608  # building test input string, not executing SQL
+    )
+    items = [
+        {"transaction_id": f"txn_{i}", "category": "Food", "subcategory": "Coffee"}
+        for i in range(25)
+    ]
+
+    real_execute = db.execute
+    select_calls: list[str] = []
+
+    def counting_execute(query: str, *args: object, **kwargs: object) -> object:
+        if query.strip().upper().startswith("SELECT"):
+            select_calls.append(query)
+        return real_execute(query, *args, **kwargs)
+
+    monkeypatch.setattr(db, "execute", counting_execute)
+
+    result = bulk_categorize(db, items)
+
+    assert result.applied == 25
+    # Expected reads: 1 batch description fetch + 1 merchant fetch +
+    # any small bookkeeping. Generous upper bound = 5; previous impl was 50+.
+    assert len(select_calls) <= 5, (
+        f"Expected <=5 SELECTs, got {len(select_calls)}:\n" + "\n".join(select_calls)
+    )

--- a/tests/moneybin/test_services/test_categorization_service.py
+++ b/tests/moneybin/test_services/test_categorization_service.py
@@ -6,6 +6,7 @@ matching, prompt construction, and response parsing.
 
 from collections.abc import Generator
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -601,10 +602,10 @@ def test_bulk_categorize_uses_constant_number_of_db_calls(
     real_execute = db.execute
     select_calls: list[str] = []
 
-    def counting_execute(query: str, params: list[object] | None = None) -> object:
+    def counting_execute(query: str, params: list[Any] | None = None) -> object:
         if query.strip().upper().startswith("SELECT"):
             select_calls.append(query)
-        return real_execute(query, params)  # type: ignore[arg-type]
+        return real_execute(query, params)
 
     monkeypatch.setattr(db, "execute", counting_execute)
 

--- a/tests/moneybin/test_services/test_categorization_service.py
+++ b/tests/moneybin/test_services/test_categorization_service.py
@@ -616,3 +616,50 @@ def test_bulk_categorize_uses_constant_number_of_db_calls(
     assert len(select_calls) <= 5, (
         f"Expected <=5 SELECTs, got {len(select_calls)}:\n" + "\n".join(select_calls)
     )
+
+
+def test_bulk_categorize_dedupes_merchant_creation_within_batch(
+    mock_secret_store: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Two items with the same description create exactly one merchant."""
+    from moneybin.services.categorization_service import bulk_categorize
+    from moneybin.tables import FCT_TRANSACTIONS, MERCHANTS
+
+    db = Database(
+        tmp_path / "dedup.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+    )
+    db.execute(
+        f"""
+        CREATE OR REPLACE TABLE {FCT_TRANSACTIONS.full_name} AS
+        SELECT
+            'txn_' || i AS transaction_id,
+            CAST('2025-01-01' AS DATE) AS transaction_date,
+            CAST(-10.00 AS DECIMAL(18,2)) AS amount,
+            'IDENTICAL VENDOR' AS description,
+            CAST(NULL AS VARCHAR) AS memo,
+            'acct1' AS account_id
+        FROM range(3) t(i)
+        """  # noqa: S608  # building test input string, not executing SQL
+    )
+
+    items = [
+        {"transaction_id": f"txn_{i}", "category": "Food", "subcategory": "Coffee"}
+        for i in range(3)
+    ]
+
+    result = bulk_categorize(db, items)
+
+    assert result.applied == 3
+    assert result.merchants_created == 1, (
+        f"Expected 1 merchant created across 3 identical-description items, "
+        f"got {result.merchants_created}"
+    )
+
+    merchant_count = db.execute(
+        f"SELECT COUNT(*) FROM {MERCHANTS.full_name}"  # noqa: S608  # building test input string, not executing SQL
+    ).fetchone()
+    assert merchant_count is not None
+    assert merchant_count[0] == 1

--- a/tests/moneybin/test_services/test_categorization_service.py
+++ b/tests/moneybin/test_services/test_categorization_service.py
@@ -601,10 +601,10 @@ def test_bulk_categorize_uses_constant_number_of_db_calls(
     real_execute = db.execute
     select_calls: list[str] = []
 
-    def counting_execute(query: str, *args: object, **kwargs: object) -> object:
+    def counting_execute(query: str, params: list[object] | None = None) -> object:
         if query.strip().upper().startswith("SELECT"):
             select_calls.append(query)
-        return real_execute(query, *args, **kwargs)
+        return real_execute(query, params)  # type: ignore[arg-type]
 
     monkeypatch.setattr(db, "execute", counting_execute)
 


### PR DESCRIPTION
## Summary
- Replace per-item description fetch with a single `IN (...)` batch query
- Cache `_fetch_merchants(db)` once per call, reuse `_match_description` in memory
- Append newly-created merchants to the cache so duplicate descriptions in a batch don't double-create
- Drops read round-trips from O(N) to O(1) per `bulk_categorize` call

Spec: docs/specs/tabular-import-cleanup.md (Stream B2). No behavior change beyond perf and within-batch dedup (which existed by accident before — now explicit and tested).

## Test plan
- [x] `make check test`
- [x] New perf-shape test asserts ≤5 SELECTs for 25 items
- [x] New dedup test asserts 1 merchant created for 3 identical-description items