### PR TITLE
Update fix-review command to use GraphQL and process latest comments first

### DIFF
--- a/.claude/commands/fix-review.md
+++ b/.claude/commands/fix-review.md
@@ -2,47 +2,102 @@ Fetch open code review comments on the current branch's PR and address them.
 
 ## Usage
 
-- `/fix-review` — address review comments on the current branch's PR
+- `/fix-review` — address open review comments on the current branch's PR
 - `/fix-review --list` — list all open review comments and stop (no fixes)
+
+## Principles
+
+- **Latest first.** A reviewer's most recent comment in a thread is the current ask — older comments in the same thread may already be superseded. Always process threads ordered by their latest activity, newest first, and treat the latest comment as authoritative.
+- **Resolution status comes from GraphQL.** REST's `/pulls/{n}/comments` cannot tell you if a thread is resolved. Use GraphQL `reviewThreads { isResolved }` — only address threads where `isResolved == false`.
+- **Three sources, all required.** Inline review threads, review-level summaries, AND top-level PR conversation comments (the `/issues/{n}/comments` endpoint). Skipping any one of these silently drops feedback.
 
 ## Steps
 
 1. **Find the open PR** for the current branch:
    ```
-   gh pr view --json number,title,url,reviewDecision
+   gh pr view --json number,title,url,reviewDecision,headRefOid
    ```
-   If no open PR exists, report it and stop.
+   If no open PR exists, report it and stop. Capture `headRefOid` — it's the current HEAD SHA, used below to flag stale comments.
 
-2. **Fetch all review comments** (inline and top-level):
+2. **Fetch unresolved review threads via GraphQL** (this is the authoritative source for inline comments + resolution state):
    ```
-   gh api /repos/{owner}/{repo}/pulls/{number}/comments --jq '[.[] | {id, path, line, body, user: .user.login, resolved: (has("in_reply_to_id") | not)}]'
-   gh api /repos/{owner}/{repo}/pulls/{number}/reviews --jq '[.[] | select(.state != "APPROVED") | {id, state, body, user: .user.login}]'
+   gh api graphql -f query='
+     query($owner:String!, $repo:String!, $number:Int!) {
+       repository(owner:$owner, name:$repo) {
+         pullRequest(number:$number) {
+           reviewThreads(first:100) {
+             nodes {
+               id
+               isResolved
+               isOutdated
+               path
+               line
+               originalLine
+               comments(first:50) {
+                 nodes {
+                   id
+                   databaseId
+                   author { login }
+                   body
+                   createdAt
+                   originalCommit { oid }
+                   commit { oid }
+                 }
+               }
+             }
+           }
+         }
+       }
+     }' -F owner={owner} -F repo={repo} -F number={number}
    ```
-   Replace `{owner}/{repo}` with the actual repo from `gh repo view --json nameWithOwner`.
+   Replace `{owner}`, `{repo}`, `{number}` from `gh repo view --json nameWithOwner` and step 1.
 
-3. In `--list` mode: print a summary of all open comments grouped by file, including reviewer, line, and comment text — then stop.
+   Filter to `isResolved == false`. For each thread, the **latest comment** (max `createdAt`) is the current ask.
 
