### PR TITLE
Simplify MCP tools: drop unused loggers, tighten error paths

### DIFF
--- a/src/moneybin/mcp/decorator.py
+++ b/src/moneybin/mcp/decorator.py
@@ -1,26 +1,10 @@
-"""MCP tool decorator with sensitivity tier, privacy logging, and error handling.
-
-Wraps tool functions with:
-
-1. Sensitivity logging via the privacy middleware stub.
-2. Domain exception classification into error ``ResponseEnvelope`` values.
-3. Direct return of ``ResponseEnvelope`` (the server serializes the dataclass).
+"""MCP tool decorator: sensitivity logging, error classification, envelope guard.
 
 Classified exceptions (``UserError``, ``DatabaseKeyError``, ``FileNotFoundError``)
 become error envelopes so every surface — MCP, CLI ``--output json``, future
 HTTP — returns a consistent shape. Anything else propagates to the server's
-``mask_error_details`` boundary.
-
-The decorator does NOT register the tool with the server; the registration
-layer in ``moneybin.mcp.tools.*`` does that, optionally passing ``tags={domain}``
-so the visibility system can hide extended-namespace tools.
-
-Usage::
-
-    @mcp_tool(sensitivity="medium")
-    def spending_summary(months: int = 3) -> ResponseEnvelope:
-        service = SpendingService(get_database())
-        return service.summary(months).to_envelope()
+``mask_error_details`` boundary. Registration of the wrapped function with
+FastMCP happens separately in ``moneybin.mcp._registration``.
 """
 
 from __future__ import annotations
@@ -29,7 +13,7 @@ import functools
 import inspect
 import logging
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Literal
 
 from moneybin.errors import classify_user_error
 from moneybin.mcp.privacy import Sensitivity, log_tool_call
@@ -40,15 +24,11 @@ logger = logging.getLogger(__name__)
 
 def _check_envelope(fn_name: str, result: Any) -> ResponseEnvelope:
     if not isinstance(result, ResponseEnvelope):
-        # Log the contract violation explicitly: with mask_error_details=True
-        # at the server boundary, the TypeError is otherwise wrapped in a
-        # generic ToolError and the developer signal is lost.
-        logger.error(
-            f"Tool {fn_name} returned {type(result).__name__}, expected ResponseEnvelope"
-        )
-        raise TypeError(
-            f"{fn_name} returned {type(result).__name__}, expected ResponseEnvelope"
-        )
+        # mask_error_details=True at the server boundary swallows the TypeError
+        # into a generic ToolError, so log the contract violation first.
+        msg = f"{fn_name} returned {type(result).__name__}, expected ResponseEnvelope"
+        logger.error(msg)
+        raise TypeError(msg)
     return result
 
 
@@ -63,21 +43,13 @@ def _classify_or_raise(fn_name: str, exc: Exception) -> ResponseEnvelope:
 
 def mcp_tool(
     *,
-    sensitivity: str,
+    sensitivity: Literal["low", "medium", "high"],
     domain: str | None = None,
 ) -> Callable[..., Any]:
     """Mark a function as an MCP tool with a sensitivity tier and optional domain.
 
