### PR TITLE
Refresh documentation to reflect current shipped state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ moneybin/
 
 ## Pipeline verification
 
-Every PR runs the scenario suite via [`.github/workflows/scenarios.yml`](.github/workflows/scenarios.yml). Each scenario boots an empty encrypted DuckDB, runs `generate → transform → match → categorize`, and reports three correctness signals:
+PRs that touch code run the scenario suite via [`.github/workflows/scenarios.yml`](.github/workflows/scenarios.yml) — docs-only changes (`**/*.md`, `docs/**`) are skipped via `paths-ignore`. Each scenario boots an empty encrypted DuckDB, runs `generate → transform → match → categorize`, and reports three correctness signals:
 
 - **Assertions** — invariants like FK integrity, sign convention, balanced transfers.
 - **Expectations** — per-record claims on hand-labeled fixtures.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing to MoneyBin
+
+## Setup
+
+```bash
+git clone https://github.com/bsaffel/moneybin.git
+cd moneybin
+make setup
+```
+
+Requires Python 3.11+ and [uv](https://docs.astral.sh/uv/).
+
+## Development workflow
+
+```bash
+make check        # Format + lint + type-check (Ruff + Pyright)
+make test         # Unit tests
+make test-all     # Unit + integration
+make test-cov     # With coverage report
+```
+
+`make check test` is the pre-commit gate. Run it before pushing.
+
+SQL formatting: `uv run sqlmesh -p sqlmesh format`.
+
+## Project structure
+
+```
+moneybin/
+├── src/moneybin/
+│   ├── mcp/                # MCP server (FastMCP, tools, resources, prompts)
+│   ├── cli/                # Typer CLI (thin wrappers over service layer)
+│   ├── services/           # Business logic (shared by MCP + CLI)
+│   ├── extractors/         # File parsers (OFX, PDF, tabular)
+│   ├── loaders/            # DuckDB data loaders
+│   ├── matching/           # Cross-source dedup + transfer detection engine
+│   ├── validation/         # Reusable assertions + evaluations
+│   ├── testing/
+│   │   ├── synthetic/      # Persona-based synthetic data generator
+│   │   └── scenarios/      # Whole-pipeline scenario runner
+│   ├── metrics/            # prometheus_client registry + DuckDB persistence
+│   ├── logging/            # Stream-based logging config + sanitization
+│   ├── database.py         # Connection factory (encryption, schemas)
+│   ├── migrations.py       # Dual-path migration runner (SQL + Python)
+│   ├── config.py           # Pydantic Settings (single source of truth)
+│   └── log_sanitizer.py    # PII detection and masking
+├── sqlmesh/models/         # SQL transformations (prep/, core/)
+├── tests/                  # pytest (unit + integration + e2e)
+└── docs/
+    ├── specs/              # Feature specs (status tracking in INDEX.md)
+    ├── decisions/          # ADRs
+    └── guides/             # User-facing feature docs
+```
+
+## Pipeline verification
+
+Every PR runs the scenario suite via [`.github/workflows/scenarios.yml`](.github/workflows/scenarios.yml). Each scenario boots an empty encrypted DuckDB, runs `generate → transform → match → categorize`, and reports three correctness signals:
+
+- **Assertions** — invariants like FK integrity, sign convention, balanced transfers.
+- **Expectations** — per-record claims on hand-labeled fixtures.
+- **Evaluations** — aggregate scores like categorization accuracy and transfer-detection F1.
+
+Run locally:
+
+```bash
+moneybin synthetic verify --list                       # Show shipped scenarios
+moneybin synthetic verify --scenario basic-full-pipeline
+moneybin synthetic verify --all --output json          # CI mode
+```
+
+Scenarios live at `src/moneybin/testing/scenarios/data/*.yaml`. The runner is documented in [`docs/specs/testing-scenario-runner.md`](docs/specs/testing-scenario-runner.md).
+
+## Working with synthetic data
+
+The synthetic data generator (see [`docs/guides/synthetic-data.md`](docs/guides/synthetic-data.md)) is the primary source of test data for development. Three personas (`basic`, `family`, `freelancer`), ~200 real merchants, deterministic seeds.
+
+```bash
+moneybin synthetic generate --persona family --profile dev-family
+```
+
+Ground-truth labels live in `synthetic.ground_truth` and feed scenario evaluations.
+
+## Commit and branch conventions
+
+See [`.claude/rules/branching.md`](.claude/rules/branching.md). Branches are `{type}/{kebab-summary}` where type maps to a PR label (`feat/`, `fix/`, `docs/`, `refactor/`, `chore/`, `deps/`, `ci/`, `security/`, `test/`, `perf/`).
+
+Commit messages: imperative mood, < 72-char subject, body explains *why*.
+
+## Specs and shipping
+
+Feature work is tracked through specs in `docs/specs/`. The [Spec Index](docs/specs/INDEX.md) is the single source of truth for status. When a feature ships, update the spec status, the index, and the README roadmap. See [`.claude/rules/shipping.md`](.claude/rules/shipping.md) for the full checklist.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Once connected, ask things like:
 | Rule-based categorization (exact / substring / regex), merchant normalization, bulk ops, **auto-rule learning** from your edits | [Categorization](docs/guides/categorization.md) |
 | AES-256-GCM encryption at rest, key management, automatic schema migrations | [Database & Security](docs/guides/database-security.md) |
 | Multi-profile isolation (per-profile DB, config, logs) | [Profiles](docs/guides/profiles.md) |
-| MCP server: 8 tool domains, prompt templates, resources, `--output json` parity with CLI | [MCP Server](docs/guides/mcp-server.md) |
+| MCP server: 9 tool domains, prompt templates, resources, `--output json` parity with CLI | [MCP Server](docs/guides/mcp-server.md) |
 | Direct SQL: shell, DuckDB UI, key tables documented | [SQL Access](docs/guides/sql-access.md) |
 | Synthetic data generator (3 personas, ~200 merchants, ground-truth labels) | [Synthetic Data](docs/guides/synthetic-data.md) |
 | Structured logs + Prometheus-style metrics with DuckDB persistence | [Observability](docs/guides/observability.md) |

--- a/README.md
+++ b/README.md
@@ -19,47 +19,37 @@
 
 MoneyBin is a personal financial data platform built on Python, DuckDB, and SQLMesh. It imports data from bank files, transforms it through an auditable SQL pipeline, and exposes it through an AI-native [MCP](https://modelcontextprotocol.io) server and a CLI.
 
-It's designed for people who want to understand their money without handing it to a cloud service — and for engineers who want their financial data in a real database, not a spreadsheet.
+It's for people who want to understand their money without handing it to a cloud service, and for engineers who want their financial data in a real database, not a spreadsheet.
 
-> **Status:** MoneyBin is in active early development. The core pipeline (import, transform, query) works today. Many features are designed but not yet shipped — the [roadmap](#roadmap) is honest about what's done vs. what's next.
+> **Status:** Active development. The core pipeline — import, dedup, transfer detection, categorization with auto-rule learning, and AI-native query via MCP — works today. Bank sync, investment tracking, and budgets are designed and on the [roadmap](#roadmap).
 
-## Why MoneyBin?
+## Why MoneyBin
 
-**AI-native from day one.** Built around the [Model Context Protocol](https://modelcontextprotocol.io). Connect it to Claude, ChatGPT, Cursor, or any MCP-compatible client and interact with your finances in natural language.
-
-**Encrypted by default.** Every database is AES-256-GCM encrypted from the moment it's created. No setup, no extra steps. A stolen laptop, a synced folder, a shared machine — none of them expose your financial data.
-
-**A data warehouse, not a black box.** Your data flows through a transparent, three-layer pipeline powered by [SQLMesh](https://sqlmesh.com): raw imports, staging views, and clean core tables. Every transformation is a SQL model you can read, audit, and modify. The database is [DuckDB](https://duckdb.org) — query it with standard SQL from any tool.
-
-**Your data stays local.** No cloud dependency. Nothing leaves your machine unless you choose to connect a bank sync service. Your database file is yours — copy it, back it up, query it with any DuckDB client, or export to CSV and walk away.
-
-## Where This Is Going
-
-The long-term vision for MoneyBin is a personal finance platform where AI does the tedious work and you stay in control. Not all of this is built yet — see the [roadmap](#roadmap) for current status — but this is what we're building toward:
-
-- **Import once, never again.** Connect your banks via Plaid or SimpleFIN. New transactions flow in automatically. File imports handle everything else — CSV exports from any institution, OFX statements, tax documents. Migration profiles let you bring your history from Tiller, Mint, YNAB, or Maybe without starting over.
-- **AI that understands your finances.** Ask your AI assistant to review your month, find subscriptions you forgot about, prepare for taxes, or explain a spending spike. MoneyBin's MCP server gives the AI structured access to your data with built-in privacy controls — it sees what you allow, nothing more.
-- **Categorization that learns.** Start with rules you define. Over time, MoneyBin proposes new rules from your corrections — so each import requires less manual work. The goal is near-zero-touch categorization by your third month.
-- **One database, many views.** Your canonical financial data lives in DuckDB. Query it with SQL, explore it in the DuckDB web UI, pipe it to notebooks, or let an AI assistant summarize it. No proprietary format, no export needed.
+- **AI-native.** Built on [MCP](https://modelcontextprotocol.io). Connect Claude, ChatGPT, Cursor, or any MCP client and ask questions in natural language. Sensitivity tiers and consent controls are part of the protocol surface, not bolted on.
+- **Encrypted by default.** Every database is AES-256-GCM encrypted from creation. Stolen laptop, synced folder, shared machine — none of them expose your data.
+- **A real database, not a black box.** Three-layer SQLMesh pipeline (raw → staging → core) over [DuckDB](https://duckdb.org). Every transformation is a SQL model you can read, audit, and modify. Query with any DuckDB client.
+- **Local-first.** No cloud dependency. Nothing leaves your machine unless you connect a sync service. Your `.duckdb` file is yours — copy it, back it up, or walk away.
 
 ## How It Works
 
 ```mermaid
 graph LR
-    A["Bank Files\n(OFX, CSV, PDF)"] --> B["Extractors"]
-    B --> C["Raw Tables"]
-    C --> D["SQLMesh\nPipeline"]
-    D --> E["Core Tables"]
-    E --> F["MCP Server\n(AI Clients)"]
+    A["Bank Files<br/>(OFX, CSV/TSV/Excel,<br/>Parquet, PDF)"] --> B["Extractors<br/>+ Loaders"]
+    A2["Bank Sync<br/>(Plaid, SimpleFIN)<br/>via moneybin-server"] -.-> B2["Sync Client"]
+    B --> C["Raw Tables<br/>(raw.*)"]
+    B2 -.-> C
+    C --> D["Staging<br/>(prep.* views)"]
+    D --> M["Matching<br/>(dedup + transfers)"]
+    M --> CAT["Categorization<br/>(rules + auto-rules)"]
+    CAT --> E["Core Tables<br/>(core.*)"]
+    E --> F["MCP Server"]
     E --> G["CLI"]
     E --> H["DuckDB SQL"]
 ```
 
-Import your financial data from local files, transform it through a documented SQL pipeline, then interact through AI assistants, the command line, or direct SQL.
+> Solid arrows are shipped; dashed arrows are designed (see [`sync-overview.md`](docs/specs/sync-overview.md)).
 
 ## Quick Start
-
-### 1. Install
 
 ```bash
 git clone https://github.com/bsaffel/moneybin.git
@@ -69,308 +59,79 @@ make setup
 
 Requires Python 3.11+ and [uv](https://docs.astral.sh/uv/).
 
-### 2. Import Your Data
-
 ```bash
-# Import OFX/QFX bank statements
-moneybin import file path/to/downloads/checking.qfx
-
-# Import a CSV with a saved institution profile
-moneybin import file path/to/transactions.csv
-
-# Extract W-2 tax data from a PDF
-moneybin import file path/to/w2.pdf
-
-# Check what's been imported
+moneybin import file path/to/checking.qfx     # OFX/QFX
+moneybin import file path/to/transactions.csv # CSV/TSV/Excel/Parquet/Feather
+moneybin import file path/to/w2.pdf           # W-2 PDF
 moneybin import status
 
-# Build the core analytical model
-moneybin transform apply
-```
-
-### 3. Connect Your AI Assistant
-
-Generate and install the MCP config for your client:
-
-```bash
-# Generate config for Claude Desktop (prints JSON)
-moneybin mcp config generate --client claude-desktop
-
-# Or install directly into the client's config file
 moneybin mcp config generate --client claude-desktop --install
 ```
 
-Supports Claude Desktop, Cursor, and Windsurf. Works with any MCP-compatible client.
+`import file` is the golden path: extract → load → transform → categorize, in one command. See the [Data Import guide](docs/guides/data-import.md) for formats, batch management, and migration profiles (Tiller, Mint, YNAB, Maybe).
 
-Then ask things like:
+Once connected, ask things like:
 
 - *"What's my spending by category this month?"*
-- *"Find all my recurring subscriptions and their annual cost"*
-- *"Help me categorize my uncategorized transactions"*
-- *"How much did I pay in taxes last year?"*
+- *"Find all my recurring subscriptions and their annual cost."*
+- *"Help me categorize my uncategorized transactions."*
 
 ## What Works Today
 
-### Data Import
+| Capability | Guide |
+|---|---|
+| Import: OFX/QFX, CSV/TSV/Excel/Parquet/Feather, W-2 PDF; heuristic column detection; migration profiles (Tiller, Mint, YNAB, Maybe) | [Data Import](docs/guides/data-import.md) |
+| Three-layer SQL pipeline: raw → staging → core, multi-source union, source-agnostic consumers | [Data Pipeline](docs/guides/data-pipeline.md) |
+| Cross-source dedup, transfer detection, golden-record merge, review/undo workflow | [Data Pipeline](docs/guides/data-pipeline.md) · [matching specs](docs/specs/matching-overview.md) |
+| Rule-based categorization (exact / substring / regex), merchant normalization, bulk ops, **auto-rule learning** from your edits | [Categorization](docs/guides/categorization.md) |
+| AES-256-GCM encryption at rest, key management, automatic schema migrations | [Database & Security](docs/guides/database-security.md) |
+| Multi-profile isolation (per-profile DB, config, logs) | [Profiles](docs/guides/profiles.md) |
+| MCP server: 8 tool domains, prompt templates, resources, `--output json` parity with CLI | [MCP Server](docs/guides/mcp-server.md) |
+| Direct SQL: shell, DuckDB UI, key tables documented | [SQL Access](docs/guides/sql-access.md) |
+| Synthetic data generator (3 personas, ~200 merchants, ground-truth labels) | [Synthetic Data](docs/guides/synthetic-data.md) |
+| Structured logs + Prometheus-style metrics with DuckDB persistence | [Observability](docs/guides/observability.md) |
 
-| Source | Format | Status |
-|--------|--------|--------|
-| Bank statements | OFX / QFX | Working |
-| Tax forms | W-2 PDF | Working |
-| Bank transactions | CSV, TSV, Excel, Parquet, Feather | Working |
-
-- **Heuristic column detection** — 100+ header aliases, content validation, date format disambiguation, international number formats. Most bank exports just work without configuration.
-- **Built-in migration formats** — Tiller, Mint, YNAB, Maybe. Bring your history from other tools.
-- **Saved formats** — auto-detected mappings are saved so repeat imports are instant.
-- **Account matching on re-import** — re-importing the same account under a different name (e.g. "Chase Checking" vs "CHASE CHECKING ACCT") matches against the existing account ID instead of creating duplicates. Use `--yes` to auto-accept fuzzy matches non-interactively.
-- **Import management** — batch tracking, preview (dry run), and revert.
-
-### Data Pipeline
-
-```
-Raw (raw.*)          Staging (prep.*)         Core (core.*)
-─────────────        ────────────────         ─────────────
-Untouched data  ──>  Light cleaning,     ──>  Canonical, deduplicated,
-from extractors      type casting (views)     multi-source (tables)
-```
-
-- **One canonical table per entity** — `dim_accounts`, `fct_transactions`, etc. All consumers read from core.
-- **Multi-source union** — core models combine every staging source with a `source_type` column.
-- **Dedup in core** — `ROW_NUMBER()` windows for within-source duplicates.
-- **Adding a data source** means writing staging views and adding a CTE to the relevant core model. No changes to consumers.
-
-### Categorization
-
-- **Rule engine** — exact match, substring, and regex rules with a priority hierarchy.
-- **Merchant normalization** — map messy bank descriptions (`STARBUCKS #12345 SEATTLE WA`) to clean merchant names.
-- **Bulk operations** — categorize, create rules, and create merchants in batches.
-- **Auto-rule generation** — when you categorize a transaction, MoneyBin proposes a reusable rule using merchant-first pattern extraction. Review pending proposals with `moneybin categorize auto-review`, batch-approve with `moneybin categorize auto-confirm --approve-all`, and future imports auto-categorize matching transactions. Approved rules are stored alongside user-defined rules with `created_by='auto_rule'`. After repeated user overrides of an auto-rule, it deactivates itself and proposes the corrected category.
-
-### Data Quality & Matching
-
-- **Cross-source dedup** — same transaction imported from multiple sources (e.g., CSV and OFX of the same account) collapses to one canonical row via a tiered matching engine.
-- **Transfer detection** — pairs the two sides of an account-to-account transfer (Tier 4 matching, 4-signal scoring) into `core.bridge_transfers`.
-- **Golden-record merge** — provenance tracked in `meta.fct_transaction_provenance`; user decisions persisted in `app.match_decisions`.
-- **Review workflow** — `moneybin matches run`, `review`, `history`, `undo`, `backfill` for inspecting and correcting matches.
-
-```bash
-moneybin matches run               # Re-run the matching engine
-moneybin matches review            # Walk through proposed matches
-moneybin matches undo <id>         # Revert a match decision
-```
-
-### Database & Security
-
-- **AES-256-GCM encryption at rest** — every database, from creation. Zero-friction auto-key for single-user machines; passphrase mode for shared environments.
-- **Key management** — lock, unlock, rotate-key, backup, restore.
-- **Local-first architecture** — no cloud account, no telemetry, no external network calls.
-- **Automatic schema migrations** — upgrades happen transparently on first run after a package update. Versioned SQL and Python migrations, drift detection, stuck migration recovery. Power users can inspect state with `moneybin db migrate status`.
-- **Defense in depth** — PII sanitization in logs, parameterized SQL throughout, path validation on file operations.
-
-### Observability
-
-- **Structured logging** — stream-based routing (`cli`, `mcp`, `sqlmesh`) with daily log files, human-readable and JSON formatters, PII sanitization.
-- **Metrics** — `prometheus_client`-backed counters, gauges, and histograms with automatic DuckDB persistence across restarts.
-- **Instrumentation** — `@tracked` decorator and `track_duration` context manager for zero-boilerplate operation timing.
-- **CLI** — `moneybin stats show` for lifetime metric aggregates; `moneybin logs tail --stream mcp` for stream-filtered log viewing.
-
-### Multi-Profile Support
-
-Each profile is an isolation boundary with its own database, config, and logs under `~/.moneybin/profiles/<name>/`.
-
-```bash
-moneybin profile create work       # Create a new profile
-moneybin profile list              # Show all profiles
-moneybin --profile work import file statement.qfx   # Use a specific profile
-moneybin profile switch work       # Change the default
-```
-
-### MCP Server
-
-The MCP server exposes financial data to AI assistants with structured tools, prompt templates, and resources. It's the primary programmatic interface — not an afterthought.
-
-```bash
-moneybin mcp list-tools            # See all registered tools
-moneybin mcp list-prompts          # See all registered prompts
-moneybin mcp config                # Show current MCP config
-```
-
-### Synthetic Data Generator
-
-Generate realistic, deterministic financial data for testing and demos.
-
-```bash
-moneybin synthetic generate --persona basic --profile test-data
-```
-
-- **Three personas** — `basic` (single income), `family` (dual income, kids), `freelancer` (variable income).
-- **~200 real merchants** across 14+ spending categories with realistic amounts and seasonal patterns.
-- **Ground-truth labels** — every transaction has a known-correct category and transfer pair, enabling automated accuracy testing.
-- **Deterministic** — same persona + same seed = same data every time.
-
-### Scenario Verification
-
-Whole-pipeline correctness checks against synthetic personas and hand-labeled fixtures.
-
-```bash
-moneybin synthetic verify --list                       # show shipped scenarios
-moneybin synthetic verify --scenario basic-full-pipeline
-moneybin synthetic verify --all --output json          # CI mode
-```
-
-Each scenario boots an empty encrypted DuckDB, runs the configured pipeline (`generate → transform → match → categorize`), and reports three correctness signals: **assertions** (invariants like FK integrity, sign convention, balanced transfers), **expectations** (per-record claims on labeled fixtures), and **evaluations** (aggregate scores like categorization accuracy and transfer-detection F1). The `.github/workflows/scenarios.yml` job runs the full suite on every PR.
-
-### CLI
-
-Domain commands at the top level for fast access:
-
-```bash
-moneybin import file <path>        # Import financial data files
-moneybin transform apply           # Run SQLMesh pipeline
-moneybin transform status          # Check pipeline state
-moneybin categorize apply-rules    # Apply categorization rules
-moneybin db shell                  # Interactive SQL shell
-moneybin db ps                     # Show processes holding the database
-moneybin logs tail -f              # Follow log output
-```
-
-> For full command documentation, see the [CLI Reference](docs/guides/cli-reference.md). For detailed feature guides, see the [Feature Guide](docs/guides/).
+Full command reference: [CLI Reference](docs/guides/cli-reference.md).
 
 ## Roadmap
 
-Legend: ✅ shipped | 📐 designed (spec written) | 🗓️ planned
+✅ shipped · 📐 designed · 🗓️ planned
 
-### Import & Ingestion
-
-| Feature | Status |
-|---------|--------|
-| OFX/QFX bank statement import | ✅ |
-| W-2 PDF extraction | ✅ |
-| CSV import with institution profiles | ✅ |
-| Universal tabular import (CSV, TSV, Excel, Parquet, Feather) | ✅ |
-| Heuristic column detection | ✅ |
-| Competitor migration profiles (Tiller, Mint, YNAB, Maybe) | ✅ |
-| Native PDF parsing (beyond W-2) | 🗓️ |
-| AI-assisted file parsing fallback | 🗓️ |
-
-### Data Quality & Matching
-
-| Feature | Status |
-|---------|--------|
-| Within-source dedup | ✅ |
-| Cross-source dedup (same transaction from different imports) | ✅ |
-| Transfer detection across accounts | ✅ |
-| Golden-record merge rules | ✅ |
-
-### Categorization
-
-| Feature | Status |
-|---------|--------|
-| Rule engine (exact, substring, regex) | ✅ |
-| Merchant normalization | ✅ |
-| Bulk categorization | ✅ |
-| Auto-rule generation from user edits | ✅ |
-| ML-powered categorization | 🗓️ |
-| Merchant entity resolution | 🗓️ |
-
-### Bank Sync
-
-| Feature | Status |
-|---------|--------|
-| Plaid Transactions API | 📐 |
-| SimpleFIN provider | 🗓️ |
-| Plaid Investments | 🗓️ |
-
-### Tracking & Analysis
-
-| Feature | Status |
-|---------|--------|
-| Net worth & balance tracking | 📐 |
-| Budget tracking (targets, rollovers) | 📐 |
+| Area | Status |
+|---|---|
+| OFX/QFX, tabular (CSV/TSV/Excel/Parquet/Feather), W-2 PDF import; competitor migration profiles | ✅ |
+| Cross-source dedup, transfer detection, golden-record merge | ✅ |
+| Rule engine + merchant normalization + auto-rule generation | ✅ |
+| Encryption at rest, key management, multi-profile, schema migrations, observability | ✅ |
+| Native PDF parsing (beyond W-2), AI-assisted file parsing | 🗓️ |
+| ML-powered categorization, merchant entity resolution | 🗓️ |
+| Plaid Transactions sync (via `moneybin-server`) | 📐 |
+| SimpleFIN sync, Plaid Investments | 🗓️ |
+| Net worth & balance tracking, budget tracking | 📐 |
 | Investment tracking (holdings, cost basis) | 🗓️ |
-
-### Infrastructure
-
-| Feature | Status |
-|---------|--------|
-| AES-256-GCM encryption at rest | ✅ |
-| Key management (lock/unlock/rotate) | ✅ |
-| Multi-profile support (isolated DBs, config, logs) | ✅ |
-| CLI restructure (profiles, domain commands, base dir) | ✅ |
-| Database migration system | ✅ |
-| Observability (metrics, structured logging) | ✅ |
-| Synthetic test data generator | ✅ |
-| Whole-pipeline scenario runner (`synthetic verify`) | ✅ |
 | Privacy tiers & consent model | 📐 |
 | Export (CSV, Excel, Google Sheets) | 🗓️ |
 
-## How MoneyBin Is Different
+Per-feature design specs live in [`docs/specs/`](docs/specs/INDEX.md).
 
-MoneyBin occupies a different niche than existing tools:
+## How It Compares
 
-- **[Beancount](https://beancount.github.io/) / [Fava](https://beancount.github.io/fava/)** — Plain-text double-entry accounting. Excellent for accountants who want precision and portability. MoneyBin trades the plain-text ledger for a SQL-queryable database and AI-native interface, targeting people who want insights without learning accounting syntax.
+|  | Beancount/Fava | Firefly III | Actual Budget | MoneyBin |
+|---|---|---|---|---|
+| Storage | Plain-text ledger | MySQL/Postgres | Local SQLite | Encrypted DuckDB |
+| Bank sync | — | Nordigen (6000+) | Limited | Designed (Plaid/SimpleFIN) |
+| AI integration | — | — | — | Native MCP |
+| Query interface | Text + Fava UI | Web UI + API | Web UI | SQL, MCP, CLI |
+| Maturity | Years | Years | Years | Active early dev |
 
-- **[Firefly III](https://www.firefly-iii.org/)** — Self-hosted web app with broad bank sync (6000+ institutions via Nordigen). Mature and full-featured. MoneyBin prioritizes local-first encryption and AI interaction over a web UI, at the cost of current maturity.
-
-- **[Actual Budget](https://actualbudget.org/)** — Desktop-first envelope budgeting. Great UX for zero-based budgeting. MoneyBin is less opinionated about budgeting methodology and more focused on being a queryable data platform.
-
-**What MoneyBin brings that they don't:**
-
-- Native AI integration via MCP (not a bolt-on)
-- AES-256-GCM encryption at rest by default
-- Auditable SQL transformation pipeline (SQLMesh + DuckDB)
-- Direct SQL access to your financial data
-
-**What they have that MoneyBin doesn't (yet):**
-
-- Bank sync with thousands of institutions
-- Investment tracking
-- Visual dashboards and web UIs
-- Years of community maturity
-
-## Project Structure
-
-```
-moneybin/
-├── src/moneybin/
-│   ├── mcp/                # MCP server (FastMCP, tools, resources, prompts)
-│   ├── cli/                # Typer CLI (thin wrappers over service layer)
-│   ├── services/           # Business logic (shared by MCP + CLI)
-│   ├── extractors/         # File parsers (OFX, PDF, CSV)
-│   ├── loaders/            # DuckDB data loaders
-│   ├── database.py         # Connection factory (encryption, schemas, migrations)
-│   ├── config.py           # Pydantic Settings (single source of truth)
-│   └── log_sanitizer.py    # PII detection and masking for logs
-├── sqlmesh/                # SQLMesh project
-│   └── models/             # SQL transformation models
-│       ├── prep/           #   Staging views (1:1 with raw sources)
-│       └── core/           #   Canonical tables (multi-source, deduplicated)
-├── tests/                  # pytest suite (unit + integration)
-├── docs/
-│   ├── specs/              # Feature specs with status tracking
-│   └── decisions/          # Architecture Decision Records
-└── ~/.moneybin/            # User data (default location)
-    └── profiles/<name>/    # Per-profile: database, config, logs, temp
-```
-
-## Development
-
-```bash
-make setup              # Set up development environment
-make check              # Format + lint + type-check (ruff + pyright)
-make test               # Run unit tests
-make test-all           # Run all tests including integration
-make test-cov           # Tests with coverage report
-```
-
-MoneyBin uses [uv](https://docs.astral.sh/uv/) for package management, [Ruff](https://docs.astral.sh/ruff/) for formatting and linting, and [Pyright](https://github.com/microsoft/pyright) for type checking.
+MoneyBin's bet: AI-native interaction + auditable SQL pipeline + encryption by default, in exchange for less coverage on bank sync, no investment tracking yet, and no web UI. The other tools are mature and excellent at what they do — pick the one that fits your priorities.
 
 ## Documentation
 
-- [Feature Guide](docs/guides/) — Detailed documentation for every shipped feature
-- [Spec Index](docs/specs/INDEX.md) — Feature specs and status tracking
-- [Architecture Decision Records](docs/decisions/) — Key design decisions and rationale
-- [Privacy & Data Protection](docs/specs/privacy-data-protection.md) — Encryption, key management, threat model
+- [Feature Guides](docs/guides/) — what's shipped, how to use it
+- [Spec Index](docs/specs/INDEX.md) — design specs and status
+- [Architecture Decision Records](docs/decisions/) — key design decisions
+- [Contributing](CONTRIBUTING.md) — dev setup, project structure, scenario runner
 
 ## License
 

--- a/docs/guides/categorization.md
+++ b/docs/guides/categorization.md
@@ -57,15 +57,11 @@ Each merchant mapping specifies:
 
 All categorization operations support batch mode for efficient processing. These are designed for AI assistants that review and categorize many transactions in a single interaction turn.
 
-**Via MCP tools:**
-- `bulk_categorize` — categorize many transactions in one call
-- `bulk_create_categorization_rules` — define multiple rules at once
-- `bulk_create_merchant_mappings` — set up merchant recognition in batch
-
-**Via individual MCP tools:**
-- `categorize_transaction` — assign a category (auto-creates merchant mapping)
-- `create_categorization_rule` — create a single rule
-- `create_merchant_mapping` — create a single merchant mapping
+**Via MCP tools** (all batch-capable — single or many records per call):
+- `categorize.bulk` — categorize one or many transactions (auto-creates merchant mappings)
+- `categorize.create_rules` — create one or many categorization rules
+- `categorize.create_merchants` — create one or many merchant mappings
+- `categorize.delete_rule` — remove a rule
 
 ## Category Taxonomy
 
@@ -79,7 +75,7 @@ moneybin categorize seed
 **Top-level categories include:** Food & Drink, Shopping, Travel, Transportation, Entertainment, Bills & Utilities, Health & Fitness, Personal Care, Education, Income, Transfer, and more.
 
 You can also:
-- **Create custom categories** via the `create_category` MCP tool
+- **Create custom categories** via the `categorize.create_category` MCP tool
 - **Toggle categories on/off** — disabled categories are hidden from the taxonomy but existing categorizations are preserved
 
 ## Auto-Rules
@@ -88,7 +84,7 @@ MoneyBin learns categorization patterns from how you (or your AI assistant) cate
 
 ### How learning works
 
-Every time `bulk_categorize` writes a categorization (CLI, MCP, or AI agent), MoneyBin records the `(pattern, category)` pair. After enough independent transactions categorize the same way, the proposal moves from `tracking` to `pending` and shows up in `auto-review`. You decide whether to promote it to a real rule.
+Every time `categorize.bulk` writes a categorization (CLI, MCP, or AI agent), MoneyBin records the `(pattern, category)` pair. After enough independent transactions categorize the same way, the proposal moves from `tracking` to `pending` and shows up in `auto-review`. You decide whether to promote it to a real rule.
 
 | Term | Meaning |
 |---|---|
@@ -149,7 +145,7 @@ You'll see the new proposal in `auto-review`. Approve it to install the correcte
 
 ### What patterns get proposed
 
-The proposal pattern comes from the merchant resolution that already happens during `bulk_categorize`:
+The proposal pattern comes from the merchant resolution that already happens during `categorize.bulk`:
 
 - **If the transaction matched an existing merchant** — the merchant's `raw_pattern` and `match_type` are used (e.g., `AMZN` / `exact`). This is the precise substring that matches statement descriptions, not the canonical display name.
 - **If no merchant matched** — the cleaned-up description with `match_type='contains'` is used as a fallback.

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-MoneyBin's CLI is organized by domain with commands in workflow order. Every command supports `--help` for detailed usage.
+MoneyBin's CLI is organized by domain in workflow order. Every command supports `--help`.
 
 ## Global Options
 
@@ -8,6 +8,8 @@ MoneyBin's CLI is organized by domain with commands in workflow order. Every com
 |--------|-------|-------------|
 | `--profile` | `-p` | Use a specific profile for this command |
 | `--verbose` | `-v` | Enable debug logging |
+
+Most query/list commands also accept `--output json` for machine-readable parity with the MCP server.
 
 ## Command Tree
 
@@ -21,7 +23,7 @@ moneybin
 │   ├── show         Show resolved settings
 │   └── set          Set a config value
 │
-├── import           Data import
+├── import           File import
 │   ├── file         Import a financial file (auto-detects type)
 │   ├── status       Summary of all imported data
 │   ├── history      List recent imports with batch details
@@ -31,6 +33,30 @@ moneybin
 │   ├── show-format  Show format details
 │   └── delete-format Delete a user-saved format
 │
+├── sync             Bank sync via moneybin-server (📐 designed)
+│   ├── login / logout
+│   ├── connect / disconnect
+│   ├── pull / status
+│   ├── rotate-key
+│   └── schedule {set,show,remove}
+│
+├── categorize       Categorization management
+│   ├── apply-rules  Run rules + merchants on uncategorized transactions
+│   ├── seed         Initialize default categories (Plaid PFCv2)
+│   ├── stats        Coverage statistics
+│   ├── list-rules   Display active manual rules
+│   ├── auto-review  List pending auto-rule proposals
+│   ├── auto-confirm Approve/reject auto-rule proposals
+│   ├── auto-rules   List active auto-generated rules
+│   └── auto-stats   Auto-rule health (active, pending, categorized)
+│
+├── matches          Dedup + transfer review
+│   ├── run          Run matcher against existing transactions
+│   ├── review       Review pending match proposals (interactive or flagged)
+│   ├── history      Show recent match decisions
+│   ├── undo         Reverse a match decision
+│   └── backfill     One-time scan of existing data for latent matches
+│
 ├── transform        SQLMesh pipeline
 │   ├── apply        Apply pending changes
 │   ├── plan         Preview what will change
@@ -39,14 +65,18 @@ moneybin
 │   ├── audit        Run data quality audits
 │   └── restate      Force recompute a model for a date range
 │
-├── categorize       Categorization management
-│   ├── apply-rules  Run rules on uncategorized transactions
-│   ├── seed         Initialize default categories (Plaid PFCv2)
-│   ├── stats        Coverage statistics
-│   └── list-rules   Display active rules
+├── track            Balance, net worth, budgets, recurring (🗓️/📐)
+│   ├── balance show
+│   ├── networth show
+│   ├── budget show
+│   ├── recurring show
+│   └── investments show
 │
 ├── stats            Observability
 │   └── show         Lifetime metric aggregates
+│
+├── export           Export to CSV/Excel/Sheets (🗓️ planned)
+│   └── run
 │
 ├── mcp              MCP server
 │   ├── serve        Start the MCP server
@@ -63,25 +93,24 @@ moneybin
 │   ├── info         Database metadata (size, tables, encryption, versions)
 │   ├── backup       Create timestamped backup
 │   ├── restore      Restore from a backup file
-│   ├── lock         Clear cached encryption key
-│   ├── unlock       Derive key from passphrase and cache
+│   ├── lock / unlock
 │   ├── key          Print the encryption key
 │   ├── rotate-key   Re-encrypt with a new key
-│   ├── ps           Show processes holding the database
-│   ├── kill         Kill processes holding the database
-│   └── migrate
-│       ├── apply    Apply pending schema migrations
-│       └── status   Show migration state and drift warnings
+│   ├── ps / kill    Inspect or kill processes holding the DB
+│   └── migrate {apply,status}
 │
 ├── logs             Log management
 │   ├── tail         View recent log entries (-f to follow)
 │   ├── path         Print log directory path
 │   └── clean        Delete old log files
 │
-└── synthetic        Test data generation
+└── synthetic        Test data + scenario verification
     ├── generate     Generate synthetic data for a persona
-    └── reset        Wipe and regenerate from scratch
+    ├── reset        Wipe and regenerate from scratch
+    └── verify       Run scenario suites (--list, --scenario, --all)
 ```
+
+Commands marked 📐 (designed) or 🗓️ (planned) reserve the namespace and print a pointer to the owning spec when invoked.
 
 ## Common Workflows
 
@@ -93,18 +122,23 @@ moneybin categorize seed
 moneybin import file ~/Downloads/checking.qfx
 ```
 
-### Import and categorize
+### Import, dedup, and categorize
 
 ```bash
 moneybin import file ~/Downloads/chase_may.csv --account-name "Chase Checking"
-moneybin categorize apply-rules
+moneybin matches review                # Review any pending dedup/transfer proposals
+moneybin categorize apply-rules        # Apply rules + merchants
+moneybin categorize auto-review        # Inspect auto-rule proposals
+moneybin categorize auto-confirm --approve-all
 moneybin categorize stats
 ```
+
+`import file` runs the matcher and rule-based categorization automatically. The explicit commands above are useful when reviewing pending work or tuning behavior.
 
 ### Query your data
 
 ```bash
-moneybin db query "SELECT category, SUM(amount) FROM core.fct_transactions GROUP BY category ORDER BY SUM(amount)"
+moneybin db query "SELECT category, SUM(amount) FROM core.fct_transactions GROUP BY 1"
 moneybin db shell
 ```
 
@@ -112,6 +146,14 @@ moneybin db shell
 
 ```bash
 moneybin mcp config generate --client claude-desktop --install
+```
+
+### Verify the pipeline (developer)
+
+```bash
+moneybin synthetic verify --list
+moneybin synthetic verify --scenario basic-full-pipeline
+moneybin synthetic verify --all --output json
 ```
 
 ### Database maintenance

--- a/docs/guides/data-pipeline.md
+++ b/docs/guides/data-pipeline.md
@@ -24,9 +24,9 @@ Exact data from file extractors and loaders. Never modified after import.
 | `raw.tabular_accounts` | Tabular account metadata |
 | `raw.w2_forms` | W-2 PDF tax data |
 
-### Staging Layer (`prep.*`)
+### Staging Layer (`prep.stg_*`)
 
-Light cleaning, type casting, and union-then-match logic. DuckDB views — they recompute from raw data on each transform.
+Light cleaning and type casting. One view per raw source. DuckDB views — they recompute from raw data on each transform.
 
 | View | Purpose |
 |------|---------|
@@ -36,6 +36,13 @@ Light cleaning, type casting, and union-then-match logic. DuckDB views — they 
 | `prep.stg_ofx__institutions` | OFX institution metadata |
 | `prep.stg_tabular__transactions` | Clean tabular transactions |
 | `prep.stg_tabular__accounts` | Clean tabular accounts |
+
+### Matching Intermediate Views (`prep.int_*`)
+
+Sit between staging and core, implementing the union → match → merge flow that produces the golden record. Also DuckDB views.
+
+| View | Purpose |
+|------|---------|
 | `prep.int_transactions__unioned` | All sources unioned with `source_type` |
 | `prep.int_transactions__matched` | Unioned rows annotated with accepted match decisions |
 | `prep.int_transactions__merged` | Golden-record merge — one winning row per matched cluster |

--- a/docs/guides/data-pipeline.md
+++ b/docs/guides/data-pipeline.md
@@ -4,11 +4,11 @@ MoneyBin uses a three-layer medallion architecture powered by [SQLMesh](https://
 
 ## Three-Layer Architecture
 
-```
-Raw (raw.*)          Staging (prep.*)         Core (core.*)
------------          ---------------          -------------
-Untouched data  -->  Light cleaning,     -->  Canonical, deduplicated,
-from extractors      type casting (views)     multi-source (tables)
+```mermaid
+graph LR
+    R["Raw (raw.*)<br/>Untouched data<br/>from extractors"] --> S["Staging (prep.*)<br/>Light cleaning,<br/>type casting (views)"]
+    S --> M["Matching<br/>(dedup + transfers)"]
+    M --> C["Core (core.*)<br/>Canonical, deduplicated,<br/>multi-source (tables)"]
 ```
 
 ### Raw Layer (`raw.*`)
@@ -26,7 +26,7 @@ Exact data from file extractors and loaders. Never modified after import.
 
 ### Staging Layer (`prep.*`)
 
-Light cleaning and type casting. One view per raw source. These are DuckDB views, not materialized tables — they compute on the fly from raw data.
+Light cleaning, type casting, and union-then-match logic. DuckDB views — they recompute from raw data on each transform.
 
 | View | Purpose |
 |------|---------|
@@ -36,6 +36,9 @@ Light cleaning and type casting. One view per raw source. These are DuckDB views
 | `prep.stg_ofx__institutions` | OFX institution metadata |
 | `prep.stg_tabular__transactions` | Clean tabular transactions |
 | `prep.stg_tabular__accounts` | Clean tabular accounts |
+| `prep.int_transactions__unioned` | All sources unioned with `source_type` |
+| `prep.int_transactions__matched` | Unioned rows annotated with accepted match decisions |
+| `prep.int_transactions__merged` | Golden-record merge — one winning row per matched cluster |
 
 ### Core Layer (`core.*`)
 
@@ -44,56 +47,71 @@ Canonical, deduplicated, multi-source tables. All consumers (MCP server, CLI, di
 | Table | Purpose |
 |-------|---------|
 | `core.dim_accounts` | All accounts from all sources, deduplicated |
-| `core.fct_transactions` | All transactions from all sources, deduplicated, with categorization |
+| `core.fct_transactions` | All transactions, deduplicated, with categorization |
+| `core.bridge_transfers` | Linked debit/credit pairs from transfer detection |
+| `meta.fct_transaction_provenance` | Per-transaction lineage: which source rows merged into the golden record |
+
+## Matching: Dedup and Transfers
+
+The matching engine runs after staging and before core materialization. It identifies two kinds of relationships:
+
+- **Dedup matches** — the same transaction imported from two sources (e.g., the OFX statement and a Mint CSV export). One canonical row wins; the other is suppressed in core.
+- **Transfer matches** — a debit on one account paired with the offsetting credit on another (e.g., credit-card payment from checking). Linked in `core.bridge_transfers` so spending reports don't double-count.
+
+Both go through a review/accept/reject workflow with full undo. See the [matching specs](../specs/matching-overview.md) for the four-tier scoring model.
+
+```bash
+moneybin matches run                   # Run matcher against existing data
+moneybin matches review                # Interactive review of pending proposals
+moneybin matches review --accept-all   # Non-interactive bulk accept
+moneybin matches history               # Recent decisions
+moneybin matches undo <match-id>       # Reverse a decision
+moneybin matches backfill              # One-time scan of all existing data
+```
+
+`moneybin import file` runs the matcher automatically; the standalone commands are for reviewing pending work or tuning thresholds.
 
 ## Key Design Decisions
 
 - **One canonical table per entity.** Consumers never query raw or staging directly.
-- **Multi-source union.** Core models `UNION ALL` from every staging source with a `source_type` column tracking origin (`ofx`, `csv`, `tsv`, `excel`, `parquet`, etc.).
-- **Dedup in core.** `ROW_NUMBER()` windows handle within-source duplicates.
-- **Adding a data source** means writing staging views and adding a CTE to the relevant core model. No consumer changes needed.
+- **Multi-source union, then match.** Core unions every staging source (`UNION ALL` with a `source_type` column), then applies match decisions to choose a golden record per cluster.
+- **Match decisions are persisted, not recomputed.** Accept/reject/undo state lives in `app.match_decisions` and is replayed on every transform — review work is durable.
+- **Adding a data source** means writing staging views and adding a CTE to the relevant intermediate model. No consumer changes needed.
 - **Accounting sign convention.** Negative = expense, positive = income. `DECIMAL(18,2)` for amounts, `DATE` for dates.
 
 ## SQLMesh Transforms
 
-SQLMesh manages the transformation pipeline. The pipeline runs automatically after each `moneybin import file` command unless `--skip-transform` is specified.
+SQLMesh manages the transformation pipeline. It runs automatically after each `moneybin import file` unless `--skip-transform` is specified.
 
 ```bash
-# Apply all pending changes (rebuild core tables from raw data)
-moneybin transform apply
-
-# Preview what will change before applying
-moneybin transform plan
-
-# Check current model state
-moneybin transform status
-
-# Validate model SQL without running
-moneybin transform validate
-
-# Run data quality audits
-moneybin transform audit
-
-# Force recompute a model for a date range
-moneybin transform restate
+moneybin transform apply       # Apply pending changes (rebuild from raw data)
+moneybin transform plan        # Preview changes before applying
+moneybin transform status      # Current model state
+moneybin transform validate    # Check model SQL parses correctly
+moneybin transform audit       # Run data quality audits
+moneybin transform restate     # Force recompute a model for a date range
 ```
 
 ### Model Files
 
-SQLMesh models live under `sqlmesh/models/`:
-
 ```
 sqlmesh/models/
-├── prep/           # Staging views (1:1 with raw sources)
+├── prep/                                  # Staging views (1:1 with raw + intermediate)
 │   ├── stg_ofx__transactions.sql
 │   ├── stg_ofx__accounts.sql
 │   ├── stg_ofx__balances.sql
 │   ├── stg_ofx__institutions.sql
 │   ├── stg_tabular__transactions.sql
-│   └── stg_tabular__accounts.sql
-└── core/           # Canonical tables (multi-source, deduplicated)
-    ├── dim_accounts.sql
-    └── fct_transactions.sql
+│   ├── stg_tabular__accounts.sql
+│   ├── int_transactions__unioned.sql
+│   ├── int_transactions__matched.sql
+│   └── int_transactions__merged.sql
+├── core/                                  # Canonical tables
+│   ├── dim_accounts.sql
+│   ├── fct_transactions.sql
+│   └── bridge_transfers.sql
+└── meta/                                  # Lineage and provenance
+    └── fct_transaction_provenance.sql
 ```
 
-Each model is a plain SQL file with a `MODEL()` header that declares dependencies, materialization strategy, and scheduling.
+Each model is a plain SQL file with a `MODEL()` header that declares dependencies, materialization, and scheduling.

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -128,7 +128,7 @@ moneybin mcp list-prompts
 
 ## Response Envelope
 
-Every tool returns the standard response envelope: a structured `data` payload, a `meta` block (timing, row counts, sensitivity tier), and an optional `errors` list. The `--output json` flag on equivalent CLI commands produces the same envelope, so MCP and CLI consumers can share parsing logic.
+Every tool returns the standard response envelope: `summary` (row counts, truncation, sensitivity tier, currency), `data` (the payload — list of records or a single result dict), `actions` (contextual next-step hints), and an optional `error` (populated when the tool fails with a classified `UserError`; `data` is empty in that case). The `--output json` flag on equivalent CLI commands produces the same envelope, so MCP and CLI consumers can share parsing logic. See [`mcp-architecture`](../specs/mcp-architecture.md) §4 for the full schema.
 
 ## Server Management
 

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -21,78 +21,94 @@ After connecting, you can ask your AI assistant things like:
 - *"Import this CSV file and set up categorization rules"*
 - *"How much did I pay in taxes last year?"*
 - *"Show me my monthly income vs expenses trend"*
-- *"Look for unusual or suspicious transactions in the last month"*
 
-## Available Tools
+## Tool Catalog
 
-The MCP server exposes 30+ tools across these domains:
+Tools are organized into domain namespaces. Names are stable — AI clients call `<domain>.<action>`.
 
-### Query & Analysis
-
-| Tool | Description |
-|------|-------------|
-| `query_transactions` | Search transactions with date, amount, payee, and account filters |
-| `get_monthly_summary` | Income vs expenses summary by month |
-| `get_spending_by_category` | Spending breakdown by category for a month |
-| `get_account_balances` | Most recent balance for each account |
-| `get_budget_status` | Budget vs actual spending comparison |
-| `find_recurring_transactions` | Detect subscriptions and regular charges |
-| `get_w2_summary` | W-2 tax data (wages, withholding, employer info) |
-| `get_categorization_stats` | Categorization coverage statistics |
-| `list_accounts` | All financial accounts with type and institution |
-| `list_institutions` | Connected financial institutions |
-| `list_categories` | Active category taxonomy |
-| `list_categorization_rules` | Active auto-categorization rules |
-| `list_merchants` | Merchant name mappings |
-
-### Import
+### accounts
 
 | Tool | Description |
 |------|-------------|
-| `import_file` | Import a financial data file (OFX, CSV, Excel, etc.) |
-| `import_preview` | Preview file structure and column mapping (dry run) |
-| `import_history` | List past imports with batch details |
-| `import_revert` | Undo an import batch |
-| `list_formats` | Available tabular import formats |
+| `accounts.list` | All financial accounts with type and institution |
+| `accounts.balances` | Most recent balance for each account |
 
-### Categorization
+### transactions
 
 | Tool | Description |
 |------|-------------|
-| `get_uncategorized_transactions` | Find transactions needing categorization |
-| `categorize_transaction` | Assign a category (auto-creates merchant mapping) |
-| `bulk_categorize` | Categorize many transactions in one call |
-| `create_categorization_rule` | Create an auto-categorization rule |
-| `bulk_create_categorization_rules` | Create multiple rules at once |
-| `create_merchant_mapping` | Map raw description to clean merchant name |
-| `bulk_create_merchant_mappings` | Create multiple merchant mappings at once |
-| `create_category` | Create a custom category or subcategory |
-| `toggle_category` | Enable or disable a category |
-| `seed_categories` | Initialize default category taxonomy |
-| `delete_categorization_rule` | Remove a categorization rule |
+| `transactions.search` | Search with date, amount, payee, account, and category filters |
+| `transactions.recurring` | Detect subscriptions and regular charges |
 
-### Budget
+### spending
 
 | Tool | Description |
 |------|-------------|
-| `set_budget` | Create or update a monthly budget for a category |
+| `spending.summary` | Income vs expenses summary by month |
+| `spending.by_category` | Spending breakdown by category for a period |
 
-### Database
+### categorize
 
 | Tool | Description |
 |------|-------------|
-| `list_tables` | List all tables and views in the database |
-| `describe_table` | Show columns, types, and row count for a table |
-| `run_read_query` | Execute arbitrary read-only SQL (power user) |
+| `categorize.categories` | List active category taxonomy |
+| `categorize.rules` | List active categorization rules |
+| `categorize.merchants` | List merchant name mappings |
+| `categorize.stats` | Categorization coverage statistics |
+| `categorize.uncategorized` | Find transactions needing categorization |
+| `categorize.bulk` | Categorize many transactions in one call (auto-creates merchant mapping) |
+| `categorize.create_rules` | Create one or many categorization rules |
+| `categorize.delete_rule` | Remove a rule |
+| `categorize.create_merchants` | Create one or many merchant mappings |
+| `categorize.create_category` | Create a custom category or subcategory |
+| `categorize.toggle_category` | Enable or disable a category |
+| `categorize.seed` | Initialize default category taxonomy (Plaid PFCv2) |
+| `categorize.auto_review` | List pending auto-rule proposals |
+| `categorize.auto_confirm` | Approve or reject auto-rule proposals |
+| `categorize.auto_stats` | Auto-rule health (active, pending, transactions covered) |
+
+### import
+
+| Tool | Description |
+|------|-------------|
+| `import.file` | Import a financial data file (auto-detects format) |
+| `import.csv_preview` | Preview structure and column mapping (dry run) |
+| `import.list_formats` | Available tabular import formats and saved profiles |
+| `import.status` | Summary of all imported data |
+
+### budget
+
+| Tool | Description |
+|------|-------------|
+| `budget.set` | Create or update a monthly budget for a category |
+| `budget.status` | Budget vs actual spending comparison |
+
+### tax
+
+| Tool | Description |
+|------|-------------|
+| `tax.w2` | W-2 summary (wages, withholding, employer info) for a year |
+
+### sql
+
+| Tool | Description |
+|------|-------------|
+| `sql.query` | Execute arbitrary read-only SQL (power user) |
+
+### moneybin
+
+| Tool | Description |
+|------|-------------|
+| `moneybin.discover` | Tool catalog and capability discovery for AI clients |
 
 ```bash
-# See all registered tools with full descriptions
+# See all registered tools with full descriptions and schemas
 moneybin mcp list-tools
 ```
 
 ## Prompt Templates
 
-Prompt templates guide AI assistants through multi-step financial workflows. Each template provides structured instructions and context so the AI knows which tools to call and in what order.
+Prompt templates guide AI assistants through multi-step financial workflows. Each provides structured instructions and context so the AI knows which tools to call and in what order.
 
 | Prompt | Description |
 |--------|-------------|
@@ -107,9 +123,12 @@ Prompt templates guide AI assistants through multi-step financial workflows. Eac
 | `transaction_search` | Find transactions matching a description |
 
 ```bash
-# See all registered prompts with descriptions
 moneybin mcp list-prompts
 ```
+
+## Response Envelope
+
+Every tool returns the standard response envelope: a structured `data` payload, a `meta` block (timing, row counts, sensitivity tier), and an optional `errors` list. The `--output json` flag on equivalent CLI commands produces the same envelope, so MCP and CLI consumers can share parsing logic.
 
 ## Server Management
 

--- a/docs/guides/sql-access.md
+++ b/docs/guides/sql-access.md
@@ -23,7 +23,7 @@ The shell and UI connect to the encrypted database transparently — no manual k
 
 ## MCP SQL Access
 
-The `run_read_query` MCP tool lets AI assistants execute arbitrary read-only SQL:
+The `sql.query` MCP tool lets AI assistants execute arbitrary read-only SQL:
 
 ```sql
 -- Only SELECT, WITH, DESCRIBE, SHOW, PRAGMA, and EXPLAIN are allowed
@@ -57,6 +57,8 @@ df = conn.execute("SELECT * FROM core.fct_transactions").fetchdf()
 |-------|-------------|-------------|
 | `core.fct_transactions` | All transactions, all sources, deduplicated | `transaction_id`, `date`, `amount`, `description`, `category`, `subcategory`, `account_id`, `source_type` |
 | `core.dim_accounts` | All accounts, all sources, deduplicated | `account_id`, `account_name`, `account_type`, `institution_name` |
+| `core.bridge_transfers` | Linked debit/credit pairs from transfer detection | `transfer_id`, `debit_transaction_id`, `credit_transaction_id`, `date_offset_days`, `amount` |
+| `meta.fct_transaction_provenance` | Per-transaction lineage to source rows | `transaction_id`, `source_transaction_id`, `source_type`, `source_origin`, `source_file`, `match_id` |
 
 ### Raw (source data, untouched)
 
@@ -73,11 +75,17 @@ df = conn.execute("SELECT * FROM core.fct_transactions").fetchdf()
 
 | Table | Description |
 |-------|-------------|
-| `app.categorization_rules` | Active auto-categorization rules |
-| `app.merchant_mappings` | Merchant name normalization mappings |
+| `app.categorization_rules` | Active rules (manual + auto-rules; `created_by` distinguishes) |
+| `app.merchants` | Merchant name normalization mappings |
 | `app.categories` | Category taxonomy |
+| `app.transaction_categories` | Manual per-transaction category overrides |
+| `app.transaction_notes` | User-attached notes on transactions |
 | `app.budgets` | Monthly budget targets |
-| `app.import_log` | Import batch tracking |
+| `app.match_decisions` | Dedup + transfer match decisions (status, reversal, replayed each transform) |
+| `app.proposed_rules` | Auto-rule proposals (tracking → pending → approved/rejected) |
+| `app.rule_deactivations` | Audit trail when override-driven self-healing deactivates a rule |
+| `app.metrics` | Persisted prometheus_client metric snapshots |
+| `raw.import_log` | Import batch tracking (file path, row counts, format, timestamp) |
 
 ## Example Queries
 

--- a/docs/guides/synthetic-data.md
+++ b/docs/guides/synthetic-data.md
@@ -58,7 +58,14 @@ moneybin synthetic generate --persona <name> --profile <profile>
 
 # Reset (wipe and regenerate) — refuses to wipe non-generated profiles
 moneybin synthetic reset --persona <name> --profile <profile>
+
+# Run scenario verification suites against synthetic fixtures
+moneybin synthetic verify --list
+moneybin synthetic verify --scenario basic-full-pipeline
+moneybin synthetic verify --all --output json
 ```
+
+`synthetic verify` runs whole-pipeline scenarios — generate → transform → match → categorize — and reports assertions, expectations, and evaluations. See [`testing-scenario-runner`](../specs/testing-scenario-runner.md) for the model and [CONTRIBUTING.md](../../CONTRIBUTING.md) for the developer workflow.
 
 ### Safety
 


### PR DESCRIPTION
## Summary
Brings README, feature guides, and contributor docs back in line with the current state of the project. Existing guides referenced removed CLI commands, pre-namespacing MCP tool names, and missing core/meta tables. Also splits developer/contributor content out of the README into a dedicated `CONTRIBUTING.md`.

## Impact
- Public README is now an end-of-MVP product pitch — tighter, links out to guides instead of inlining everything.
- Developers should look in `CONTRIBUTING.md` for setup, project structure, and the scenario runner.
- AI clients and scripts that rely on guides for tool/command names will see corrections (e.g. `bulk_categorize` → `categorize.bulk`, `run_read_query` → `sql.query`).
- No code changes — docs only.

## Changes

### README + CONTRIBUTING
- Rewrite README mermaid diagram to include bank sync (`moneybin-server`) as dashed/designed.
- Collapse the previous five roadmap tables into one 12-row matrix; tighten the comparison matrix; drop the ASCII pipeline diagram, expanded MCP tool listing, and "What Works Today" prose sections.
- Move scenario runner, project structure, and dev workflow content out of the README and into a new `CONTRIBUTING.md`.

### CLI reference
- Add the `matches` command group (`run`, `review`, `history`, `undo`, `backfill`).
- Add categorize auto-rule commands (`auto-review`, `auto-confirm`, `auto-rules`, `auto-stats`).
- Add `synthetic verify`, `track`, `sync`, and `export` groups (designed/planned commands flagged as such).
- Tighten "Common Workflows" to reflect the import → matches review → categorize loop.

### Data pipeline guide
- Add a "Matching: Dedup and Transfers" section covering `core.bridge_transfers`, the four-tier engine, and the `moneybin matches` CLI workflow.
- Document the `prep.int_transactions__unioned/__matched/__merged` intermediate views and `meta.fct_transaction_provenance`.
- Replace ASCII pipeline diagram with mermaid.

### MCP server guide
- Replace all stale flat tool names with the current `<domain>.<action>` namespacing (30 tools across `accounts`, `transactions`, `spending`, `categorize`, `import`, `budget`, `tax`, `sql`, `moneybin`).
- Add the `moneybin.discover` tool and the auto-rule tools.
- Add a short note on the standard response envelope and CLI parity.

### SQL access guide
- Rename stale tool: `run_read_query` → `sql.query`.
- Add `core.bridge_transfers`, `meta.fct_transaction_provenance` to the key-tables list.
- Add `app.match_decisions`, `app.proposed_rules`, `app.rule_deactivations`, `app.metrics`, `app.transaction_categories`, `app.transaction_notes`.
- Correct `app.merchant_mappings` → `app.merchants` and `app.import_log` → `raw.import_log` against actual schema.

### Other guides
- `categorization.md`: namespaced MCP tool references (`bulk_categorize` → `categorize.bulk`, `create_category` → `categorize.create_category`).
- `synthetic-data.md`: add `synthetic verify` examples and link to scenario runner spec / CONTRIBUTING.

## Testing
Doc-only — no code paths exercised. Verified each cited table, column, MCP tool name, and CLI command against the current source (`sqlmesh/models/`, `src/moneybin/sql/schema/`, `src/moneybin/cli/commands/`, `src/moneybin/mcp/tools/`).

## Notes
Private tracking docs (`private/implementation.md`, `private/specs/{spec_implementation,mvp-roadmap,feature-roadmap}.md`) were already updated separately and live outside this PR. No spec status changes are part of this PR — `INDEX.md` was already correct.