-4. **Group comments by file** and read each affected file in full before making any changes.
+3. **Fetch review-level summaries** (top-level review bodies that aren't `APPROVED`):
+   ```
+   gh api --paginate /repos/{owner}/{repo}/pulls/{number}/reviews \
+     --jq '[.[] | select(.state != "APPROVED" and (.body // "") != "") | {id, state, body, user: .user.login, submitted_at}]'
+   ```
 
-5. **Address each comment**:
-   - Apply the change if the reviewer's suggestion is clear and correct.
+4. **Fetch top-level PR conversation comments** (these are NOT in `/pulls/{n}/comments`):
+   ```
+   gh api --paginate /repos/{owner}/{repo}/issues/{number}/comments \
+     --jq '[.[] | {id, body, user: .user.login, created_at, updated_at}]'
+   ```
+   Filter out comments authored by the current user (`gh api /user --jq .login`) and bot comments that aren't actionable (e.g. coverage bots) — but when in doubt, include it.
+
+5. **Sort everything newest-first** by latest activity:
+   - Threads: by max `createdAt` of their comments
+   - Reviews: by `submitted_at`
+   - Issue comments: by `updated_at`
+
+   Merge into a single list and process in that order. The most recent unresolved feedback gets read and addressed first.
+
+6. **In `--list` mode**: print the merged list (newest first), grouped by source (Thread / Review / Conversation), showing for each: reviewer, file:line (if applicable), latest-comment timestamp, body, and `[OUTDATED]` if `isOutdated` or if `originalCommit.oid != headRefOid`. Then stop.
+
+7. **Read each affected file in full** before making changes. For inline threads, also note if the thread is `isOutdated` — the line numbers may no longer match; locate the relevant code by content, not line number.
+
+8. **Address each item**:
+   - Apply the change if the reviewer's latest comment is clear and correct.
    - If the comment is a question or discussion point rather than a change request, note it in the final summary for the user to respond to — do not silently skip it.
    - If you disagree with a suggestion or it conflicts with project conventions (see CLAUDE.md and `.claude/rules/`), note it in the summary and do not apply it — let the user decide.
    - Do not make changes beyond what the comment requests. Do not refactor surrounding code opportunistically.
 
-6. **Verify**:
+9. **Verify**:
    ```
    make check test-all
    ```
 
-7. **Show a summary** organized by comment:
-   - Changes applied and why
-   - Comments that need a human response (questions, discussions)
-   - Suggestions skipped and why (conflict with conventions, disagreement)
+10. **Show a summary** organized newest-first, grouped by source, listing every item fetched in step 5 with its disposition:
+    - **Applied** — what changed and why
+    - **Needs human response** — questions, discussion points
+    - **Skipped** — with reason (convention conflict, disagreement, outdated/already-fixed)
 
-   Ask the user to confirm before committing.
+    Every unresolved thread, non-approved review, and conversation comment from steps 2–4 must appear in this summary with one of those three dispositions. Do not drop items.
 
-8. **After confirmation**, stage only the files changed to address review comments, commit, and push:
-   - Commit message: `Address PR review comments` with a bulleted body listing what was changed
-   - Include `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
-   - Push to the current branch's remote tracking branch
+    Ask the user to confirm before committing.
+
+11. **After confirmation**, stage only the files changed to address review comments, commit, and push:
+    - Commit message: `Address PR review comments` with a bulleted body listing what was changed
+    - Push to the current branch's remote tracking branch


### PR DESCRIPTION
## Summary
Rewrites `/fix-review` so it stops missing review feedback. The previous version pulled inline comments via REST without resolution state, ignored top-level PR conversation comments entirely, and didn't paginate — which led to "everything is fixed" reports when newer comments hadn't actually been addressed.

## Impact
Anyone using `/fix-review` should get more reliable behavior: unresolved threads are processed newest-first, top-level PR comments are no longer dropped, and the final summary must account for every fetched item. No workflow changes required.

## Changes

### Switch inline comments to GraphQL
The REST `/pulls/{n}/comments` endpoint can't tell you whether a thread is resolved. The new version uses GraphQL `reviewThreads { isResolved, isOutdated, comments }` and filters to `isResolved == false`, treating the latest comment in each unresolved thread as the current ask.

- Adds `headRefOid` capture so threads can be flagged outdated when their `originalCommit.oid` no longer matches HEAD.

### Add the missing source: PR conversation comments
Top-level PR comments live at `/issues/{n}/comments`, not `/pulls/{n}/comments`. The old command never fetched them, so general-thread feedback was invisible.

### Paginate everything
All `gh api` calls now use `--paginate` so busy PRs don't truncate at 30 items.

### Latest-first ordering and required dispositions
Threads, reviews, and conversation comments are merged and sorted newest-first by latest activity. The summary step now requires every fetched item to be marked **Applied**, **Needs human response**, or **Skipped** — no silent drops.

### Drop stale Co-Authored-By trailer
Removed the hardcoded `Co-Authored-By: Claude Sonnet 4.6` line from the commit step (model version was wrong/stale).

## Testing
Documentation-only change to a slash command spec. Reviewer should sanity-check the GraphQL query shape and the three principles stated at the top of the file.

## Notes
This file also exists at `~/.claude/commands/fix-review.md` (user level). Project commands take precedence on name collision, so updating the project copy ensures everyone using the moneybin repo gets the new behavior. The user-level copy was already updated separately.