-    Args:
-        sensitivity: Data sensitivity tier (``"low"``, ``"medium"``, ``"high"``).
-        domain: Extended-namespace name (e.g. ``"categorize"``). Tools with a
-            domain start hidden and are revealed per-session via
-            ``moneybin.discover``. The registration layer translates this into
-            ``mcp.tool(tags={domain})``.
-
-    Returns:
-        Decorator that wraps the function with privacy logging, error
-        classification, and direct ``ResponseEnvelope`` return.
+    Tools with a ``domain`` start hidden; ``moneybin.discover`` enables them
+    per-session via FastMCP tag visibility.
     """
     tier = Sensitivity(sensitivity)
 

--- a/src/moneybin/mcp/prompts.py
+++ b/src/moneybin/mcp/prompts.py
@@ -9,12 +9,9 @@ See ``mcp-tool-surface.md`` section 14.
 
 from __future__ import annotations
 
-import logging
 import textwrap
 
 from .server import mcp
-
-logger = logging.getLogger(__name__)
 
 
 def _dedent(text: str) -> str:

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -8,8 +8,6 @@ Tools:
 
 from __future__ import annotations
 
-import logging
-
 from fastmcp import FastMCP
 
 from moneybin.database import get_database
@@ -17,8 +15,6 @@ from moneybin.mcp._registration import register
 from moneybin.mcp.decorator import mcp_tool
 from moneybin.protocol.envelope import ResponseEnvelope
 from moneybin.services.account_service import AccountService
-
-logger = logging.getLogger(__name__)
 
 
 @mcp_tool(sensitivity="low")

--- a/src/moneybin/mcp/tools/budget.py
+++ b/src/moneybin/mcp/tools/budget.py
@@ -8,7 +8,6 @@ Tools:
 
 from __future__ import annotations
 
-import logging
 from decimal import Decimal
 
 from fastmcp import FastMCP
@@ -18,8 +17,6 @@ from moneybin.mcp._registration import register
 from moneybin.mcp.decorator import mcp_tool
 from moneybin.protocol.envelope import ResponseEnvelope
 from moneybin.services.budget_service import BudgetService
-
-logger = logging.getLogger(__name__)
 
 
 @mcp_tool(sensitivity="low", domain="budget")

--- a/src/moneybin/mcp/tools/categorize.py
+++ b/src/moneybin/mcp/tools/categorize.py
@@ -1,23 +1,4 @@
-# src/moneybin/mcp/tools/categorize.py
-"""Categorize namespace tools — rules, merchants, bulk categorization.
-
-Tools:
-    - categorize.categories — List categories (low)
-    - categorize.rules — List categorization rules (low)
-    - categorize.merchants — List merchant mappings (low)
-    - categorize.stats — Categorization coverage stats (low)
-    - categorize.uncategorized — Find uncategorized transactions (medium)
-    - categorize.bulk — Bulk-assign categories (medium)
-    - categorize.create_rules — Create categorization rules (low)
-    - categorize.delete_rule — Soft-delete a rule (low)
-    - categorize.create_merchants — Create merchant mappings (low)
-    - categorize.create_category — Create a custom category (low)
-    - categorize.toggle_category — Enable/disable a category (low)
-    - categorize.seed — Seed default categories from taxonomy (low)
-    - categorize.auto_review — List pending auto-rule proposals (medium)
-    - categorize.auto_confirm — Approve/reject auto-rule proposals (medium)
-    - categorize.auto_stats — Auto-rule health metrics (low)
-"""
+"""Categorize namespace tools — rules, merchants, bulk categorization."""
 
 from __future__ import annotations
 
@@ -78,11 +59,6 @@ def _validate_match_type(match_type: str) -> MatchType:
             f"Must be one of: {', '.join(sorted(_VALID_MATCH_TYPES))}"
         )
     return match_type  # type: ignore[return-value]  # validated above
-
-
-# ---------------------------------------------------------------------------
-# Read tools
-# ---------------------------------------------------------------------------
 
 
 @mcp_tool(sensitivity="low", domain="categorize")
@@ -262,10 +238,12 @@ def categorize_uncategorized(
                 ON t.transaction_id = c.transaction_id
             WHERE c.transaction_id IS NULL
             ORDER BY t.transaction_date DESC
+            LIMIT ?
             """,
+            [clamped_limit],
         )
         columns = [desc[0] for desc in result.description]
-        fetched = result.fetchmany(clamped_limit)
+        fetched = result.fetchall()
     except duckdb.CatalogException:
         return build_envelope(
             data=[],
@@ -282,11 +260,6 @@ def categorize_uncategorized(
             "Use categorize.create_rules to set up automatic categorization",
         ],
     )
-
-
-# ---------------------------------------------------------------------------
-# Write tools
-# ---------------------------------------------------------------------------
 
 
 @mcp_tool(sensitivity="medium", domain="categorize")
@@ -437,13 +410,10 @@ def categorize_delete_rule(rule_id: str) -> ResponseEnvelope:
         """,
         [rule_id],
     ).fetchone()
-    if row:
-        return build_envelope(
-            data={"rule_id": rule_id, "action": "deactivated"},
-            sensitivity="low",
-        )
+    if not row:
+        raise UserError(f"Rule {rule_id} not found", code="RULE_NOT_FOUND")
     return build_envelope(
-        data={"error": f"Rule {rule_id} not found"},
+        data={"rule_id": rule_id, "action": "deactivated"},
         sensitivity="low",
     )
 
@@ -467,7 +437,7 @@ def categorize_create_merchants(
             sensitivity="low",
         )
 
-    db = get_database()
+    service = CategorizationService(get_database())
     created = 0
     skipped = 0
     error_details: list[dict[str, str]] = []
@@ -498,7 +468,7 @@ def categorize_create_merchants(
         subcategory = str(item.get("subcategory", "")).strip() or None
 
         try:
-            CategorizationService(db).create_merchant(
+            service.create_merchant(
                 raw_pattern,
                 canonical_name,
                 match_type=match_type,
@@ -603,14 +573,11 @@ def categorize_toggle_category(
         """,
         [is_active, category_id],
     ).fetchone()
