### PR TITLE
Remove Claude co-author trailer from /fix-* commands

### DIFF
--- a/.claude/commands/fix-ci.md
+++ b/.claude/commands/fix-ci.md
@@ -52,5 +52,4 @@ Find and fix failures in the latest CI run for a branch.
 
 10. **After confirmation**, stage only the files changed to fix CI (do not stage unrelated unstaged files), commit, and push:
     - Commit message: `Fix CI failures: <brief description>` with a bulleted body listing each fix
-    - Include `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
     - Push to the current branch's remote tracking branch

--- a/.claude/commands/fix-scenarios.md
+++ b/.claude/commands/fix-scenarios.md
@@ -125,5 +125,4 @@ non-zero CI exit and as per-scenario PASS/FAIL lines in the JSONL artifact.
     stage unrelated unstaged files), commit, and push:
     - Commit message: `Fix scenario failures: <brief description>` with a bulleted
       body listing each scenario fixed and how
-    - Include `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
     - Push to the current branch's remote tracking branch

--- a/.claude/commands/fix-security.md
+++ b/.claude/commands/fix-security.md
@@ -41,5 +41,4 @@ Find and fix open security findings from CodeQL and pip-audit.
 
 9. **After confirmation**, stage only the files changed to address security findings, commit, and push:
    - Commit message: `Fix security findings: <brief description>` with a bulleted body listing each fix
-   - Include `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
    - Push to the current branch's remote tracking branch


### PR DESCRIPTION
### Summary
The `/fix-ci`, `/fix-scenarios`, and `/fix-security` slash commands instructed Claude to append a `Co-Authored-By: Claude Sonnet 4.6` trailer on commits. This PR removes that instruction so commits from those commands match the rest of the project's commit style.

### Impact
- Future `/fix-ci`, `/fix-scenarios`, and `/fix-security` invocations will produce commits without the Claude co-author trailer.
- No code or runtime behavior changes.

### Changes
#### Slash command cleanup
Removed the single bullet instructing inclusion of the co-author trailer from each command's commit step.

- `.claude/commands/fix-ci.md` — drop trailer instruction
- `.claude/commands/fix-scenarios.md` — drop trailer instruction
- `.claude/commands/fix-security.md` — drop trailer instruction

### Testing
Docs-only change to slash command prompts; no tests applicable. Reviewer should confirm the diff is exactly the three removed bullets.