### PR TITLE
Add YAML-driven golden fixtures for normalize_description

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -79,6 +79,25 @@ Migration(version=2, name="new", filename="V002__new.sql", checksum="def456",
           content=b"SELECT 1;", path=Path("/tmp/V002__new.sql"), file_type="sql")
 ```
 
+## Golden-Case Fixtures
+
+For pure functions whose correctness is best expressed as input → output pairs,
+keep cases in a YAML fixture file under `tests/.../fixtures/` and write a
+parametrized test asserting exact equality.
+
+**When to add:** Real-world input that should produce a specific output, and no
+existing case covers it.
+
+**How to add:**
+
+1. Append a row to the fixture YAML with a unique, kebab-case `id` naming the
+   *behavior under test*, not the input.
+2. Run the test. Fix the function until it passes — do NOT relax `expected` to
+   match incorrect output.
+
+**Why exact equality:** Loose assertions hide subtle regressions like extra
+whitespace or partial strips. Goldens force every character intentional.
+
 ## Test Coverage by Layer
 
 Every shipped feature must have tests at the appropriate layers:

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -155,26 +155,24 @@ Fix: grant the workflow permission to call `gh pr review` by adding to
 
 See PR #58 conversation for the exchange where this came up.
 
-## Multi-word city stripping in `normalize_description` (post-PR #66)
+## City-token stripping in `normalize_description` (post-PR #66)
 
-`_TRAILING_LOCATION` in `src/moneybin/services/_text.py` strips a single
-optional all-caps city token before `ST ZIP` (e.g. `WHOLEFDS MKT AUSTIN
-TX 78701` → `WHOLEFDS MKT`). It does not handle multi-word cities — so
-`SAN FRANCISCO CA 94105` normalizes to `SAN` instead of the intended
-merchant prefix. Common cities affected: SAN JOSE, LOS ANGELES, NEW
-YORK, SANTA BARBARA.
-
-The naive multi-word extension (`(?:[A-Z][A-Za-z]{3,}(?:\s+[A-Z][A-Za-z]+)*\s+)?`)
-doesn't help because `re.sub` picks the leftmost match — it greedily
-consumes `FRANCISCO CA 94105` from the second word and leaves the first
-word dangling.
+`_TRAILING_LOCATION` in `src/moneybin/services/_text.py` strips bare
+`ST ZIP` only — it deliberately leaves trailing city tokens in place
+(e.g. `WHOLEFDS MKT AUSTIN TX 78701` → `WHOLEFDS MKT AUSTIN`). The
+optional city group was removed in PR #66 review because it produced
+false positives on merchant tokens (`TARGET STORE NY 10001` → `TARGET`,
+`SHELL MART NY 10001` → `SHELL`). At the lexical level a trailing
+all-caps token is indistinguishable from a merchant descriptor.
 
 A correct fix likely needs one of:
 - A known-cities allowlist (US Census places ≥10k population is ~5k entries)
-- Anchoring on the start-of-string-or-whitespace-after-known-merchant-prefix
-- Two-pass: detect city using state+zip as anchor, validate that what
-  remains is a plausible merchant token
+- Two-pass: detect city using state+zip as anchor, then validate that
+  what remains is a plausible merchant token (heuristics on token
+  length, presence of known suffixes like `MKT`, `STORE`, etc.)
 
-Add a golden case (`san-francisco-multi-word-city`) when fixed.
+Add goldens for both directions when fixed:
+- `WHOLEFDS MKT AUSTIN TX 78701` → `WHOLEFDS MKT` (city stripped)
+- `TARGET STORE NY 10001` → `TARGET STORE` (merchant token preserved)
 
-Flagged by claude[bot] (P2) in PR #66 review.
+Flagged by claude[bot] and chatgpt-codex-connector in PR #66 review.

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -154,3 +154,27 @@ Fix: grant the workflow permission to call `gh pr review` by adding to
 ```
 
 See PR #58 conversation for the exchange where this came up.
+
+## Multi-word city stripping in `normalize_description` (post-PR #66)
+
+`_TRAILING_LOCATION` in `src/moneybin/services/_text.py` strips a single
+optional all-caps city token before `ST ZIP` (e.g. `WHOLEFDS MKT AUSTIN
+TX 78701` → `WHOLEFDS MKT`). It does not handle multi-word cities — so
+`SAN FRANCISCO CA 94105` normalizes to `SAN` instead of the intended
+merchant prefix. Common cities affected: SAN JOSE, LOS ANGELES, NEW
+YORK, SANTA BARBARA.
+
+The naive multi-word extension (`(?:[A-Z][A-Za-z]{3,}(?:\s+[A-Z][A-Za-z]+)*\s+)?`)
+doesn't help because `re.sub` picks the leftmost match — it greedily
+consumes `FRANCISCO CA 94105` from the second word and leaves the first
+word dangling.
+
+A correct fix likely needs one of:
+- A known-cities allowlist (US Census places ≥10k population is ~5k entries)
+- Anchoring on the start-of-string-or-whitespace-after-known-merchant-prefix
+- Two-pass: detect city using state+zip as anchor, validate that what
+  remains is a plausible merchant token
+
+Add a golden case (`san-francisco-multi-word-city`) when fixed.
+
+Flagged by claude[bot] (P2) in PR #66 review.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -88,7 +88,7 @@ Single source of truth for spec status. Update this table when a spec's status c
 | [Synthetic Data Generator](testing-synthetic-data.md) | Feature | implemented | Persona-based synthetic financial data: YAML-driven personas/merchants, deterministic seeding, ground-truth labels, Level 2 realism |
 | [E2E Testing](e2e-testing.md) | Feature | implemented | Subprocess-based E2E tests: smoke tests (help, no-DB, DB commands), golden-path workflow tests (synthetic, CSV, OFX, lock/unlock, categorization) |
 | [Scenario Runner](testing-scenario-runner.md) | Feature | implemented | Whole-pipeline correctness: empty DB → pipeline → assertions/expectations/evaluations against synthetic ground truth and hand-labeled fixtures; `moneybin synthetic verify` CLI; validation primitives reusable for live-data checks |
-| [Normalize-Description Fixtures](testing-normalize-description-fixtures.md) | Feature | ready | YAML golden cases for `normalize_description()`; parametrized exact-equality tests; contributor-facing surface for adding real-world transaction descriptions |
+| [Normalize-Description Fixtures](testing-normalize-description-fixtures.md) | Feature | implemented | YAML golden cases for `normalize_description()`; parametrized exact-equality tests; contributor-facing surface for adding real-world transaction descriptions |
 | `testing-csv-fixtures.md` | Feature | planned | Curated bank export samples with expected-result YAML for format detection testing |
 | `testing-anonymized-data.md` | Feature | planned | Structure-preserving anonymization of real databases with statistical similarity guarantees |
 | `testing-format-compat.md` | Feature | planned | Extractor verification against fixture files |

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -88,6 +88,7 @@ Single source of truth for spec status. Update this table when a spec's status c
 | [Synthetic Data Generator](testing-synthetic-data.md) | Feature | implemented | Persona-based synthetic financial data: YAML-driven personas/merchants, deterministic seeding, ground-truth labels, Level 2 realism |
 | [E2E Testing](e2e-testing.md) | Feature | implemented | Subprocess-based E2E tests: smoke tests (help, no-DB, DB commands), golden-path workflow tests (synthetic, CSV, OFX, lock/unlock, categorization) |
 | [Scenario Runner](testing-scenario-runner.md) | Feature | implemented | Whole-pipeline correctness: empty DB → pipeline → assertions/expectations/evaluations against synthetic ground truth and hand-labeled fixtures; `moneybin synthetic verify` CLI; validation primitives reusable for live-data checks |
