### PR TITLE
Add comprehensive scenario testing spec and bug-report recipe

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -148,3 +148,20 @@ When adding a new CLI command:
 - No shared mutable state between tests.
 - Use `monkeypatch` for env vars.
 - Descriptive test names that explain the scenario.
+
+## Scenario Expectations Must Be Independently Derived
+
+Scenario assertions, expectations, and tolerances must be derived **independently of the program's output**. A test that codifies "what the code currently produces" only proves the code is consistent with itself — it does not prove the code is correct.
+
+When authoring or modifying a scenario:
+
+1. **Allowed derivation paths.** Expected row counts, match outcomes, category labels, and tolerances must come from one of:
+   - **The input fixture** — count the rows yourself; label outcomes by hand before running the pipeline.
+   - **The persona / generator config** — derive expected values via a deterministic formula over declared parameters (e.g., `years × accounts × mean_txns_per_month × 12`).
+   - **Hand-authored ground truth** written *before* running the pipeline.
+2. **Forbidden: observe-and-paste.** Running the scenario, observing the output, and pasting the resulting number into the YAML is not acceptable, even if the output "looks right."
+3. **Tolerances require a formula.** A bare `±15%` is not acceptable. Any tolerance must accompany the formula it absorbs and a comment explaining the source of variance (e.g., "seeded RNG produces ±5% per year over 3 years → ~15%").
+4. **When code change breaks an expectation, fix the code first.** The default response to a failing scenario expectation is to investigate the code, not to update the expectation. Updating the expectation requires a written justification in the PR explaining why the new value is correct in itself — not "what the new code produces."
+5. **Negative expectations are required where applicable.** If a scenario asserts "these N records should match," it must also include cases that should *not* match. Otherwise the test only catches under-matching, not over-matching.
+
+This rule applies to YAML scenario expectations, pytest assertions in `tests/scenarios/`, and any future bug-report-driven scenario. See [`docs/specs/testing-scenario-comprehensive.md`](../../docs/specs/testing-scenario-comprehensive.md) for the full taxonomy and contributor recipe.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,17 @@ moneybin synthetic verify --scenario basic-full-pipeline
 moneybin synthetic verify --all --output json          # CI mode
 ```
 
-Scenarios live at `src/moneybin/testing/scenarios/data/*.yaml`. The runner is documented in [`docs/specs/testing-scenario-runner.md`](docs/specs/testing-scenario-runner.md).
+Scenarios live at `src/moneybin/testing/scenarios/data/*.yaml`. The runner is documented in [`docs/specs/testing-scenario-runner.md`](docs/specs/testing-scenario-runner.md). Per [`docs/specs/testing-scenario-comprehensive.md`](docs/specs/testing-scenario-comprehensive.md), scenarios are migrating to `tests/scenarios/` as pytest tests.
+
+### Authoring a new scenario (especially for a user bug report)
+
+The prescribed recipe is in [`docs/guides/scenario-authoring.md`](docs/guides/scenario-authoring.md). Summary:
+
+1. Get the bug report and an anonymized DB snapshot ([`testing-anonymized-data.md`](docs/specs/testing-anonymized-data.md)) — never commit raw user data.
+2. Build a fixture under `tests/scenarios/data/fixtures/<bug-id>/`.
+3. Write the expectation **independently of program output** — derive it from the fixture, the persona config, or hand-authored ground truth. Never observe-and-paste. See [`.claude/rules/testing.md`](.claude/rules/testing.md) "Scenario Expectations Must Be Independently Derived."
+4. Verify the scenario fails on the broken code, then passes on the fix.
+5. Cover Tier 1 invariants (always) plus relevant Tier 2–4 checks per [`docs/specs/testing-scenario-comprehensive.md`](docs/specs/testing-scenario-comprehensive.md).
 
 ## Working with synthetic data
 

--- a/docs/guides/scenario-authoring.md
+++ b/docs/guides/scenario-authoring.md
@@ -1,0 +1,163 @@
+# Scenario Authoring Guide
+
+This guide is the prescribed recipe for adding a scenario to MoneyBin's pipeline test suite — most commonly to reproduce a user bug report and lock in regression coverage. It is written so a coding agent can execute it end-to-end given only a bug report and (ideally) an anonymized DB snapshot.
+
+**Architectural authority:** The taxonomy and rules below come from [`docs/specs/testing-scenario-comprehensive.md`](../specs/testing-scenario-comprehensive.md) and [`.claude/rules/testing.md`](../../.claude/rules/testing.md). Read both before authoring. They are normative — deviations need explicit PR justification.
+
+---
+
+## When to Author a Scenario
+
+| Situation | Author a scenario? |
+|---|---|
+| User bug report involving the data pipeline (raw → prep → core) | **Yes** |
+| User bug report involving matching, categorization, transfers, or reconciliation | **Yes** |
+| User bug report in pure CLI / argument parsing | No — add an E2E test instead |
+| Internal refactor with no behavior change | No — existing scenarios cover regressions |
+| New pipeline stage or new data source | **Yes** — add a scenario alongside the feature |
+
+---
+
+## The Recipe
+
+### Step 1 — Capture the bug
+
+Collect from the user (or the report intake flow):
+
+1. **Symptom**: what they expected vs. what happened (e.g., "I imported X, ran transform, and saw 17 transactions in core; should have been 20").
+2. **Reproducer data**: an anonymized snapshot of the relevant slice of their database, produced via [`testing-anonymized-data.md`](../specs/testing-anonymized-data.md) tooling. If the anonymizer is not yet available, hand-author a minimal fixture — see Step 2.
+3. **Pipeline stage where the bug manifests**: import? transform? match? categorize?
+4. **Affected tables / fields**: which `core.*` table shows the wrong value.
+
+Do **not** copy un-anonymized real user data into the repo under any circumstance. If you cannot produce an anonymized fixture, stop and route the report through the privacy-aware intake.
+
+### Step 2 — Build the fixture
+
+Place the fixture under `tests/scenarios/data/fixtures/<bug-id>/`. Choose `<bug-id>` to be a stable, descriptive slug (`csv-amazon-trailing-comma`, `transfer-same-day-collision`).
+
+Fixture types:
+
+- **CSV / OFX / PDF input file**: drop the anonymized export at `<bug-id>/input.csv` (or `.ofx`, etc.).
+- **Pre-loaded raw rows**: a YAML file describing rows to insert directly into raw tables (used when the bug is in `transform` or downstream and you don't need to re-exercise the loader).
+- **Pre-loaded core state**: rare; only when reproducing a bug in a downstream stage that depends on existing state.
+
+Add a `<bug-id>/README.md` with:
+
+- The original symptom (anonymized — no user names, no real merchants).
+- Why the fixture has the shape it does (which row triggers the bug and why).
+- The expected behavior, derived independently of the broken code.
+
+### Step 3 — Express the bug as an expectation (independently derived)
+
+This is the most important step. The expectation must be derivable from the fixture alone — not from running the broken code, not from running the *fixed* code, not from "looks right."
+
+Allowed derivation paths (per `.claude/rules/testing.md`):
+
+1. **Count the input fixture by hand.** "I authored 20 rows in `input.csv`. After dedup, 3 are duplicates of one other. Expected: 17 rows in `fct_transactions`."
+2. **Derive from persona / generator config.** "Family persona, 3 accounts × 3 years × 80 txns/account/month × 12 months = 8,640 rows."
+3. **Hand-author ground truth.** "I labeled rows 4 and 7 as a transfer pair. Expected: `fct_transactions` shows them sharing a `transfer_pair_id`."
+
+Forbidden:
+
+- Running the scenario, observing the row count, and pasting it into the YAML.
+- Bare tolerance bands (`±15%`) without a formula for the variance source.
+- "It currently produces this, so that's the expected value."
+
+If your scenario asserts positive matching, **also include negative cases** — records that should *not* match — under the same fixture. Otherwise you only catch under-matching, not over-matching.
+
+### Step 4 — Pick the tier coverage
+
+Per [`testing-scenario-comprehensive.md`](../specs/testing-scenario-comprehensive.md), every scenario covers:
+
+- **Tier 1 (Structural Invariants) — required.** Row counts, schema, FK integrity, no-NULLs, no-dupes, source attribution, provenance, sign convention, amount precision, date bounds.
+- **Tier 2 (Semantic Correctness) — when applicable.** Balanced transfers, P/R for categorization/transfers, match confidence, negative expectations.
+- **Tier 3 (Pipeline Behavior) — for behavior bugs.** Idempotency, incremental safety, empty-input, malformed-input, subprocess parity.
+- **Tier 4 (Distribution / Quality) — for multi-account or multi-year fixtures.** Amount distribution, date continuity, ground-truth coverage, category distribution.
+- **Tier 5 (Operational) — opt-in.** Duration, memory.
+
+Declare the tier coverage in the test docstring (e.g., `tiers: T1, T2-balanced-transfers, T3-incremental`).
+
+### Step 5 — Write the test
+
+Tests live in `tests/scenarios/test_<bug-id>.py`. Use the shared fixtures from `tests/scenarios/conftest.py` to bootstrap an encrypted DB and isolated `MONEYBIN_HOME`.
+
+Use the assertion primitives from `src/moneybin/validation/`:
+
+```python
+import pytest
+from moneybin.validation import (
+    assert_row_count,
+    assert_no_duplicates,
+    assert_source_system_populated,
+    assert_negative_match,
+)
+
+
+@pytest.mark.scenarios
+def test_csv_amazon_trailing_comma(scenario_db, load_fixture, run_pipeline):
+    """Reproduce bug #142: trailing comma in Amazon CSV row dropped from raw.
+
+    tiers: T1, T3-malformed-input
+    derivation: 20 rows in input.csv counted by hand; 3 are intentional dupes.
+    """
+    load_fixture("csv-amazon-trailing-comma/input.csv")
+    run_pipeline(["transform", "match"])
+
+    assert_row_count(scenario_db, "raw.tabular_transactions", expected=20)
+    assert_row_count(scenario_db, "core.fct_transactions", expected=17)
+    assert_no_duplicates(scenario_db, "core.fct_transactions", "transaction_id")
+    assert_source_system_populated(scenario_db, expected={"csv"})
+```
+
+### Step 6 — Verify failure first
+
+Before fixing the bug, **run the new scenario against the broken code**. It must fail with the same symptom the user reported. If it doesn't, your fixture or expectation doesn't actually capture the bug — go back to Step 2 or 3.
+
+```bash
+uv run pytest tests/scenarios/test_<bug-id>.py -v
+```
+
+### Step 7 — Fix the code → verify pass
+
+Now fix the underlying bug. Re-run:
+
+```bash
+uv run pytest tests/scenarios/test_<bug-id>.py -v
+make verify-scenarios   # confirm no regressions in other scenarios
+```
+
+Both must pass. If the fix breaks another scenario, that's signal — investigate before updating any expectations. Per the independent-expectations rule, "the new code produces a different number" is not justification.
+
+### Step 8 — Land
+
+Open a PR with:
+
+- The fixture
+- The new test
+- The fix
+- A note in the PR description linking to the original bug report
+
+The scenario is now permanent regression coverage. Future code changes that re-introduce the bug will fail this test in CI.
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Pasted observed row count into expected | Re-derive from fixture or persona config |
+| Tolerance band with no formula | Add a comment explaining the variance source, or replace with exact value |
+| Only positive expectations | Add a negative fixture: records that should *not* match |
+| Skipped Tier 1 because "the bug isn't structural" | Tier 1 is always required — they're cheap and catch unrelated regressions |
+| Used real user data because anonymizer wasn't ready | Hand-author a minimal fixture instead — never commit raw user data |
+| Test passes against broken code | Fixture or expectation is wrong — not the code |
+
+---
+
+## Reference
+
+- [`docs/specs/testing-scenario-comprehensive.md`](../specs/testing-scenario-comprehensive.md) — full taxonomy and architectural rules
+- [`.claude/rules/testing.md`](../../.claude/rules/testing.md) — independent-expectations rule
+- [`docs/specs/testing-anonymized-data.md`](../specs/testing-anonymized-data.md) — anonymizer (the prescribed fixture-production tool)
+- [`docs/specs/testing-scenario-runner.md`](../specs/testing-scenario-runner.md) — pre-existing assertion / expectation / evaluation primitives
+- [`docs/specs/data-reconciliation.md`](../specs/data-reconciliation.md) — runtime user-facing checks that share assertion primitives

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -89,8 +89,9 @@ Single source of truth for spec status. Update this table when a spec's status c
 | [E2E Testing](e2e-testing.md) | Feature | implemented | Subprocess-based E2E tests: smoke tests (help, no-DB, DB commands), golden-path workflow tests (synthetic, CSV, OFX, lock/unlock, categorization) |
 | [Scenario Runner](testing-scenario-runner.md) | Feature | implemented | Whole-pipeline correctness: empty DB → pipeline → assertions/expectations/evaluations against synthetic ground truth and hand-labeled fixtures; `moneybin synthetic verify` CLI; validation primitives reusable for live-data checks |
 | [Normalize-Description Fixtures](testing-normalize-description-fixtures.md) | Feature | implemented | YAML golden cases for `normalize_description()`; parametrized exact-equality tests; contributor-facing surface for adding real-world transaction descriptions |
+| [Comprehensive Scenario Testing](testing-scenario-comprehensive.md) | Feature | draft | Five-tier assertion taxonomy, independent-expectations rule, bug-report recipe, relocation of scenarios to `tests/scenarios/`. Architectural authority for all future scenario work. |
+| [Anonymized Data Generator](testing-anonymized-data.md) | Feature | planned | Structure-preserving anonymization of real databases for shipping bug-report fixtures and format seeds without leaking PII; statistical similarity guarantees. |
 | `testing-csv-fixtures.md` | Feature | planned | Curated bank export samples with expected-result YAML for format detection testing |
-| `testing-anonymized-data.md` | Feature | planned | Structure-preserving anonymization of real databases with statistical similarity guarantees |
 | `testing-format-compat.md` | Feature | planned | Extractor verification against fixture files |
 | `testing-migration-safety.md` | Feature | planned | Pre/post migration data integrity assertions |
 

--- a/docs/specs/testing-anonymized-data.md
+++ b/docs/specs/testing-anonymized-data.md
@@ -1,0 +1,88 @@
+# Feature: Anonymized Data Generator
+
+## Status
+planned
+
+## Goal
+
+Produce a structure-preserving anonymized copy of a real user's MoneyBin database — preserving statistical properties (transaction distributions, account relationships, spending patterns, temporal cadence) while removing personally-identifying detail (real merchant names, exact amounts, exact dates, account identifiers, descriptions). The anonymized output is the **prescribed mechanism for shipping scenario fixtures and bug-report reproductions** without leaking PII.
+
+## Background
+
+MoneyBin is a personal financial data warehouse. Real user data is the most valuable test corpus we have — it captures format quirks, edge cases, and provider behaviors that synthetic personas cannot. But shipping real data is a privacy non-starter. The synthetic data generator ([`testing-synthetic-data.md`](testing-synthetic-data.md)) covers Level 2 realism for life-like financial histories, but cannot reproduce the *specific* bug-triggering data shape that a user encountered.
+
+This spec fills that gap. It is a **peer child spec** of `testing-overview.md` alongside the synthetic generator: different problem (data masking pipeline vs. financial life simulator), same output layer (`synthetic` schema, raw table writes).
+
+### Primary use cases
+
+1. **Automated bug reports.** When a user files a bug, the support flow (manual today, eventually automated via an agent loop) produces an anonymized snapshot of the relevant slice of their database. The snapshot becomes a fixture under `tests/scenarios/data/fixtures/<bug-id>/`. A scenario authored against that fixture per [`testing-scenario-comprehensive.md`](testing-scenario-comprehensive.md)'s recipe gives permanent regression coverage.
+2. **Format-compatibility seeds.** Anonymized real CSV/OFX exports populate `tests/fixtures/csv_formats/` per the deferred [`testing-csv-fixtures.md`](testing-csv-fixtures.md).
+3. **Distribution-faithful evaluation corpora.** Categorization and matching evaluations run against anonymized real data alongside synthetic personas, providing a sanity check that scores aren't gaming the synthetic generator's biases.
+
+### Why this is a separate engine
+
+The synthetic generator builds data from declared persona parameters. The anonymizer transforms existing data through a masking pipeline. They share the output schema but nothing else — different inputs, different operations, different correctness criteria. Co-locating them would couple a creative simulator with a deterministic transformer.
+
+### Related specs
+
+- [`testing-overview.md`](testing-overview.md) — umbrella; this is a child spec.
+- [`testing-synthetic-data.md`](testing-synthetic-data.md) — peer; same output layer, different engine.
+- [`testing-scenario-comprehensive.md`](testing-scenario-comprehensive.md) — primary consumer; defines the bug-report recipe that depends on this anonymizer.
+- [`privacy-data-protection.md`](privacy-data-protection.md) — the privacy guarantees this spec must not violate.
+- [`privacy-and-ai-trust.md`](privacy-and-ai-trust.md) — the redaction primitives some of this work will reuse.
+
+## Design Principles
+
+1. **Statistical similarity, not identity.** Anonymized output must preserve distributions (amount histograms, merchant frequencies, category mix, inter-arrival times, account relationships) within configurable tolerance. It must not preserve any single record's identifying detail.
+2. **Re-identification resistance.** No combination of anonymized fields should be sufficient to recover a real merchant, real amount, real date, or real account. Standards target: k-anonymity ≥ k for all quasi-identifier projections; documented threat model.
+3. **Round-trippable through the existing pipeline.** Anonymized data writes to the same raw schemas as real imports, so the full `transform → match → categorize` pipeline runs unchanged on it. This is what makes scenario fixtures real-shaped.
+4. **Ground-truth preservation where present.** If the source database has user-confirmed categorizations or transfer pairs, the anonymizer preserves those labels (mapped to anonymized IDs) so evaluations have ground truth.
+5. **Deterministic given a seed.** Re-running the anonymizer against the same source DB with the same seed produces the same output. Required for reproducible scenario fixtures.
+
+## Requirements
+
+*To be detailed in a future iteration. The current document is a placeholder establishing scope and primary use cases.*
+
+High-level requirement areas:
+
+- Merchant name substitution (canonical merchant catalog → anonymized substitutes preserving category)
+- Amount perturbation (distribution-preserving, within configurable noise bounds)
+- Date shifting (preserves day-of-week, day-of-month, and inter-arrival distributions)
+- Account ID replacement (consistent within a snapshot; preserves account relationships)
+- Description scrubbing (PII patterns removed; structure preserved)
+- Category and ground-truth label preservation
+- Differential privacy bounds on aggregate statistics
+- CLI: `moneybin synthetic anonymize --source <profile> --target <profile> --seed N`
+
+## Data Model
+
+Output writes to the existing `synthetic` schema raw tables, identical to the synthetic generator. No new tables.
+
+## Implementation Plan
+
+*Deferred. This spec is a planned placeholder; implementation plan will be authored when the spec is promoted from `planned` to `draft`.*
+
+## CLI Interface
+
+```
+moneybin synthetic anonymize --source <profile> --target <profile> --seed N [--noise-bounds <preset>]
+```
+
+## Testing Strategy
+
+- Unit tests for each masking primitive (merchant substitution, amount perturbation, date shifting)
+- Statistical similarity tests: KS-test or Wasserstein distance between source and anonymized distributions, within configured tolerance
+- Re-identification tests: attempt known re-identification attacks (k-anonymity violation, deanonymization via amount + date joins)
+- End-to-end: anonymize a real DB → run full pipeline → verify outputs are pipeline-valid (FK integrity, sign convention, etc.)
+
+## Dependencies
+
+- `testing-synthetic-data.md` — shared output schema and ground-truth conventions
+- `privacy-data-protection.md` — encryption/at-rest guarantees
+- `privacy-and-ai-trust.md` — redaction primitives (regex patterns, PII detectors)
+
+## Out of Scope
+
+- Anonymization of derived analytics tables (`core.fct_balances_daily`, etc.) — anonymize raw, let the pipeline derive.
+- Cross-user anonymization for community datasets — covered separately under `categorization-overview.md`'s community model.
+- Real-time anonymization streams — this is a batch operation against snapshots.

--- a/docs/specs/testing-scenario-comprehensive.md
+++ b/docs/specs/testing-scenario-comprehensive.md
@@ -1,0 +1,254 @@
+# Feature: Comprehensive Scenario Testing
+
+## Status
+draft
+
+## Goal
+
+Make the scenario suite an exhaustive, regression-proof check on the data pipeline, with a contributor recipe (executable by an AI coding agent) for converting any user bug report into a permanent scenario. This spec ships concrete enhancements to the existing scenarios and runner — but it also functions as the **architectural authority for all future scenario work**: every new scenario, every new assertion, and every bug-report reproduction must conform to the taxonomy and rules defined here.
+
+## Background
+
+### Why this spec
+
+The audit summarized in [the recent code-review thread] found that the existing six scenarios (in `src/moneybin/testing/scenarios/data/`) are closer to smoke tests than the kind of audit a data engineer would run. They check sign convention, FK integrity, and a handful of evaluations — but they miss obvious data-engineering invariants like:
+
+- Idempotency (re-running the pipeline doesn't duplicate rows)
+- Source attribution (`source_system` populated and matches input)
+- Schema drift detection
+- Negative expectations (records that should *not* match)
+- Empty / malformed input handling
+- Date continuity per account
+- Ground-truth coverage (evaluations gaming a tiny labeled subset)
+
+Worse, one expectation (`family-full-pipeline` row count `~2,900 ±15%`) appears to have been set by running the pipeline once and observing the result. That pattern — observe-and-paste — produces tests that prove the code is consistent with itself, not that it is correct.
+
+### Scope boundary with `data-reconciliation.md`
+
+[`data-reconciliation.md`](data-reconciliation.md) is **runtime + user-facing**: SQLMesh views (`core.reconciliation_*`), a `moneybin reconciliation check` CLI, MCP tools, metrics. It runs against live user data and produces investigation reports.
+
+This spec is **pre-merge + contributor-facing**: scenario YAML / pytest assertions, fixture authoring, AI-agent recipes for translating bug reports into reproductions. It runs in CI and gates merges.
+
+The two share primitives (row accounting, orphan detection, temporal coverage). This spec formalizes that sharing by extracting a common assertion library at `src/moneybin/validation/` that both consumers depend on.
+
+### Related specs
+
+- [`testing-overview.md`](testing-overview.md) — umbrella; this spec is a child.
+- [`testing-scenario-runner.md`](testing-scenario-runner.md) — host of the assertion/expectation/evaluation primitives this spec extends.
+- [`testing-synthetic-data.md`](testing-synthetic-data.md) — produces ground-truth labels consumed here.
+- [`testing-anonymized-data.md`](testing-anonymized-data.md) — soft dependency; the prescribed tool for producing fixtures from real user databases when reproducing bug reports without leaking PII.
+- [`data-reconciliation.md`](data-reconciliation.md) — peer; shares assertion primitives but targets runtime user data.
+
+## Design Principles
+
+1. **Independent expectations.** Tests prove correctness only when the expected output is derived from something other than the code under test. See `.claude/rules/testing.md` ("Scenario Expectations Must Be Independently Derived").
+2. **Comprehensive by taxonomy.** Every scenario is evaluated against a five-tier checklist (Section: The Five Tiers). Coverage gaps are explicit, not implicit.
+3. **Pytest-native.** Scenarios are pytest tests, not a parallel runner. We get fixtures, parametrization, parallelism, IDE integration, and JSON output for free.
+4. **Architectural authority for future agents.** This spec is normative. Future scenarios MUST cite which tier each assertion covers. The bug-report recipe is the only sanctioned path for translating a user report into a scenario.
+
+## Requirements
+
+### R1 — Five-tier assertion taxonomy
+
+Every scenario MUST be evaluated against the following tiers. The scenario YAML (or pytest test docstring) MUST declare which tiers it covers and explain any tier it intentionally skips.
+
+#### Tier 1 — Structural Invariants (every scenario)
+
+| Check | Primitive |
+|---|---|
+| Row counts in `raw.* → prep.stg_* → core.fct_*` match an independently-derived expected value | `assert_row_count` |
+| Schema snapshot: column set + types per core table | `assert_schema_snapshot` |
+| FK integrity: `fct_transactions.account_id ∈ dim_accounts.account_id` | `assert_valid_foreign_keys` (existing) |
+| No-NULLs on required columns: `amount`, `transaction_date`, `account_id`, `source_system` | `assert_no_nulls` (existing) |
+| No-duplicates on natural keys (`transaction_id`, `account_id`) | `assert_no_duplicates` (existing) |
+| `source_system` populated and ∈ expected set per scenario | `assert_source_system_populated` |
+| Provenance completeness: every `transaction_id` has ≥1 provenance row | `assert_no_orphans` (existing) |
+| Sign convention: expense<0, income>0, transfers exempt | `assert_sign_convention` (existing) |
+| Amount precision: `DECIMAL(18,2)`, no truncation | `assert_amount_precision` |
+| Date bounds: all `transaction_date` within scenario's declared date range | `assert_date_bounds` |
+
+#### Tier 2 — Semantic Correctness (where applicable)
+
+| Check | Primitive |
+|---|---|
+| Balanced transfers: confirmed transfer pairs sum to zero | `assert_balanced_transfers` (existing) |
+| Categorization accuracy + per-category precision/recall vs ground truth | `score_categorization` (existing — extend with P/R breakdown) |
+| Transfer detection: F1 + raw precision and recall (separately, to catch one-sided bias) | `score_transfer_detection` (existing — extend) |
+| Match confidence distribution within expected bounds | `assert_distribution_within_bounds` (existing — wire in) |
+| **Negative expectations**: labeled non-matches that must NOT collapse | `assert_negative_match` |
+
+#### Tier 3 — Pipeline Behavior
+
+| Check | Primitive |
+|---|---|
+| Idempotency: re-run `transform` / re-load same fixture → row counts unchanged | `assert_idempotent` |
+| Incremental safety: load A then B with overlap → only new rows added; A's matches not reprocessed | `assert_incremental_safe` |
+| Empty-input handling: empty CSV → empty raw, no crash, downstream tables empty | `assert_empty_input_safe` |
+| Malformed-input handling: missing column / bad header → loader rejects with clear error, no partial load | `assert_malformed_input_rejected` |
+| Subprocess parity: same input via subprocess vs. in-process produces identical output | `assert_subprocess_parity` |
+
+#### Tier 4 — Distribution / Quality
+
+| Check | Primitive |
+|---|---|
+| Amount distribution bounds (min/max/mean within plausible range) | `assert_amount_distribution` |
+| Date continuity: no month-long gaps per account in multi-year scenarios | `assert_date_continuity` |
+| Ground-truth coverage: ≥90% of `fct_transactions` labeled in `synthetic.ground_truth` | `assert_ground_truth_coverage` |
+| Category distribution sanity (no single category swallows >X% of rows) | `assert_category_distribution` |
+
+#### Tier 5 — Operational
+
+| Check | Primitive |
+|---|---|
+| Step duration thresholds (perf regression detection) | pytest `--durations`, slow-marker gating |
+| Memory ceiling | `pytest-memray` or equivalent, optional |
+
+### R2 — Per-scenario tier matrix
+
+This spec ships with a binding matrix declaring what each existing scenario covers and what it must add. Future agents MUST update this matrix when adding a scenario.
+
+| Scenario | T1 (all 10) | T2 | T3 | T4 | T5 |
+|---|---|---|---|---|---|
+| `basic-full-pipeline` | required | categorization P/R | **idempotency** (new) | — | — |
+| `family-full-pipeline` | required (replace `±15%` with derived formula) | balanced transfers, categorization P/R, transfer F1 + P + R | **idempotency** (new) | **date continuity, ground-truth coverage** (new) | — |
+| `dedup-cross-source` | required | match confidence dist, **negative expectations** (new) | **incremental safety** (new) | — | — |
+| `transfer-detection-cross-account` | required | transfer F1 + P + R, **negative pairs** (new) | — | date continuity | — |
+| `migration-roundtrip` | required + **pre/post row count parity** (new) | — | — | — | — |
+| `encryption-key-propagation` | required (replace `min_rows ≥ 100` with derived count) | — | subprocess parity | — | — |
+| `idempotency-rerun` *(new)* | required | — | idempotency, incremental safety | — | — |
+| `dedup-negative-fixture` *(new)* | required | negative expectations | — | — | — |
+| `empty-input-handling` *(new)* | required (zero-row variants) | — | empty-input safe | — | — |
+| `malformed-input-rejection` *(new)* | required | — | malformed-input rejected | — | — |
+
+### R3 — Independent-expectations rule
+
+The rule lives in [`.claude/rules/testing.md`](../../.claude/rules/testing.md) under "Scenario Expectations Must Be Independently Derived." Summary of the contract:
+
+- Allowed derivation paths: input fixture (count by hand), persona/generator config (deterministic formula), or hand-authored ground truth written before running.
+- Forbidden: observe-and-paste.
+- Tolerances require an accompanying formula and a variance comment.
+- Failing expectations default to "fix the code"; updating the expectation requires PR justification.
+- Negative expectations are required wherever positive expectations exist.
+
+### R4 — Bug-report recipe
+
+A contributor (or their coding agent) MUST follow [`docs/guides/scenario-authoring.md`](../guides/scenario-authoring.md) when translating a user bug report into a permanent scenario. The recipe:
+
+1. Capture the bug report and (ideally) an anonymized DB snapshot via `testing-anonymized-data.md` tooling.
+2. Reproduce by extracting an isolated fixture under `tests/scenarios/data/fixtures/<bug-id>/`.
+3. Express the bug as an expectation derived independently per R3.
+4. Verify the scenario fails on the broken code.
+5. Fix the code → verify the scenario passes.
+6. Land the scenario as permanent regression coverage.
+
+### R5 — Relocation to `tests/scenarios/`
+
+The scenario runner, steps, loader, fixture loader, expectations module, and YAML data move from `src/moneybin/testing/scenarios/` to `tests/scenarios/`. The synthetic data **generator** (`src/moneybin/testing/synthetic/`) stays in `src/` because `moneybin synthetic generate` remains a supported user command. The `moneybin synthetic verify` CLI is removed; scenarios run via `pytest tests/scenarios/ -m scenarios` and a `make verify-scenarios` target. The bespoke `ResponseEnvelope` is dropped in favor of `pytest-json-report`.
+
+### R6 — Shared validation library
+
+Reusable check primitives (the `assert_*` functions in the tier tables) live at `src/moneybin/validation/` and are consumed by both the scenario suite and `data-reconciliation.md`'s runtime views. This is the only validation code that ships with the package — scenario fixtures and runner code are test-only.
+
+## Data Model
+
+No schema changes. This spec adds tests and assertion primitives, and relocates existing test infrastructure.
+
+## Implementation Plan
+
+### Files to Create
+
+- `src/moneybin/validation/structural.py` — `assert_row_count`, `assert_schema_snapshot`, `assert_source_system_populated`, `assert_amount_precision`, `assert_date_bounds`
+- `src/moneybin/validation/behavioral.py` — `assert_idempotent`, `assert_incremental_safe`, `assert_empty_input_safe`, `assert_malformed_input_rejected`, `assert_subprocess_parity`
+- `src/moneybin/validation/quality.py` — `assert_amount_distribution`, `assert_date_continuity`, `assert_ground_truth_coverage`, `assert_category_distribution`
+- `src/moneybin/validation/semantic.py` — `assert_negative_match`, P/R breakdown helpers
+- `tests/scenarios/conftest.py` — shared fixtures: encrypted DB bootstrap, MONEYBIN_HOME isolation, persona generator helpers
+- `tests/scenarios/test_basic_full_pipeline.py` — port + add idempotency
+- `tests/scenarios/test_family_full_pipeline.py` — port + replace `±15%`, add date continuity, ground-truth coverage
+- `tests/scenarios/test_dedup_cross_source.py` — port + add negative-fixture cases, incremental safety
+- `tests/scenarios/test_transfer_detection.py` — port + add negative pairs
+- `tests/scenarios/test_migration_roundtrip.py` — port + add pre/post row-count parity
+- `tests/scenarios/test_encryption_key_propagation.py` — port + replace `min_rows ≥ 100` with derived count
+- `tests/scenarios/test_idempotency_rerun.py` *(new)*
+- `tests/scenarios/test_dedup_negative_fixture.py` *(new)*
+- `tests/scenarios/test_empty_input_handling.py` *(new)*
+- `tests/scenarios/test_malformed_input_rejection.py` *(new)*
+- `tests/scenarios/data/fixtures/dedup-negative/...` — hand-authored fixture: same date/amount, different merchants, must NOT collapse
+- `tests/scenarios/data/fixtures/empty-input/...` — empty CSV / OFX
+- `tests/scenarios/data/fixtures/malformed/...` — missing-header CSV, truncated OFX
+- `docs/guides/scenario-authoring.md` — full bug-report recipe
+
+### Files to Modify
+
+- `.claude/rules/testing.md` — add "Scenario Expectations Must Be Independently Derived" (done in this branch)
+- `CONTRIBUTING.md` — link to `docs/guides/scenario-authoring.md` and add a one-paragraph summary of the recipe
+- `docs/specs/INDEX.md` — add this spec
+- `docs/specs/testing-overview.md` — reference this spec; note relocation to `tests/`
+- `docs/specs/testing-scenario-runner.md` — note that scenarios now live in `tests/scenarios/`, link to this spec for taxonomy
+- `Makefile` — add `verify-scenarios` target
+- `.github/workflows/scenarios.yml` — replace `moneybin synthetic verify --all --output=json` with `uv run pytest tests/scenarios/ -m scenarios --json-report`
+
+### Files to Delete
+
+- `src/moneybin/testing/scenarios/` (entire directory — migrated to `tests/scenarios/`)
+- `src/moneybin/cli/commands/synthetic.py::verify` and its E2E tests (the only `src/` consumer)
+
+### Sequencing
+
+1. **Phase 1 — Relocation.** Move `src/moneybin/testing/scenarios/` to `tests/scenarios/`, port to pytest, drop ResponseEnvelope, remove `synthetic verify` CLI, update CI workflow. No new behavior; existing assertions/expectations preserved 1:1.
+2. **Phase 2 — Validation library.** Extract shared primitives to `src/moneybin/validation/`. Update existing scenarios to use them. No new assertions yet.
+3. **Phase 3 — Tier 1 backfill.** Add the missing Tier 1 assertions to every existing scenario (source attribution, schema snapshot, amount precision, date bounds). Replace `±15%` and `min_rows ≥ 100` with derived formulas.
+4. **Phase 4 — New scenarios.** Author the four new scenarios (`idempotency-rerun`, `dedup-negative-fixture`, `empty-input-handling`, `malformed-input-rejection`).
+5. **Phase 5 — Tier 2/4 enrichment.** Add P/R breakdowns, ground-truth coverage, date continuity to applicable scenarios.
+6. **Phase 6 — Recipe + governance.** Ship `docs/guides/scenario-authoring.md` and CONTRIBUTING.md updates. Update `testing-overview.md` and `testing-scenario-runner.md` references.
+
+Each phase ships independently as its own PR. After Phase 6, this spec moves to `implemented` and becomes the binding architectural reference for all future scenario work.
+
+### Key Decisions
+
+- **Drop ResponseEnvelope.** No installed base; pytest expresses step-level halting via fixture failure context and mixed result types via separate test functions / parametrize cases. `pytest-json-report` covers the CI artifact need. If a future agent loop needs richer metadata, design that on real requirements.
+- **Synthetic generator stays in `src/`.** `moneybin synthetic generate` is a legitimate user command for trying the tool with sample data. Only the *verifier* (a contributor tool) moves to `tests/`.
+- **Validation primitives in `src/moneybin/validation/`.** Both this spec and `data-reconciliation.md` consume them. Tests-only code stays in `tests/`.
+
+## CLI Interface
+
+`moneybin synthetic verify` is **removed**.
+
+Replacement:
+
+```bash
+make verify-scenarios                                          # Run all scenario tests
+uv run pytest tests/scenarios/ -m scenarios -v                 # Same, manual
+uv run pytest tests/scenarios/test_dedup_cross_source.py -v    # Single scenario
+uv run pytest tests/scenarios/ -m scenarios --json-report      # CI artifact
+```
+
+The `synthetic generate` command is unchanged.
+
+## MCP Interface
+
+None. Scenarios are contributor tooling.
+
+## Testing Strategy
+
+Self-applying. The deliverables of this spec *are* the testing strategy. Two meta-checks:
+
+1. **Tier matrix lint.** A small pytest-collection-time check verifies every test in `tests/scenarios/` declares (via marker or docstring tag) which tier(s) it covers. CI fails on missing declarations.
+2. **Independent-derivation review.** Code review enforces R3. PRs touching `tests/scenarios/` that update an expected value without justification get flagged.
+
+## Synthetic Data Requirements
+
+No new synthetic data shapes required for the existing personas. New scenarios reuse `basic` and `family`. The empty-input and malformed-input scenarios use hand-authored fixtures (not generator output).
+
+## Dependencies
+
+- `pytest-json-report` (new dev dependency) — replaces ResponseEnvelope's JSON output role.
+- [`testing-scenario-runner.md`](testing-scenario-runner.md) — provides the existing assertion library this spec extends.
+- [`testing-synthetic-data.md`](testing-synthetic-data.md) — provides ground-truth labels consumed by Tier 2/4 evaluations.
+- [`testing-anonymized-data.md`](testing-anonymized-data.md) — *soft* dependency. The bug-report recipe references the anonymizer as the prescribed tool for producing PII-free fixtures from real user databases. Until the anonymizer ships, contributors hand-author fixtures or use synthetic personas.
+
+## Out of Scope
+
+- **Runtime user-data reconciliation.** Lives in [`data-reconciliation.md`](data-reconciliation.md). This spec shares primitives with that one but targets pre-merge CI, not runtime user reports.
+- **Performance / load testing.** Tier 5 (Operational) sketches durations and memory ceilings as future work; this spec does not implement them.
+- **Anonymizer implementation.** [`testing-anonymized-data.md`](testing-anonymized-data.md) owns the anonymization engine. This spec only consumes its output.
+- **MCP exposure of scenarios.** Scenarios are contributor tooling. Exposing them via MCP would require a separate spec.


### PR DESCRIPTION
## Summary

Establishes the architectural authority for MoneyBin's scenario test suite: a five-tier assertion taxonomy, an independent-expectations rule that forbids observe-and-paste tests, and an agent-executable recipe for translating user bug reports into permanent regression coverage. Also drafts a placeholder spec for the anonymized-data generator that will produce PII-free fixtures.

## Impact

- **For contributors / coding agents:** New scenarios MUST follow the recipe in `docs/guides/scenario-authoring.md` and conform to the tier matrix in `testing-scenario-comprehensive.md`. Expectations may no longer be derived from running the program — they must come from the input fixture, persona/generator config, or hand-authored ground truth.
- **For reviewers:** PRs that change a scenario's expected value require written justification — "the new code produces a different number" is not acceptable.
- **No code changes** in this PR. Implementation is sequenced into six phases on top of this spec.

## Changes

### New spec: comprehensive scenario testing

`docs/specs/testing-scenario-comprehensive.md` (status: `draft`) defines:

- A five-tier taxonomy (structural, semantic, behavioral, distribution, operational) every scenario is evaluated against.
- A per-scenario tier matrix listing what each existing scenario must add and four new scenarios to author (`idempotency-rerun`, `dedup-negative-fixture`, `empty-input-handling`, `malformed-input-rejection`).
- Relocation of scenarios from `src/moneybin/testing/scenarios/` to `tests/scenarios/`, dropping the bespoke `ResponseEnvelope` in favor of `pytest-json-report`. The synthetic generator stays in `src/` since `moneybin synthetic generate` remains a user command; only `synthetic verify` is removed.
- A six-phase implementation plan, each phase shippable independently.

### New rule: independent expectations

`.claude/rules/testing.md` adds "Scenario Expectations Must Be Independently Derived" — codifies the allowed derivation paths, forbids observe-and-paste, requires formulas for tolerances, and requires negative cases wherever positive expectations exist.

### New stub spec: anonymized data generator

`docs/specs/testing-anonymized-data.md` (status: `planned`) explicitly framed around enabling automated bug-report fixtures, format-compatibility seeds, and distribution-faithful evaluation corpora without leaking PII.

### New guide: bug-report recipe

`docs/guides/scenario-authoring.md` is an eight-step recipe a coding agent can execute given a bug report and an anonymized snapshot: capture → fixture → independent expectation → tier coverage → write test → verify failure → fix code → land.

### CONTRIBUTING + INDEX updates

`CONTRIBUTING.md` adds an "Authoring a new scenario" subsection linking to the recipe. `docs/specs/INDEX.md` adds entries for both new specs and reframes the anonymized-data summary around its primary use cases.

## Testing

Docs-only PR — no code changes, no tests to run. Pre-commit hooks (Ruff, EOF, whitespace, YAML, large-files, merge-conflicts) all passed locally.

## Notes

- Scope boundary with `data-reconciliation.md` is explicit in the new spec: reconciliation = runtime user-facing checks; this spec = pre-merge contributor-facing checks. The two share assertion primitives via a future `src/moneybin/validation/` library extracted in Phase 2.
- The recipe references `testing-anonymized-data.md` as a soft dependency. Until the anonymizer ships, contributors hand-author fixtures or use synthetic personas — the recipe still works.
- After this lands, a follow-up should hand off Phase 1 (relocation to `tests/scenarios/`) to the writing-plans skill.