### PR TITLE
Simplify services/: cache regexes, reuse CategorizationService

### DIFF
--- a/src/moneybin/services/auto_rule_service.py
+++ b/src/moneybin/services/auto_rule_service.py
@@ -161,6 +161,13 @@ class AutoRuleService:
     def __init__(self, db: Database) -> None:
         """Bind the service to a database connection."""
         self._db = db
+        self._cat_service: CategorizationService | None = None
+
+    @property
+    def _categorization(self) -> CategorizationService:
+        if self._cat_service is None:
+            self._cat_service = CategorizationService(self._db)
+        return self._cat_service
 
     # -- Observation --
 
@@ -770,7 +777,7 @@ class AutoRuleService:
             if txn_row is not None
             else None
         )
-        match = CategorizationService(self._db).find_matching_rule(
+        match = self._categorization.find_matching_rule(
             transaction_id,
             rules_override=rules_override,
             txn_row_override=txn_row_override,
@@ -853,8 +860,7 @@ class AutoRuleService:
         (subsequent ``apply_rules`` runs use ``INSERT OR IGNORE`` and won't
         override). Only assigns when the priority winner is this rule.
         """
-        cat_service = CategorizationService(self._db)
-        active_rules = cat_service.fetch_active_rules()
+        active_rules = self._categorization.fetch_active_rules()
         scan_cap = get_settings().categorization.auto_rule_backfill_scan_cap
         rows = self._db.execute(
             f"""

--- a/src/moneybin/services/categorization_service.py
+++ b/src/moneybin/services/categorization_service.py
@@ -15,6 +15,7 @@ import re
 import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
+from functools import lru_cache
 from time import perf_counter
 from typing import Any, Literal
 
@@ -173,6 +174,11 @@ class SeedResult:
         )
 
 
+@lru_cache(maxsize=512)
+def _compile_regex(pattern: str) -> re.Pattern[str]:
+    return re.compile(pattern, re.IGNORECASE)
+
+
 def matches_pattern(text: str, pattern: str, match_type: str) -> bool:
     """Check if text matches a pattern using the specified match type.
 
@@ -193,10 +199,11 @@ def matches_pattern(text: str, pattern: str, match_type: str) -> bool:
         return pattern_lower in text_lower
     elif match_type == "regex":
         try:
-            return bool(re.search(pattern, text, re.IGNORECASE))
+            compiled = _compile_regex(pattern)
         except re.error:
             logger.warning("Invalid regex pattern in merchant rule")
             return False
+        return bool(compiled.search(text))
     else:
         logger.warning(f"Unknown match_type: {match_type}")
         return False

--- a/src/moneybin/services/categorization_service.py
+++ b/src/moneybin/services/categorization_service.py
@@ -203,6 +203,7 @@ def matches_pattern(text: str, pattern: str, match_type: str) -> bool:
         except re.error:
             logger.warning("Invalid regex pattern in merchant rule")
             return False
+        # search() cannot raise re.error after successful compilation
         return bool(compiled.search(text))
     else:
         logger.warning(f"Unknown match_type: {match_type}")


### PR DESCRIPTION
### Summary
Pre-push `/simplify` pass on `src/moneybin/services/`. Two efficiency wins on the bulk-categorization hot path; no behavior changes.

### Impact
No workflow changes for callers. Internal-only refactor.

### Changes

#### `categorization_service.matches_pattern` — cached regex compilation
`re.search(pattern, text, re.IGNORECASE)` recompiled the pattern on every call. With `lru_cache(maxsize=512)` around a `_compile_regex` helper, each unique merchant/rule pattern compiles once and is reused across all transactions in a bulk run.

#### `AutoRuleService` — single shared `CategorizationService`
- `_active_rule_covers_transaction` constructed `CategorizationService(self._db)` per call (once per transaction during `record_categorization` loops). Now uses a lazily-initialized `_categorization` property.
- `_categorize_existing_with_rule` had its own ad-hoc instance; switched to the same property.

### Testing
- `make format && make lint` clean.
- `uv run pyright` on both files: 0 errors.
- `uv run pytest tests/moneybin/test_services/`: 166 passed.
- Full test suite: all passing.