+| [Normalize-Description Fixtures](testing-normalize-description-fixtures.md) | Feature | ready | YAML golden cases for `normalize_description()`; parametrized exact-equality tests; contributor-facing surface for adding real-world transaction descriptions |
 | `testing-csv-fixtures.md` | Feature | planned | Curated bank export samples with expected-result YAML for format detection testing |
 | `testing-anonymized-data.md` | Feature | planned | Structure-preserving anonymization of real databases with statistical similarity guarantees |
 | `testing-format-compat.md` | Feature | planned | Extractor verification against fixture files |

--- a/docs/specs/testing-normalize-description-fixtures.md
+++ b/docs/specs/testing-normalize-description-fixtures.md
@@ -1,7 +1,7 @@
 # Feature: Normalize-Description Golden Fixtures
 
 ## Status
-ready
+implemented
 
 ## Goal
 

--- a/docs/specs/testing-normalize-description-fixtures.md
+++ b/docs/specs/testing-normalize-description-fixtures.md
@@ -1,0 +1,155 @@
+# Feature: Normalize-Description Golden Fixtures
+
+## Status
+ready
+
+## Goal
+
+Provide a YAML-driven golden-case fixture for `normalize_description()` so
+contributors can add real-world transaction descriptions and their expected
+normalized form, and so the test suite asserts exact equality rather than
+loose substring checks.
+
+## Background
+
+`moneybin.services._text.normalize_description` is the deterministic regex
+cleanup applied to raw transaction descriptions before merchant-pattern
+matching and auto-rule pattern extraction. Call sites:
+
+- `services/auto_rule_service.py::_extract_pattern` — fallback when no
+  merchant is linked to a transaction.
+- `services/auto_rule_service.py::apply_rules` — used during rule evaluation
+  alongside `LOWER(description)` SQL matching.
+
+Existing coverage in
+`tests/moneybin/test_services/test_categorization_service.py::TestNormalizeDescription`
+has two gaps:
+
+1. Several assertions use `"X" not in result` rather than exact equality, so
+   regressions that subtly change output (extra whitespace, partial strip)
+   pass undetected.
+2. There is no documented surface for contributors to add cases when they
+   encounter a real description that should normalize a specific way.
+
+Related specs:
+- [Auto-Rule Generation](categorization-auto-rules.md) — primary consumer of
+  `normalize_description` via merchant-first pattern extraction.
+- [Categorization Overview](categorization-overview.md) — broader context.
+
+## Requirements
+
+1. A YAML fixture file enumerates `(raw, expected)` pairs with a stable `id`
+   per case.
+2. A parametrized pytest test loads every case and asserts
+   `normalize_description(raw) == expected` exactly.
+3. Pytest test ids match the fixture `id` so failures point at the offending
+   row.
+4. Loader rejects duplicate `id` values at collection time.
+5. All ten existing `TestNormalizeDescription` cases are migrated into the
+   fixture with exact-equality expectations. Where the current regex output
+   does not match the intended normalized form, the regex in `_text.py` is
+   fixed in the same change.
+6. Contributor-facing documentation explains when, where, and how to add a
+   case, and what to do when the test fails.
+7. Existing call sites of `normalize_description`
+   (`auto_rule_service._extract_pattern`, `auto_rule_service.apply_rules`)
+   continue to pass their own tests after any regex changes.
+
+## Data Model
+
+No database changes. Fixture file only:
+
+`tests/moneybin/test_services/fixtures/normalize_description_cases.yaml`
+
+```yaml
+cases:
+  - id: square-prefix-and-store-id
+    raw: "SQ *STARBUCKS #1234"
+    expected: "STARBUCKS"
+    note: "Square POS prefix + trailing store id"
+  - id: trailing-city-state
+    raw: "STARBUCKS SEATTLE WA"
+    expected: "STARBUCKS"
+```
+
+Schema per case:
+- `id` (string, required, unique) — used as pytest parametrize id.
+- `raw` (string, required) — input passed verbatim to
+  `normalize_description`.
+- `expected` (string, required) — exact expected output.
+- `note` (string, optional) — short reviewer-facing context.
+
+## Implementation Plan
+
+### Files to Create
+
+- `tests/moneybin/test_services/fixtures/normalize_description_cases.yaml` —
+  golden cases, seeded with the migrated existing tests.
+
+### Files to Modify
+
+- `tests/moneybin/test_services/test_categorization_service.py` — replace
+  `TestNormalizeDescription` with `TestNormalizeDescriptionGoldens` plus a
+  module-level `_load_normalize_cases()` helper.
+- `src/moneybin/services/_text.py` — adjust regexes as needed so migrated
+  cases pass on the intended exact output (no behavior change beyond making
+  current cases produce clean results).
+- `.claude/rules/testing.md` — add a "Golden-case fixtures" subsection
+  documenting the contribution workflow.
+
+### Key Decisions
+
+- **YAML, not JSON or Python.** Aligns with existing project convention for
+  contributor-facing fixtures (synthetic-data personas/merchants, scenario
+  runner). See memory: project standardizes on YAML to support a future
+  community contribution model.
+- **Single fixture file per pure function.** No directory-of-cases pattern —
+  the function is small and the case count is small.
+- **Migrate the existing class wholesale.** No reason to keep
+  `TestNormalizeDescription` alongside the new parametrized class; the new
+  class subsumes it.
+- **Fix the regex in the same PR when migration reveals dirty output.** The
+  user explicitly chose this over capturing-current-behavior; the rationale is
+  that loose assertions hid actual cleanup gaps and we should fix them now
+  while the change is in flight.
+- **No layer-2 fixture in this spec.** Merchant-pattern matching is covered by
+  the scenario runner (see `testing-scenario-runner.md`); adding a parallel
+  fixture format here would duplicate that surface.
+
+## CLI Interface
+
+None.
+
+## MCP Interface
+
+None.
+
+## Testing Strategy
+
+- **Unit:** Every YAML row exercises `normalize_description` directly via
+  `pytest.mark.parametrize`. Failures surface with the case `id` in the test
+  output.
+- **Loader sanity:** A separate unit test verifies the loader raises on
+  duplicate `id` values.
+- **Regression safety:** Run the full categorization-service and
+  auto-rule-service test suites after regex changes; both depend on
+  `normalize_description` and would catch behavioral drift in real call sites.
+- **No integration or E2E layer.** `normalize_description` is a pure function
+  with no I/O; layered tests would add no signal.
+
+## Synthetic Data Requirements
+
+None.
+
+## Dependencies
+
+None beyond existing project deps (PyYAML is already used by the synthetic
+data generator and scenario runner).
+
+## Out of Scope
+
+- Layer-2 (raw description → merchant_id / category) golden cases.
+- Changes to `auto_rule_service` pattern-extraction logic.
+- New normalization features (e.g., handling additional POS prefixes beyond
+  the current set) — those should arrive as new cases plus targeted regex
+  changes after this spec ships.

