### PR TITLE
Collapse N+1 COUNT(*) queries in `db info` into one UNION ALL

### DIFF
--- a/docs/followups.md
+++ b/docs/followups.md
@@ -214,3 +214,38 @@ Add goldens for both directions when fixed:
 - `TARGET STORE NY 10001` → `TARGET STORE` (merchant token preserved)
 
 Flagged by claude[bot] and chatgpt-codex-connector in PR #66 review.
+
+## CLI simplify pass — deferred findings (refactor/cli-simplify)
+
+Surfaced by `/simplify` review agents on the cli/ pass. Each was deemed
+out of scope for the narrow PR (which only collapses N+1 COUNT queries
+in `db info`) and parked here for future, focused changes.
+
+- **Lazy command-group imports in `cli/main.py`** — top-level imports of
+  every command module make `moneybin --help` pay the cost of loading
+  DuckDB, Plaid, etc. Defer with `typer.Typer(callback=...)` or
+  per-subcommand lazy imports. Quantify startup before/after first.
+- **`ImportConfig` dataclass for `import file`** — the command currently
+  takes ~16 typer options that get plumbed through. A frozen dataclass
+  would tighten the signature and make the call sites in tests less
+  brittle. Watch out for typer's introspection of parameter defaults.
+- **`render_or_json()` helper across `cli/commands/`** — the
+  `if json_output: typer.echo(json.dumps(...)) else: <table>` pattern
+  is repeated in `db.py`, `accounts.py`, and others. A small helper
+  taking `(payload, table_renderer)` would collapse it.
+- **Table-formatter helpers** — Rich `Table` construction is
+  copy-pasted with column-name-only differences. Consider a
+  `render_rows(rows, columns)` utility once a third command needs it
+  (rule of three).
+- **Broad `except Exception` audit in `synthetic.py` / `transform.py`** —
+  several handlers swallow all exceptions and re-raise as `typer.Exit`,
+  losing tracebacks. Narrow to expected types (`duckdb.Error`,
+  `OSError`, `pydantic.ValidationError`) where feasible.
+- **`_with_encryption_key` context manager for db key commands** — the
+  rotate/rekey/unlock paths each repeat the "load key → open db → run
+  op → zero key" dance. Extract a `with _encryption_key(...) as db:`
+  helper. Touches privacy-sensitive code; needs careful review.
+- **Stringly-typed validation flags → `Literal`** — several CLI options
+  accept free-form strings then validate against a hardcoded set
+  (`--format`, `--mode`, etc.). Switch to `Literal[...]` types so typer
+  generates the choices and pyright catches typos at call sites.

