### PR TITLE
Fix test_cli_profiles xdist flakiness via per-test MONEYBIN_HOME

### DIFF
--- a/tests/moneybin/conftest.py
+++ b/tests/moneybin/conftest.py
@@ -58,12 +58,9 @@ def temp_profile(profile: str) -> Generator[str, None, None]:
         # Don't check exists() because tests may mock it - just try to remove
         base = get_base_dir()
         profile_dir = base / "profiles" / normalized
-        # ignore_errors covers two distinct xdist races: ENOTEMPTY when
-        # workers race the shared profiles/ dir teardown, and ENOENT when
-        # tests in test_cli_profiles.py share fixed profile names ("alice",
-        # "bob") across workers. Narrowing this masks the second race as
-        # CLI FileNotFoundError instead — properly fixing it needs those
-        # tests to use isolated tmp_path, which is out of scope here.
+        # ignore_errors handles ENOTEMPTY when xdist workers race teardown
+        # of the shared profiles/ dir for tests that don't isolate
+        # MONEYBIN_HOME.
         shutil.rmtree(profile_dir, ignore_errors=True)
 
 

--- a/tests/moneybin/test_cli/test_cli_profiles.py
+++ b/tests/moneybin/test_cli/test_cli_profiles.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 import os
 from collections.abc import Generator
 from contextlib import contextmanager
+from pathlib import Path
 
+import pytest
 from pytest_mock import MockerFixture
 from typer.testing import CliRunner
 
@@ -22,6 +24,21 @@ from moneybin.utils.user_config import normalize_profile_name
 from tests.moneybin.conftest import temp_profile
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_moneybin_home(  # pyright: ignore[reportUnusedFunction]
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Give each test its own MONEYBIN_HOME to prevent xdist worker races.
+
+    Tests in this file create profile directories with fixed names
+    ("alice", "bob"). Without isolation, parallel xdist workers race on
+    the shared ``~/.moneybin/profiles/`` tree — one worker's cleanup
+    deletes another's profile mid-test, surfacing as a CLI
+    "Profile 'alice' does not exist" error.
+    """
+    monkeypatch.setenv("MONEYBIN_HOME", str(tmp_path))
 
 
 @contextmanager


### PR DESCRIPTION
## Summary

Tests in `test_cli_profiles.py` were intermittently failing under `pytest-xdist` because they created profile dirs with fixed names (`alice`, `bob`) under the real `~/.moneybin/profiles/`. Parallel workers raced cleanup against each other, surfacing as `Profile 'alice' does not exist`. This PR isolates each test to its own `MONEYBIN_HOME`.

## Impact

- No workflow changes for users. Test-only fix.
- Removes the need for the matching `## CLI profiles xdist flakiness` follow-up entry queued in `docs/followups.md` (added on the `refactor/mcp-simplify` branch — drop after #77 merges).

## Changes

### Per-test `MONEYBIN_HOME` isolation

Add an autouse fixture in `tests/moneybin/test_cli/test_cli_profiles.py` that monkeypatches `MONEYBIN_HOME` to `tmp_path`. `get_base_dir()` reads `MONEYBIN_HOME` first, so each test (and each xdist worker running it) gets a private profiles tree.

- New autouse fixture `_isolated_moneybin_home(tmp_path, monkeypatch)`.
- `_create_profile` is unchanged — it now writes into the per-test `tmp_path` automatically via `get_base_dir()`.

### Drop obsolete xdist-race comment

The `temp_profile` cleanup comment in `tests/moneybin/conftest.py` described the exact race this PR eliminates. Trim it to just the remaining ENOTEMPTY case for callers that don't isolate `MONEYBIN_HOME`.

## Testing

- `uv run pytest tests/moneybin/test_cli/test_cli_profiles.py -q` × 5 consecutive runs under default `-n auto` — 14/14 each run.
- `make format && make lint` clean.
- `uv run pyright` — 0 errors.
- `make test` — 1329 passed.

## Notes

The follow-up entry in `docs/followups.md` describing this flakiness lives on `refactor/mcp-simplify` (PR #77), not main. Once #77 merges, drop the section in a tiny follow-up commit on this branch.