### PR TITLE
Fix rule loading and update matching docs for shipped status

### DIFF
--- a/.claude/rules/cli.md
+++ b/.claude/rules/cli.md
@@ -1,6 +1,6 @@
 ---
 description: "CLI development: Typer patterns, error handling, command registration, non-interactive parity"
-globs: ["src/moneybin/cli/**", "src/moneybin/main.py"]
+paths: ["src/moneybin/cli/**", "src/moneybin/main.py"]
 ---
 
 # CLI Development

--- a/.claude/rules/data-extraction.md
+++ b/.claude/rules/data-extraction.md
@@ -1,6 +1,6 @@
 ---
 description: "Data extraction and loading: day-boundary extraction, incremental sync, dedup strategy, parameter design"
-globs: ["src/moneybin/extractors/**", "src/moneybin/connectors/**", "src/moneybin/loaders/**"]
+paths: ["src/moneybin/extractors/**", "src/moneybin/connectors/**", "src/moneybin/loaders/**"]
 ---
 
 # Data Extraction & Loading

--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -1,6 +1,6 @@
 ---
 description: "Database standards: DuckDB patterns, SQL formatting, schema conventions, model naming, column comments"
-globs: ["**/*.sql", "sqlmesh/**", "src/moneybin/sql/**", "src/moneybin/database.py", "src/moneybin/schema.py", "src/moneybin/loaders/**"]
+paths: ["**/*.sql", "sqlmesh/**", "src/moneybin/sql/**", "src/moneybin/database.py", "src/moneybin/schema.py", "src/moneybin/loaders/**"]
 ---
 
 # Database Standards

--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -1,3 +1,8 @@
+---
+description: "Documentation: diagram conventions when authoring Markdown"
+paths: ["**/*.md"]
+---
+
 # Documentation
 
 ## Diagrams

--- a/.claude/rules/identifiers.md
+++ b/.claude/rules/identifiers.md
@@ -1,6 +1,6 @@
 ---
 description: "Identifier generation: content hashes, truncated UUIDs, source-provided IDs, semantic slugs"
-globs: ["src/moneybin/**/*.py", "sqlmesh/models/**"]
+paths: ["src/moneybin/**/*.py", "sqlmesh/models/**"]
 ---
 
 # Identifiers

--- a/.claude/rules/mcp-server.md
+++ b/.claude/rules/mcp-server.md
@@ -1,6 +1,6 @@
 ---
 description: "MCP server: tool taxonomy, response envelope, sensitivity tiers, service layer architecture"
-globs: ["src/moneybin/mcp/**", "src/moneybin/services/**"]
+paths: ["src/moneybin/mcp/**", "src/moneybin/services/**"]
 ---
 
 # MCP Server

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,6 +1,6 @@
 ---
 description: "Security: SQL injection prevention, input validation, XSS, PII in logs, exception wrapping"
-globs: ["src/moneybin/**/*.py", "**/*.sql"]
+paths: ["src/moneybin/**/*.py", "**/*.sql"]
 ---
 
 # Security

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,6 +1,6 @@
 ---
 description: "Testing standards: pytest patterns, fixtures, mocking strategy, database test helpers"
-globs: ["tests/**", "**/conftest.py", "src/moneybin/testing/**"]
+paths: ["tests/**", "**/conftest.py", "src/moneybin/testing/**"]
 ---
 
 # Testing Standards

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,16 +71,26 @@ Security-critical parameters (crypto cost factors, key lengths, salt sizes) defi
 - **No PII or financial data in logs.** Log record counts, IDs, and status codes only.
 - **Parameterized SQL** with `?` placeholders. See `.claude/rules/security.md` for full standards.
 
-## Conditional Rules Index
+## Rules Index
 
-These `.claude/rules/` files load only when editing matching files. If you need guidance outside the current glob match, read the relevant file directly.
+Files in `.claude/rules/` auto-load via Claude Code's `paths:` frontmatter — path-scoped rules load when Claude reads a matching file; unscoped rules load every session. The table below is for discoverability when planning work that hasn't touched matching files yet. Read a rule directly if you need it before editing.
 