--- a/src/moneybin/cli/commands/db.py
+++ b/src/moneybin/cli/commands/db.py
@@ -359,18 +359,23 @@ def db_info(
             from sqlglot import exp
 
             table_rows: list[dict[str, object]] = []
-            for schema, table in tables:
-                safe_schema = exp.to_identifier(schema, quoted=True).sql("duckdb")  # type: ignore[reportUnknownMemberType]  # sqlglot has no stubs
-                safe_table = exp.to_identifier(table, quoted=True).sql("duckdb")  # type: ignore[reportUnknownMemberType]  # sqlglot has no stubs
-                count_result = db.execute(
-                    f"SELECT COUNT(*) FROM {safe_schema}.{safe_table}"  # noqa: S608 — sqlglot-quoted catalog identifiers
-                ).fetchone()
-                count = count_result[0] if count_result else 0
-                table_rows.append({
-                    "schema": schema,
-                    "table": table,
-                    "rows": count,
-                })
+            if tables:
+                # One round trip instead of N — UNION ALL over per-table counts
+                # so DuckDB plans them together.
+                count_selects: list[str] = []
+                for schema, table in tables:
+                    safe_schema = exp.to_identifier(schema, quoted=True).sql("duckdb")  # type: ignore[reportUnknownMemberType]  # sqlglot has no stubs
+                    safe_table = exp.to_identifier(table, quoted=True).sql("duckdb")  # type: ignore[reportUnknownMemberType]  # sqlglot has no stubs
+                    sql = (
+                        f"SELECT '{schema}' AS schema, '{table}' AS \"table\", "  # noqa: S608 — sqlglot-quoted catalog identifiers; labels are information_schema-sourced
+                        f"COUNT(*) AS rows FROM {safe_schema}.{safe_table}"
+                    )
+                    count_selects.append(sql)
+                union_sql = " UNION ALL ".join(count_selects)
+                count_rows = db.execute(union_sql).fetchall()  # noqa: S608 — sqlglot-quoted catalog identifiers and information_schema-sourced names
+                table_rows = [
+                    {"schema": s, "table": t, "rows": c} for s, t, c in count_rows
+                ]
 
             payload["tables"] = table_rows
 

--- a/src/moneybin/cli/commands/db.py
+++ b/src/moneybin/cli/commands/db.py
@@ -366,8 +366,12 @@ def db_info(
                 for schema, table in tables:
                     safe_schema = exp.to_identifier(schema, quoted=True).sql("duckdb")  # type: ignore[reportUnknownMemberType]  # sqlglot has no stubs
                     safe_table = exp.to_identifier(table, quoted=True).sql("duckdb")  # type: ignore[reportUnknownMemberType]  # sqlglot has no stubs
+                    # Double single-quotes per SQL standard so identifiers like
+                    # `o'clock` survive embedding as string literal labels.
+                    label_schema = schema.replace("'", "''")
+                    label_table = table.replace("'", "''")
                     sql = (
-                        f"SELECT '{schema}' AS schema, '{table}' AS \"table\", "  # noqa: S608 — sqlglot-quoted catalog identifiers; labels are information_schema-sourced
+                        f"SELECT '{label_schema}' AS schema, '{label_table}' AS \"table\", "  # noqa: S608 — sqlglot-quoted FROM identifiers; labels are quote-escaped
                         f"COUNT(*) AS rows FROM {safe_schema}.{safe_table}"
                     )
                     count_selects.append(sql)

--- a/tests/moneybin/test_cli/test_db_commands.py
+++ b/tests/moneybin/test_cli/test_db_commands.py
@@ -853,10 +853,16 @@ class TestDbInfoCommand:
 
         mock_db = MagicMock()
         mock_db.__enter__ = lambda self: self  # type: ignore[assignment]
-        mock_db.execute.return_value.fetchall.return_value = [
-            ("core", "fct_transactions")
-        ]
-        mock_db.execute.return_value.fetchone.return_value = (42,)
+
+        def execute_side_effect(sql: str, *_args: Any, **_kw: Any) -> MagicMock:
+            result = MagicMock()
+            if "information_schema" in sql:
+                result.fetchall.return_value = [("core", "fct_transactions")]
+            else:
+                result.fetchall.return_value = [("core", "fct_transactions", 42)]
+            return result
+
+        mock_db.execute.side_effect = execute_side_effect
         mock_db.sql.return_value.fetchone.return_value = ("v1.2.3",)
         mocker.patch("moneybin.database.Database", return_value=mock_db)
 


### PR DESCRIPTION
## Summary

Narrow `/simplify` pass on `cli/`. The only code change collapses the per-table COUNT(*) loop in `moneybin db info` into a single `UNION ALL` so DuckDB plans the counts together — N round trips become 1. Out-of-scope findings from the simplify review are parked in `docs/followups.md` for future focused work.

## Impact

- No behavior change for `moneybin db info` output. JSON and table renderings are identical.
- On databases with many tables, `db info` is meaningfully faster (single round trip vs N).
- No workflow changes for teammates.

## Changes

#### `db info`: one UNION ALL instead of N COUNT(*) queries

Each table count is rendered as a `SELECT '<schema>' AS schema, '<table>' AS "table", COUNT(*) AS rows FROM <quoted>.<quoted>` and joined with `UNION ALL`. Identifiers are quoted via `sqlglot.exp.to_identifier(..., quoted=True)` exactly as the prior loop did; the schema/table label literals are sourced from `information_schema` and never user-controlled.

- `src/moneybin/cli/commands/db.py` — collapse the loop; `# noqa: S608` notes the sqlglot quoting + information_schema source.
- `tests/moneybin/test_cli/test_db_commands.py` — switch the mock to a `side_effect` that branches on `"information_schema" in sql` so both query shapes return the right rows.

#### Park deferred simplify findings

Added a `## CLI simplify pass — deferred findings (refactor/cli-simplify)` section to `docs/followups.md` listing items the simplify pass surfaced but didn't address: lazy command-group imports in `cli/main.py`, an `ImportConfig` dataclass for `import file`, a `render_or_json()` helper, table-formatter helpers, a broad `except Exception` audit, a `_with_encryption_key` context manager, and `Literal`-typed CLI flags.

## Testing

- `make check test` — full pre-commit gate passes.
- `uv run pytest tests/moneybin/test_cli/test_db_commands.py -v` — db_info tests pass with the new mock shape.

## Notes

The deferred findings in `docs/followups.md` are intentionally not addressed here — each is large enough to deserve its own focused PR, and bundling them would dilute review.