### PR TITLE
Simplify matching/ — explicit column list + Literal types

### DIFF
--- a/src/moneybin/matching/engine.py
+++ b/src/moneybin/matching/engine.py
@@ -15,6 +15,7 @@ from moneybin.database import Database
 from moneybin.matching import UNIONED_TABLE
 from moneybin.matching.assignment import assign_greedy
 from moneybin.matching.persistence import (
+    MatchTier,
     create_match_decision,
     get_rejected_pairs,
 )
@@ -154,7 +155,7 @@ class TransactionMatcher:
     def _run_tier(
         self,
         *,
-        tier: str,
+        tier: MatchTier,
         candidates_fn: Callable[[set[tuple[str, str]]], list[CandidatePair]],
         excluded_ids: set[tuple[str, str]],
         result: MatchResult,

--- a/src/moneybin/matching/persistence.py
+++ b/src/moneybin/matching/persistence.py
@@ -6,21 +6,42 @@ All database access uses parameterized queries via the Database class.
 import json
 import logging
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal, get_args
 
 from moneybin.database import Database
 
 logger = logging.getLogger(__name__)
 
-VALID_MATCH_TYPES = {"dedup", "transfer"}
+MatchType = Literal["dedup", "transfer"]
+MatchStatus = Literal["accepted", "pending", "rejected", "reversed"]
+MatchTier = Literal["2b", "3"]
 
+VALID_MATCH_TYPES = frozenset(get_args(MatchType))
 
-def _columns(db: Database) -> list[str]:
-    """Return column names for app.match_decisions."""
-    return [
-        desc[0]
-        for desc in db.execute("SELECT * FROM app.match_decisions LIMIT 0").description
-    ]
+# Column order matches the CREATE TABLE in app.match_decisions migration; kept
+# in sync with the schema so SELECT/zip never re-derives it at runtime.
+_MATCH_DECISION_COLUMNS: tuple[str, ...] = (
+    "match_id",
+    "source_transaction_id_a",
+    "source_type_a",
+    "source_origin_a",
+    "source_transaction_id_b",
+    "source_type_b",
+    "source_origin_b",
+    "account_id",
+    "confidence_score",
+    "match_signals",
+    "match_type",
+    "match_tier",
+    "account_id_b",
+    "match_status",
+    "match_reason",
+    "decided_by",
+    "decided_at",
+    "reversed_at",
+    "reversed_by",
+)
+_MATCH_DECISION_SELECT = ", ".join(_MATCH_DECISION_COLUMNS)
 
 
 def create_match_decision(
@@ -36,11 +57,11 @@ def create_match_decision(
     account_id: str,
     confidence_score: float,
     match_signals: dict[str, Any],
-    match_tier: str | None,
-    match_status: str,
+    match_tier: MatchTier | None,
+    match_status: MatchStatus,
     decided_by: str,
     match_reason: str | None = None,
-    match_type: str = "dedup",
+    match_type: MatchType = "dedup",
     account_id_b: str | None = None,
 ) -> None:
     """Insert a new match decision."""
@@ -88,14 +109,13 @@ def get_active_matches(
         params.append(match_type)
     rows = db.execute(
         f"""
-        SELECT * FROM app.match_decisions
+        SELECT {_MATCH_DECISION_SELECT} FROM app.match_decisions
         {where}
         ORDER BY decided_at DESC
         """,  # noqa: S608 — match_type validated above
         params,
     ).fetchall()
-    cols = _columns(db)
-    return [dict(zip(cols, row, strict=True)) for row in rows]
+    return [dict(zip(_MATCH_DECISION_COLUMNS, row, strict=True)) for row in rows]
 
 
 def get_pending_matches(
@@ -116,18 +136,17 @@ def get_pending_matches(
         params.append(match_type)
     rows = db.execute(
         f"""
-        SELECT * FROM app.match_decisions
+        SELECT {_MATCH_DECISION_SELECT} FROM app.match_decisions
         {where}
         ORDER BY confidence_score DESC
         """,  # noqa: S608 — match_type validated above
         params,
     ).fetchall()
-    cols = _columns(db)
-    return [dict(zip(cols, row, strict=True)) for row in rows]
+    return [dict(zip(_MATCH_DECISION_COLUMNS, row, strict=True)) for row in rows]
 
 
 def update_match_status(
-    db: Database, match_id: str, *, status: str, decided_by: str
+    db: Database, match_id: str, *, status: MatchStatus, decided_by: str
 ) -> None:
     """Update the status of a match decision (e.g., pending -> accepted)."""
     db.execute(
@@ -158,7 +177,9 @@ def undo_match(db: Database, match_id: str, *, reversed_by: str) -> None:
     )
 
 
-def get_rejected_pairs(db: Database, match_type: str = "dedup") -> list[dict[str, Any]]:
+def get_rejected_pairs(
+    db: Database, match_type: MatchType = "dedup"
+) -> list[dict[str, Any]]:
     """Return rejected pair keys to avoid re-proposing them."""
     rows = db.execute(
         """
@@ -198,12 +219,11 @@ def get_match_log(
     params.append(limit)
     rows = db.execute(
         f"""
-        SELECT * FROM app.match_decisions
+        SELECT {_MATCH_DECISION_SELECT} FROM app.match_decisions
         {where}
         ORDER BY decided_at DESC
         LIMIT ?
         """,  # noqa: S608 — match_type validated above; limit is parameterized
         params,
     ).fetchall()
-    cols = _columns(db)
-    return [dict(zip(cols, row, strict=True)) for row in rows]
+    return [dict(zip(_MATCH_DECISION_COLUMNS, row, strict=True)) for row in rows]

--- a/src/moneybin/matching/scoring.py
+++ b/src/moneybin/matching/scoring.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from moneybin.database import Database
 from moneybin.matching import UNIONED_TABLE, quote_table_ref
+from moneybin.matching.persistence import MatchTier
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +106,7 @@ def _get_candidates(
     *,
     table: str,
     date_window_days: int,
-    tier: str,
+    tier: MatchTier,
     excluded_ids: set[tuple[str, str]] | None,
     rejected_pairs: list[dict[str, Any]] | None,
 ) -> list[CandidatePair]:


### PR DESCRIPTION
## Summary

Second pass in the per-module `/simplify` sweep. Replaces stringly-typed status/tier/type parameters with `Literal` aliases and removes a runtime `SELECT * LIMIT 0` schema probe in favor of an explicit column tuple.

## Impact

No behavioral change. Pyright now catches typos in `match_status`/`match_tier`/`match_type` arguments at type-check time. Each `get_*_matches` call does one DuckDB round-trip instead of two.

## Changes

### Literal types
Add three `Literal` aliases in `persistence.py`:
- `MatchType = Literal["dedup", "transfer"]`
- `MatchStatus = Literal["accepted", "pending", "rejected", "reversed"]`
- `MatchTier = Literal["2b", "3"]`

Apply them on the write side (`create_match_decision`, `update_match_status`) and the read side (`get_rejected_pairs`). `engine._run_tier` and `scoring._get_candidates` adopt `MatchTier` for the tier parameter.

`VALID_MATCH_TYPES` is now derived via `frozenset(get_args(MatchType))` so the runtime check stays in sync with the type alias automatically.

### Explicit column list
Replace the `_columns(db)` helper (which ran `SELECT * FROM app.match_decisions LIMIT 0` to read schema) with a module-level `_MATCH_DECISION_COLUMNS` tuple. A short comment notes it's kept in sync with the migration. `_MATCH_DECISION_SELECT = ", ".join(...)` provides a precomputed comma-separated form for the SELECT list.

`get_active_matches`, `get_pending_matches`, `get_match_log` now use `SELECT {_MATCH_DECISION_SELECT}` instead of `SELECT *` and zip rows against the constant.

## Testing

`uv run pytest tests/moneybin/matching tests/moneybin/test_services/test_matching_service.py tests/moneybin/test_cli/test_matches.py` — 127 passed.

## Notes

This branch was based on the discarded FastMCP revert commit. Reset to current `origin/main`; matching/ is independent of MCP, so the simplify changes apply cleanly.