### PR TITLE
Refactor import_service module into ImportService class

### DIFF
--- a/src/moneybin/cli/commands/import_cmd.py
+++ b/src/moneybin/cli/commands/import_cmd.py
@@ -174,7 +174,7 @@ def import_file(
         moneybin import file export.csv --override date=Date --override amount=Amount
     """
     from moneybin.cli.utils import handle_cli_errors
-    from moneybin.services.import_service import import_file as run_import
+    from moneybin.services.import_service import ImportService
 
     source = Path(file_path)
 
@@ -202,8 +202,7 @@ def import_file(
 
     try:
         with handle_cli_errors() as db:
-            result = run_import(
-                db=db,
+            result = ImportService(db).import_file(
                 file_path=source,
                 apply_transforms=not skip_transform,
                 institution=institution,

--- a/src/moneybin/cli/commands/matches.py
+++ b/src/moneybin/cli/commands/matches.py
@@ -46,9 +46,9 @@ def matches_run(
                 logger.info("No new matches found")
 
             if not skip_transform and result.auto_merged:
-                from moneybin.services.import_service import run_transforms
+                from moneybin.services.import_service import ImportService
 
-                run_transforms()
+                ImportService(db).run_transforms()
     except duckdb_mod.CatalogException:
         logger.error(_NO_TRANSFORMS_MSG)
         raise typer.Exit(1) from None
@@ -200,9 +200,9 @@ def matches_review(
                     break
 
         if accepted_any and not skip_transform:
-            from moneybin.services.import_service import run_transforms
+            from moneybin.services.import_service import ImportService
 
-            run_transforms()
+            ImportService(db).run_transforms()
 
 
 @app.command("history")
@@ -295,9 +295,9 @@ def matches_backfill(
                 logger.info("Run 'moneybin matches review' when ready")
 
             if not skip_transform and result.auto_merged:
-                from moneybin.services.import_service import run_transforms
+                from moneybin.services.import_service import ImportService
 
-                run_transforms()
+                ImportService(db).run_transforms()
     except duckdb_mod.CatalogException:
         logger.error(_NO_TRANSFORMS_MSG)
         raise typer.Exit(1) from None

--- a/src/moneybin/cli/commands/synthetic.py
+++ b/src/moneybin/cli/commands/synthetic.py
@@ -54,7 +54,7 @@ def _run_generate(
     from moneybin.cli.utils import handle_cli_errors
     from moneybin.config import get_current_profile, set_current_profile
     from moneybin.database import close_database
-    from moneybin.services.import_service import run_transforms
+    from moneybin.services.import_service import ImportService
     from moneybin.testing.synthetic.engine import GeneratorEngine
     from moneybin.testing.synthetic.writer import SyntheticWriter
 
@@ -123,7 +123,7 @@ def _run_generate(
             if not skip_transform:
                 logger.info("⚙️  Running SQLMesh to materialize pipeline...")
                 try:
-                    run_transforms()
+                    ImportService(db).run_transforms()
                 except Exception:  # noqa: BLE001 — SQLMesh failures are non-fatal here
                     logger.warning(
                         "⚠️  SQLMesh transforms failed — raw data is intact, "

--- a/src/moneybin/cli/commands/transform.py
+++ b/src/moneybin/cli/commands/transform.py
@@ -55,13 +55,13 @@ def apply_transforms() -> None:
     Equivalent to 'moneybin transform plan --apply'. Rebuilds only changed
     models since the last run.
     """
-    from moneybin.services.import_service import run_transforms
+    from moneybin.services.import_service import ImportService
 
     logger.info("⚙️  Applying SQLMesh transforms...")
 
     try:
-        with handle_cli_errors():
-            run_transforms()
+        with handle_cli_errors() as db:
+            ImportService(db).run_transforms()
         logger.info("✅ SQLMesh transforms applied")
     except typer.Exit:
         raise

--- a/src/moneybin/mcp/tools/import_tools.py
+++ b/src/moneybin/mcp/tools/import_tools.py
@@ -70,15 +70,14 @@ def import_file(
         institution: Institution name (OFX only).
         format_name: Use a specific named format (bypass auto-detection).
     """
-    from moneybin.services.import_service import import_file as run_import
+    from moneybin.services.import_service import ImportService
 
     validated = _validate_file_path(file_path)
     if isinstance(validated, ResponseEnvelope):
         return validated
 
     try:
-        result = run_import(
-            get_database(),
+        result = ImportService(get_database()).import_file(
             str(validated),
             account_id=account_id,
             account_name=account_name,

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -85,46 +85,6 @@ class ResolvedMapping:
     confidence: str
 
 
-def _query_date_range(
-    db: Database,
-    table: str,
-    date_expr: str,
-    file_path: Path,
-) -> str:
-    """Query min/max date range for a source file from a raw table.
-
-    Both ``table`` and ``date_expr`` are interpolated into SQL — callers
-    must only pass hardcoded trusted strings, never user input.
-
-    Args:
-        db: Database instance.
-        table: Qualified table name (e.g. ``raw.ofx_transactions``).
-        date_expr: SQL expression for the date value — may be a bare column
-            name (``transaction_date``) or a cast expression
-            (``CAST(date_posted AS DATE)``).
-        file_path: Source file path to filter on.
-
-    Returns:
-        Date range string like ``"2024-01-01 to 2024-03-31"``, or empty
-        string if unavailable.
-    """
-    try:
-        result = db.execute(
-            f"""
-            SELECT MIN({date_expr}) AS min_date,
-                   MAX({date_expr}) AS max_date
-            FROM {table}
-            WHERE source_file = ?
-            """,  # noqa: S608 — table and date_expr are hardcoded by callers, not user input
-            [str(file_path)],
-        ).fetchone()
-        if result and result[0]:
-            return f"{result[0]} to {result[1]}"
-    except Exception:  # noqa: BLE001 — date range is best-effort; any DB failure returns empty string
-        logger.debug(f"Could not determine date range from {table}", exc_info=True)
-    return ""
-
-
 def _display_label(file_type: str, file_path: Path) -> str:
     """User-facing label for a detected file type.
 
@@ -166,711 +126,755 @@ def _detect_file_type(file_path: Path) -> str:
     )
 
 
-def _resolve_account_via_matcher(
-    db: Database,
-    *,
-    account_name: str,
-    account_number: str | None,
-    threshold: float,
-    auto_accept: bool,
-) -> str:
-    """Resolve an account name to an account_id using match_account().
+class ImportService:
+    """Service encapsulating the full import pipeline.
 
-    Outcomes:
-      1. Matched (number or exact slug) → return the existing account_id.
-      2. Fuzzy candidates and auto_accept=True → take the top candidate, log it.
-      3. Fuzzy candidates and auto_accept=False → log a warning listing
-         candidates, fall back to slugify(account_name).
-      4. No candidates → fall back to slugify(account_name) (creates new).
-
-    Args:
-        db: Database instance.
-        account_name: Account name from CLI/file.
-        account_number: Account number if available, for strongest match.
-        threshold: Minimum SequenceMatcher.ratio for a fuzzy candidate.
-        auto_accept: True if the user passed --yes (or stdin is non-interactive).
-
-    Returns:
-        The resolved account_id (existing or freshly slugified).
+    Matches the AccountService/CategorizationService pattern: constructed
+    with a Database instance, exposes public methods, private helpers use
+    ``self._db`` instead of a ``db`` parameter.
     """
-    from moneybin.extractors.tabular.account_matching import match_account
-    from moneybin.metrics.registry import ACCOUNT_MATCH_OUTCOMES_TOTAL
-    from moneybin.utils import slugify
 
-    try:
-        # GROUP BY account_id collapses duplicates from the same account being
-        # imported with slightly different names (e.g. "Chase Checking" vs
-        # "CHASE CHECKING"); take the most-recently-seen name.
-        rows = db.execute(
-            """
-            SELECT account_id,
-                   LAST(account_name ORDER BY loaded_at) AS account_name,
-                   LAST(account_number ORDER BY loaded_at) AS account_number
-            FROM raw.tabular_accounts
-            GROUP BY account_id
-            """
-        ).fetchall()
-    except duckdb.CatalogException:  # raw.tabular_accounts absent on first import
-        logger.debug("raw.tabular_accounts unavailable; skipping account match")
-        ACCOUNT_MATCH_OUTCOMES_TOTAL.labels(result="table_missing").inc()
+    def __init__(self, db: Database) -> None:
+        """Initialize ImportService with a Database instance."""
+        self._db = db
+
+    def _query_date_range(
+        self,
+        table: str,
+        date_expr: str,
+        file_path: Path,
+    ) -> str:
+        """Query min/max date range for a source file from a raw table.
+
+        Both ``table`` and ``date_expr`` are interpolated into SQL — callers
+        must only pass hardcoded trusted strings, never user input.
+
+        Args:
+            table: Qualified table name (e.g. ``raw.ofx_transactions``).
+            date_expr: SQL expression for the date value — may be a bare column
+                name (``transaction_date``) or a cast expression
+                (``CAST(date_posted AS DATE)``).
+            file_path: Source file path to filter on.
+
+        Returns:
+            Date range string like ``"2024-01-01 to 2024-03-31"``, or empty
+            string if unavailable.
+        """
+        try:
+            result = self._db.execute(
+                f"""
+                SELECT MIN({date_expr}) AS min_date,
+                       MAX({date_expr}) AS max_date
+                FROM {table}
+                WHERE source_file = ?
+                """,  # noqa: S608 — table and date_expr are hardcoded by callers, not user input
+                [str(file_path)],
+            ).fetchone()
+            if result and result[0]:
+                return f"{result[0]} to {result[1]}"
+        except Exception:  # noqa: BLE001 — date range is best-effort; any DB failure returns empty string
+            logger.debug(f"Could not determine date range from {table}", exc_info=True)
+        return ""
+
+    def _resolve_account_via_matcher(
+        self,
+        *,
+        account_name: str,
+        account_number: str | None,
+        threshold: float,
+        auto_accept: bool,
+    ) -> str:
+        """Resolve an account name to an account_id using match_account().
+
+        Outcomes:
+          1. Matched (number or exact slug) → return the existing account_id.
+          2. Fuzzy candidates and auto_accept=True → take the top candidate, log it.
+          3. Fuzzy candidates and auto_accept=False → log a warning listing
+             candidates, fall back to slugify(account_name).
+          4. No candidates → fall back to slugify(account_name) (creates new).
+
+        Args:
+            account_name: Account name from CLI/file.
+            account_number: Account number if available, for strongest match.
+            threshold: Minimum SequenceMatcher.ratio for a fuzzy candidate.
+            auto_accept: True if the user passed --yes (or stdin is non-interactive).
+
+        Returns:
+            The resolved account_id (existing or freshly slugified).
+        """
+        from moneybin.extractors.tabular.account_matching import match_account
+        from moneybin.metrics.registry import ACCOUNT_MATCH_OUTCOMES_TOTAL
+        from moneybin.utils import slugify
+
+        try:
+            # GROUP BY account_id collapses duplicates from the same account being
+            # imported with slightly different names (e.g. "Chase Checking" vs
+            # "CHASE CHECKING"); take the most-recently-seen name.
+            rows = self._db.execute(
+                """
+                SELECT account_id,
+                       LAST(account_name ORDER BY loaded_at) AS account_name,
+                       LAST(account_number ORDER BY loaded_at) AS account_number
+                FROM raw.tabular_accounts
+                GROUP BY account_id
+                """
+            ).fetchall()
+        except duckdb.CatalogException:  # raw.tabular_accounts absent on first import
+            logger.debug("raw.tabular_accounts unavailable; skipping account match")
+            ACCOUNT_MATCH_OUTCOMES_TOTAL.labels(result="table_missing").inc()
+            return slugify(account_name)
+
+        existing = [
+            {"account_id": r[0], "account_name": r[1], "account_number": r[2]}
+            for r in rows
+        ]
+
+        result = match_account(
+            account_name,
+            account_number=account_number,
+            existing_accounts=existing,
+            threshold=threshold,
+        )
+
+        if result.matched and result.account_id:
+            logger.info(f"Matched account to existing id {result.account_id!r}")
+            ACCOUNT_MATCH_OUTCOMES_TOTAL.labels(result="exact").inc()
+            return result.account_id
+
+        if result.candidates:
+            if auto_accept:
+                top = result.candidates[0]
+                if top["account_id"]:
+                    logger.info(
+                        f"⚙️  Auto-accepting fuzzy match → {top['account_id']!r}"
+                    )
+                    ACCOUNT_MATCH_OUTCOMES_TOTAL.labels(result="fuzzy_accepted").inc()
+                    return top["account_id"]
+                # Fuzzy candidates exist but none have an account_id — this should
+                # be rare (suggests stale/orphaned rows in raw.tabular_accounts),
+                # but we must surface it instead of silently slugifying.
+                logger.warning(
+                    "⚠️  Auto-accept requested but top fuzzy candidate has no "
+                    "account_id; falling back to slugify(account_name)."
+                )
+                ACCOUNT_MATCH_OUTCOMES_TOTAL.labels(result="fuzzy_no_id").inc()
+            else:
+                candidate_ids = ", ".join(
+                    filter(None, (c["account_id"] for c in result.candidates))
+                )
+                logger.warning(
+                    f"⚠️  Account did not match exactly. Fuzzy candidate ids: "
+                    f"{candidate_ids}. "
+                    "Use --yes to auto-accept the top candidate, "
+                    "or --account-id to pick explicitly."
+                )
+                ACCOUNT_MATCH_OUTCOMES_TOTAL.labels(result="fuzzy_ambiguous").inc()
+        else:
+            ACCOUNT_MATCH_OUTCOMES_TOTAL.labels(result="slugify_new").inc()
+
         return slugify(account_name)
 
-    existing = [
-        {"account_id": r[0], "account_name": r[1], "account_number": r[2]} for r in rows
-    ]
+    def run_transforms(self) -> bool:
+        """Run SQLMesh transforms to rebuild core tables.
 
-    result = match_account(
-        account_name,
-        account_number=account_number,
-        existing_accounts=existing,
-        threshold=threshold,
-    )
+        Uses ``sqlmesh_context()`` to handle encrypted DB injection into
+        SQLMesh's adapter cache.  Requires an active Database singleton
+        (via ``get_database()``) — ``sqlmesh_context()`` reuses its
+        connection.
 
-    if result.matched and result.account_id:
-        logger.info(f"Matched account to existing id {result.account_id!r}")
-        ACCOUNT_MATCH_OUTCOMES_TOTAL.labels(result="exact").inc()
-        return result.account_id
+        Seeds ``app.seed_source_priority`` from config before running so
+        ``int_transactions__merged`` can resolve per-field winners. Without
+        this, the LEFT JOIN onto ``seed_source_priority`` produces NULL
+        priorities for every row, causing ARG_MIN(value, NULL_key) to drop
+        non-NULL values for fields that key on a CASE-with-NULL-fallthrough
+        pattern (description, memo, etc.). Callers that go straight to
+        transforms (``transform apply``, synthetic generation) would
+        otherwise materialize NULL descriptions in core.fct_transactions.
 
-    if result.candidates:
-        if auto_accept:
-            top = result.candidates[0]
-            if top["account_id"]:
-                logger.info(f"⚙️  Auto-accepting fuzzy match → {top['account_id']!r}")
-                ACCOUNT_MATCH_OUTCOMES_TOTAL.labels(result="fuzzy_accepted").inc()
-                return top["account_id"]
-            # Fuzzy candidates exist but none have an account_id — this should
-            # be rare (suggests stale/orphaned rows in raw.tabular_accounts),
-            # but we must surface it instead of silently slugifying.
-            logger.warning(
-                "⚠️  Auto-accept requested but top fuzzy candidate has no "
-                "account_id; falling back to slugify(account_name)."
-            )
-            ACCOUNT_MATCH_OUTCOMES_TOTAL.labels(result="fuzzy_no_id").inc()
-        else:
-            candidate_ids = ", ".join(
-                filter(None, (c["account_id"] for c in result.candidates))
-            )
-            logger.warning(
-                f"⚠️  Account did not match exactly. Fuzzy candidate ids: "
-                f"{candidate_ids}. "
-                "Use --yes to auto-accept the top candidate, "
-                "or --account-id to pick explicitly."
-            )
-            ACCOUNT_MATCH_OUTCOMES_TOTAL.labels(result="fuzzy_ambiguous").inc()
-    else:
-        ACCOUNT_MATCH_OUTCOMES_TOTAL.labels(result="slugify_new").inc()
-
-    return slugify(account_name)
-
-
-def run_transforms() -> bool:
-    """Run SQLMesh transforms to rebuild core tables.
-
-    Uses ``sqlmesh_context()`` to handle encrypted DB injection into
-    SQLMesh's adapter cache.  Requires an active Database singleton
-    (via ``get_database()``) — ``sqlmesh_context()`` reuses its
-    connection.
-
-    Seeds ``app.seed_source_priority`` from config before running so
-    ``int_transactions__merged`` can resolve per-field winners. Without
-    this, the LEFT JOIN onto ``seed_source_priority`` produces NULL
-    priorities for every row, causing ARG_MIN(value, NULL_key) to drop
-    non-NULL values for fields that key on a CASE-with-NULL-fallthrough
-    pattern (description, memo, etc.). Callers that go straight to
-    transforms (``transform apply``, synthetic generation) would
-    otherwise materialize NULL descriptions in core.fct_transactions.
-
-    Returns:
-        True if transforms ran successfully.
-    """
-    from moneybin.config import get_settings
-    from moneybin.database import get_database
-    from moneybin.matching.priority import seed_source_priority
-
-    logger.info("Running SQLMesh transforms")
-
-    seed_source_priority(get_database(), get_settings().matching)
-
-    with sqlmesh_context() as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    logger.info("SQLMesh transforms completed")
-    return True
-
-
-def _import_ofx(
-    db: Database,
-    file_path: Path,
-    *,
-    institution: str | None = None,
-) -> ImportResult:
-    """Import an OFX/QFX file.
-
-    Args:
-        db: Database instance.
-        file_path: Path to the OFX/QFX file.
-        institution: Optional institution name override.
-
-    Returns:
-        ImportResult with summary of imported data.
-    """
-    from moneybin.extractors.ofx_extractor import OFXExtractor
-    from moneybin.loaders.ofx_loader import OFXLoader
-
-    result = ImportResult(file_path=str(file_path), file_type="ofx")
-
-    # Extract
-    extractor = OFXExtractor()
-    data = extractor.extract_from_file(file_path, institution)
-
-    # Load using OFXLoader (which manages its own connection)
-    loader = OFXLoader(db)
-    row_counts = loader.load_data(data)
-
-    result.institutions = row_counts.get("institutions", 0)
-    result.accounts = row_counts.get("accounts", 0)
-    result.transactions = row_counts.get("transactions", 0)
-    result.balances = row_counts.get("balances", 0)
-    result.details = row_counts
-
-    if result.transactions > 0:
-        result.date_range = _query_date_range(
-            db, "raw.ofx_transactions", "CAST(date_posted AS DATE)", file_path
-        )
-
-    return result
-
-
-def _import_w2(
-    db: Database,
-    file_path: Path,
-) -> ImportResult:
-    """Import a W-2 PDF file.
-
-    Args:
-        db: Database instance.
-        file_path: Path to the W-2 PDF.
-
-    Returns:
-        ImportResult with summary of imported data.
-    """
-    from moneybin.extractors.w2_extractor import W2Extractor
-    from moneybin.loaders.w2_loader import W2Loader
-
-    result = ImportResult(file_path=str(file_path), file_type="w2")
-
-    # Extract
-    extractor = W2Extractor()
-    data = extractor.extract_from_file(file_path)
-
-    # Load
-    loader = W2Loader(db)
-    row_count = loader.load_data(data)
-
-    result.w2_forms = row_count
-    result.details = {"w2_forms": row_count}
-
-    return result
-
-
-def _import_tabular(
-    db: Database,
-    file_path: Path,
-    *,
-    account_name: str | None = None,
-    account_id: str | None = None,
-    format_name: str | None = None,
-    overrides: dict[str, str] | None = None,
-    sign: str | None = None,
-    date_format_override: str | None = None,
-    number_format_override: str | None = None,
-    save_format: bool = True,
-    sheet: str | None = None,
-    delimiter: str | None = None,
-    encoding: str | None = None,
-    no_row_limit: bool = False,
-    no_size_limit: bool = False,
-    auto_accept: bool = False,
-) -> ImportResult:
-    """Import a tabular file through the five-stage pipeline.
-
-    Args:
-        db: Database instance.
-        file_path: Path to the file.
-        account_name: Account name for single-account files.
-        account_id: Explicit account ID (bypass matching).
-        format_name: Explicit format name (bypass detection).
-        overrides: Field→column overrides.
-        sign: Sign convention override.
-        date_format_override: Date format override (strptime string).
-        number_format_override: Number format override.
-        save_format: Auto-save detected format for future imports.
-        sheet: Excel sheet name.
-        delimiter: Explicit delimiter.
-        encoding: Explicit encoding.
-        no_row_limit: Override row count limit.
-        no_size_limit: Override file size limit.
-        auto_accept: Auto-accept the top fuzzy account match without prompting.
-
-    Returns:
-        ImportResult with summary.
-    """
-    import polars as pl
-
-    from moneybin.extractors.tabular.column_mapper import map_columns
-    from moneybin.extractors.tabular.format_detector import detect_format
-    from moneybin.extractors.tabular.formats import (
-        TabularFormat,
-        load_builtin_formats,
-        load_formats_from_db,
-        merge_formats,
-        save_format_to_db,
-    )
-    from moneybin.extractors.tabular.readers import read_file
-    from moneybin.extractors.tabular.transforms import transform_dataframe
-    from moneybin.loaders.tabular_loader import TabularLoader
-    from moneybin.utils import slugify
-
-    result = ImportResult(file_path=str(file_path), file_type="tabular")
-    _t0 = time.monotonic()
-
-    # Load formats early so explicit --format can influence file reading
-    builtin_formats = load_builtin_formats()
-    all_formats = merge_formats(builtin_formats, load_formats_from_db(db))
-
-    matched_format: TabularFormat | None = None
-    if format_name:
-        if format_name not in all_formats:
-            raise ValueError(
-                f"Unknown format {format_name!r}. Available: {sorted(all_formats)}"
-            )
-        matched_format = all_formats[format_name]
-
-    # Stage 1: Format detection — apply matched format's properties as defaults
-    effective_delimiter = delimiter or (
-        matched_format.delimiter if matched_format else None
-    )
-    effective_encoding = encoding or (
-        matched_format.encoding if matched_format else None
-    )
-    effective_sheet = sheet or (matched_format.sheet if matched_format else None)
-
-    format_info = detect_format(
-        file_path,
-        format_override=matched_format.file_type
-        if matched_format and matched_format.file_type != "auto"
-        else None,
-        delimiter_override=effective_delimiter,
-        encoding_override=effective_encoding,
-        no_size_limit=no_size_limit,
-    )
-
-    # Stage 2: Read file
-    read_result = read_file(
-        file_path,
-        format_info,
-        sheet=effective_sheet,
-        skip_rows=matched_format.skip_rows
-        if matched_format and matched_format.skip_rows
-        else None,
-        skip_trailing_patterns=matched_format.skip_trailing_patterns
-        if matched_format
-        else None,
-        no_row_limit=no_row_limit,
-    )
-    df = read_result.df
-
-    if len(df) == 0:
-        raise ValueError(f"No data rows found in {file_path.name}")
-
-    # Stage 3: Column mapping — match by headers if not already matched by name
-    if not matched_format:
-        headers = list(df.columns)
-        for fmt in all_formats.values():
-            if fmt.matches_headers(headers):
-                matched_format = fmt
-                break
-
-    if matched_format:
-        resolved = ResolvedMapping(
-            field_mapping=matched_format.field_mapping,
-            date_format=matched_format.date_format,
-            sign_convention=matched_format.sign_convention,
-            number_format=matched_format.number_format,
-            is_multi_account=matched_format.multi_account,
-            confidence="high",
-        )
-        format_source = (
-            "built-in" if matched_format.name in builtin_formats else "saved"
-        )
-    else:
-        mapping_result = map_columns(df, overrides=overrides)
-        resolved = ResolvedMapping(
-            field_mapping=mapping_result.field_mapping,
-            date_format=mapping_result.date_format or "%Y-%m-%d",
-            sign_convention=mapping_result.sign_convention,
-            number_format=mapping_result.number_format,
-            is_multi_account=mapping_result.is_multi_account,
-            confidence=mapping_result.confidence,
-        )
-        format_source = "detected"
-
-        if mapping_result.sign_needs_confirmation and not sign:
-            logger.warning(
-                "⚠️  Sign convention is ambiguous (all amounts appear positive). "
-                f"Proceeding with '{resolved.sign_convention}' — "
-                "use --sign to override if expense amounts look wrong."
-            )
-
-        if mapping_result.confidence == "low":
-            raise ValueError(
-                f"Could not reliably detect column mapping for "
-                f"{file_path.name}. Use --override to specify columns manually."
-            )
-
-    # Record format match and detection confidence metrics
-    if matched_format:
-        TABULAR_FORMAT_MATCHES.labels(
-            format_name=matched_format.name, format_source=format_source
-        ).inc()
-    TABULAR_DETECTION_CONFIDENCE.labels(confidence=resolved.confidence).inc()
-
-    # Apply CLI overrides — rebuild a new ResolvedMapping (frozen)
-    if sign or date_format_override or number_format_override:
-        resolved = dataclasses.replace(
-            resolved,
-            sign_convention=cast(SignConventionType, sign)
-            if sign
-            else resolved.sign_convention,
-            date_format=date_format_override or resolved.date_format,
-            number_format=cast(NumberFormatType, number_format_override)
-            if number_format_override
-            else resolved.number_format,
-        )
-
-    # Determine account info
-    source_type = format_info.file_type
-    if source_type in ("semicolon", "pipe"):
-        source_type = "csv"
-
-    # Build per-row account_ids and a name→id mapping for the accounts table
-    acct_name_col = resolved.field_mapping.get("account_name")
-    acct_id_to_name: dict[str, str] = {}
-
-    if account_id:
-        account_ids: str | list[str] = account_id
-        acct_id_to_name[account_id] = account_name or account_id
-    elif account_name:
+        Returns:
+            True if transforms ran successfully.
+        """
         from moneybin.config import get_settings
+        from moneybin.matching.priority import seed_source_priority
 
-        threshold = get_settings().data.tabular.account_match_threshold
-        aid = _resolve_account_via_matcher(
-            db,
-            account_name=account_name,
-            account_number=None,  # no --account-number CLI flag yet
-            threshold=threshold,
-            auto_accept=auto_accept,
+        logger.info("Running SQLMesh transforms")
+
+        seed_source_priority(self._db, get_settings().matching)
+
+        with sqlmesh_context() as ctx:
+            ctx.plan(auto_apply=True, no_prompts=True)
+
+        logger.info("SQLMesh transforms completed")
+        return True
+
+    def _import_ofx(
+        self,
+        file_path: Path,
+        *,
+        institution: str | None = None,
+    ) -> ImportResult:
+        """Import an OFX/QFX file.
+
+        Args:
+            file_path: Path to the OFX/QFX file.
+            institution: Optional institution name override.
+
+        Returns:
+            ImportResult with summary of imported data.
+        """
+        from moneybin.extractors.ofx_extractor import OFXExtractor
+        from moneybin.loaders.ofx_loader import OFXLoader
+
+        result = ImportResult(file_path=str(file_path), file_type="ofx")
+
+        # Extract
+        extractor = OFXExtractor()
+        data = extractor.extract_from_file(file_path, institution)
+
+        # Load using OFXLoader (which manages its own connection)
+        loader = OFXLoader(self._db)
+        row_counts = loader.load_data(data)
+
+        result.institutions = row_counts.get("institutions", 0)
+        result.accounts = row_counts.get("accounts", 0)
+        result.transactions = row_counts.get("transactions", 0)
+        result.balances = row_counts.get("balances", 0)
+        result.details = row_counts
+
+        if result.transactions > 0:
+            result.date_range = self._query_date_range(
+                "raw.ofx_transactions", "CAST(date_posted AS DATE)", file_path
+            )
+
+        return result
+
+    def _import_w2(
+        self,
+        file_path: Path,
+    ) -> ImportResult:
+        """Import a W-2 PDF file.
+
+        Args:
+            file_path: Path to the W-2 PDF.
+
+        Returns:
+            ImportResult with summary of imported data.
+        """
+        from moneybin.extractors.w2_extractor import W2Extractor
+        from moneybin.loaders.w2_loader import W2Loader
+
+        result = ImportResult(file_path=str(file_path), file_type="w2")
+
+        # Extract
+        extractor = W2Extractor()
+        data = extractor.extract_from_file(file_path)
+
+        # Load
+        loader = W2Loader(self._db)
+        row_count = loader.load_data(data)
+
+        result.w2_forms = row_count
+        result.details = {"w2_forms": row_count}
+
+        return result
+
+    def _import_tabular(
+        self,
+        file_path: Path,
+        *,
+        account_name: str | None = None,
+        account_id: str | None = None,
+        format_name: str | None = None,
+        overrides: dict[str, str] | None = None,
+        sign: str | None = None,
+        date_format_override: str | None = None,
+        number_format_override: str | None = None,
+        save_format: bool = True,
+        sheet: str | None = None,
+        delimiter: str | None = None,
+        encoding: str | None = None,
+        no_row_limit: bool = False,
+        no_size_limit: bool = False,
+        auto_accept: bool = False,
+    ) -> ImportResult:
+        """Import a tabular file through the five-stage pipeline.
+
+        Args:
+            file_path: Path to the file.
+            account_name: Account name for single-account files.
+            account_id: Explicit account ID (bypass matching).
+            format_name: Explicit format name (bypass detection).
+            overrides: Field→column overrides.
+            sign: Sign convention override.
+            date_format_override: Date format override (strptime string).
+            number_format_override: Number format override.
+            save_format: Auto-save detected format for future imports.
+            sheet: Excel sheet name.
+            delimiter: Explicit delimiter.
+            encoding: Explicit encoding.
+            no_row_limit: Override row count limit.
+            no_size_limit: Override file size limit.
+            auto_accept: Auto-accept the top fuzzy account match without prompting.
+
+        Returns:
+            ImportResult with summary.
+        """
+        import polars as pl
+
+        from moneybin.extractors.tabular.column_mapper import map_columns
+        from moneybin.extractors.tabular.format_detector import detect_format
+        from moneybin.extractors.tabular.formats import (
+            TabularFormat,
+            load_builtin_formats,
+            load_formats_from_db,
+            merge_formats,
+            save_format_to_db,
         )
-        account_ids = aid
-        acct_id_to_name[aid] = account_name
-    elif resolved.is_multi_account and acct_name_col and acct_name_col in df.columns:
-        # Per-row account assignment from the DataFrame column
-        raw_names = [
-            str(v) if v is not None else "unknown" for v in df[acct_name_col].to_list()
-        ]
-        account_ids = [slugify(name) for name in raw_names]
-        for aid, name in zip(account_ids, raw_names, strict=True):
-            if aid not in acct_id_to_name:
-                acct_id_to_name[aid] = name
-    else:
-        raise ValueError("Single-account files require --account-name or --account-id")
+        from moneybin.extractors.tabular.readers import read_file
+        from moneybin.extractors.tabular.transforms import transform_dataframe
+        from moneybin.loaders.tabular_loader import TabularLoader
+        from moneybin.utils import slugify
 
-    source_origin = (
-        matched_format.name if matched_format else slugify(account_name or "unknown")
-    )
+        result = ImportResult(file_path=str(file_path), file_type="tabular")
+        _t0 = time.monotonic()
 
-    # Create import batch
-    loader = TabularLoader(db)
-    import_id = loader.create_import_batch(
-        source_file=str(file_path),
-        source_type=source_type,
-        source_origin=source_origin,
-        account_names=sorted(acct_id_to_name.values()),
-        format_name=matched_format.name if matched_format else None,
-        format_source=format_source,
-    )
+        # Load formats early so explicit --format can influence file reading
+        builtin_formats = load_builtin_formats()
+        all_formats = merge_formats(builtin_formats, load_formats_from_db(self._db))
 
-    # Stage 4: Transform
-    from moneybin.config import get_settings
+        matched_format: TabularFormat | None = None
+        if format_name:
+            if format_name not in all_formats:
+                raise ValueError(
+                    f"Unknown format {format_name!r}. Available: {sorted(all_formats)}"
+                )
+            matched_format = all_formats[format_name]
 
-    tabular_cfg = get_settings().data.tabular
-    try:
-        transform_result = transform_dataframe(
-            df=df,
-            field_mapping=resolved.field_mapping,
-            date_format=resolved.date_format,
-            sign_convention=resolved.sign_convention,
-            number_format=resolved.number_format,
-            account_id=account_ids,
+        # Stage 1: Format detection — apply matched format's properties as defaults
+        effective_delimiter = delimiter or (
+            matched_format.delimiter if matched_format else None
+        )
+        effective_encoding = encoding or (
+            matched_format.encoding if matched_format else None
+        )
+        effective_sheet = sheet or (matched_format.sheet if matched_format else None)
+
+        format_info = detect_format(
+            file_path,
+            format_override=matched_format.file_type
+            if matched_format and matched_format.file_type != "auto"
+            else None,
+            delimiter_override=effective_delimiter,
+            encoding_override=effective_encoding,
+            no_size_limit=no_size_limit,
+        )
+
+        # Stage 2: Read file
+        read_result = read_file(
+            file_path,
+            format_info,
+            sheet=effective_sheet,
+            skip_rows=matched_format.skip_rows
+            if matched_format and matched_format.skip_rows
+            else None,
+            skip_trailing_patterns=matched_format.skip_trailing_patterns
+            if matched_format
+            else None,
+            no_row_limit=no_row_limit,
+        )
+        df = read_result.df
+
+        if len(df) == 0:
+            raise ValueError(f"No data rows found in {file_path.name}")
+
+        # Stage 3: Column mapping — match by headers if not already matched by name
+        if not matched_format:
+            headers = list(df.columns)
+            for fmt in all_formats.values():
+                if fmt.matches_headers(headers):
+                    matched_format = fmt
+                    break
+
+        if matched_format:
+            resolved = ResolvedMapping(
+                field_mapping=matched_format.field_mapping,
+                date_format=matched_format.date_format,
+                sign_convention=matched_format.sign_convention,
+                number_format=matched_format.number_format,
+                is_multi_account=matched_format.multi_account,
+                confidence="high",
+            )
+            format_source = (
+                "built-in" if matched_format.name in builtin_formats else "saved"
+            )
+        else:
+            mapping_result = map_columns(df, overrides=overrides)
+            resolved = ResolvedMapping(
+                field_mapping=mapping_result.field_mapping,
+                date_format=mapping_result.date_format or "%Y-%m-%d",
+                sign_convention=mapping_result.sign_convention,
+                number_format=mapping_result.number_format,
+                is_multi_account=mapping_result.is_multi_account,
+                confidence=mapping_result.confidence,
+            )
+            format_source = "detected"
+
+            if mapping_result.sign_needs_confirmation and not sign:
+                logger.warning(
+                    "⚠️  Sign convention is ambiguous (all amounts appear positive). "
+                    f"Proceeding with '{resolved.sign_convention}' — "
+                    "use --sign to override if expense amounts look wrong."
+                )
+
+            if mapping_result.confidence == "low":
+                raise ValueError(
+                    f"Could not reliably detect column mapping for "
+                    f"{file_path.name}. Use --override to specify columns manually."
+                )
+
+        # Record format match and detection confidence metrics
+        if matched_format:
+            TABULAR_FORMAT_MATCHES.labels(
+                format_name=matched_format.name, format_source=format_source
+            ).inc()
+        TABULAR_DETECTION_CONFIDENCE.labels(confidence=resolved.confidence).inc()
+
+        # Apply CLI overrides — rebuild a new ResolvedMapping (frozen)
+        if sign or date_format_override or number_format_override:
+            resolved = dataclasses.replace(
+                resolved,
+                sign_convention=cast(SignConventionType, sign)
+                if sign
+                else resolved.sign_convention,
+                date_format=date_format_override or resolved.date_format,
+                number_format=cast(NumberFormatType, number_format_override)
+                if number_format_override
+                else resolved.number_format,
+            )
+
+        # Determine account info
+        source_type = format_info.file_type
+        if source_type in ("semicolon", "pipe"):
+            source_type = "csv"
+
+        # Build per-row account_ids and a name→id mapping for the accounts table
+        acct_name_col = resolved.field_mapping.get("account_name")
+        acct_id_to_name: dict[str, str] = {}
+
+        if account_id:
+            account_ids: str | list[str] = account_id
+            acct_id_to_name[account_id] = account_name or account_id
+        elif account_name:
+            from moneybin.config import get_settings
+
+            threshold = get_settings().data.tabular.account_match_threshold
+            aid = self._resolve_account_via_matcher(
+                account_name=account_name,
+                account_number=None,  # no --account-number CLI flag yet
+                threshold=threshold,
+                auto_accept=auto_accept,
+            )
+            account_ids = aid
+            acct_id_to_name[aid] = account_name
+        elif (
+            resolved.is_multi_account and acct_name_col and acct_name_col in df.columns
+        ):
+            # Per-row account assignment from the DataFrame column
+            raw_names = [
+                str(v) if v is not None else "unknown"
+                for v in df[acct_name_col].to_list()
+            ]
+            account_ids = [slugify(name) for name in raw_names]
+            for aid, name in zip(account_ids, raw_names, strict=True):
+                if aid not in acct_id_to_name:
+                    acct_id_to_name[aid] = name
+        else:
+            raise ValueError(
+                "Single-account files require --account-name or --account-id"
+            )
+
+        source_origin = (
+            matched_format.name
+            if matched_format
+            else slugify(account_name or "unknown")
+        )
+
+        # Create import batch
+        loader = TabularLoader(self._db)
+        import_id = loader.create_import_batch(
             source_file=str(file_path),
             source_type=source_type,
             source_origin=source_origin,
-            import_id=import_id,
-            balance_pass_threshold=tabular_cfg.balance_pass_threshold,
-            balance_tolerance_cents=tabular_cfg.balance_tolerance_cents,
+            account_names=sorted(acct_id_to_name.values()),
+            format_name=matched_format.name if matched_format else None,
+            format_source=format_source,
         )
-    except Exception as e:  # noqa: BLE001  # re-raised as ValueError after recording rejection in DB
+
+        # Stage 4: Transform
+        from moneybin.config import get_settings
+
+        tabular_cfg = get_settings().data.tabular
+        try:
+            transform_result = transform_dataframe(
+                df=df,
+                field_mapping=resolved.field_mapping,
+                date_format=resolved.date_format,
+                sign_convention=resolved.sign_convention,
+                number_format=resolved.number_format,
+                account_id=account_ids,
+                source_file=str(file_path),
+                source_type=source_type,
+                source_origin=source_origin,
+                import_id=import_id,
+                balance_pass_threshold=tabular_cfg.balance_pass_threshold,
+                balance_tolerance_cents=tabular_cfg.balance_tolerance_cents,
+            )
+        except Exception as e:  # noqa: BLE001  # re-raised as ValueError after recording rejection in DB
+            loader.finalize_import_batch(
+                import_id=import_id,
+                rows_total=len(df),
+                rows_imported=0,
+                rows_rejected=len(df),
+            )
+            IMPORT_ERRORS_TOTAL.labels(
+                source_type=source_type, error_type="transform"
+            ).inc()
+            raise ValueError(f"Transform failed: {e}") from e
+
+        # Stage 5: Load — one account record per unique account
+        institution = matched_format.institution_name if matched_format else None
+        unique_ids = sorted(acct_id_to_name.keys())
+        account_df = pl.DataFrame({
+            "account_id": unique_ids,
+            "account_name": [acct_id_to_name[aid] for aid in unique_ids],
+            "account_number": [None] * len(unique_ids),
+            "account_number_masked": [None] * len(unique_ids),
+            "account_type": [None] * len(unique_ids),
+            "institution_name": [institution] * len(unique_ids),
+            "currency": [None] * len(unique_ids),
+            "source_file": [str(file_path)] * len(unique_ids),
+            "source_type": [source_type] * len(unique_ids),
+            "source_origin": [source_origin] * len(unique_ids),
+            "import_id": [import_id] * len(unique_ids),
+        })
+
+        rows_imported = loader.load_transactions(transform_result.transactions)
+        loader.load_accounts(account_df)
+
         loader.finalize_import_batch(
             import_id=import_id,
             rows_total=len(df),
-            rows_imported=0,
-            rows_rejected=len(df),
-        )
-        IMPORT_ERRORS_TOTAL.labels(
-            source_type=source_type, error_type="transform"
-        ).inc()
-        raise ValueError(f"Transform failed: {e}") from e
-
-    # Stage 5: Load — one account record per unique account
-    institution = matched_format.institution_name if matched_format else None
-    unique_ids = sorted(acct_id_to_name.keys())
-    account_df = pl.DataFrame({
-        "account_id": unique_ids,
-        "account_name": [acct_id_to_name[aid] for aid in unique_ids],
-        "account_number": [None] * len(unique_ids),
-        "account_number_masked": [None] * len(unique_ids),
-        "account_type": [None] * len(unique_ids),
-        "institution_name": [institution] * len(unique_ids),
-        "currency": [None] * len(unique_ids),
-        "source_file": [str(file_path)] * len(unique_ids),
-        "source_type": [source_type] * len(unique_ids),
-        "source_origin": [source_origin] * len(unique_ids),
-        "import_id": [import_id] * len(unique_ids),
-    })
-
-    rows_imported = loader.load_transactions(transform_result.transactions)
-    loader.load_accounts(account_df)
-
-    loader.finalize_import_batch(
-        import_id=import_id,
-        rows_total=len(df),
-        rows_imported=rows_imported,
-        rows_rejected=transform_result.rows_rejected,
-        rows_skipped_trailing=read_result.rows_skipped_trailing,
-        rejection_details=[
-            {"row_number": str(r.row_number), "reason": r.reason}
-            for r in transform_result.rejection_details
-        ]
-        or None,
-        detection_confidence=resolved.confidence,
-        number_format=resolved.number_format,
-        date_format=resolved.date_format,
-        sign_convention=resolved.sign_convention,
-        balance_validated=transform_result.balance_validated,
-    )
-
-    # Record import metrics
-    IMPORT_RECORDS_TOTAL.labels(source_type=source_type).inc(rows_imported)
-    IMPORT_DURATION_SECONDS.labels(source_type=source_type).observe(
-        time.monotonic() - _t0
-    )
-
-    result.accounts = len(unique_ids)
-    result.transactions = rows_imported
-    result.details = {"transactions": rows_imported, "accounts": len(unique_ids)}
-
-    if rows_imported > 0:
-        result.date_range = _query_date_range(
-            db, "raw.tabular_transactions", "transaction_date", file_path
+            rows_imported=rows_imported,
+            rows_rejected=transform_result.rows_rejected,
+            rows_skipped_trailing=read_result.rows_skipped_trailing,
+            rejection_details=[
+                {"row_number": str(r.row_number), "reason": r.reason}
+                for r in transform_result.rejection_details
+            ]
+            or None,
+            detection_confidence=resolved.confidence,
+            number_format=resolved.number_format,
+            date_format=resolved.date_format,
+            sign_convention=resolved.sign_convention,
+            balance_validated=transform_result.balance_validated,
         )
 
-    # Auto-save detected format for future imports
-    if (
-        save_format
-        and not matched_format
-        and resolved.confidence in ("high", "medium")
-        and rows_imported > 0
-    ):
+        # Record import metrics
+        IMPORT_RECORDS_TOTAL.labels(source_type=source_type).inc(rows_imported)
+        IMPORT_DURATION_SECONDS.labels(source_type=source_type).observe(
+            time.monotonic() - _t0
+        )
+
+        result.accounts = len(unique_ids)
+        result.transactions = rows_imported
+        result.details = {"transactions": rows_imported, "accounts": len(unique_ids)}
+
+        if rows_imported > 0:
+            result.date_range = self._query_date_range(
+                "raw.tabular_transactions", "transaction_date", file_path
+            )
+
+        # Auto-save detected format for future imports
+        if (
+            save_format
+            and not matched_format
+            and resolved.confidence in ("high", "medium")
+            and rows_imported > 0
+        ):
+            try:
+                detected_fmt = TabularFormat(
+                    name=source_origin,
+                    institution_name=account_name or source_origin,
+                    file_type=format_info.file_type,
+                    delimiter=format_info.delimiter,
+                    encoding=format_info.encoding,
+                    header_signature=list(df.columns),
+                    field_mapping=resolved.field_mapping,
+                    sign_convention=resolved.sign_convention,
+                    date_format=resolved.date_format,
+                    number_format=resolved.number_format,
+                    multi_account=resolved.is_multi_account,
+                    source="detected",
+                    times_used=1,
+                )
+                save_format_to_db(self._db, detected_fmt)
+                logger.info(f"Auto-saved format {source_origin!r} for future imports")
+            except Exception:  # noqa: BLE001 — format save is best-effort; import already succeeded
+                logger.debug("Could not auto-save format", exc_info=True)
+
+        return result
+
+    def import_file(
+        self,
+        file_path: str | Path,
+        *,
+        apply_transforms: bool = True,
+        institution: str | None = None,
+        account_id: str | None = None,
+        account_name: str | None = None,
+        format_name: str | None = None,
+        overrides: dict[str, str] | None = None,
+        sign: str | None = None,
+        date_format: str | None = None,
+        number_format: str | None = None,
+        save_format: bool = True,
+        sheet: str | None = None,
+        delimiter: str | None = None,
+        encoding: str | None = None,
+        no_row_limit: bool = False,
+        no_size_limit: bool = False,
+        auto_accept: bool = False,
+    ) -> ImportResult:
+        """Import a financial data file into DuckDB.
+
+        Auto-detects file type by extension and runs the appropriate
+        extract -> load -> transform pipeline.
+
+        Args:
+            file_path: Path to the file to import.
+            apply_transforms: Whether to run SQLMesh transforms after loading.
+                Defaults to True.
+            institution: Institution name (OFX only). Auto-detected for OFX if
+                omitted.
+            account_id: Explicit account ID for tabular imports (bypasses name
+                matching).
+            account_name: Account name for single-account tabular files.
+            format_name: Explicit format name for tabular imports (bypasses
+                auto-detection).
+            overrides: Field→column overrides for tabular imports.
+            sign: Sign convention override for tabular imports.
+            date_format: Date format override for tabular imports.
+            number_format: Number format override for tabular imports.
+            save_format: Auto-save detected format for future imports.
+            sheet: Excel sheet name for tabular imports.
+            delimiter: Explicit delimiter for tabular imports.
+            encoding: Explicit encoding for tabular imports.
+            no_row_limit: Override row count limit for tabular imports.
+            no_size_limit: Override file size limit for tabular imports.
+            auto_accept: Auto-accept the top fuzzy account match without prompting
+                (CLI: --yes / -y). Defaults to False.
+
+        Returns:
+            ImportResult with summary of what was imported.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            ValueError: If the file type is not supported.
+        """
+        path = Path(file_path)
+
+        if not path.exists():
+            raise FileNotFoundError(f"File not found: {path}")
+
+        file_type = _detect_file_type(path)
+        logger.info(f"Importing {_display_label(file_type, path)} file: {path}")
+
+        if file_type == "ofx":
+            result = self._import_ofx(path, institution=institution)
+        elif file_type == "w2":
+            result = self._import_w2(path)
+        elif file_type == "tabular":
+            result = self._import_tabular(
+                path,
+                account_name=account_name,
+                account_id=account_id,
+                format_name=format_name,
+                overrides=overrides,
+                sign=sign,
+                date_format_override=date_format,
+                number_format_override=number_format,
+                save_format=save_format,
+                sheet=sheet,
+                delimiter=delimiter,
+                encoding=encoding,
+                no_row_limit=no_row_limit,
+                no_size_limit=no_size_limit,
+                auto_accept=auto_accept,
+            )
+        else:
+            raise ValueError(f"Unsupported file type: {file_type}")
+
+        # Run matching and SQLMesh transforms after loading raw data
+        if apply_transforms and file_type in ("ofx", "tabular"):
+            try:
+                self._run_matching()
+            except Exception:  # noqa: BLE001 — matching is best-effort; first import may precede SQLMesh views
+                logger.debug(
+                    "Matching skipped (views may not exist yet)", exc_info=True
+                )
+            result.core_tables_rebuilt = self.run_transforms()
+
+            # Apply deterministic categorization to new transactions
+            self._apply_categorization()
+
+        logger.info(f"Import complete: {result.summary()}")
+        return result
+
+    def _run_matching(self) -> None:
+        """Run transaction matching after import.
+
+        Seeds source priority from config and runs the matcher engine.
+        Results are logged; pending matches prompt user action.
+        """
+        from moneybin.config import get_settings
+        from moneybin.matching.engine import TransactionMatcher
+        from moneybin.matching.priority import seed_source_priority
+
+        settings = get_settings().matching
+        seed_source_priority(self._db, settings)
+        matcher = TransactionMatcher(self._db, settings)
+        result = matcher.run()
+
+        if result.has_matches:
+            logger.info(f"Matching: {result.summary()}")
+            if result.has_pending:
+                logger.info("Run 'moneybin matches review' when ready")
+
+    def _apply_categorization(self) -> None:
+        """Run deterministic categorization on uncategorized transactions.
+
+        Called after SQLMesh transforms complete. Applies merchant lookups
+        and active rules — no LLM dependency.
+        """
+        from moneybin.services.auto_rule_service import AutoRuleService
+        from moneybin.services.categorization_service import CategorizationService
+
         try:
-            detected_fmt = TabularFormat(
-                name=source_origin,
-                institution_name=account_name or source_origin,
-                file_type=format_info.file_type,
-                delimiter=format_info.delimiter,
-                encoding=format_info.encoding,
-                header_signature=list(df.columns),
-                field_mapping=resolved.field_mapping,
-                sign_convention=resolved.sign_convention,
-                date_format=resolved.date_format,
-                number_format=resolved.number_format,
-                multi_account=resolved.is_multi_account,
-                source="detected",
-                times_used=1,
+            service = CategorizationService(self._db)
+            stats = service.apply_deterministic()
+            if stats["total"] > 0:
+                logger.info(
+                    f"Auto-categorized {stats['total']} transactions "
+                    f"({stats['merchant']} merchant, {stats['rule']} rule)"
+                )
+            pending = AutoRuleService(self._db).stats().pending_proposals
+            if pending:
+                logger.info(f"  {pending} new auto-rule proposals")
+                logger.info(
+                    "  💡 Run 'moneybin categorize auto-review' to review proposed rules"
+                )
+        except Exception:  # noqa: BLE001 — categorization is best-effort; failure skips without aborting import
+            logger.debug(
+                "Categorization skipped (tables may not exist yet)",
+                exc_info=True,
             )
-            save_format_to_db(db, detected_fmt)
-            logger.info(f"Auto-saved format {source_origin!r} for future imports")
-        except Exception:  # noqa: BLE001 — format save is best-effort; import already succeeded
-            logger.debug("Could not auto-save format", exc_info=True)
-
-    return result
-
-
-def import_file(
-    db: Database,
-    file_path: str | Path,
-    *,
-    apply_transforms: bool = True,
-    institution: str | None = None,
-    account_id: str | None = None,
-    account_name: str | None = None,
-    format_name: str | None = None,
-    overrides: dict[str, str] | None = None,
-    sign: str | None = None,
-    date_format: str | None = None,
-    number_format: str | None = None,
-    save_format: bool = True,
-    sheet: str | None = None,
-    delimiter: str | None = None,
-    encoding: str | None = None,
-    no_row_limit: bool = False,
-    no_size_limit: bool = False,
-    auto_accept: bool = False,
-) -> ImportResult:
-    """Import a financial data file into DuckDB.
-
-    Auto-detects file type by extension and runs the appropriate
-    extract -> load -> transform pipeline.
-
-    Args:
-        db: Database instance.
-        file_path: Path to the file to import.
-        apply_transforms: Whether to run SQLMesh transforms after loading.
-            Defaults to True.
-        institution: Institution name (OFX only). Auto-detected for OFX if
-            omitted.
-        account_id: Explicit account ID for tabular imports (bypasses name
-            matching).
-        account_name: Account name for single-account tabular files.
-        format_name: Explicit format name for tabular imports (bypasses
-            auto-detection).
-        overrides: Field→column overrides for tabular imports.
-        sign: Sign convention override for tabular imports.
-        date_format: Date format override for tabular imports.
-        number_format: Number format override for tabular imports.
-        save_format: Auto-save detected format for future imports.
-        sheet: Excel sheet name for tabular imports.
-        delimiter: Explicit delimiter for tabular imports.
-        encoding: Explicit encoding for tabular imports.
-        no_row_limit: Override row count limit for tabular imports.
-        no_size_limit: Override file size limit for tabular imports.
-        auto_accept: Auto-accept the top fuzzy account match without prompting
-            (CLI: --yes / -y). Defaults to False.
-
-    Returns:
-        ImportResult with summary of what was imported.
-
-    Raises:
-        FileNotFoundError: If the file does not exist.
-        ValueError: If the file type is not supported.
-    """
-    path = Path(file_path)
-
-    if not path.exists():
-        raise FileNotFoundError(f"File not found: {path}")
-
-    file_type = _detect_file_type(path)
-    logger.info(f"Importing {_display_label(file_type, path)} file: {path}")
-
-    if file_type == "ofx":
-        result = _import_ofx(db, path, institution=institution)
-    elif file_type == "w2":
-        result = _import_w2(db, path)
-    elif file_type == "tabular":
-        result = _import_tabular(
-            db,
-            path,
-            account_name=account_name,
-            account_id=account_id,
-            format_name=format_name,
-            overrides=overrides,
-            sign=sign,
-            date_format_override=date_format,
-            number_format_override=number_format,
-            save_format=save_format,
-            sheet=sheet,
-            delimiter=delimiter,
-            encoding=encoding,
-            no_row_limit=no_row_limit,
-            no_size_limit=no_size_limit,
-            auto_accept=auto_accept,
-        )
-    else:
-        raise ValueError(f"Unsupported file type: {file_type}")
-
-    # Run matching and SQLMesh transforms after loading raw data
-    if apply_transforms and file_type in ("ofx", "tabular"):
-        try:
-            _run_matching(db)
-        except Exception:  # noqa: BLE001 — matching is best-effort; first import may precede SQLMesh views
-            logger.debug("Matching skipped (views may not exist yet)", exc_info=True)
-        result.core_tables_rebuilt = run_transforms()
-
-        # Apply deterministic categorization to new transactions
-        _apply_categorization(db)
-
-    logger.info(f"Import complete: {result.summary()}")
-    return result
-
-
-def _run_matching(db: Database) -> None:
-    """Run transaction matching after import.
-
-    Seeds source priority from config and runs the matcher engine.
-    Results are logged; pending matches prompt user action.
-    """
-    from moneybin.config import get_settings
-    from moneybin.matching.engine import TransactionMatcher
-    from moneybin.matching.priority import seed_source_priority
-
-    settings = get_settings().matching
-    seed_source_priority(db, settings)
-    matcher = TransactionMatcher(db, settings)
-    result = matcher.run()
-
-    if result.has_matches:
-        logger.info(f"Matching: {result.summary()}")
-        if result.has_pending:
-            logger.info("Run 'moneybin matches review' when ready")
-
-
-def _apply_categorization(db: Database) -> None:
-    """Run deterministic categorization on uncategorized transactions.
-
-    Called after SQLMesh transforms complete. Applies merchant lookups
-    and active rules — no LLM dependency.
-
-    Args:
-        db: Database instance.
-    """
-    from moneybin.services.auto_rule_service import AutoRuleService
-    from moneybin.services.categorization_service import CategorizationService
-
-    try:
-        service = CategorizationService(db)
-        stats = service.apply_deterministic()
-        if stats["total"] > 0:
-            logger.info(
-                f"Auto-categorized {stats['total']} transactions "
-                f"({stats['merchant']} merchant, {stats['rule']} rule)"
-            )
-        pending = AutoRuleService(db).stats().pending_proposals
-        if pending:
-            logger.info(f"  {pending} new auto-rule proposals")
-            logger.info(
-                "  💡 Run 'moneybin categorize auto-review' to review proposed rules"
-            )
-    except Exception:  # noqa: BLE001 — categorization is best-effort; failure skips without aborting import
-        logger.debug(
-            "Categorization skipped (tables may not exist yet)",
-            exc_info=True,
-        )

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -127,15 +127,16 @@ def _detect_file_type(file_path: Path) -> str:
 
 
 class ImportService:
-    """Service encapsulating the full import pipeline.
+    """Orchestrates the full file import pipeline.
 
-    Matches the AccountService/CategorizationService pattern: constructed
-    with a Database instance, exposes public methods, private helpers use
-    ``self._db`` instead of a ``db`` parameter.
+    Detects file type, extracts and loads to raw tables, runs SQLMesh
+    transforms, applies matching, and runs deterministic categorization.
+    Both CLI commands and MCP tools call this same service — no
+    duplication.
     """
 
     def __init__(self, db: Database) -> None:
-        """Initialize ImportService with a Database instance."""
+        """Initialize ImportService with an open Database connection."""
         self._db = db
 
     def _query_date_range(
@@ -278,9 +279,10 @@ class ImportService:
         """Run SQLMesh transforms to rebuild core tables.
 
         Uses ``sqlmesh_context()`` to handle encrypted DB injection into
-        SQLMesh's adapter cache.  Requires an active Database singleton
-        (via ``get_database()``) — ``sqlmesh_context()`` reuses its
-        connection.
+        SQLMesh's adapter cache. ``sqlmesh_context()`` reuses the active
+        ``get_database()`` singleton internally, so ``self._db`` should
+        be that same singleton (typical caller pattern is
+        ``ImportService(get_database()).run_transforms()``).
 
         Seeds ``app.seed_source_priority`` from config before running so
         ``int_transactions__merged`` can resolve per-field winners. Without

--- a/tests/integration/test_integration_existing.py
+++ b/tests/integration/test_integration_existing.py
@@ -90,7 +90,7 @@ class TestImportPipeline:
         # SQLMesh needs the encryption key passed via adapter cache.
         # sqlmesh_context() reuses the singleton's open connection.
         db_path = encrypted_db.path
-        from moneybin.services.import_service import run_transforms
+        from moneybin.services.import_service import ImportService
 
         with pytest.MonkeyPatch.context() as mp:
             # Set the singleton so sqlmesh_context() can reuse the connection
@@ -99,7 +99,7 @@ class TestImportPipeline:
             mock_settings = MagicMock()
             mock_settings.database.path = db_path
             mp.setattr("moneybin.database.get_settings", lambda: mock_settings)
-            result = run_transforms()
+            result = ImportService(encrypted_db).run_transforms()
 
         assert result is True
 

--- a/tests/integration/test_tabular_description_regression.py
+++ b/tests/integration/test_tabular_description_regression.py
@@ -27,7 +27,7 @@ def test_tabular_import_preserves_description(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Importing a CSV must round-trip every description into core.fct_transactions."""
-    from moneybin.services.import_service import import_file
+    from moneybin.services.import_service import ImportService
 
     secret_store = MagicMock()
     secret_store.get_key.return_value = "integration-test-key-0123456789abcdef"
@@ -46,7 +46,9 @@ def test_tabular_import_preserves_description(
     fixture = FIXTURES_DIR / "standard.csv"
     assert fixture.exists(), f"missing fixture: {fixture}"
 
-    result = import_file(db, fixture, account_name="checking", auto_accept=True)
+    result = ImportService(db).import_file(
+        fixture, account_name="checking", auto_accept=True
+    )
     assert result.transactions > 0, "fixture should yield transactions"
     assert result.core_tables_rebuilt, "transforms should have run"
 

--- a/tests/moneybin/test_cli/test_import_cmd_tabular.py
+++ b/tests/moneybin/test_cli/test_import_cmd_tabular.py
@@ -47,7 +47,7 @@ class TestImportFileAccountName:
     def mock_import_file(self, mocker: Any) -> MagicMock:
         """Mock the import_file service function."""
         return mocker.patch(
-            "moneybin.services.import_service.import_file",
+            "moneybin.services.import_service.ImportService.import_file",
             return_value=_make_import_result(),
         )
 
@@ -68,7 +68,6 @@ class TestImportFileAccountName:
 
         assert result.exit_code == 0
         mock_import_file.assert_called_once_with(
-            db=mock_get_database.return_value,
             file_path=csv_file,
             apply_transforms=True,
             institution=None,
@@ -136,7 +135,7 @@ class TestImportFileValidation:
         # Mock service so we don't need a real DB.
         mocker.patch("moneybin.cli.utils.get_database", return_value=MagicMock())
         mocker.patch(
-            "moneybin.services.import_service.import_file",
+            "moneybin.services.import_service.ImportService.import_file",
             return_value=_make_import_result(),
         )
 
@@ -157,7 +156,7 @@ class TestImportFileValidation:
 
         mocker.patch("moneybin.cli.utils.get_database", return_value=MagicMock())
         mocker.patch(
-            "moneybin.services.import_service.import_file",
+            "moneybin.services.import_service.ImportService.import_file",
             return_value=_make_import_result(),
         )
 

--- a/tests/moneybin/test_cli/test_import_command.py
+++ b/tests/moneybin/test_cli/test_import_command.py
@@ -42,7 +42,7 @@ def test_import_file_passes_yes_flag_through(csv_path: Path) -> None:
             _fake_db_ctx,
         ),
         patch(
-            "moneybin.services.import_service.import_file",
+            "moneybin.services.import_service.ImportService.import_file",
             side_effect=fake_run_import,
         ),
     ):
@@ -69,7 +69,7 @@ def test_import_file_default_auto_accept_false(csv_path: Path) -> None:
             _fake_db_ctx,
         ),
         patch(
-            "moneybin.services.import_service.import_file",
+            "moneybin.services.import_service.ImportService.import_file",
             side_effect=fake_run_import,
         ),
     ):