-| Rule | Covers | Loads for |
-|------|--------|-----------|
-| `security.md` | SQL injection, input validation, XSS, PII, exception wrapping | `src/moneybin/**/*.py`, `**/*.sql` |
-| `database.md` | DuckDB patterns, SQL conventions, schema, column comments | `**/*.sql`, `sqlmesh/**`, `src/moneybin/sql/**`, `src/moneybin/database.py`, `src/moneybin/schema.py`, `src/moneybin/loaders/**` |
-| `mcp-server.md` | Tool taxonomy, response envelope, sensitivity tiers, services | `src/moneybin/mcp/**`, `src/moneybin/services/**` |
-| `cli.md` | Typer patterns, error handling, command registration, icons | `src/moneybin/cli/**`, `src/moneybin/main.py` |
-| `testing.md` | Pytest patterns, fixtures, mocking strategy, DB test helpers | `tests/**`, `**/conftest.py`, `src/moneybin/testing/**` |
-| `data-extraction.md` | Incremental sync, dedup, parameter design, new data sources | `src/moneybin/extractors/**`, `src/moneybin/connectors/**`, `src/moneybin/loaders/**` |
-| `identifiers.md` | Content hashes, truncated UUIDs, source IDs, semantic slugs | `src/moneybin/**/*.py`, `sqlmesh/models/**` |
+### Path-scoped
+
+| Rule | Covers |
+|------|--------|
+| `security.md` | SQL injection, input validation, XSS, PII, exception wrapping |
+| `database.md` | DuckDB patterns, SQL conventions, schema, column comments |
+| `mcp-server.md` | Tool taxonomy, response envelope, sensitivity tiers, services |
+| `cli.md` | Typer patterns, error handling, command registration, icons |
+| `testing.md` | Pytest patterns, fixtures, mocking strategy, DB test helpers |
+| `data-extraction.md` | Incremental sync, dedup, parameter design, new data sources |
+| `identifiers.md` | Content hashes, truncated UUIDs, source IDs, semantic slugs |
+| `documentation.md` | Diagram conventions (Mermaid over ASCII) |
+
+### Always loaded (workflow rules)
+
+| Rule | Covers |
+|------|--------|
+| `shipping.md` | Post-implementation checklist: README updates, roadmap icons, `/simplify` pre-push pass |
+| `branching.md` | Branch prefix → PR label mapping, commit message style |

--- a/README.md
+++ b/README.md
@@ -144,6 +144,19 @@ from extractors      type casting (views)     multi-source (tables)
 - **Merchant normalization** — map messy bank descriptions (`STARBUCKS #12345 SEATTLE WA`) to clean merchant names.
 - **Bulk operations** — categorize, create rules, and create merchants in batches.
 
+### Data Quality & Matching
+
+- **Cross-source dedup** — same transaction imported from multiple sources (e.g., CSV and OFX of the same account) collapses to one canonical row via a tiered matching engine.
+- **Transfer detection** — pairs the two sides of an account-to-account transfer (Tier 4 matching, 4-signal scoring) into `core.bridge_transfers`.
+- **Golden-record merge** — provenance tracked in `meta.fct_transaction_provenance`; user decisions persisted in `app.match_decisions`.
+- **Review workflow** — `moneybin matches run`, `review`, `history`, `undo`, `backfill` for inspecting and correcting matches.
+
+```bash
+moneybin matches run               # Re-run the matching engine
+moneybin matches review            # Walk through proposed matches
+moneybin matches undo <id>         # Revert a match decision
+```
+
 ### Database & Security
 
 - **AES-256-GCM encryption at rest** — every database, from creation. Zero-friction auto-key for single-user machines; passphrase mode for shared environments.
@@ -231,9 +244,9 @@ Legend: ✅ shipped | 📐 designed (spec written) | 🗓️ planned
 | Feature | Status |
 |---------|--------|
 | Within-source dedup | ✅ |
-| Cross-source dedup (same transaction from different imports) | 📐 |
-| Transfer detection across accounts | 📐 |
-| Golden-record merge rules | 📐 |
+| Cross-source dedup (same transaction from different imports) | ✅ |
+| Transfer detection across accounts | ✅ |
+| Golden-record merge rules | ✅ |
 
 ### Categorization
 

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -44,8 +44,8 @@ Single source of truth for spec status. Update this table when a spec's status c
 | Spec | Type | Status | Summary |
 |---|---|---|---|
 | [Overview](matching-overview.md) | Umbrella | ready | Cross-source dedup, transfer detection, golden-record merge rules; core as gold analytics layer |