-    if row:
-        action = "enabled" if is_active else "disabled"
-        return build_envelope(
-            data={"category_id": category_id, "action": action},
-            sensitivity="low",
-        )
+    if not row:
+        raise UserError(f"Category {category_id} not found", code="CATEGORY_NOT_FOUND")
+    action = "enabled" if is_active else "disabled"
     return build_envelope(
-        data={"error": f"Category {category_id} not found"},
+        data={"category_id": category_id, "action": action},
         sensitivity="low",
     )
 

--- a/src/moneybin/mcp/tools/discover.py
+++ b/src/moneybin/mcp/tools/discover.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from fastmcp import Context, FastMCP
 from fastmcp.server.transforms.visibility import enable_components
 
@@ -14,8 +12,6 @@ from moneybin.protocol.envelope import (
     build_envelope,
     build_error_envelope,
 )
-
-logger = logging.getLogger(__name__)
 
 
 @mcp_tool(sensitivity="low")

--- a/src/moneybin/mcp/tools/import_tools.py
+++ b/src/moneybin/mcp/tools/import_tools.py
@@ -10,7 +10,6 @@ Tools:
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 
 from fastmcp import FastMCP
@@ -20,8 +19,6 @@ from moneybin.errors import UserError
 from moneybin.mcp._registration import register
 from moneybin.mcp.decorator import mcp_tool
 from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
-
-logger = logging.getLogger(__name__)
 
 
 def _validate_file_path(file_path: str) -> Path:

--- a/src/moneybin/mcp/tools/spending.py
+++ b/src/moneybin/mcp/tools/spending.py
@@ -8,8 +8,6 @@ Tools:
 
 from __future__ import annotations
 
-import logging
-
 from fastmcp import FastMCP
 
 from moneybin.database import get_database
@@ -17,8 +15,6 @@ from moneybin.mcp._registration import register
 from moneybin.mcp.decorator import mcp_tool
 from moneybin.protocol.envelope import ResponseEnvelope
 from moneybin.services.spending_service import SpendingService
-
-logger = logging.getLogger(__name__)
 
 
 @mcp_tool(sensitivity="low")

--- a/src/moneybin/mcp/tools/sql.py
+++ b/src/moneybin/mcp/tools/sql.py
@@ -7,8 +7,6 @@ Tools:
 
 from __future__ import annotations
 
-import logging
-
 from fastmcp import FastMCP
 
 from moneybin.database import get_database
@@ -16,8 +14,6 @@ from moneybin.mcp._registration import register
 from moneybin.mcp.decorator import mcp_tool
 from moneybin.mcp.privacy import get_max_rows, validate_read_only_query
 from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
-
-logger = logging.getLogger(__name__)
 
 
 @mcp_tool(sensitivity="medium")

--- a/src/moneybin/mcp/tools/tax.py
+++ b/src/moneybin/mcp/tools/tax.py
@@ -7,8 +7,6 @@ Tools:
 
 from __future__ import annotations
 
-import logging
-
 from fastmcp import FastMCP
 
 from moneybin.database import get_database
@@ -16,8 +14,6 @@ from moneybin.mcp._registration import register
 from moneybin.mcp.decorator import mcp_tool
 from moneybin.protocol.envelope import ResponseEnvelope
 from moneybin.services.tax_service import TaxService
-
-logger = logging.getLogger(__name__)
 
 
 @mcp_tool(sensitivity="high", domain="tax")

--- a/src/moneybin/mcp/tools/transactions.py
+++ b/src/moneybin/mcp/tools/transactions.py
@@ -8,7 +8,6 @@ Tools:
 
 from __future__ import annotations
 
-import logging
 from decimal import Decimal
 
 from fastmcp import FastMCP
@@ -18,8 +17,6 @@ from moneybin.mcp._registration import register
 from moneybin.mcp.decorator import mcp_tool
 from moneybin.protocol.envelope import ResponseEnvelope
 from moneybin.services.transaction_service import TransactionService
-
-logger = logging.getLogger(__name__)
 
 
 @mcp_tool(sensitivity="medium")


### PR DESCRIPTION
## Summary

- Drop ASCII banner separators and unused module-level loggers across `mcp/` tools.
- Type the `sensitivity` parameter on `@mcp_tool` as `Literal["low","medium","high"]` instead of bare `str`.
- Trim verbose module and function docstrings to single lines (one short sentence each).
- Push `LIMIT ?` into `categorize.uncategorized` SQL and switch from `fetchmany` to `fetchall` so the slice happens in DuckDB.
- Hoist `CategorizationService(get_database())` construction out of the per-item loop in `categorize_create_merchants`.
- Raise `UserError` (instead of returning a success envelope with an `error` key) for not-found paths in `categorize_delete_rule` and `categorize_toggle_category`, matching the `create_category` pattern and producing a proper error envelope via the decorator.

## Test plan

- [x] `make format && make lint` clean
- [x] `uv run pyright src/moneybin/mcp/` — 0 errors
- [x] `make test` — 1329 passed