### PR TITLE
Give @claude mention step its own review/approve prompt

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -58,3 +58,31 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--allowedTools Bash,Read,Grep,Glob"
+          prompt: |
+            Respond to the @claude mention in the PR comment. If the request is
+            a re-review (or otherwise asks you to re-evaluate the PR), inspect
+            the current code against previously-raised review threads and any
+            new concerns, using project conventions in CLAUDE.md and
+            .claude/rules/.
+
+            Resolve any previously-posted review threads whose issues are now
+            fixed in the current code. Use the gh CLI and environment variables
+            already present in the runner — do not interpolate untrusted event
+            payload fields into shell commands. Steps:
+            1. Determine the PR number: gh pr view --json number -q .number
+            2. Parse owner and repo from the GITHUB_REPOSITORY environment variable.
+            3. Fetch open threads via gh api graphql, passing owner, repo, and
+               number as -f variables so no user-controlled data is
+               shell-interpolated.
+            4. For each unresolved thread, read its comment body, check whether
+               the current code addresses the issue, and if so resolve it via
+               the resolveReviewThread GraphQL mutation.
+            Only resolve threads where the fix is clearly present — leave
+            threads open if the issue is partially addressed or still present.
+
+            After resolving threads, if no new issues remain and all
+            previously-raised threads are now resolved, submit an approval:
+              gh pr review --approve --body "All issues resolved."
+            If any threads remain open or you found new issues, do not approve —
+            post a summary comment instead describing what's outstanding.


### PR DESCRIPTION
### Summary
The `issue_comment` (@claude mention) step in `ai-review.yml` had no prompt, so re-review requests posted as PR comments produced freeform responses that hedged with "I can't formally approve" instead of submitting an approval. The automated `pull_request` step worked correctly because its prompt explicitly tells Claude to run `gh pr review --approve` when issues are resolved. This PR gives the mention step the same instructions so behavior is consistent across both triggers.

### Impact
- Re-reviews triggered via `@claude` PR comments will now resolve fixed threads and submit an approval when nothing is outstanding, matching the automated review behavior.
- No workflow changes required from contributors.

### Changes
#### `ai-review.yml` — interactive step prompt
Added `claude_args` and `prompt:` to the `Interactive @claude mentions` step. The prompt mirrors the automated step's instructions: inspect current code against existing review threads, resolve threads whose issues are fixed via the `resolveReviewThread` GraphQL mutation, then either approve the PR or post a summary of what's still outstanding.

### Testing
- Trigger an `@claude` re-review on an open PR where prior issues are now fixed; confirm it submits an approval rather than hedging.
- Trigger an `@claude` re-review on a PR with outstanding issues; confirm it posts a summary comment and does not approve.

### Notes
The prompt reuses the same shell-injection-safe pattern as the automated step (gh CLI with `-f` GraphQL variables, no interpolation of event payload fields).