-| [Same-Record Dedup](matching-same-record-dedup.md) | Feature | in-progress | Cross-source dedup + golden-record merge rules (pillars A+C) |
-| [Transfer Detection](matching-transfer-detection.md) | Feature | in-progress | Transfer pair detection across accounts (pillar B); shared matching engine, bridge table, always-review v1 |
+| [Same-Record Dedup](matching-same-record-dedup.md) | Feature | implemented | Cross-source dedup + golden-record merge rules (pillars A+C); shared matching engine, `prep.int_transactions__matched`/`__merged`, `meta.fct_transaction_provenance`, `app.match_decisions`, `moneybin matches run/review/history/undo/backfill` CLI |
+| [Transfer Detection](matching-transfer-detection.md) | Feature | implemented | Transfer pair detection across accounts (pillar B); shared matching engine (Tier 4), `core.bridge_transfers`, always-review v1, 4-signal scoring |
 
 ## Categorization
 

--- a/docs/specs/matching-same-record-dedup.md
+++ b/docs/specs/matching-same-record-dedup.md
@@ -1,7 +1,7 @@
 # Same-Record Dedup & Golden-Record Merge Rules
 
-> Last updated: 2026-04-19
-> Status: in-progress
+> Last updated: 2026-04-26
+> Status: implemented
 > Parent: [`matching-overview.md`](matching-overview.md) (pillars A + C)
 > Companions: `CLAUDE.md` "Architecture: Data Layers", `.claude/rules/database.md` (column naming, model prefixes)
 

--- a/docs/specs/matching-transfer-detection.md
+++ b/docs/specs/matching-transfer-detection.md
@@ -1,7 +1,7 @@
 # Transfer Detection
 
-> Last updated: 2026-04-19
-> Status: in-progress
+> Last updated: 2026-04-26
+> Status: implemented
 > Parent: [`matching-overview.md`](matching-overview.md) (pillar B)
 > Companions: [`matching-same-record-dedup.md`](matching-same-record-dedup.md) (sibling spec, pillars A+C), [`categorization-overview.md`](categorization-overview.md) (independent axis), `CLAUDE.md` "Architecture: Data Layers", `.claude/rules/database.md` (column naming, model prefixes)
 


### PR DESCRIPTION
## Summary
Switches `.claude/rules/` files to use Claude Code's `paths:` frontmatter (was `globs:`, a Cursor convention CC ignores) so conditional rules actually scope to matching files. Marks the same-record-dedup and transfer-detection specs as `implemented` and refreshes the README roadmap and "What Works Today" section to match.

## Impact
- Future Claude Code sessions in this repo load only the rule files relevant to the files being edited, instead of inlining all 10 rules every session. AGENTS.md is updated to reflect the new mechanism.
- README accurately reflects matching as a shipped feature; no workflow changes for contributors.

## Changes

### Conditional rule loading (`404e895`)
Renamed `globs:` → `paths:` across all 7 path-scoped rule files. Added `paths: ["**/*.md"]` to `documentation.md`. Reorganized AGENTS.md "Rules Index" into path-scoped vs always-loaded sections and dropped the duplicated path column (single source of truth lives in each rule's frontmatter).

### Spec status updates (`6af5c71`)
Bumped `matching-same-record-dedup.md` and `matching-transfer-detection.md` from `in-progress` → `implemented`. Updated `INDEX.md` summaries to reference the shipped engine, tables (`prep.int_transactions__matched/__merged`, `meta.fct_transaction_provenance`, `app.match_decisions`, `core.bridge_transfers`), and CLI surface.

### README refresh (`ae73c4a`)
Bumped 3 roadmap entries (cross-source dedup, transfer detection, golden-record merge) to ✅. Added a "Data Quality & Matching" section under "What Works Today" with `moneybin matches run/review/undo` examples.

## Testing
- Verified all 5 documented `moneybin matches` subcommands (`run`, `review`, `history`, `undo`, `backfill`) exist in `src/moneybin/cli/commands/matches.py`.
- Path-scoped loading confirmed working in-session: reading `matches.py` auto-injected `cli.md`, `identifiers.md`, and `security.md`.
- No code changes; pre-commit hooks passed on each commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)