--- a/tests/moneybin/test_cli/test_import_commands.py
+++ b/tests/moneybin/test_cli/test_import_commands.py
@@ -29,7 +29,7 @@ class TestImportFileCommand:
     def mock_import_file(self, mocker: Any) -> MagicMock:
         """Mock the import_file service function."""
         mock = mocker.patch(
-            "moneybin.services.import_service.import_file",
+            "moneybin.services.import_service.ImportService.import_file",
             return_value=ImportResult(
                 file_path="test.ofx",
                 file_type="ofx",
@@ -61,7 +61,6 @@ class TestImportFileCommand:
         result = runner.invoke(app, ["file", str(test_file)])
         assert result.exit_code == 0
         mock_import_file.assert_called_once_with(
-            db=mock_get_database.return_value,
             file_path=test_file,
             apply_transforms=True,
             institution=None,
@@ -95,7 +94,6 @@ class TestImportFileCommand:
         result = runner.invoke(app, ["file", str(test_file), "--skip-transform"])
         assert result.exit_code == 0
         mock_import_file.assert_called_once_with(
-            db=mock_get_database.return_value,
             file_path=test_file,
             apply_transforms=False,
             institution=None,
@@ -131,7 +129,6 @@ class TestImportFileCommand:
         )
         assert result.exit_code == 0
         mock_import_file.assert_called_once_with(
-            db=mock_get_database.return_value,
             file_path=test_file,
             apply_transforms=True,
             institution="Wells Fargo",

--- a/tests/moneybin/test_cli/test_matches.py
+++ b/tests/moneybin/test_cli/test_matches.py
@@ -41,7 +41,7 @@ class TestMatchesRun:
 class TestMatchesReview:
     """Tests for the matches review command."""
 
-    @patch("moneybin.services.import_service.run_transforms")
+    @patch("moneybin.services.import_service.ImportService.run_transforms")
     @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.matching.persistence.update_match_status")
     def test_accept_single_runs_transform(
@@ -61,9 +61,9 @@ class TestMatchesReview:
         mock_update.assert_called_once_with(
             mock_get_db.return_value, "abc123", status="accepted", decided_by="user"
         )
-        mock_run_transforms.assert_called_once_with()
+        mock_run_transforms.assert_called_once()
 
-    @patch("moneybin.services.import_service.run_transforms")
+    @patch("moneybin.services.import_service.ImportService.run_transforms")
     @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.matching.persistence.update_match_status")
     def test_reject_single_does_not_run_transform(
@@ -85,7 +85,7 @@ class TestMatchesReview:
         )
         mock_run_transforms.assert_not_called()
 
-    @patch("moneybin.services.import_service.run_transforms")
+    @patch("moneybin.services.import_service.ImportService.run_transforms")
     @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.matching.persistence.get_pending_matches")
     @patch("moneybin.matching.persistence.update_match_status")
@@ -106,9 +106,9 @@ class TestMatchesReview:
 
         assert result.exit_code == 0
         assert mock_update.call_count == 2
-        mock_run_transforms.assert_called_once_with()
+        mock_run_transforms.assert_called_once()
 
-    @patch("moneybin.services.import_service.run_transforms")
+    @patch("moneybin.services.import_service.ImportService.run_transforms")
     @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.matching.persistence.update_match_status")
     def test_accept_single_can_skip_transform(
@@ -135,7 +135,7 @@ class TestMatchesReview:
         mock_update.assert_called_once()
         mock_run_transforms.assert_not_called()
 
-    @patch("moneybin.services.import_service.run_transforms")
+    @patch("moneybin.services.import_service.ImportService.run_transforms")
     @patch("moneybin.cli.utils.get_database")
     @patch("moneybin.matching.persistence.get_pending_matches")
     @patch("moneybin.matching.persistence.update_match_status")
@@ -164,7 +164,7 @@ class TestMatchesReview:
         mock_update.assert_called_once_with(
             mock_get_db.return_value, "abc123", status="accepted", decided_by="user"
         )
-        mock_run_transforms.assert_called_once_with()
+        mock_run_transforms.assert_called_once()
 
 
 class TestMatchesHistory:

--- a/tests/moneybin/test_import_matching_integration.py
+++ b/tests/moneybin/test_import_matching_integration.py
@@ -7,10 +7,10 @@ from unittest.mock import MagicMock, patch
 class TestImportMatchingIntegration:
     """Tests that matching is hooked into the import pipeline."""
 
-    @patch("moneybin.services.import_service.run_transforms")
-    @patch("moneybin.services.import_service._run_matching")
-    @patch("moneybin.services.import_service._apply_categorization")
-    @patch("moneybin.services.import_service._import_ofx")
+    @patch("moneybin.services.import_service.ImportService.run_transforms")
+    @patch("moneybin.services.import_service.ImportService._run_matching")
+    @patch("moneybin.services.import_service.ImportService._apply_categorization")
+    @patch("moneybin.services.import_service.ImportService._import_ofx")
     @patch("moneybin.services.import_service._detect_file_type", return_value="ofx")
     def test_matching_runs_before_transforms(
         self,
@@ -22,7 +22,7 @@ class TestImportMatchingIntegration:
         tmp_path: Path,
     ) -> None:
         """Verify _run_matching is called before run_transforms during import."""
-        from moneybin.services.import_service import ImportResult, import_file
+        from moneybin.services.import_service import ImportResult, ImportService
 
         qfx = tmp_path / "test.qfx"
         qfx.touch()
@@ -33,15 +33,15 @@ class TestImportMatchingIntegration:
 
         db = MagicMock()
         db.path = tmp_path / "test.duckdb"
-        import_file(db, qfx, apply_transforms=True)
+        ImportService(db).import_file(qfx, apply_transforms=True)
 
-        mock_matching.assert_called_once_with(db)
+        mock_matching.assert_called_once_with()
         mock_transforms.assert_called_once()
 
-    @patch("moneybin.services.import_service.run_transforms")
-    @patch("moneybin.services.import_service._run_matching")
-    @patch("moneybin.services.import_service._apply_categorization")
-    @patch("moneybin.services.import_service._import_ofx")
+    @patch("moneybin.services.import_service.ImportService.run_transforms")
+    @patch("moneybin.services.import_service.ImportService._run_matching")
+    @patch("moneybin.services.import_service.ImportService._apply_categorization")
+    @patch("moneybin.services.import_service.ImportService._import_ofx")
     @patch("moneybin.services.import_service._detect_file_type", return_value="ofx")
     def test_apply_transforms_false_skips_matching(
         self,
@@ -53,7 +53,7 @@ class TestImportMatchingIntegration:
         tmp_path: Path,
     ) -> None:
         """Verify matching is skipped when apply_transforms=False."""
-        from moneybin.services.import_service import ImportResult, import_file
+        from moneybin.services.import_service import ImportResult, ImportService
 
         qfx = tmp_path / "test.qfx"
         qfx.touch()
@@ -63,15 +63,15 @@ class TestImportMatchingIntegration:
 
         db = MagicMock()
         db.path = tmp_path / "test.duckdb"
-        import_file(db, qfx, apply_transforms=False)
+        ImportService(db).import_file(qfx, apply_transforms=False)
 
         mock_matching.assert_not_called()
         mock_transforms.assert_not_called()
 
-    @patch("moneybin.services.import_service.run_transforms")
-    @patch("moneybin.services.import_service._run_matching")
-    @patch("moneybin.services.import_service._apply_categorization")
-    @patch("moneybin.services.import_service._import_ofx")
+    @patch("moneybin.services.import_service.ImportService.run_transforms")
+    @patch("moneybin.services.import_service.ImportService._run_matching")
+    @patch("moneybin.services.import_service.ImportService._apply_categorization")
+    @patch("moneybin.services.import_service.ImportService._import_ofx")
     @patch("moneybin.services.import_service._detect_file_type", return_value="ofx")
     def test_matching_failure_does_not_abort_import(
         self,
@@ -83,7 +83,7 @@ class TestImportMatchingIntegration:
         tmp_path: Path,
     ) -> None:
         """Verify matching errors are swallowed (best-effort)."""
-        from moneybin.services.import_service import ImportResult, import_file
+        from moneybin.services.import_service import ImportResult, ImportService
 
         qfx = tmp_path / "test.qfx"
         qfx.touch()
@@ -95,7 +95,7 @@ class TestImportMatchingIntegration:
 
         db = MagicMock()
         db.path = tmp_path / "test.duckdb"
-        result = import_file(db, qfx, apply_transforms=True)
+        result = ImportService(db).import_file(qfx, apply_transforms=True)
 
         # Import should succeed despite matching failure
         assert result.transactions == 3
@@ -116,9 +116,7 @@ class TestApplyCategorizationProposalSummary:
         """Pending proposals trigger a hint line referencing auto-review."""
         import logging
 
-        from moneybin.services.import_service import (
-            _apply_categorization,  # pyright: ignore[reportPrivateUsage]
-        )
+        from moneybin.services.import_service import ImportService
 
         cat = mock_cat_cls.return_value
         cat.apply_deterministic.return_value = {
@@ -133,7 +131,7 @@ class TestApplyCategorizationProposalSummary:
         )
 
         with caplog.at_level(logging.INFO, logger="moneybin.services.import_service"):  # type: ignore[attr-defined]
-            _apply_categorization(MagicMock())
+            ImportService(MagicMock())._apply_categorization()  # pyright: ignore[reportPrivateUsage]
 
         text = "\n".join(r.message for r in caplog.records)  # type: ignore[attr-defined]
         assert "4 new auto-rule proposals" in text
@@ -150,9 +148,7 @@ class TestApplyCategorizationProposalSummary:
         """No pending proposals → no hint line."""
         import logging
 
-        from moneybin.services.import_service import (
-            _apply_categorization,  # pyright: ignore[reportPrivateUsage]
-        )
+        from moneybin.services.import_service import ImportService
 
         cat = mock_cat_cls.return_value
         cat.apply_deterministic.return_value = {
@@ -167,7 +163,7 @@ class TestApplyCategorizationProposalSummary:
         )
 
         with caplog.at_level(logging.INFO, logger="moneybin.services.import_service"):  # type: ignore[attr-defined]
-            _apply_categorization(MagicMock())
+            ImportService(MagicMock())._apply_categorization()  # pyright: ignore[reportPrivateUsage]
 
         text = "\n".join(r.message for r in caplog.records)  # type: ignore[attr-defined]
         assert "auto-rule proposals" not in text

--- a/tests/moneybin/test_services/test_import_service_class.py
+++ b/tests/moneybin/test_services/test_import_service_class.py
@@ -1,0 +1,25 @@
+"""Tests for the ImportService class shape."""
+
+from unittest.mock import MagicMock
+
+from moneybin.database import Database
+from moneybin.services.import_service import ImportService
+
+
+class TestImportServiceShape:
+    """Verify ImportService matches the AccountService/CategorizationService pattern."""
+
+    def test_constructor_accepts_database(self) -> None:
+        db = MagicMock(spec=Database)
+        service = ImportService(db)
+        assert service is not None
+
+    def test_exposes_import_file_method(self) -> None:
+        db = MagicMock(spec=Database)
+        service = ImportService(db)
+        assert callable(service.import_file)
+
+    def test_exposes_run_transforms_method(self) -> None:
+        db = MagicMock(spec=Database)
+        service = ImportService(db)
+        assert callable(service.run_transforms)

--- a/tests/moneybin/test_services/test_tabular_import_service.py
+++ b/tests/moneybin/test_services/test_tabular_import_service.py
@@ -73,9 +73,7 @@ def test_resolve_account_via_matcher_uses_existing_id_on_match(
 ) -> None:
     """Matched account name → reuses the existing account_id."""
     from moneybin.database import Database
-    from moneybin.services.import_service import (
-        _resolve_account_via_matcher,  # type: ignore[reportPrivateUsage]
-    )
+    from moneybin.services.import_service import ImportService
 
     db = Database(
         tmp_path / "match.duckdb",
@@ -92,8 +90,7 @@ def test_resolve_account_via_matcher_uses_existing_id_on_match(
             ('chase-checking', 'Chase Checking', NULL, NULL, NULL, NULL, NULL,
              'old.csv', 'csv', 'chase', 'imp1')
         """)
-        aid = _resolve_account_via_matcher(
-            db,
+        aid = ImportService(db)._resolve_account_via_matcher(  # type: ignore[reportPrivateUsage]
             account_name="Chase Checking",
             account_number=None,
             threshold=0.6,
@@ -109,9 +106,7 @@ def test_resolve_account_via_matcher_creates_new_when_no_candidates(
 ) -> None:
     """No fuzzy candidates → fall back to slugify (creates a new account)."""
     from moneybin.database import Database
-    from moneybin.services.import_service import (
-        _resolve_account_via_matcher,  # type: ignore[reportPrivateUsage]
-    )
+    from moneybin.services.import_service import ImportService
 
     db = Database(
         tmp_path / "new.duckdb",
@@ -123,8 +118,7 @@ def test_resolve_account_via_matcher_creates_new_when_no_candidates(
         # not the except-Exception fallback.
         row = db.execute("SELECT COUNT(*) FROM raw.tabular_accounts").fetchone()
         assert row is not None and row[0] == 0
-        aid = _resolve_account_via_matcher(
-            db,
+        aid = ImportService(db)._resolve_account_via_matcher(  # type: ignore[reportPrivateUsage]
             account_name="Brand New Account",
             account_number=None,
             threshold=0.6,
@@ -140,9 +134,7 @@ def test_resolve_account_via_matcher_auto_accepts_top_candidate(
 ) -> None:
     """With auto_accept=True, a fuzzy candidate is taken without prompting."""
     from moneybin.database import Database
-    from moneybin.services.import_service import (
-        _resolve_account_via_matcher,  # type: ignore[reportPrivateUsage]
-    )
+    from moneybin.services.import_service import ImportService
 
     db = Database(
         tmp_path / "fuzzy.duckdb",
@@ -160,8 +152,7 @@ def test_resolve_account_via_matcher_auto_accepts_top_candidate(
              'old.csv', 'csv', 'chase', 'imp1')
         """)
         with caplog.at_level("INFO"):
-            aid = _resolve_account_via_matcher(
-                db,
+            aid = ImportService(db)._resolve_account_via_matcher(  # type: ignore[reportPrivateUsage]
                 account_name="Chase Checking",
                 account_number=None,
                 threshold=0.6,
@@ -178,9 +169,7 @@ def test_resolve_account_via_matcher_warns_and_falls_back_when_not_auto(
 ) -> None:
     """Without auto_accept, fuzzy candidates trigger a warning + slugify fallback."""
     from moneybin.database import Database
-    from moneybin.services.import_service import (
-        _resolve_account_via_matcher,  # type: ignore[reportPrivateUsage]
-    )
+    from moneybin.services.import_service import ImportService
 
     db = Database(
         tmp_path / "fuzzy2.duckdb",
@@ -198,8 +187,7 @@ def test_resolve_account_via_matcher_warns_and_falls_back_when_not_auto(
              'old.csv', 'csv', 'chase', 'imp1')
         """)
         with caplog.at_level("WARNING"):
-            aid = _resolve_account_via_matcher(
-                db,
+            aid = ImportService(db)._resolve_account_via_matcher(  # type: ignore[reportPrivateUsage]
                 account_name="Chase Checking",
                 account_number=None,
                 threshold=0.6,

--- a/tests/moneybin/test_synthetic/test_cli.py
+++ b/tests/moneybin/test_synthetic/test_cli.py
@@ -68,7 +68,7 @@ class TestGenerateCommand:
     @pytest.fixture
     def mock_run_transforms(self, mocker: Any) -> MagicMock:
         return mocker.patch(
-            "moneybin.services.import_service.run_transforms",
+            "moneybin.services.import_service.ImportService.run_transforms",
             return_value=True,
         )
 


### PR DESCRIPTION
### Summary
Refactors `import_service.py` from module-level functions into an `ImportService` class, bringing it in line with the rest of the service layer (`AccountService`, `CategorizationService`, `SpendingService`, `TransactionService`). All CLI, MCP, and test callers are migrated to instantiate the class with a `Database`.

### Impact
- Callers must now instantiate `ImportService(db)` instead of calling module functions. All in-tree callers are updated; no external API.
- No behavior change — pure refactor.

### Changes

#### Introduce `ImportService` class
Wraps the prior module-level functions as methods on a class that takes a `Database` in its constructor, matching the established service pattern.
- `import_file`, `run_transforms`, and related orchestration become methods on `ImportService`
- Pure helpers (`_detect_file_type`, `_display_label`, `ImportResult`, `ResolvedMapping`) stay module-level
- Adds shape tests for the new class

#### Migrate callers to `ImportService`
- CLI: `import`, `transform`, `matches`, `synthetic`
- MCP: import tools
- Tests: import command, integration, tabular, matching, synthetic, regression suites

#### Docstring cleanup (post-`/simplify` pass)
- Class docstring describes purpose rather than narrating the refactor
- `run_transforms` docstring corrected — it uses `self._db`, not a fresh `get_database()` call

### Testing
- Existing unit, integration, and E2E suites cover all migrated call sites
- New shape tests verify constructor and method surface on `ImportService`

### Notes
Branch lands as 6 mechanical commits for reviewability. Intermediate commits aren't individually green (MCP/integration tests rely on caller migration commits) — review the branch as a whole.