--- a/docs/superpowers/plans/2026-04-30-normalize-description-fixtures.md
+++ b/docs/superpowers/plans/2026-04-30-normalize-description-fixtures.md
@@ -172,9 +172,7 @@ class TestNormalizeDescriptionGoldens:
     """
 
     @pytest.mark.unit
-    @pytest.mark.parametrize(
-        "case", _load_normalize_cases(), ids=lambda c: c["id"]
-    )
+    @pytest.mark.parametrize("case", _load_normalize_cases(), ids=lambda c: c["id"])
     def test_case(self, case: dict[str, str]) -> None:
         assert normalize_description(case["raw"]) == case["expected"]
 ```
@@ -340,24 +338,25 @@ Requirement 4 of the spec: the loader rejects duplicate `id` values. Currently t
 Add the following test method to `TestNormalizeDescriptionGoldens` (or as a sibling top-level test if the class style does not fit):
 
 ```python
-    @pytest.mark.unit
-    def test_loader_rejects_duplicate_ids(self, tmp_path: Path) -> None:
-        """The loader must surface duplicate ids loudly at collection time."""
-        bad_yaml = tmp_path / "dup.yaml"
-        bad_yaml.write_text(
-            "cases:\n"
-            '  - {id: a, raw: "x", expected: "x"}\n'
-            '  - {id: a, raw: "y", expected: "y"}\n'
-        )
+@pytest.mark.unit
+def test_loader_rejects_duplicate_ids(self, tmp_path: Path) -> None:
+    """The loader must surface duplicate ids loudly at collection time."""
+    bad_yaml = tmp_path / "dup.yaml"
+    bad_yaml.write_text(
+        "cases:\n"
+        '  - {id: a, raw: "x", expected: "x"}\n'
+        '  - {id: a, raw: "y", expected: "y"}\n'
+    )
 
-        # Inline the loader logic against the temp file rather than
-        # monkeypatching the module-level constant.
-        import yaml as _yaml
-        raw = _yaml.safe_load(bad_yaml.read_text())
-        cases = raw["cases"]
-        ids = [c["id"] for c in cases]
-        duplicates = {i for i in ids if ids.count(i) > 1}
-        assert duplicates == {"a"}
+    # Inline the loader logic against the temp file rather than
+    # monkeypatching the module-level constant.
+    import yaml as _yaml
+
+    raw = _yaml.safe_load(bad_yaml.read_text())
+    cases = raw["cases"]
+    ids = [c["id"] for c in cases]
+    duplicates = {i for i in ids if ids.count(i) > 1}
+    assert duplicates == {"a"}
 ```
 
 This test pins the duplicate-detection behavior. It is intentionally inline (not calling `_load_normalize_cases`) because `_load_normalize_cases` is bound to the real fixture path; refactoring it to take an injectable path is YAGNI for one test. If a future test wants to exercise more loader behavior, refactor then.

--- a/docs/superpowers/plans/2026-04-30-normalize-description-fixtures.md
+++ b/docs/superpowers/plans/2026-04-30-normalize-description-fixtures.md
@@ -1,0 +1,496 @@
+# Normalize-Description Golden Fixtures Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the loose-assertion `TestNormalizeDescription` test class with a YAML-driven golden-case fixture, fix the city+state+zip trailing-location regex gap surfaced during migration, and document the contribution surface.
+
+**Architecture:** A single YAML file (`tests/moneybin/test_services/fixtures/normalize_description_cases.yaml`) holds `(id, raw, expected)` triples. A module-level loader in the existing `test_categorization_service.py` reads the file once and feeds a parametrized pytest. The loader rejects duplicate ids. The regex in `src/moneybin/services/_text.py` is tightened so an all-caps `CITY STATE ZIP` tail is stripped as a unit.
+
+**Tech Stack:** pytest, PyYAML (already a project dep via the synthetic data generator), Python 3.12+, `re` stdlib.
+
+**Spec:** `docs/specs/testing-normalize-description-fixtures.md`
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `tests/moneybin/test_services/fixtures/normalize_description_cases.yaml` | Create | Golden cases — single source of truth for expected normalization outputs |
+| `tests/moneybin/test_services/test_categorization_service.py` | Modify | Replace `TestNormalizeDescription` (lines ~117–166) with `TestNormalizeDescriptionGoldens` plus `_load_normalize_cases()` helper |
+| `src/moneybin/services/_text.py` | Modify | Tighten `_TRAILING_LOCATION` regex to capture all-caps `CITY STATE ZIP` as a unit |
+| `.claude/rules/testing.md` | Modify | Add "Golden-case fixtures" subsection documenting the contribution workflow |
+| `docs/specs/INDEX.md` | (already modified in worktree) | Adds the spec entry — no further changes needed |
+
+---
+
+## Task 1: Add YAML fixture file with golden cases
+
+**Files:**
+- Create: `tests/moneybin/test_services/fixtures/normalize_description_cases.yaml`
+
+The fixture seeds the migrated existing cases. Two of them (`whole-foods-trailing-state-zip` and `combined-prefix-store-id-city-state`) describe outputs the current regex does NOT yet produce — the regex fix in Task 4 makes them pass.
+
+- [ ] **Step 1: Create the fixtures directory and YAML file**
+
+```bash
+mkdir -p tests/moneybin/test_services/fixtures
+```
+
+Write `tests/moneybin/test_services/fixtures/normalize_description_cases.yaml`:
+
+```yaml
+# Golden cases for moneybin.services._text.normalize_description.
+#
+# Add a case here when you encounter a real transaction description that
+# should normalize a specific way. Each case is run through
+# normalize_description(raw) and asserted equal to expected.
+#
+# If a new case fails, fix the regexes in src/moneybin/services/_text.py
+# until it passes. Do NOT relax `expected` to match the current output.
+#
+# Schema:
+#   id       (str, required, unique) — pytest parametrize id
+#   raw      (str, required)         — input passed verbatim
+#   expected (str, required)         — exact expected output
+#   note     (str, optional)         — reviewer-facing context
+cases:
+  - id: square-prefix-and-store-id
+    raw: "SQ *STARBUCKS #1234"
+    expected: "STARBUCKS"
+    note: "Square POS prefix + trailing store id"
+
+  - id: toast-prefix
+    raw: "TST*PIZZA PLACE"
+    expected: "PIZZA PLACE"
+
+  - id: paypal-short-prefix
+    raw: "PP*SPOTIFY"
+    expected: "SPOTIFY"
+
+  - id: paypal-long-prefix
+    raw: "PAYPAL *NETFLIX"
+    expected: "NETFLIX"
+
+  - id: venmo-prefix
+    raw: "VENMO *JOHN DOE"
+    expected: "JOHN DOE"
+
+  - id: cke-prefix-with-trailing-id
+    raw: "CKE*CHIPOTLE 02345"
+    expected: "CHIPOTLE"
+
+  - id: trailing-city-state
+    raw: "STARBUCKS SEATTLE WA"
+    expected: "STARBUCKS"
+
+  - id: trailing-store-id
+    raw: "TARGET 00012345"
+    expected: "TARGET"
+
+  - id: whole-foods-trailing-state-zip
+    raw: "WHOLEFDS MKT AUSTIN TX 78701"
+    expected: "WHOLEFDS MKT"
+    note: "All-caps city before state+zip — exercises the city+state+zip-as-unit branch"
+
+  - id: combined-prefix-store-id-city-state
+    raw: "SQ *STARBUCKS #1234 SEATTLE WA"
+    expected: "STARBUCKS"
+    note: "Prefix, store id, and city+state all present"
+
+  - id: collapses-multiple-spaces
+    raw: "SQ  *  COFFEE   SHOP"
+    expected: "COFFEE SHOP"
+
+  - id: empty-string
+    raw: ""
+    expected: ""
+
+  - id: whitespace-only
+    raw: "   "
+    expected: ""
+```
+
+- [ ] **Step 2: Verify the YAML parses**
+
+Run: `uv run python -c "import yaml; from pathlib import Path; data = yaml.safe_load(Path('tests/moneybin/test_services/fixtures/normalize_description_cases.yaml').read_text()); print(len(data['cases']), 'cases')"`
+
+Expected: `13 cases`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/moneybin/test_services/fixtures/normalize_description_cases.yaml
+git commit -m "test: add golden-case fixture for normalize_description"
+```
+
+---
+
+## Task 2: Add YAML loader and parametrized test (RED)
+
+**Files:**
+- Modify: `tests/moneybin/test_services/test_categorization_service.py`
+
+The new `TestNormalizeDescriptionGoldens` class replaces the existing `TestNormalizeDescription` class. The loader is module-level so it runs at collection time and pytest can use real ids.
+
+- [ ] **Step 1: Read the current state of the test file**
+
+Run: `head -30 tests/moneybin/test_services/test_categorization_service.py` — confirm imports include `from moneybin.services._text import normalize_description` and `import pytest`. (They already do at lines 16 and ~10.)
+
+- [ ] **Step 2: Add the loader helper and the new test class above the existing `TestNormalizeDescription`**
+
+Locate the line `class TestNormalizeDescription:` (currently around line 118). Insert the following ABOVE it (do not yet remove the old class — we delete it in Task 5 once the new class is green):
+
+```python
+import yaml
+
+_FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def _load_normalize_cases() -> list[dict[str, str]]:
+    """Load normalize_description golden cases from YAML.
+
+    Raises ValueError if any `id` is duplicated to prevent silent shadowing
+    when contributors append cases.
+    """
+    raw = yaml.safe_load(
+        (_FIXTURES_DIR / "normalize_description_cases.yaml").read_text()
+    )
+    cases = raw["cases"]
+    ids = [c["id"] for c in cases]
+    duplicates = {i for i in ids if ids.count(i) > 1}
+    if duplicates:
+        raise ValueError(f"Duplicate case ids: {sorted(duplicates)}")
+    return cases
+
+
+class TestNormalizeDescriptionGoldens:
+    """Golden cases for normalize_description loaded from YAML.
+
+    See tests/moneybin/test_services/fixtures/normalize_description_cases.yaml
+    for the fixture format and contributor instructions.
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "case", _load_normalize_cases(), ids=lambda c: c["id"]
+    )
+    def test_case(self, case: dict[str, str]) -> None:
+        assert normalize_description(case["raw"]) == case["expected"]
+```
+
+Also add `from pathlib import Path` to the imports at the top of the file if it is not already imported. Check by running:
+`grep -n "from pathlib" tests/moneybin/test_services/test_categorization_service.py`
+
+If absent, add `from pathlib import Path` near the other stdlib imports.
+
+- [ ] **Step 3: Run the new test class — expect 2 failures**
+
+Run: `uv run pytest tests/moneybin/test_services/test_categorization_service.py::TestNormalizeDescriptionGoldens -v`
+
+Expected: 13 collected, 11 passing, **2 failing**:
+- `test_case[whole-foods-trailing-state-zip]` — actual `'WHOLEFDS MKT AUSTIN'`, expected `'WHOLEFDS MKT'`
+- `test_case[combined-prefix-store-id-city-state]` may pass already (audit showed it produces `'STARBUCKS'`); if it does, the only failure is `whole-foods-trailing-state-zip`. Either outcome is fine — proceed to Task 3.
+
+- [ ] **Step 4: Commit the test scaffolding**
+
+```bash
+git add tests/moneybin/test_services/test_categorization_service.py
+git commit -m "test: add YAML-driven goldens class for normalize_description (RED)"
+```
+
+---
+
+## Task 3: Confirm the failure mode and write the regex fix as a focused failing case
+
+**Files:**
+- (No new files; this task is verification only)
+
+The point of this task is to make the regex change minimal and targeted — write down exactly which input → output the regex must change, and run the failing test once more before touching `_text.py`.
+
+- [ ] **Step 1: Re-run the specific failing case in isolation**
+
+Run: `uv run pytest tests/moneybin/test_services/test_categorization_service.py::TestNormalizeDescriptionGoldens::test_case -v -k whole-foods`
+
+Expected output includes:
+
+```
+AssertionError: assert 'WHOLEFDS MKT AUSTIN' == 'WHOLEFDS MKT'
+```
+
+- [ ] **Step 2: Confirm root cause by reading the current regex**
+
+Read `src/moneybin/services/_text.py` lines 17–24. The `_TRAILING_LOCATION` regex has three alternatives:
+
+1. `[A-Z]{2}\s+\d{5}(?:-\d{4})?$` — matches ` TX 78701` only, leaving the city.
+2. `[A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)*,?\s+[A-Z]{2}$` — city+state, no zip.
+3. `\d{5}(?:-\d{4})?$` — bare zip.
+
+For `WHOLEFDS MKT AUSTIN TX 78701`, alternative 1 strips ` TX 78701`, leaving `WHOLEFDS MKT AUSTIN`. The regex runs once via `.sub()`, so the orphaned city is not removed. The fix: add a fourth alternative that matches city+state+zip as a unit, OR widen alternative 1 to optionally consume a leading city token.
+
+Decision: widen alternative 1. The new pattern is:
+
+```
+(?:[A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+)*\s+)?[A-Z]{2}\s+\d{5}(?:-\d{4})?$
+```
+
+The leading optional group matches one or more capitalized tokens (covering all-caps `AUSTIN` and mixed-case `San Francisco`).
+
+No code change yet — proceed to Task 4.
+
+---
+
+## Task 4: Fix the trailing city+state+zip regex (GREEN)
+
+**Files:**
+- Modify: `src/moneybin/services/_text.py:18-24`
+
+- [ ] **Step 1: Apply the regex change**
+
+Replace the current `_TRAILING_LOCATION` definition:
+
+```python
+# Trailing location: city/state/zip patterns
+_TRAILING_LOCATION = re.compile(
+    r"\s+"
+    r"(?:[A-Z]{2}\s+\d{5}(?:-\d{4})?$"  # ST 12345 or ST 12345-6789
+    r"|[A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)*,?\s+[A-Z]{2}$"  # City, ST (city must be 3+ chars)
+    r"|\d{5}(?:-\d{4})?$"  # bare zip code
+    r")"
+)
+```
+
+with:
+
+```python
+# Trailing location: city/state/zip patterns
+_TRAILING_LOCATION = re.compile(
+    r"\s+"
+    r"(?:(?:[A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+)*\s+)?[A-Z]{2}\s+\d{5}(?:-\d{4})?$"  # [City ]ST 12345 [-6789]
+    r"|[A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)*,?\s+[A-Z]{2}$"  # City, ST
+    r"|\d{5}(?:-\d{4})?$"  # bare zip code
+    r")"
+)
+```
+
+The change: the first alternative now has an optional leading `(?:[A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+)*\s+)?` that consumes a city token before the state+zip. The other two alternatives are unchanged.
+
+- [ ] **Step 2: Run the goldens — expect all 13 to pass**
+
+Run: `uv run pytest tests/moneybin/test_services/test_categorization_service.py::TestNormalizeDescriptionGoldens -v`
+
+Expected: `13 passed`.
+
+- [ ] **Step 3: Run the full categorization-service test file — expect no regressions**
+
+Run: `uv run pytest tests/moneybin/test_services/test_categorization_service.py -v`
+
+Expected: all tests pass (the old `TestNormalizeDescription` still exists and will still pass — its assertions are looser, so a tighter regex does not break them).
+
+- [ ] **Step 4: Run the auto-rule-service tests — these are the real downstream consumers**
+
+Run: `uv run pytest tests/moneybin/test_services/test_auto_rule_service.py -v`
+
+Expected: all tests pass. If any fail, the regex change perturbed `_extract_pattern` behavior — investigate and adjust the regex rather than relaxing the test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/moneybin/services/_text.py
+git commit -m "fix: strip all-caps city before state+zip in normalize_description"
+```
+
+---
+
+## Task 5: Remove the old `TestNormalizeDescription` class
+
+**Files:**
+- Modify: `tests/moneybin/test_services/test_categorization_service.py`
+
+The new goldens class subsumes every case in the old class. Removing it eliminates the loose-assertion shape entirely.
+
+- [ ] **Step 1: Delete the old class**
+
+Find the block starting `class TestNormalizeDescription:` (around line 118) through the last method `test_normalizes_whitespace` (around line 165). Delete the entire class definition and its docstring/comment header (the `# ---` separator above it can stay or go; preserve symmetry with the surrounding sections).
+
+- [ ] **Step 2: Run the full test file**
+
+Run: `uv run pytest tests/moneybin/test_services/test_categorization_service.py -v`
+
+Expected: all tests pass; the test count drops by 10 (the deleted class) but adds 13 (the parametrized goldens) — net +3.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/moneybin/test_services/test_categorization_service.py
+git commit -m "test: remove TestNormalizeDescription class superseded by goldens"
+```
+
+---
+
+## Task 6: Add a loader test for duplicate ids
+
+**Files:**
+- Modify: `tests/moneybin/test_services/test_categorization_service.py`
+
+Requirement 4 of the spec: the loader rejects duplicate `id` values. Currently this is implemented in `_load_normalize_cases` but uncovered.
+
+- [ ] **Step 1: Write a failing test that exercises the duplicate-id branch**
+
+Add the following test method to `TestNormalizeDescriptionGoldens` (or as a sibling top-level test if the class style does not fit):
+
+```python
+    @pytest.mark.unit
+    def test_loader_rejects_duplicate_ids(self, tmp_path: Path) -> None:
+        """The loader must surface duplicate ids loudly at collection time."""
+        bad_yaml = tmp_path / "dup.yaml"
+        bad_yaml.write_text(
+            "cases:\n"
+            '  - {id: a, raw: "x", expected: "x"}\n'
+            '  - {id: a, raw: "y", expected: "y"}\n'
+        )
+
+        # Inline the loader logic against the temp file rather than
+        # monkeypatching the module-level constant.
+        import yaml as _yaml
+        raw = _yaml.safe_load(bad_yaml.read_text())
+        cases = raw["cases"]
+        ids = [c["id"] for c in cases]
+        duplicates = {i for i in ids if ids.count(i) > 1}
+        assert duplicates == {"a"}
+```
+
+This test pins the duplicate-detection behavior. It is intentionally inline (not calling `_load_normalize_cases`) because `_load_normalize_cases` is bound to the real fixture path; refactoring it to take an injectable path is YAGNI for one test. If a future test wants to exercise more loader behavior, refactor then.
+
+- [ ] **Step 2: Run the new test**
+
+Run: `uv run pytest tests/moneybin/test_services/test_categorization_service.py::TestNormalizeDescriptionGoldens::test_loader_rejects_duplicate_ids -v`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/moneybin/test_services/test_categorization_service.py
+git commit -m "test: pin duplicate-id detection for normalize_description fixtures"
+```
+
+---
+
+## Task 7: Document the contribution surface
+
+**Files:**
+- Modify: `.claude/rules/testing.md`
+
+- [ ] **Step 1: Read the current structure of testing.md**
+
+Run: `grep -n "^##\|^###" .claude/rules/testing.md`
+
+Confirm there is a section near "Test Fixture Factories". The new subsection is added immediately after it.
+
+- [ ] **Step 2: Insert the new subsection**
+
+Locate the end of the `## Test Fixture Factories` section (it ends just before the `## Test Coverage by Layer` heading). Insert the following before the next `##`:
+
+```markdown
+## Golden-Case Fixtures
+
+For pure functions whose correctness is best expressed as a table of
+`(input → expected_output)` pairs (e.g., `normalize_description`), keep the
+cases in a YAML file under `tests/.../fixtures/` and a parametrized test that
+asserts exact equality.
+
+**When to add a case:** You encountered a real-world input that should produce
+a specific output, and either no existing case covers it, or the function
+currently produces a different output than it should.
+
+**How to add a case:**
+
+1. Append a row to the fixture YAML (e.g.,
+   `tests/moneybin/test_services/fixtures/normalize_description_cases.yaml`).
+2. Give it a unique, kebab-case `id` that names the *behavior under test*,
+   not the input string.
+3. Run the test file. If your case fails, fix the function until it passes —
+   do NOT relax `expected` to match the current (incorrect) output.
+
+**Why exact equality:** Loose assertions (`"X" not in result`,
+`"Y" in result`) hide subtle regressions like extra whitespace, partial
+strips, or order changes. Goldens force every output character to be
+intentional.
+```
+
+- [ ] **Step 3: Verify the markdown renders cleanly**
+
+Run: `uv run python -c "import re; t = open('.claude/rules/testing.md').read(); assert '## Golden-Case Fixtures' in t; print('section present')"`
+
+Expected: `section present`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/rules/testing.md
+git commit -m "docs: document golden-case fixture contribution workflow"
+```
+
+---
+
+## Task 8: Pre-push quality pass
+
+**Files:** all changed files in this branch.
+
+Per `.claude/rules/shipping.md`, run the `/simplify` review and the standard pre-commit checklist before pushing.
+
+- [ ] **Step 1: Run formatter and linter**
+
+Run: `make format && make lint`
+
+Expected: clean.
+
+- [ ] **Step 2: Run type check on modified files**
+
+Run: `uv run pyright src/moneybin/services/_text.py tests/moneybin/test_services/test_categorization_service.py`
+
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 3: Run the full unit test suite**
+
+Run: `uv run pytest -m "not integration and not e2e" -q`
+
+Expected: all pass.
+
+- [ ] **Step 4: Run `make test`**
+
+Run: `make test`
+
+Expected: clean.
+
+- [ ] **Step 5: If anything from steps 1–4 fails, fix and amend the relevant commit**
+
+Do NOT push with any of the above failing.
+
+---
+
+## Task 9: Final commit and ready for PR
+
+**Files:** none (housekeeping).
+
+- [ ] **Step 1: Confirm the spec status entry in INDEX.md is in this branch**
+
+Run: `git log --oneline main..HEAD -- docs/specs/INDEX.md docs/specs/testing-normalize-description-fixtures.md`
+
+If those changes are not yet committed (they were carried via `git stash pop` from the brainstorming session), commit them now:
+
+```bash
+git add docs/specs/INDEX.md docs/specs/testing-normalize-description-fixtures.md
+git commit -m "docs: add spec for normalize_description golden fixtures"
+```
+
+- [ ] **Step 2: Confirm branch is ready**
+
+Run: `git log --oneline main..HEAD`
+
+Expected: a clean sequence of commits matching the tasks above (spec, fixture, RED test, regex fix, old class removal, loader test, docs, pre-push fixes if any).
+
+- [ ] **Step 3: Push and open PR (only on user request)**
+
+Do NOT push or open a PR without explicit user approval per the project's branching/shipping conventions.

--- a/src/moneybin/services/_text.py
+++ b/src/moneybin/services/_text.py
@@ -17,7 +17,7 @@ _POS_PREFIXES = re.compile(
 # Trailing location: city/state/zip patterns
 _TRAILING_LOCATION = re.compile(
     r"\s+"
-    r"(?:(?:[A-Z][A-Za-z]+\s+)?[A-Z]{2}\s+\d{5}(?:-\d{4})?$"  # [City ]ST 12345 [-6789]
+    r"(?:(?:[A-Z][A-Za-z]{3,}\s+)?[A-Z]{2}\s+\d{5}(?:-\d{4})?$"  # [City ]ST 12345 [-6789]
     r"|[A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)*,?\s+[A-Z]{2}$"  # City, ST
     r"|\d{5}(?:-\d{4})?$"  # bare zip code
     r")"

--- a/src/moneybin/services/_text.py
+++ b/src/moneybin/services/_text.py
@@ -17,7 +17,7 @@ _POS_PREFIXES = re.compile(
 # Trailing location: city/state/zip patterns
 _TRAILING_LOCATION = re.compile(
     r"\s+"
-    r"(?:(?:[A-Z][A-Za-z]{3,}\s+)?[A-Z]{2}\s+\d{5}(?:-\d{4})?$"  # [City ]ST 12345 [-6789]
+    r"(?:[A-Z]{2}\s+\d{5}(?:-\d{4})?$"  # ST 12345 [-6789]
     r"|[A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)*,?\s+[A-Z]{2}$"  # City, ST
     r"|\d{5}(?:-\d{4})?$"  # bare zip code
     r")"

--- a/src/moneybin/services/_text.py
+++ b/src/moneybin/services/_text.py
@@ -17,8 +17,8 @@ _POS_PREFIXES = re.compile(
 # Trailing location: city/state/zip patterns
 _TRAILING_LOCATION = re.compile(
     r"\s+"
-    r"(?:[A-Z]{2}\s+\d{5}(?:-\d{4})?$"  # ST 12345 or ST 12345-6789
-    r"|[A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)*,?\s+[A-Z]{2}$"  # City, ST (city must be 3+ chars)
+    r"(?:(?:[A-Z][A-Za-z]+\s+)?[A-Z]{2}\s+\d{5}(?:-\d{4})?$"  # [City ]ST 12345 [-6789]
+    r"|[A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)*,?\s+[A-Z]{2}$"  # City, ST
     r"|\d{5}(?:-\d{4})?$"  # bare zip code
     r")"
 )

--- a/tests/moneybin/test_services/fixtures/normalize_description_cases.yaml
+++ b/tests/moneybin/test_services/fixtures/normalize_description_cases.yaml
@@ -51,6 +51,11 @@ cases:
     expected: "WHOLEFDS MKT"
     note: "All-caps city before state+zip — exercises the city+state+zip-as-unit branch"
 
+  - id: short-token-before-state-zip-not-treated-as-city
+    raw: "SHELL GAS NY 10001"
+    expected: "SHELL GAS"
+    note: "City group requires 4+ chars so 'GAS' is not stripped as a city"
+
   - id: combined-prefix-store-id-city-state
     raw: "SQ *STARBUCKS #1234 SEATTLE WA"
     expected: "STARBUCKS"

--- a/tests/moneybin/test_services/fixtures/normalize_description_cases.yaml
+++ b/tests/moneybin/test_services/fixtures/normalize_description_cases.yaml
@@ -46,15 +46,15 @@ cases:
     raw: "TARGET 00012345"
     expected: "TARGET"
 
-  - id: whole-foods-trailing-state-zip
+  - id: trailing-state-zip-leaves-city-token
     raw: "WHOLEFDS MKT AUSTIN TX 78701"
-    expected: "WHOLEFDS MKT"
-    note: "All-caps city before state+zip — exercises the city+state+zip-as-unit branch"
+    expected: "WHOLEFDS MKT AUSTIN"
+    note: "Only ST+ZIP is stripped; trailing city token is preserved (safer for merchant matching than guessing which token is a city)"
 
-  - id: short-token-before-state-zip-not-treated-as-city
+  - id: merchant-token-before-state-zip-not-stripped-as-city
     raw: "SHELL GAS NY 10001"
     expected: "SHELL GAS"
-    note: "City group requires 4+ chars so 'GAS' is not stripped as a city"
+    note: "ST+ZIP stripped; preceding merchant tokens left intact"
 
   - id: combined-prefix-store-id-city-state
     raw: "SQ *STARBUCKS #1234 SEATTLE WA"

--- a/tests/moneybin/test_services/fixtures/normalize_description_cases.yaml
+++ b/tests/moneybin/test_services/fixtures/normalize_description_cases.yaml
@@ -1,0 +1,69 @@
+# Golden cases for moneybin.services._text.normalize_description.
+#
+# Add a case here when you encounter a real transaction description that
+# should normalize a specific way. Each case is run through
+# normalize_description(raw) and asserted equal to expected.
+#
+# If a new case fails, fix the regexes in src/moneybin/services/_text.py
+# until it passes. Do NOT relax `expected` to match the current output.
+#
+# Schema:
+#   id       (str, required, unique) — pytest parametrize id
+#   raw      (str, required)         — input passed verbatim
+#   expected (str, required)         — exact expected output
+#   note     (str, optional)         — reviewer-facing context
+cases:
+  - id: square-prefix-and-store-id
+    raw: "SQ *STARBUCKS #1234"
+    expected: "STARBUCKS"
+    note: "Square POS prefix + trailing store id"
+
+  - id: toast-prefix
+    raw: "TST*PIZZA PLACE"
+    expected: "PIZZA PLACE"
+
+  - id: paypal-short-prefix
+    raw: "PP*SPOTIFY"
+    expected: "SPOTIFY"
+
+  - id: paypal-long-prefix
+    raw: "PAYPAL *NETFLIX"
+    expected: "NETFLIX"
+
+  - id: venmo-prefix
+    raw: "VENMO *JOHN DOE"
+    expected: "JOHN DOE"
+
+  - id: cke-prefix-with-trailing-id
+    raw: "CKE*CHIPOTLE 02345"
+    expected: "CHIPOTLE"
+
+  - id: trailing-city-state
+    raw: "STARBUCKS SEATTLE WA"
+    expected: "STARBUCKS"
+
+  - id: trailing-store-id
+    raw: "TARGET 00012345"
+    expected: "TARGET"
+
+  - id: whole-foods-trailing-state-zip
+    raw: "WHOLEFDS MKT AUSTIN TX 78701"
+    expected: "WHOLEFDS MKT"
+    note: "All-caps city before state+zip — exercises the city+state+zip-as-unit branch"
+
+  - id: combined-prefix-store-id-city-state
+    raw: "SQ *STARBUCKS #1234 SEATTLE WA"
+    expected: "STARBUCKS"
+    note: "Prefix, store id, and city+state all present"
+
+  - id: collapses-multiple-spaces
+    raw: "SQ  *  COFFEE   SHOP"
+    expected: "COFFEE SHOP"
+
+  - id: empty-string
+    raw: ""
+    expected: ""
+
+  - id: whitespace-only
+    raw: "   "
+    expected: ""

--- a/tests/moneybin/test_services/test_categorization_service.py
+++ b/tests/moneybin/test_services/test_categorization_service.py
@@ -4,6 +4,7 @@ Covers merchant normalization, pattern matching, rule engine, merchant
 matching, prompt construction, and response parsing.
 """
 
+from collections import Counter
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
@@ -120,20 +121,26 @@ _FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 def _load_normalize_cases(
     path: Path | None = None,
-) -> list[dict[str, str]]:
+) -> list[dict[str, Any]]:
     """Load normalize_description golden cases from YAML.
 
-    Raises ValueError if any `id` is duplicated to prevent silent shadowing
-    when contributors append cases.
+    Validates that each case has string `raw` and `expected` fields, and that
+    `id` values are unique to prevent silent shadowing when contributors append
+    cases.
     """
     if path is None:
         path = _FIXTURES_DIR / "normalize_description_cases.yaml"
     raw = yaml.safe_load(path.read_text())
     cases = raw["cases"]
-    ids = [c["id"] for c in cases]
-    duplicates = {i for i in ids if ids.count(i) > 1}
+    counts = Counter(c["id"] for c in cases)
+    duplicates = sorted(i for i, n in counts.items() if n > 1)
     if duplicates:
-        raise ValueError(f"Duplicate case ids: {sorted(duplicates)}")
+        raise ValueError(f"Duplicate case ids: {duplicates}")
+    for c in cases:
+        if not isinstance(c.get("raw"), str) or not isinstance(c.get("expected"), str):
+            raise ValueError(
+                f"Case {c.get('id')!r}: 'raw' and 'expected' must be strings"
+            )
     return cases
 
 
@@ -146,7 +153,7 @@ class TestNormalizeDescriptionGoldens:
 
     @pytest.mark.unit
     @pytest.mark.parametrize("case", _load_normalize_cases(), ids=lambda c: c["id"])
-    def test_case(self, case: dict[str, str]) -> None:
+    def test_case(self, case: dict[str, Any]) -> None:
         assert normalize_description(case["raw"]) == case["expected"]
 
     @pytest.mark.unit

--- a/tests/moneybin/test_services/test_categorization_service.py
+++ b/tests/moneybin/test_services/test_categorization_service.py
@@ -122,12 +122,7 @@ _FIXTURES_DIR = Path(__file__).parent / "fixtures"
 def _load_normalize_cases(
     path: Path | None = None,
 ) -> list[dict[str, Any]]:
-    """Load normalize_description golden cases from YAML.
-
-    Validates that each case has string `raw` and `expected` fields, and that
-    `id` values are unique to prevent silent shadowing when contributors append
-    cases.
-    """
+    """Load and validate normalize_description golden cases from YAML."""
     if path is None:
         path = _FIXTURES_DIR / "normalize_description_cases.yaml"
     raw = yaml.safe_load(path.read_text())
@@ -145,11 +140,7 @@ def _load_normalize_cases(
 
 
 class TestNormalizeDescriptionGoldens:
-    """Golden cases for normalize_description loaded from YAML.
-
-    See tests/moneybin/test_services/fixtures/normalize_description_cases.yaml
-    for the fixture format and contributor instructions.
-    """
+    """Parametrized golden-case tests for normalize_description()."""
 
     @pytest.mark.unit
     @pytest.mark.parametrize("case", _load_normalize_cases(), ids=lambda c: c["id"])

--- a/tests/moneybin/test_services/test_categorization_service.py
+++ b/tests/moneybin/test_services/test_categorization_service.py
@@ -118,15 +118,17 @@ def db_with_transactions(db: Database) -> Database:
 _FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
-def _load_normalize_cases() -> list[dict[str, str]]:
+def _load_normalize_cases(
+    path: Path | None = None,
+) -> list[dict[str, str]]:
     """Load normalize_description golden cases from YAML.
 
     Raises ValueError if any `id` is duplicated to prevent silent shadowing
     when contributors append cases.
     """
-    raw = yaml.safe_load(
-        (_FIXTURES_DIR / "normalize_description_cases.yaml").read_text()
-    )
+    if path is None:
+        path = _FIXTURES_DIR / "normalize_description_cases.yaml"
+    raw = yaml.safe_load(path.read_text())
     cases = raw["cases"]
     ids = [c["id"] for c in cases]
     duplicates = {i for i in ids if ids.count(i) > 1}
@@ -146,6 +148,19 @@ class TestNormalizeDescriptionGoldens:
     @pytest.mark.parametrize("case", _load_normalize_cases(), ids=lambda c: c["id"])
     def test_case(self, case: dict[str, str]) -> None:
         assert normalize_description(case["raw"]) == case["expected"]
+
+    @pytest.mark.unit
+    def test_loader_rejects_duplicate_ids(self, tmp_path: Path) -> None:
+        """The loader must surface duplicate ids loudly at collection time."""
+        bad_yaml = tmp_path / "dup.yaml"
+        bad_yaml.write_text(
+            "cases:\n"
+            '  - {id: a, raw: "x", expected: "x"}\n'
+            '  - {id: a, raw: "y", expected: "y"}\n'
+        )
+
+        with pytest.raises(ValueError, match="Duplicate case ids"):
+            _load_normalize_cases(bad_yaml)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/moneybin/test_services/test_categorization_service.py
+++ b/tests/moneybin/test_services/test_categorization_service.py
@@ -148,56 +148,6 @@ class TestNormalizeDescriptionGoldens:
         assert normalize_description(case["raw"]) == case["expected"]
 
 
-class TestNormalizeDescription:
-    """Tests for normalize_description()."""
-
-    @pytest.mark.unit
-    def test_strips_square_prefix(self) -> None:
-        assert normalize_description("SQ *STARBUCKS #1234") == "STARBUCKS"
-
-    @pytest.mark.unit
-    def test_strips_toast_prefix(self) -> None:
-        assert normalize_description("TST*PIZZA PLACE") == "PIZZA PLACE"
-
-    @pytest.mark.unit
-    def test_strips_paypal_prefix(self) -> None:
-        assert normalize_description("PP*SPOTIFY") == "SPOTIFY"
-
-    @pytest.mark.unit
-    def test_strips_trailing_state_zip(self) -> None:
-        result = normalize_description("WHOLEFDS MKT AUSTIN TX 78701")
-        assert "78701" not in result
-
-    @pytest.mark.unit
-    def test_strips_trailing_city_state(self) -> None:
-        result = normalize_description("STARBUCKS SEATTLE WA")
-        assert "SEATTLE" not in result
-        assert "WA" not in result
-
-    @pytest.mark.unit
-    def test_strips_trailing_store_id(self) -> None:
-        result = normalize_description("TARGET 00012345")
-        assert "00012345" not in result
-
-    @pytest.mark.unit
-    def test_preserves_core_name(self) -> None:
-        assert "STARBUCKS" in normalize_description("SQ *STARBUCKS #1234 SEATTLE WA")
-
-    @pytest.mark.unit
-    def test_empty_string(self) -> None:
-        assert normalize_description("") == ""
-
-    @pytest.mark.unit
-    def test_none_handled(self) -> None:
-        # normalize_description expects str but should handle edge cases
-        assert normalize_description("   ") == ""
-
-    @pytest.mark.unit
-    def test_normalizes_whitespace(self) -> None:
-        result = normalize_description("SQ  *  COFFEE   SHOP")
-        assert "  " not in result
-
-
 # ---------------------------------------------------------------------------
 # Pattern matching
 # ---------------------------------------------------------------------------

--- a/tests/moneybin/test_services/test_categorization_service.py
+++ b/tests/moneybin/test_services/test_categorization_service.py
@@ -10,6 +10,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+import yaml
 from pytest_mock import MockerFixture
 
 from moneybin.database import Database
@@ -113,6 +114,38 @@ def db_with_transactions(db: Database) -> Database:
 # ---------------------------------------------------------------------------
 # Merchant name normalization
 # ---------------------------------------------------------------------------
+
+_FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def _load_normalize_cases() -> list[dict[str, str]]:
+    """Load normalize_description golden cases from YAML.
+
+    Raises ValueError if any `id` is duplicated to prevent silent shadowing
+    when contributors append cases.
+    """
+    raw = yaml.safe_load(
+        (_FIXTURES_DIR / "normalize_description_cases.yaml").read_text()
+    )
+    cases = raw["cases"]
+    ids = [c["id"] for c in cases]
+    duplicates = {i for i in ids if ids.count(i) > 1}
+    if duplicates:
+        raise ValueError(f"Duplicate case ids: {sorted(duplicates)}")
+    return cases
+
+
+class TestNormalizeDescriptionGoldens:
+    """Golden cases for normalize_description loaded from YAML.
+
+    See tests/moneybin/test_services/fixtures/normalize_description_cases.yaml
+    for the fixture format and contributor instructions.
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("case", _load_normalize_cases(), ids=lambda c: c["id"])
+    def test_case(self, case: dict[str, str]) -> None:
+        assert normalize_description(case["raw"]) == case["expected"]
 
 
 class TestNormalizeDescription:


### PR DESCRIPTION
## Summary
Closes the test-coverage gap on `normalize_description()` by introducing a YAML-driven golden-case fixture with exact-equality assertions. Contributors can now extend coverage by appending YAML rows.

## Impact
- New contribution surface: `tests/moneybin/test_services/fixtures/normalize_description_cases.yaml` is the canonical place to add normalization test cases.
- New `.claude/rules/testing.md` section ("Golden-Case Fixtures") documents the pattern for future pure-function tests.
- No behavior change in `normalize_description()` itself — the goldens lock in current behavior. A previously-attempted city-stripping regex change was reverted during review (false-positive merchant tokens); see `docs/followups.md` for the deferred work.

## Changes

### Spec & plan
- `docs/specs/testing-normalize-description-fixtures.md` (status: implemented) and `INDEX.md` entry
- `docs/superpowers/plans/2026-04-30-normalize-description-fixtures.md`

### Golden-case fixture and parametrized tests
- `tests/moneybin/test_services/fixtures/normalize_description_cases.yaml` — 13 cases covering prefixes (Square/Toast/PayPal/Venmo/CKE), trailing locations, combined patterns, and edge cases
- `_load_normalize_cases()` validates schema (string `raw`/`expected`) and rejects duplicate `id`s via `Counter`
- `TestNormalizeDescriptionGoldens` parametrizes over the YAML; legacy `TestNormalizeDescription` class removed (superseded)

### Rule documentation
- `.claude/rules/testing.md`: new "Golden-Case Fixtures" section codifying when/how to add cases

### Follow-up tracked
- `docs/followups.md`: city-token stripping limitation (`WHOLEFDS MKT AUSTIN TX 78701` → `WHOLEFDS MKT AUSTIN`) with fix paths outlined — deferred because the lexical regex can't distinguish merchant tokens from cities.

## Testing
- 49/49 categorization service tests pass; full unit suite (1239 tests) green
- `make check test` clean (format, lint, pyright, pytest)
- Loader-rejection test exercises real `ValueError` branch via `path` parameter seam

## Notes
- `.claude/rules/testing.md` will conflict with PR #67 (also adds a section there). Whichever merges second needs to rebase.