### PR TITLE
Add curated moneybin://schema MCP resource for ad-hoc SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Full command reference: [CLI Reference](docs/guides/cli-reference.md).
 | Net worth & balance tracking, budget tracking | 📐 |
 | Investment tracking (holdings, cost basis) | 🗓️ |
 | Privacy tiers & consent model | 📐 |
-| MCP SQL schema discoverability (curated `moneybin://schema` resource) | 📐 |
+| MCP SQL schema discoverability (curated `moneybin://schema` resource) | ✅ |
 | Export (CSV, Excel, Google Sheets) | 🗓️ |
 
 Per-feature design specs live in [`docs/specs/`](docs/specs/INDEX.md).

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Full command reference: [CLI Reference](docs/guides/cli-reference.md).
 | Net worth & balance tracking, budget tracking | 📐 |
 | Investment tracking (holdings, cost basis) | 🗓️ |
 | Privacy tiers & consent model | 📐 |
+| MCP SQL schema discoverability (curated `moneybin://schema` resource) | 📐 |
 | Export (CSV, Excel, Google Sheets) | 🗓️ |
 
 Per-feature design specs live in [`docs/specs/`](docs/specs/INDEX.md).

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -259,3 +259,20 @@ logic, examples that lag behind schema changes), revisit the **sibling
 `.examples.sql`** approach: one file per table next to the model, parsed
 at startup. See `docs/specs/mcp-sql-discoverability.md` Section "Out of
 Scope" and the brainstorming session that produced it.
+
+## MCP schema discoverability — app.* drift coverage
+
+The drift tests in `tests/moneybin/test_services/test_schema_catalog.py`
+only exercise `core.*` interface tables because the `schema_catalog_db`
+fixture only seeds `core.dim_accounts`, `core.fct_transactions`, and
+`core.bridge_transfers`. Six `app.*` interface tables (`categories`,
+`budgets`, `transaction_notes`, `merchants`, `categorization_rules`,
+`transaction_categories`) are silently skipped — a column rename in any
+of them is not caught by CI until the schema doc is read at runtime.
+
+Add a `create_app_interface_tables_raw()` helper to
+`tests/moneybin/db_helpers.py` (parallel to `create_core_tables_raw`)
+and extend the `schema_catalog_db` fixture to call it. The DDL exists in
+`src/moneybin/sql/schema/app_*.sql` and could be loaded directly via
+`schema.py:init_schemas()` if a non-private interface is exposed, or
+mirrored as Python constants like the core helpers do today.

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -249,3 +249,13 @@ in `db info`) and parked here for future, focused changes.
   accept free-form strings then validate against a hardcoded set
   (`--format`, `--mode`, etc.). Switch to `Literal[...]` types so typer
   generates the choices and pyright catches typos at call sites.
+## Schema examples co-location (post-`mcp-sql-discoverability`)
+
+Example queries currently live in `src/moneybin/services/schema_catalog.py`
+(`EXAMPLES` dict) with one-line pointer comments in each interface model
+and DDL file. If example drift becomes a real maintenance problem
+(examples that reference dropped columns, examples that contradict model
+logic, examples that lag behind schema changes), revisit the **sibling
+`.examples.sql`** approach: one file per table next to the model, parsed
+at startup. See `docs/specs/mcp-sql-discoverability.md` Section "Out of
+Scope" and the brainstorming session that produced it.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -71,7 +71,7 @@ Single source of truth for spec status. Update this table when a spec's status c
 |---|---|---|---|
 | [Architecture & Design](mcp-architecture.md) | Architecture | in-progress | MCP v1 design philosophy, tool taxonomy, privacy integration, CLI symmetry, Apps readiness. Supersedes archived `mcp-read-tools` and `mcp-write-tools` specs. |
 | [Tool Surface](mcp-tool-surface.md) | Architecture | in-progress | Concrete tool, prompt, resource, and service layer definitions for MCP v1 (46 tools, 4 prompts, 4 resources) |
-| [SQL Schema Discoverability](mcp-sql-discoverability.md) | Feature | draft | `moneybin://schema` resource exposes curated interface tables (core + select app) with columns, comments, and example queries; eliminates per-session schema reconnaissance |
+| [SQL Schema Discoverability](mcp-sql-discoverability.md) | Feature | in-progress | `moneybin://schema` resource exposes curated interface tables (core + select app) with columns, comments, and example queries; eliminates per-session schema reconnaissance |
 
 ## Sync
 

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -71,6 +71,7 @@ Single source of truth for spec status. Update this table when a spec's status c
 |---|---|---|---|
 | [Architecture & Design](mcp-architecture.md) | Architecture | in-progress | MCP v1 design philosophy, tool taxonomy, privacy integration, CLI symmetry, Apps readiness. Supersedes archived `mcp-read-tools` and `mcp-write-tools` specs. |
 | [Tool Surface](mcp-tool-surface.md) | Architecture | in-progress | Concrete tool, prompt, resource, and service layer definitions for MCP v1 (46 tools, 4 prompts, 4 resources) |
+| [SQL Schema Discoverability](mcp-sql-discoverability.md) | Feature | draft | `moneybin://schema` resource exposes curated interface tables (core + select app) with columns, comments, and example queries; eliminates per-session schema reconnaissance |
 
 ## Sync
 

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -71,7 +71,7 @@ Single source of truth for spec status. Update this table when a spec's status c
 |---|---|---|---|
 | [Architecture & Design](mcp-architecture.md) | Architecture | in-progress | MCP v1 design philosophy, tool taxonomy, privacy integration, CLI symmetry, Apps readiness. Supersedes archived `mcp-read-tools` and `mcp-write-tools` specs. |
 | [Tool Surface](mcp-tool-surface.md) | Architecture | in-progress | Concrete tool, prompt, resource, and service layer definitions for MCP v1 (46 tools, 4 prompts, 4 resources) |
-| [SQL Schema Discoverability](mcp-sql-discoverability.md) | Feature | in-progress | `moneybin://schema` resource exposes curated interface tables (core + select app) with columns, comments, and example queries; eliminates per-session schema reconnaissance |
+| [SQL Schema Discoverability](mcp-sql-discoverability.md) | Feature | implemented | `moneybin://schema` resource exposes curated interface tables (core + select app) with columns, comments, and example queries; eliminates per-session schema reconnaissance |
 
 ## Sync
 

--- a/docs/specs/mcp-sql-discoverability.md
+++ b/docs/specs/mcp-sql-discoverability.md
@@ -1,7 +1,7 @@
 # Feature: MCP SQL Schema Discoverability
 
 ## Status
-in-progress
+implemented
 
 ## Goal
 

--- a/docs/specs/mcp-sql-discoverability.md
+++ b/docs/specs/mcp-sql-discoverability.md
@@ -1,0 +1,186 @@
+# Feature: MCP SQL Schema Discoverability
+
+## Status
+draft
+
+## Goal
+
+Give the MCP-connected LLM enough schema context to write accurate `sql_query` calls on the first try, without spending round-trips on catalog reconnaissance. Restrict the curated surface to a small set of consumer-facing **interface tables** so the LLM doesn't reach into `raw`, `prep`, or `meta` schemas by default.
+
+## Background
+
+The `sql_query` tool (`src/moneybin/mcp/tools/sql.py`) accepts read-only SQL but ships no schema context. Today, the LLM either guesses table/column names or runs 1-3 introspection queries (`SHOW TABLES`, `DESCRIBE …`) before each non-trivial request.
+
+Existing assets this design builds on:
+
+- **`tables.py`** is the authoritative registry of `TableRef` constants.
+- **DuckDB catalog already carries column docs.** SQLMesh's `register_comments` propagates the inline `/* ... */` blocks on each model's final SELECT into `duckdb_columns().comment`. Schema DDL files apply table/column comments via `schema.py:_apply_comments()` on app startup. So `duckdb_tables()` and `duckdb_columns()` are the source of truth for both structure and prose — no parallel YAML to maintain.
+- **MCP resources** (`src/moneybin/mcp/resources.py`) already exist for `moneybin://status`, `moneybin://accounts`, `moneybin://privacy`. New resource follows the same pattern.
+- **Architecture rule**: per `mcp-architecture.md`, consumers read from **core** (analytics) and **app** (user-authored state). Raw and prep are implementation details.
+
+## Requirements
+
+1. The LLM connected via MCP can discover, in one resource read, every table it should query, including: schema-qualified name, table purpose, every column with type and prose comment, and 2-3 representative example queries per table.
+2. Only the curated **interface tables** appear in the resource. Other schemas (`raw`, `prep`, `meta`, `seeds`) are reachable only via explicit catalog queries through `sql_query`.
+3. The interface-table set is declared **once**, at the `TableRef` definition site in `tables.py`. There is no parallel list to keep in sync.
+4. The resource includes a "beyond the interface" footer that names the other schemas with one-line purposes and provides a sample catalog query so a power user (or the LLM, when explicitly asked) can spelunk further without consulting external docs.
+5. The `sql_query` tool description includes a one-line pointer to the resource, as a fallback for clients that do not auto-load resources.
+6. A startup-time / test-time assertion catches **stale-entry drift**: every `INTERFACE_TABLES` member must exist in `duckdb_tables()`.
+7. Example queries are tested end-to-end: every example query in the catalog must parse and execute against a seeded test database without error.
+8. Schema metadata is `low` sensitivity — no consent gate.
+
+## Data Model
+
+No schema changes. The feature is read-only against existing catalog tables (`duckdb_tables`, `duckdb_columns`).
+
+The `TableRef` `NamedTuple` in `src/moneybin/tables.py` gains one field:
+
+```python
+class TableRef(NamedTuple):
+    schema: str
+    name: str
+    audience: Literal["interface", "internal"] = "internal"
+
+    @property
+    def full_name(self) -> str:
+        return f"{self.schema}.{self.name}"
+```
+
+Interface tables are tagged at the call site:
+
+```python
+FCT_TRANSACTIONS = TableRef("core", "fct_transactions", audience="interface")
+DIM_ACCOUNTS = TableRef("core", "dim_accounts", audience="interface")
+BRIDGE_TRANSFERS = TableRef("core", "bridge_transfers", audience="interface")
+
+CATEGORIES = TableRef("app", "categories", audience="interface")
+BUDGETS = TableRef("app", "budgets", audience="interface")
+TRANSACTION_NOTES = TableRef("app", "transaction_notes", audience="interface")
+MERCHANTS = TableRef("app", "merchants", audience="interface")
+CATEGORIZATION_RULES = TableRef("app", "categorization_rules", audience="interface")
+TRANSACTION_CATEGORIES = TableRef("app", "transaction_categories", audience="interface")
+```
+
+All other `TableRef` constants stay on the default (`"internal"`).
+
+A module-level helper derives the interface tuple from the constants defined in the module:
+
+```python
+INTERFACE_TABLES: tuple[TableRef, ...] = tuple(
+    t for t in _all_table_refs() if t.audience == "interface"
+)
+```
+
+`_all_table_refs()` introspects the module's globals (`vars(sys.modules[__name__])`) and filters for `TableRef` instances. This avoids a hand-maintained second list.
+
+## Resource Document Shape
+
+`moneybin://schema` returns pretty-printed JSON:
+
+```json
+{
+  "version": 1,
+  "generated_at": "2026-05-01T18:30:00Z",
+  "conventions": {
+    "amount_sign": "negative = expense, positive = income",
+    "currency": "DECIMAL(18,2); ISO 4217 codes in currency_code columns",
+    "dates": "DATE type; transaction_date is the canonical posting date",
+    "ids": "Deterministic SHA-256 truncated to 16 hex chars; see core.fct_transactions.transaction_id"
+  },
+  "tables": [
+    {
+      "name": "core.fct_transactions",
+      "purpose": "Canonical transactions fact view; reads from the deduplicated merged layer with categorization and merchant joins; negative amount = expense, positive = income",
+      "columns": [
+        {"name": "transaction_id", "type": "VARCHAR", "nullable": false, "comment": "Gold key: deterministic SHA-256 hash, unique per real-world transaction"},
+        {"name": "amount", "type": "DECIMAL(18,2)", "nullable": false, "comment": "Transaction amount; negative = expense, positive = income"}
+      ],
+      "examples": [
+        {
+          "question": "Total spending by category last month",
+          "sql": "SELECT category, SUM(amount_absolute) AS total FROM core.fct_transactions WHERE transaction_direction = 'expense' AND transaction_year_month = STRFTIME(CURRENT_DATE - INTERVAL 1 MONTH, '%Y-%m') GROUP BY category ORDER BY total DESC"
+        }
+      ]
+    }
+  ],
+  "beyond_the_interface": {
+    "note": "The tables above are the curated query surface. Other schemas exist for raw ingest (raw), staging (prep), provenance (meta), and seed data (seeds). Use them only when the curated tables cannot answer the question.",
+    "catalog_query": "SELECT table_schema, table_name, comment FROM duckdb_tables() WHERE table_schema NOT IN ('main', 'pg_catalog') ORDER BY 1, 2"
+  }
+}
+```
+
+Key choices:
+
+- **Top-level `conventions`** captures cross-table rules once; column comments stay focused on what makes that column distinct.
+- **`purpose`** is pulled directly from `duckdb_tables().comment` (already populated from the `/* */` block above each `MODEL()`).
+- **`columns`** is a structured projection of `duckdb_columns()` filtered to interface tables — no manual transcription.
+- **`examples`** are hand-authored. They live in a Python dict in `services/schema_catalog.py`, keyed by `TableRef.full_name`. Each table gets 2-3 examples chosen to teach **idioms** (period grouping via `transaction_year_month`, sign filtering via `transaction_direction`, joins between fact and dimension tables) — not exhaustive coverage.
+
+## Implementation Plan
+
+### Files to Create
+
+- `src/moneybin/services/schema_catalog.py` — `Example` dataclass, `EXAMPLES: dict[str, list[Example]]`, `build_schema_doc() -> dict`, conventions block.
+- `tests/moneybin/test_services/test_schema_catalog.py` — see Testing Strategy.
+
+### Files to Modify
+
+- `src/moneybin/tables.py` — add `audience` field to `TableRef`, mark interface tables, add `INTERFACE_TABLES` derivation helper.
+- `src/moneybin/mcp/resources.py` — register `moneybin://schema` resource (~10 lines, calls `build_schema_doc()` and `json.dumps`).
+- `src/moneybin/mcp/tools/sql.py` — append a single line to `sql_query`'s docstring and the registration description: *"For schema, columns, and example queries, read resource `moneybin://schema`."*
+- `sqlmesh/models/core/fct_transactions.sql`, `sqlmesh/models/core/dim_accounts.sql`, `sqlmesh/models/core/bridge_transfers.sql` — add a one-line pointer comment near the top: `/* Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict) */`.
+- `src/moneybin/sql/schema/app_*.sql` files for each interface app table (e.g. `app_budgets.sql`, `app_categories.sql`, `app_merchants.sql`, `app_categorization_rules.sql`, `app_transaction_categories.sql`, `app_transaction_notes.sql`) — same pointer comment.
+- `docs/followups.md` — append a section noting that examples could move to sibling `.examples.sql` files if drift becomes a real problem (see "Out of Scope" below).
+- `docs/specs/INDEX.md` — add this spec to the **MCP** section.
+
+### Key Decisions
+
+- **No caching in v1.** `duckdb_tables()` / `duckdb_columns()` are catalog reads — microseconds. Add caching only if profiling shows it matters.
+- **Single bundled resource, not per-table resources.** Total payload is ~2-4K tokens for ~9 tables / ~95 columns. One fetch covers every subsequent query in the session; per-table would force the LLM to repeatedly fetch `fct_transactions` (used in most queries) plus a second table per join.
+- **JSON, not Markdown.** Structured output is sliceable for future tooling (e.g., a `sql_describe(table)` tool would call the same `build_schema_doc()` and project a single entry).
+- **Drift coverage.** Two tests address two drift modes: a presence assertion catches stale `INTERFACE_TABLES` entries; an example-execution test catches column renames that examples missed. The "forgot to add a new interface table" case is not mechanically catchable — it relies on convention (a comment near the top of `tables.py`).
+- **Power-user path is `sql_query` against the catalog**, not a parameterized resource. Adding `moneybin://schema/all` later is trivial if real demand emerges.
+- **Sensitivity is `low`.** Schema metadata — table names, column names, structural comments — is not PII. No consent gate; audit log entry on each read like other resources.
+
+## CLI Interface
+
+None. The schema doc is consumed by the MCP layer. If a CLI surface is desired later, it would be a thin wrapper: `moneybin mcp schema [--json|--markdown]` calling `build_schema_doc()`.
+
+## MCP Interface
+
+**New resource:**
+
+| URI | Sensitivity | Returns |
+|---|---|---|
+| `moneybin://schema` | low | JSON document describing every interface table, with conventions and example queries |
+
+**Modified tool:**
+
+| Tool | Change |
+|---|---|
+| `sql_query` | Description gains one line: *"For schema, columns, and example queries, read resource `moneybin://schema`."* No behavior change. |
+
+## Testing Strategy
+
+Three unit tests in `tests/moneybin/test_services/test_schema_catalog.py`:
+
+1. **`test_interface_tables_present_in_catalog`** — initialize the test database, then assert every `TableRef` in `INTERFACE_TABLES` appears in `duckdb_tables()`. Catches stale-entry drift (table renamed/removed but constant still tagged `interface`).
+2. **`test_examples_only_reference_interface_tables`** — every key in `EXAMPLES` must equal some `TableRef.full_name` from `INTERFACE_TABLES`. Catches orphan examples for tables that no longer exist or were never interface-tagged.
+3. **`test_examples_parse_and_run`** — seed the test database (existing fixtures), iterate every example query in `EXAMPLES`, execute it via `db.execute(query).fetchall()`. Any failure (parse error, missing column, type mismatch) fails the test. Catches column-renamed-but-example-not-updated drift.
+
+Plus one integration test in `tests/moneybin/test_mcp/test_resources.py` (or wherever existing resource tests live):
+
+4. **`test_schema_resource_returns_valid_json_with_all_interface_tables`** — read the resource, parse the JSON, assert every `INTERFACE_TABLES.full_name` is present in `tables[].name`, assert `conventions` and `beyond_the_interface` keys exist.
+
+## Dependencies
+
+None. All required machinery (DuckDB catalog tables, FastMCP resources, `Database`, `TableRef`) is already in place.
+
+## Out of Scope
+
+- **Sibling `.examples.sql` files per model.** Considered and deferred; tracked in `docs/followups.md`. If example drift becomes a real maintenance problem (examples that reference dropped columns, examples that contradict model logic), revisit by parsing per-table sibling files at startup.
+- **Per-table resources** (`moneybin://schema/<table>`). Not needed at current size; revisit if `INTERFACE_TABLES` grows past ~20 tables or column count past ~300.
+- **`moneybin://schema/all`** (uncurated view). Power users get this via `sql_query` against the DuckDB catalog. Add only if real demand emerges.
+- **Caching the schema doc.** Catalog reads are sub-millisecond; not worth the invalidation cost in v1.
+- **Auto-extracting examples from existing test cases** (e.g., test_services queries). Would couple the LLM-facing surface to test internals; explicit hand-authored examples are clearer.

--- a/docs/specs/mcp-sql-discoverability.md
+++ b/docs/specs/mcp-sql-discoverability.md
@@ -1,7 +1,7 @@
 # Feature: MCP SQL Schema Discoverability
 
 ## Status
-draft
+in-progress
 
 ## Goal
 

--- a/docs/superpowers/plans/2026-05-01-mcp-sql-discoverability.md
+++ b/docs/superpowers/plans/2026-05-01-mcp-sql-discoverability.md
@@ -152,18 +152,14 @@ TABULAR_ACCOUNTS = TableRef("raw", "tabular_accounts")
 IMPORT_LOG = TableRef("raw", "import_log")
 
 # -- App tables (application-managed data) --
-TRANSACTION_CATEGORIES = TableRef(
-    "app", "transaction_categories", audience="interface"
-)
+TRANSACTION_CATEGORIES = TableRef("app", "transaction_categories", audience="interface")
 BUDGETS = TableRef("app", "budgets", audience="interface")
 TRANSACTION_NOTES = TableRef("app", "transaction_notes", audience="interface")
 CATEGORIES = TableRef("app", "categories", audience="interface")
 USER_CATEGORIES = TableRef("app", "user_categories")
 CATEGORY_OVERRIDES = TableRef("app", "category_overrides")
 MERCHANTS = TableRef("app", "merchants", audience="interface")
-CATEGORIZATION_RULES = TableRef(
-    "app", "categorization_rules", audience="interface"
-)
+CATEGORIZATION_RULES = TableRef("app", "categorization_rules", audience="interface")
 PROPOSED_RULES = TableRef("app", "proposed_rules")
 RULE_DEACTIVATIONS = TableRef("app", "rule_deactivations")
 SCHEMA_MIGRATIONS = TableRef("app", "schema_migrations")
@@ -197,9 +193,7 @@ def _all_table_refs() -> tuple[TableRef, ...]:
     """
     module = sys.modules[__name__]
     return tuple(
-        value
-        for value in vars(module).values()
-        if isinstance(value, TableRef)
+        value for value in vars(module).values() if isinstance(value, TableRef)
     )
 
 
@@ -486,13 +480,10 @@ CORE_TABLE_COMMENTS: dict[str, str] = {
 CORE_COLUMN_COMMENTS: dict[str, dict[str, str]] = {
     "core.fct_transactions": {
         "transaction_id": (
-            "Gold key: deterministic SHA-256 hash, "
-            "unique per real-world transaction"
+            "Gold key: deterministic SHA-256 hash, unique per real-world transaction"
         ),
         "amount": "Transaction amount; negative = expense, positive = income",
-        "transaction_direction": (
-            "Derived from amount sign: expense, income, or zero"
-        ),
+        "transaction_direction": ("Derived from amount sign: expense, income, or zero"),
         "category": (
             "Spending category; from app.transaction_categories when "
             "categorized, else source value"
@@ -591,9 +582,7 @@ def test_build_schema_doc_columns_carry_type_and_comment(
     schema_db: Database,
 ) -> None:
     doc = build_schema_doc()
-    fct = next(
-        t for t in doc["tables"] if t["name"] == "core.fct_transactions"
-    )
+    fct = next(t for t in doc["tables"] if t["name"] == "core.fct_transactions")
     cols_by_name = {c["name"]: c for c in fct["columns"]}
     assert "amount" in cols_by_name
     assert "DECIMAL" in cols_by_name["amount"]["type"].upper()
@@ -604,9 +593,7 @@ def test_build_schema_doc_includes_examples_for_present_tables(
     schema_db: Database,
 ) -> None:
     doc = build_schema_doc()
-    fct = next(
-        t for t in doc["tables"] if t["name"] == "core.fct_transactions"
-    )
+    fct = next(t for t in doc["tables"] if t["name"] == "core.fct_transactions")
     assert len(fct["examples"]) >= 1
     first = fct["examples"][0]
     assert "question" in first
@@ -679,25 +666,23 @@ def build_schema_doc() -> dict[str, Any]:
             """,
             [schema_name, table_name],
         ).fetchall()
-        tables.append(
-            {
-                "name": full_name,
-                "purpose": table_comment,
-                "columns": [
-                    {
-                        "name": name,
-                        "type": dtype,
-                        "nullable": bool(nullable),
-                        "comment": comment,
-                    }
-                    for name, dtype, nullable, comment in col_rows
-                ],
-                "examples": [
-                    {"question": ex.question, "sql": ex.sql}
-                    for ex in EXAMPLES.get(full_name, [])
-                ],
-            }
-        )
+        tables.append({
+            "name": full_name,
+            "purpose": table_comment,
+            "columns": [
+                {
+                    "name": name,
+                    "type": dtype,
+                    "nullable": bool(nullable),
+                    "comment": comment,
+                }
+                for name, dtype, nullable, comment in col_rows
+            ],
+            "examples": [
+                {"question": ex.question, "sql": ex.sql}
+                for ex in EXAMPLES.get(full_name, [])
+            ],
+        })
 
     logger.info("Schema doc built: %d interface tables present", len(tables))
 
@@ -944,9 +929,10 @@ In `src/moneybin/mcp/tools/sql.py`, replace the `sql_query` docstring (lines 21-
 And update the registration description in `register_sql_tools` to:
 
 ```python
-        "Execute a read-only SQL query against the database. "
-        "Supports SELECT, WITH, DESCRIBE, SHOW, PRAGMA, EXPLAIN. "
-        "Read resource moneybin://schema for tables, columns, and example queries.",
+"Execute a read-only SQL query against the database."
+
+"Supports SELECT, WITH, DESCRIBE, SHOW, PRAGMA, EXPLAIN. "
+("Read resource moneybin://schema for tables, columns, and example queries.",)
 ```
 
 - [ ] **Step 2: Verify nothing else broke**

--- a/docs/superpowers/plans/2026-05-01-mcp-sql-discoverability.md
+++ b/docs/superpowers/plans/2026-05-01-mcp-sql-discoverability.md
@@ -1,0 +1,1126 @@
+# MCP SQL Schema Discoverability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `moneybin://schema` MCP resource that returns a curated, structured schema document (interface tables + columns + comments + example queries) so the LLM can write accurate `sql_query` calls without per-session DESCRIBE/SHOW reconnaissance.
+
+**Architecture:** Tag interface tables on `TableRef` via a new `audience` field. A new `services/schema_catalog.py` derives the interface-table tuple from the registry, joins live catalog metadata (`duckdb_tables()`, `duckdb_columns()`) with hand-authored example queries, and emits a JSON-serializable dict. The resource is a thin wrapper.
+
+**Tech Stack:** Python 3.12, DuckDB (catalog reads), FastMCP (resource registration), Pydantic-free dataclasses, pytest.
+
+**Spec:** `docs/specs/mcp-sql-discoverability.md`
+
+---
+
+## File Map
+
+**Modify:**
+- `src/moneybin/tables.py` — add `audience` to `TableRef`, mark 9 interface tables, add `INTERFACE_TABLES` helper
+- `src/moneybin/mcp/resources.py` — register `moneybin://schema`
+- `src/moneybin/mcp/tools/sql.py` — append schema pointer to docstring + registration description
+- `tests/moneybin/db_helpers.py` — extend core DDL with inline comments matching SQLMesh models
+- `sqlmesh/models/core/{fct_transactions,dim_accounts,bridge_transfers}.sql` — pointer comment
+- `src/moneybin/sql/schema/app_{categories,budgets,transaction_notes,merchants,categorization_rules,transaction_categories}.sql` — pointer comment
+- `docs/followups.md` — add co-location followup note
+
+**Create:**
+- `src/moneybin/services/schema_catalog.py` — `Example` dataclass, `EXAMPLES` dict, `build_schema_doc()`, `CONVENTIONS`
+- `tests/moneybin/test_services/test_schema_catalog.py` — drift + structure + example-execution tests
+
+---
+
+## Task 1: Add `audience` to `TableRef` and derive `INTERFACE_TABLES`
+
+**Files:**
+- Modify: `src/moneybin/tables.py`
+- Test: `tests/moneybin/test_tables.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/moneybin/test_tables.py`:
+
+```python
+"""Tests for the TableRef registry and INTERFACE_TABLES derivation."""
+
+from __future__ import annotations
+
+from moneybin.tables import (
+    BRIDGE_TRANSFERS,
+    BUDGETS,
+    CATEGORIES,
+    CATEGORIZATION_RULES,
+    DIM_ACCOUNTS,
+    FCT_TRANSACTIONS,
+    INTERFACE_TABLES,
+    MERCHANTS,
+    OFX_TRANSACTIONS,
+    TRANSACTION_CATEGORIES,
+    TRANSACTION_NOTES,
+    TableRef,
+)
+
+EXPECTED_INTERFACE = {
+    "core.fct_transactions",
+    "core.dim_accounts",
+    "core.bridge_transfers",
+    "app.categories",
+    "app.budgets",
+    "app.transaction_notes",
+    "app.merchants",
+    "app.categorization_rules",
+    "app.transaction_categories",
+}
+
+
+def test_audience_defaults_to_internal() -> None:
+    t = TableRef("foo", "bar")
+    assert t.audience == "internal"
+
+
+def test_interface_tables_set_matches_expected() -> None:
+    full_names = {t.full_name for t in INTERFACE_TABLES}
+    assert full_names == EXPECTED_INTERFACE
+
+
+def test_interface_tables_all_carry_interface_audience() -> None:
+    for t in INTERFACE_TABLES:
+        assert t.audience == "interface"
+
+
+def test_internal_tables_excluded_from_interface() -> None:
+    assert OFX_TRANSACTIONS not in INTERFACE_TABLES
+    assert OFX_TRANSACTIONS.audience == "internal"
+
+
+def test_full_name_unchanged() -> None:
+    assert FCT_TRANSACTIONS.full_name == "core.fct_transactions"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/moneybin/test_tables.py -v`
+Expected: ImportError on `INTERFACE_TABLES`, or AttributeError on `audience`.
+
+- [ ] **Step 3: Implement the change**
+
+Replace the contents of `src/moneybin/tables.py` with:
+
+```python
+"""Table registry — single source of truth for schema-qualified table names.
+
+All consumers (MCP server, CLI, services) import table constants from here.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Literal, NamedTuple
+
+# When adding a new TableRef constant: if it should be visible to MCP
+# clients via the curated `moneybin://schema` resource, pass
+# audience="interface". Otherwise it stays internal (default).
+
+
+class TableRef(NamedTuple):
+    """Reference to a database table with schema and name."""
+
+    schema: str
+    name: str
+    audience: Literal["interface", "internal"] = "internal"
+
+    @property
+    def full_name(self) -> str:
+        """Schema-qualified table name for use in SQL queries."""
+        return f"{self.schema}.{self.name}"
+
+
+# -- Core layer (canonical tables built by SQLMesh transforms) --
+DIM_ACCOUNTS = TableRef("core", "dim_accounts", audience="interface")
+FCT_TRANSACTIONS = TableRef("core", "fct_transactions", audience="interface")
+BRIDGE_TRANSFERS = TableRef("core", "bridge_transfers", audience="interface")
+
+# -- Raw tables (used until core models are built for these entities) --
+OFX_ACCOUNTS = TableRef("raw", "ofx_accounts")
+OFX_TRANSACTIONS = TableRef("raw", "ofx_transactions")
+OFX_BALANCES = TableRef("raw", "ofx_balances")
+OFX_INSTITUTIONS = TableRef("raw", "ofx_institutions")
+W2_FORMS = TableRef("raw", "w2_forms")
+
+# -- Raw tabular tables (replaces csv_* tables) --
+TABULAR_TRANSACTIONS = TableRef("raw", "tabular_transactions")
+TABULAR_ACCOUNTS = TableRef("raw", "tabular_accounts")
+IMPORT_LOG = TableRef("raw", "import_log")
+
+# -- App tables (application-managed data) --
+TRANSACTION_CATEGORIES = TableRef(
+    "app", "transaction_categories", audience="interface"
+)
+BUDGETS = TableRef("app", "budgets", audience="interface")
+TRANSACTION_NOTES = TableRef("app", "transaction_notes", audience="interface")
+CATEGORIES = TableRef("app", "categories", audience="interface")
+USER_CATEGORIES = TableRef("app", "user_categories")
+CATEGORY_OVERRIDES = TableRef("app", "category_overrides")
+MERCHANTS = TableRef("app", "merchants", audience="interface")
+CATEGORIZATION_RULES = TableRef(
+    "app", "categorization_rules", audience="interface"
+)
+PROPOSED_RULES = TableRef("app", "proposed_rules")
+RULE_DEACTIVATIONS = TableRef("app", "rule_deactivations")
+SCHEMA_MIGRATIONS = TableRef("app", "schema_migrations")
+VERSIONS = TableRef("app", "versions")
+
+# -- App tabular tables --
+TABULAR_FORMATS = TableRef("app", "tabular_formats")
+
+# -- App matching tables --
+MATCH_DECISIONS = TableRef("app", "match_decisions")
+SEED_SOURCE_PRIORITY = TableRef("app", "seed_source_priority")
+
+# -- Seed tables (materialized by SQLMesh from CSV) --
+SEED_CATEGORIES = TableRef("seeds", "categories")
+
+# -- Prep / staging views (built by SQLMesh transforms) --
+INT_TRANSACTIONS_MATCHED = TableRef("prep", "int_transactions__matched")
+
+# -- Meta schema (cross-source provenance + lineage) --
+FCT_TRANSACTION_PROVENANCE = TableRef("meta", "fct_transaction_provenance")
+
+# -- Synthetic tables (created on demand by the generator) --
+GROUND_TRUTH = TableRef("synthetic", "ground_truth")
+
+
+def _all_table_refs() -> tuple[TableRef, ...]:
+    """Collect every TableRef constant defined at module scope.
+
+    Walks this module's globals so the interface set is derived from
+    the constant declarations rather than maintained as a parallel list.
+    """
+    module = sys.modules[__name__]
+    return tuple(
+        value
+        for value in vars(module).values()
+        if isinstance(value, TableRef)
+    )
+
+
+INTERFACE_TABLES: tuple[TableRef, ...] = tuple(
+    t for t in _all_table_refs() if t.audience == "interface"
+)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/moneybin/test_tables.py -v`
+Expected: 5 passed.
+
+- [ ] **Step 5: Run pyright to confirm types**
+
+Run: `uv run pyright src/moneybin/tables.py tests/moneybin/test_tables.py`
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/moneybin/tables.py tests/moneybin/test_tables.py
+git commit -m "Tag interface tables on TableRef and derive INTERFACE_TABLES"
+```
+
+---
+
+## Task 2: Scaffold `services/schema_catalog.py` with conventions and Example dataclass
+
+**Files:**
+- Create: `src/moneybin/services/schema_catalog.py`
+- Create: `tests/moneybin/test_services/test_schema_catalog.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/moneybin/test_services/test_schema_catalog.py`:
+
+```python
+"""Tests for the schema catalog service."""
+
+from __future__ import annotations
+
+from moneybin.services.schema_catalog import (
+    CONVENTIONS,
+    EXAMPLES,
+    Example,
+)
+from moneybin.tables import INTERFACE_TABLES
+
+
+def test_conventions_has_required_keys() -> None:
+    assert set(CONVENTIONS.keys()) == {
+        "amount_sign",
+        "currency",
+        "dates",
+        "ids",
+    }
+
+
+def test_example_dataclass_shape() -> None:
+    ex = Example(question="q?", sql="SELECT 1")
+    assert ex.question == "q?"
+    assert ex.sql == "SELECT 1"
+
+
+def test_examples_only_reference_interface_tables() -> None:
+    interface_names = {t.full_name for t in INTERFACE_TABLES}
+    for table_name in EXAMPLES.keys():
+        assert table_name in interface_names, (
+            f"EXAMPLES key {table_name!r} is not an interface table"
+        )
+
+
+def test_every_interface_table_has_at_least_one_example() -> None:
+    interface_names = {t.full_name for t in INTERFACE_TABLES}
+    missing = interface_names - set(EXAMPLES.keys())
+    assert not missing, f"Interface tables missing examples: {sorted(missing)}"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/moneybin/test_services/test_schema_catalog.py -v`
+Expected: ImportError (`schema_catalog` does not exist).
+
+- [ ] **Step 3: Create the module**
+
+Create `src/moneybin/services/schema_catalog.py`:
+
+```python
+"""Schema catalog service — produces the LLM-facing schema document.
+
+Joins live DuckDB catalog metadata (table/column types and comments) with
+hand-authored example queries, filtered to the curated interface tables
+declared in `moneybin.tables`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+CONVENTIONS: dict[str, str] = {
+    "amount_sign": "negative = expense, positive = income",
+    "currency": "DECIMAL(18,2); ISO 4217 codes in currency_code columns",
+    "dates": "DATE type; transaction_date is the canonical posting date",
+    "ids": (
+        "Deterministic SHA-256 truncated to 16 hex chars; "
+        "see core.fct_transactions.transaction_id"
+    ),
+}
+
+
+@dataclass(frozen=True)
+class Example:
+    """A single example query for a table."""
+
+    question: str
+    sql: str
+
+
+EXAMPLES: dict[str, list[Example]] = {
+    "core.fct_transactions": [
+        Example(
+            question="Total spending by category last month",
+            sql=(
+                "SELECT category, SUM(amount_absolute) AS total "
+                "FROM core.fct_transactions "
+                "WHERE transaction_direction = 'expense' "
+                "AND transaction_year_month = "
+                "STRFTIME(CURRENT_DATE - INTERVAL 1 MONTH, '%Y-%m') "
+                "GROUP BY category ORDER BY total DESC"
+            ),
+        ),
+        Example(
+            question="Transactions for an account in a date range",
+            sql=(
+                "SELECT transaction_date, description, amount, category "
+                "FROM core.fct_transactions "
+                "WHERE account_id = ? "
+                "AND transaction_date BETWEEN ? AND ? "
+                "ORDER BY transaction_date DESC"
+            ),
+        ),
+        Example(
+            question="Monthly spending trend (last 12 months)",
+            sql=(
+                "SELECT transaction_year_month, "
+                "SUM(amount_absolute) AS total_spent "
+                "FROM core.fct_transactions "
+                "WHERE transaction_direction = 'expense' "
+                "AND transaction_date >= CURRENT_DATE - INTERVAL 12 MONTH "
+                "GROUP BY transaction_year_month "
+                "ORDER BY transaction_year_month"
+            ),
+        ),
+    ],
+    "core.dim_accounts": [
+        Example(
+            question="List all accounts with their institution",
+            sql=(
+                "SELECT account_id, account_type, institution_name, source_type "
+                "FROM core.dim_accounts ORDER BY institution_name, account_type"
+            ),
+        ),
+        Example(
+            question="Join accounts to transactions to label by institution",
+            sql=(
+                "SELECT a.institution_name, COUNT(*) AS txn_count, "
+                "SUM(t.amount_absolute) AS total_volume "
+                "FROM core.fct_transactions t "
+                "JOIN core.dim_accounts a USING (account_id) "
+                "GROUP BY a.institution_name ORDER BY total_volume DESC"
+            ),
+        ),
+    ],
+    "core.bridge_transfers": [
+        Example(
+            question="Confirmed transfer pairs in the last 90 days",
+            sql=(
+                "SELECT b.transfer_id, b.transfer_date, b.amount_absolute, "
+                "b.from_account_id, b.to_account_id "
+                "FROM core.bridge_transfers b "
+                "WHERE b.transfer_date >= CURRENT_DATE - INTERVAL 90 DAY "
+                "ORDER BY b.transfer_date DESC"
+            ),
+        ),
+    ],
+    "app.categories": [
+        Example(
+            question="All active categories",
+            sql=(
+                "SELECT category_id, category, subcategory, description "
+                "FROM app.categories "
+                "WHERE is_active ORDER BY category, subcategory"
+            ),
+        ),
+    ],
+    "app.budgets": [
+        Example(
+            question="Active budgets with their target amounts",
+            sql="SELECT * FROM app.budgets ORDER BY category",
+        ),
+    ],
+    "app.transaction_notes": [
+        Example(
+            question="All notes on a specific transaction",
+            sql=(
+                "SELECT transaction_id, note, created_at "
+                "FROM app.transaction_notes WHERE transaction_id = ? "
+                "ORDER BY created_at"
+            ),
+        ),
+    ],
+    "app.merchants": [
+        Example(
+            question="Merchants with their canonical names",
+            sql=(
+                "SELECT merchant_id, canonical_name, raw_pattern "
+                "FROM app.merchants ORDER BY canonical_name"
+            ),
+        ),
+    ],
+    "app.categorization_rules": [
+        Example(
+            question="Active categorization rules",
+            sql=(
+                "SELECT rule_id, merchant_pattern, category, subcategory, priority "
+                "FROM app.categorization_rules "
+                "WHERE is_active ORDER BY priority DESC"
+            ),
+        ),
+    ],
+    "app.transaction_categories": [
+        Example(
+            question="Per-transaction category assignments",
+            sql=(
+                "SELECT transaction_id, category, subcategory, categorized_by "
+                "FROM app.transaction_categories ORDER BY assigned_at DESC LIMIT 100"
+            ),
+        ),
+    ],
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/moneybin/test_services/test_schema_catalog.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/moneybin/services/schema_catalog.py tests/moneybin/test_services/test_schema_catalog.py
+git commit -m "Add CONVENTIONS, Example dataclass, and EXAMPLES dict for interface tables"
+```
+
+---
+
+## Task 3: Implement `build_schema_doc()` against the live catalog
+
+**Files:**
+- Modify: `src/moneybin/services/schema_catalog.py`
+- Modify: `tests/moneybin/test_services/test_schema_catalog.py`
+- Modify: `tests/moneybin/db_helpers.py` (add COMMENT ON DDL after CREATE)
+
+- [ ] **Step 1: Extend `db_helpers` so test core tables carry table + column comments**
+
+Comments must reach the catalog so `build_schema_doc()` can read them. Add a new helper to `tests/moneybin/db_helpers.py` (append to end of file):
+
+```python
+# Table and column comments for core tables — mirror the SQLMesh model
+# headers and inline column comments. Applied separately because the
+# minimal CREATE TABLE DDL above does not embed them.
+CORE_TABLE_COMMENTS: dict[str, str] = {
+    "core.fct_transactions": (
+        "Canonical transactions fact view; reads from the deduplicated "
+        "merged layer with categorization and merchant joins; "
+        "negative amount = expense, positive = income"
+    ),
+    "core.dim_accounts": (
+        "Canonical accounts dimension; one row per account across sources"
+    ),
+}
+
+CORE_COLUMN_COMMENTS: dict[str, dict[str, str]] = {
+    "core.fct_transactions": {
+        "transaction_id": (
+            "Gold key: deterministic SHA-256 hash, "
+            "unique per real-world transaction"
+        ),
+        "amount": "Transaction amount; negative = expense, positive = income",
+        "transaction_direction": (
+            "Derived from amount sign: expense, income, or zero"
+        ),
+        "category": (
+            "Spending category; from app.transaction_categories when "
+            "categorized, else source value"
+        ),
+    },
+    "core.dim_accounts": {
+        "account_id": "Stable per-source account identifier",
+        "institution_name": "Display name of the issuing institution",
+    },
+}
+
+
+def apply_core_table_comments(database: Database) -> None:
+    """Apply COMMENT ON TABLE/COLUMN for core test tables.
+
+    Production comments are applied by SQLMesh's `register_comments`;
+    tests need to mirror that for the schema catalog tests to see prose.
+    """
+    for table, comment in CORE_TABLE_COMMENTS.items():
+        # noqa: S608 — string-built DDL; values are module constants, not user input
+        database.execute(  # noqa: S608
+            f"COMMENT ON TABLE {table} IS '{comment.replace(chr(39), chr(39) * 2)}'"
+        )
+    for table, cols in CORE_COLUMN_COMMENTS.items():
+        for col, comment in cols.items():
+            database.execute(  # noqa: S608
+                f"COMMENT ON COLUMN {table}.{col} IS "
+                f"'{comment.replace(chr(39), chr(39) * 2)}'"
+            )
+```
+
+- [ ] **Step 2: Write the failing test for `build_schema_doc()`**
+
+Append to `tests/moneybin/test_services/test_schema_catalog.py`:
+
+```python
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import moneybin.database as db_module
+from moneybin.database import Database
+from moneybin.services.schema_catalog import build_schema_doc
+from tests.moneybin.db_helpers import (
+    apply_core_table_comments,
+    create_core_tables_raw,
+)
+
+
+@pytest.fixture()
+def schema_db(tmp_path: Path) -> Generator[Database, None, None]:
+    """Database with core tables created and comments applied."""
+    mock_store = MagicMock()
+    mock_store.get_key.return_value = "test-encryption-key-256bit-placeholder"
+    database = Database(
+        path=tmp_path / "schema.duckdb",
+        secret_store=mock_store,
+        encryption_key_alias="test",
+    )
+    database.connect()
+    create_core_tables_raw(database)
+    apply_core_table_comments(database)
+    db_module._database = database
+    try:
+        yield database
+    finally:
+        db_module._database = None
+        database.close()
+
+
+def test_build_schema_doc_top_level_keys(schema_db: Database) -> None:
+    doc = build_schema_doc()
+    assert doc["version"] == 1
+    assert "generated_at" in doc
+    assert doc["conventions"]["amount_sign"].startswith("negative")
+    assert isinstance(doc["tables"], list)
+    assert "beyond_the_interface" in doc
+    assert "catalog_query" in doc["beyond_the_interface"]
+
+
+def test_build_schema_doc_includes_present_interface_tables(
+    schema_db: Database,
+) -> None:
+    doc = build_schema_doc()
+    names = {t["name"] for t in doc["tables"]}
+    # The test DB only creates core.* via create_core_tables_raw; app tables
+    # are absent, so build_schema_doc should silently skip them rather than
+    # error. Core interface tables must be present.
+    assert "core.fct_transactions" in names
+    assert "core.dim_accounts" in names
+
+
+def test_build_schema_doc_columns_carry_type_and_comment(
+    schema_db: Database,
+) -> None:
+    doc = build_schema_doc()
+    fct = next(
+        t for t in doc["tables"] if t["name"] == "core.fct_transactions"
+    )
+    cols_by_name = {c["name"]: c for c in fct["columns"]}
+    assert "amount" in cols_by_name
+    assert "DECIMAL" in cols_by_name["amount"]["type"].upper()
+    assert "negative" in cols_by_name["amount"]["comment"].lower()
+
+
+def test_build_schema_doc_includes_examples_for_present_tables(
+    schema_db: Database,
+) -> None:
+    doc = build_schema_doc()
+    fct = next(
+        t for t in doc["tables"] if t["name"] == "core.fct_transactions"
+    )
+    assert len(fct["examples"]) >= 1
+    first = fct["examples"][0]
+    assert "question" in first
+    assert "sql" in first
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `uv run pytest tests/moneybin/test_services/test_schema_catalog.py -v`
+Expected: ImportError on `build_schema_doc`.
+
+- [ ] **Step 4: Implement `build_schema_doc()`**
+
+Append to `src/moneybin/services/schema_catalog.py`:
+
+```python
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from moneybin.database import get_database
+from moneybin.tables import INTERFACE_TABLES
+
+logger = logging.getLogger(__name__)
+
+_BEYOND_NOTE = (
+    "The tables above are the curated query surface. Other schemas exist "
+    "for raw ingest (raw), staging (prep), provenance (meta), and seed "
+    "data (seeds). Use them only when the curated tables cannot answer "
+    "the question."
+)
+_BEYOND_QUERY = (
+    "SELECT table_schema, table_name, comment FROM duckdb_tables() "
+    "WHERE table_schema NOT IN ('main', 'pg_catalog') ORDER BY 1, 2"
+)
+
+
+def build_schema_doc() -> dict[str, Any]:
+    """Return the schema document for the LLM-facing catalog.
+
+    Reads `duckdb_tables()` and `duckdb_columns()` for every interface
+    table that exists in the live database; missing tables are silently
+    skipped (the test/dev DB may not have every interface table).
+    """
+    db = get_database()
+
+    interface_names = [t.full_name for t in INTERFACE_TABLES]
+    placeholders = ",".join(["?"] * len(interface_names))
+    table_rows = db.execute(
+        f"""
+        SELECT schema_name || '.' || table_name AS full_name,
+               COALESCE(comment, '') AS comment
+        FROM duckdb_tables()
+        WHERE schema_name || '.' || table_name IN ({placeholders})
+        ORDER BY schema_name, table_name
+        """,
+        interface_names,
+    ).fetchall()
+
+    tables: list[dict[str, Any]] = []
+    for full_name, table_comment in table_rows:
+        schema_name, table_name = full_name.split(".", 1)
+        col_rows = db.execute(
+            """
+            SELECT column_name, data_type, is_nullable,
+                   COALESCE(comment, '') AS comment
+            FROM duckdb_columns()
+            WHERE schema_name = ? AND table_name = ?
+            ORDER BY column_index
+            """,
+            [schema_name, table_name],
+        ).fetchall()
+        tables.append(
+            {
+                "name": full_name,
+                "purpose": table_comment,
+                "columns": [
+                    {
+                        "name": name,
+                        "type": dtype,
+                        "nullable": bool(nullable),
+                        "comment": comment,
+                    }
+                    for name, dtype, nullable, comment in col_rows
+                ],
+                "examples": [
+                    {"question": ex.question, "sql": ex.sql}
+                    for ex in EXAMPLES.get(full_name, [])
+                ],
+            }
+        )
+
+    logger.info("Schema doc built: %d interface tables present", len(tables))
+
+    return {
+        "version": 1,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "conventions": dict(CONVENTIONS),
+        "tables": tables,
+        "beyond_the_interface": {
+            "note": _BEYOND_NOTE,
+            "catalog_query": _BEYOND_QUERY,
+        },
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/moneybin/test_services/test_schema_catalog.py -v`
+Expected: 8 passed (4 new + 4 from Task 2).
+
+- [ ] **Step 6: Type check**
+
+Run: `uv run pyright src/moneybin/services/schema_catalog.py tests/moneybin/test_services/test_schema_catalog.py tests/moneybin/db_helpers.py`
+Expected: 0 errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/moneybin/services/schema_catalog.py tests/moneybin/test_services/test_schema_catalog.py tests/moneybin/db_helpers.py
+git commit -m "Implement build_schema_doc() reading live DuckDB catalog"
+```
+
+---
+
+## Task 4: Add presence-drift assertion + example execution test
+
+**Files:**
+- Modify: `tests/moneybin/test_services/test_schema_catalog.py`
+
+- [ ] **Step 1: Append two drift tests**
+
+```python
+def test_interface_tables_present_in_catalog(schema_db: Database) -> None:
+    """Stale-entry drift: an interface-tagged table is missing from the DB.
+
+    Only checks tables the test DB actually creates (core.*); the assertion
+    here is that nothing tagged interface in the *core* schema is missing.
+    """
+    from moneybin.tables import INTERFACE_TABLES
+
+    rows = schema_db.execute(
+        "SELECT schema_name || '.' || table_name FROM duckdb_tables()"
+    ).fetchall()
+    present = {r[0] for r in rows}
+    missing_core = [
+        t.full_name
+        for t in INTERFACE_TABLES
+        if t.schema == "core" and t.full_name not in present
+    ]
+    assert not missing_core, (
+        f"INTERFACE_TABLES core entries missing from catalog: {missing_core}"
+    )
+
+
+def test_examples_parse_and_execute(schema_db: Database) -> None:
+    """Examples must parse and execute against the live schema.
+
+    Catches column-renamed-but-example-not-updated drift. Skips examples
+    for tables not present in the test DB (app.* tables not seeded here).
+    Parameterized examples (containing '?') are validated via PREPARE
+    instead of execution.
+    """
+    rows = schema_db.execute(
+        "SELECT schema_name || '.' || table_name FROM duckdb_tables()"
+    ).fetchall()
+    present = {r[0] for r in rows}
+    for table_name, examples in EXAMPLES.items():
+        if table_name not in present:
+            continue
+        for ex in examples:
+            if "?" in ex.sql:
+                schema_db.execute(f"PREPARE __probe AS {ex.sql}")
+                schema_db.execute("DEALLOCATE __probe")
+            else:
+                schema_db.execute(ex.sql).fetchall()
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `uv run pytest tests/moneybin/test_services/test_schema_catalog.py -v`
+Expected: 10 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/moneybin/test_services/test_schema_catalog.py
+git commit -m "Add drift tests for interface table presence and example execution"
+```
+
+---
+
+## Task 5: Register `moneybin://schema` resource
+
+**Files:**
+- Modify: `src/moneybin/mcp/resources.py`
+- Test: `tests/moneybin/test_mcp/test_schema_resource.py` (create)
+
+- [ ] **Step 1: Inspect existing resource test patterns**
+
+Run: `ls tests/moneybin/test_mcp/`
+Read one existing resource-style test to mirror its fixture setup (e.g., `test_resources.py` if present, otherwise the closest analog). The new test should follow whatever DB-bootstrapping pattern the existing MCP tests use.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/moneybin/test_mcp/test_schema_resource.py`:
+
+```python
+"""Test the moneybin://schema resource."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import moneybin.database as db_module
+from moneybin.database import Database
+from moneybin.mcp.resources import resource_schema
+from tests.moneybin.db_helpers import (
+    apply_core_table_comments,
+    create_core_tables_raw,
+)
+
+
+@pytest.fixture()
+def mcp_db(tmp_path: Path) -> Generator[Database, None, None]:
+    mock_store = MagicMock()
+    mock_store.get_key.return_value = "test-encryption-key-256bit-placeholder"
+    database = Database(
+        path=tmp_path / "mcp.duckdb",
+        secret_store=mock_store,
+        encryption_key_alias="test",
+    )
+    database.connect()
+    create_core_tables_raw(database)
+    apply_core_table_comments(database)
+    db_module._database = database
+    try:
+        yield database
+    finally:
+        db_module._database = None
+        database.close()
+
+
+def test_resource_schema_returns_valid_json(mcp_db: Database) -> None:
+    body = resource_schema()
+    parsed = json.loads(body)
+    assert parsed["version"] == 1
+    assert "tables" in parsed
+    assert "conventions" in parsed
+    assert "beyond_the_interface" in parsed
+
+
+def test_resource_schema_contains_core_interface_tables(
+    mcp_db: Database,
+) -> None:
+    parsed = json.loads(resource_schema())
+    names = {t["name"] for t in parsed["tables"]}
+    assert "core.fct_transactions" in names
+    assert "core.dim_accounts" in names
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `uv run pytest tests/moneybin/test_mcp/test_schema_resource.py -v`
+Expected: ImportError on `resource_schema`.
+
+- [ ] **Step 4: Add the resource to `src/moneybin/mcp/resources.py`**
+
+After the existing `resource_privacy` definition (or anywhere among the existing resources), add:
+
+```python
+from moneybin.services.schema_catalog import build_schema_doc
+
+
+@mcp.resource("moneybin://schema")
+def resource_schema() -> str:
+    """Curated schema for ad-hoc SQL: interface tables, columns, comments, example queries."""
+    logger.info("Resource read: moneybin://schema")
+    doc = build_schema_doc()
+    return json.dumps(doc, indent=2, default=str)
+```
+
+(The `json` and `logger` imports already exist at the top of the file.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/moneybin/test_mcp/test_schema_resource.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 6: Type check + lint**
+
+Run: `uv run pyright src/moneybin/mcp/resources.py && make lint`
+Expected: 0 errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/moneybin/mcp/resources.py tests/moneybin/test_mcp/test_schema_resource.py
+git commit -m "Register moneybin://schema MCP resource"
+```
+
+---
+
+## Task 6: Point `sql_query` at the schema resource
+
+**Files:**
+- Modify: `src/moneybin/mcp/tools/sql.py`
+
+- [ ] **Step 1: Edit the docstring and registration description**
+
+In `src/moneybin/mcp/tools/sql.py`, replace the `sql_query` docstring (lines 21-31) with:
+
+```python
+    """Execute a read-only SQL query against the database.
+
+    Only SELECT, WITH, DESCRIBE, SHOW, PRAGMA, and EXPLAIN queries
+    are allowed. Write operations and file-access functions are blocked.
+
+    Use this for ad-hoc analysis not covered by other tools. Results
+    are limited to the configured maximum row count.
+
+    For schema, columns, and example queries, read resource
+    `moneybin://schema` before composing non-trivial queries.
+
+    Args:
+        query: The SQL query to execute.
+    """
+```
+
+And update the registration description in `register_sql_tools` to:
+
+```python
+        "Execute a read-only SQL query against the database. "
+        "Supports SELECT, WITH, DESCRIBE, SHOW, PRAGMA, EXPLAIN. "
+        "Read resource moneybin://schema for tables, columns, and example queries.",
+```
+
+- [ ] **Step 2: Verify nothing else broke**
+
+Run: `uv run pytest tests/moneybin/test_mcp/ -q`
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/moneybin/mcp/tools/sql.py
+git commit -m "Point sql_query description at moneybin://schema resource"
+```
+
+---
+
+## Task 7: Add pointer comments to model and DDL files
+
+**Files:**
+- Modify: `sqlmesh/models/core/fct_transactions.sql`
+- Modify: `sqlmesh/models/core/dim_accounts.sql`
+- Modify: `sqlmesh/models/core/bridge_transfers.sql`
+- Modify: `src/moneybin/sql/schema/app_categories.sql`
+- Modify: `src/moneybin/sql/schema/app_budgets.sql`
+- Modify: `src/moneybin/sql/schema/app_transaction_notes.sql`
+- Modify: `src/moneybin/sql/schema/app_merchants.sql`
+- Modify: `src/moneybin/sql/schema/app_categorization_rules.sql`
+- Modify: `src/moneybin/sql/schema/app_transaction_categories.sql`
+
+The pointer comment is a single line that sits **after** the existing table-level header `/* ... */` comment (so it doesn't get picked up as the table's `COMMENT ON TABLE` description by `register_comments` / `_apply_comments`).
+
+For each SQLMesh model, insert the pointer between the existing header comment and the `MODEL(` line. Example for `fct_transactions.sql`:
+
+```sql
+/* Canonical transactions fact view; reads from the deduplicated merged layer
+   with categorization and merchant joins; negative amount = expense, positive = income */
+-- Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict)
+MODEL (
+  name core.fct_transactions,
+  ...
+);
+```
+
+For each app DDL file, insert the pointer between the existing header `/* ... */` and the `CREATE TABLE` statement. Example for `app_categories.sql`:
+
+```sql
+/* Spending category definitions; seeded from Plaid PFCv2 taxonomy and extended with user-defined categories */
+-- Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict)
+CREATE TABLE IF NOT EXISTS app.categories (
+    ...
+);
+```
+
+- [ ] **Step 1: Apply pointer to each of the 9 files above**
+
+Use Edit tool per file. The pointer line is identical for all 9: `-- Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict)`. Place it on the line immediately after the closing `*/` of the existing header.
+
+- [ ] **Step 2: Format the SQLMesh files**
+
+Run: `uv run sqlmesh -p sqlmesh format`
+Expected: no output, exit 0. (`sqlmesh format` may rewrite `--` into `/* */`; that's fine.)
+
+- [ ] **Step 3: Verify schema/SQLMesh tests still pass**
+
+Run: `uv run pytest tests/moneybin/test_services/ tests/moneybin/test_mcp/ -q`
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sqlmesh/models/core/*.sql src/moneybin/sql/schema/app_*.sql
+git commit -m "Add LLM-examples pointer comment to interface table definitions"
+```
+
+---
+
+## Task 8: Append followups note + bump spec status
+
+**Files:**
+- Modify: `docs/followups.md`
+- Modify: `docs/specs/mcp-sql-discoverability.md`
+- Modify: `docs/specs/INDEX.md`
+
+- [ ] **Step 1: Append to `docs/followups.md`**
+
+Add at the end of the file:
+
+```markdown
+
+## Schema examples co-location (post-`mcp-sql-discoverability`)
+
+Example queries currently live in `src/moneybin/services/schema_catalog.py`
+(`EXAMPLES` dict) with one-line pointer comments in each interface model
+and DDL file. If example drift becomes a real maintenance problem
+(examples that reference dropped columns, examples that contradict model
+logic, examples that lag behind schema changes), revisit the **sibling
+`.examples.sql`** approach: one file per table next to the model, parsed
+at startup. See `docs/specs/mcp-sql-discoverability.md` Section "Out of
+Scope" and the brainstorming session that produced it.
+```
+
+- [ ] **Step 2: Bump spec status to `in-progress`**
+
+In `docs/specs/mcp-sql-discoverability.md`, change:
+
+```markdown
+## Status
+draft
+```
+
+to:
+
+```markdown
+## Status
+in-progress
+```
+
+In `docs/specs/INDEX.md`, change the status column for `mcp-sql-discoverability` from `draft` to `in-progress`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/followups.md docs/specs/mcp-sql-discoverability.md docs/specs/INDEX.md
+git commit -m "Add schema-examples co-location followup; bump spec to in-progress"
+```
+
+---
+
+## Task 9: End-to-end verification
+
+- [ ] **Step 1: Run the full pre-commit checklist**
+
+Run: `make check test`
+Expected: format, lint, type-check, and full test suite all green.
+
+- [ ] **Step 2: Manually exercise the resource against a real DB**
+
+Run a small one-off script to confirm the resource produces sensible output against the actual user database:
+
+```bash
+uv run python -c "
+from moneybin.services.schema_catalog import build_schema_doc
+import json
+doc = build_schema_doc()
+print(f'tables: {len(doc[\"tables\"])}')
+for t in doc['tables']:
+    print(f'  {t[\"name\"]}: {len(t[\"columns\"])} cols, {len(t[\"examples\"])} examples')
+print('beyond:', doc['beyond_the_interface']['note'][:60], '...')
+"
+```
+
+Expected: prints all 9 interface tables (or however many exist in the active DB) with non-zero column and example counts. App tables present in the active DB should appear; missing ones should silently be absent.
+
+- [ ] **Step 3: Final review pass with `/simplify`**
+
+Per `.claude/rules/shipping.md`, run `/simplify` before pushing to catch any reuse, quality, or efficiency issues that accumulated during implementation.
+
+- [ ] **Step 4: Mark spec implemented and update README**
+
+In `docs/specs/mcp-sql-discoverability.md`, change `## Status\nin-progress` → `## Status\nimplemented`.
+In `docs/specs/INDEX.md`, change status to `implemented`.
+In `README.md`, change the roadmap row icon from 📐 to ✅.
+
+Commit:
+
+```bash
+git add docs/specs/mcp-sql-discoverability.md docs/specs/INDEX.md README.md
+git commit -m "Mark MCP SQL schema discoverability as implemented"
+```
+
+- [ ] **Step 5: Push the branch and open PR**
+
+```bash
+git push -u origin feat/mcp-sql-schema-resource
+```
+
+Open the PR using the `commit-push-pr` skill or `gh pr create`. Title: `Add curated MCP schema resource for ad-hoc SQL`.

--- a/sqlmesh/models/core/bridge_transfers.sql
+++ b/sqlmesh/models/core/bridge_transfers.sql
@@ -1,5 +1,6 @@
 /* Confirmed transfer pairs linking two fct_transactions rows;
    derived from app.match_decisions where match_type = 'transfer' */
+-- Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict)
 MODEL (
   name core.bridge_transfers,
   kind VIEW,

--- a/sqlmesh/models/core/dim_accounts.sql
+++ b/sqlmesh/models/core/dim_accounts.sql
@@ -1,4 +1,5 @@
 /* Canonical accounts dimension; deduplicated accounts from all sources, keeping the most recently extracted record per account_id */
+-- Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict)
 MODEL (
   name core.dim_accounts,
   kind FULL,

--- a/sqlmesh/models/core/fct_transactions.sql
+++ b/sqlmesh/models/core/fct_transactions.sql
@@ -1,5 +1,6 @@
 /* Canonical transactions fact view; reads from the deduplicated merged layer
    with categorization and merchant joins; negative amount = expense, positive = income */
+-- Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict)
 MODEL (
   name core.fct_transactions,
   kind VIEW,

--- a/src/moneybin/mcp/resources.py
+++ b/src/moneybin/mcp/resources.py
@@ -14,6 +14,7 @@ import json
 import logging
 from typing import Any
 
+from moneybin.services.schema_catalog import build_schema_doc
 from moneybin.tables import DIM_ACCOUNTS, FCT_TRANSACTIONS
 
 from .server import get_db, mcp, table_exists
@@ -84,35 +85,10 @@ def resource_privacy() -> str:
 
 @mcp.resource("moneybin://schema")
 def resource_schema() -> str:
-    """Core and app table schemas with column names, types, and descriptions."""
+    """Curated schema for ad-hoc SQL: interface tables, columns, comments, example queries."""
     logger.info("Resource read: moneybin://schema")
-    db = get_db()
-
-    result = db.execute("""
-        SELECT
-            schema_name,
-            table_name,
-            column_name,
-            data_type,
-            comment
-        FROM duckdb_columns()
-        WHERE schema_name IN ('core', 'app', 'raw')
-        ORDER BY schema_name, table_name, column_index
-    """)
-    rows = result.fetchall()
-
-    tables: dict[str, Any] = {}
-    for row in rows:
-        key = f"{row[0]}.{row[1]}"
-        if key not in tables:
-            tables[key] = {"schema": row[0], "table": row[1], "columns": []}
-        tables[key]["columns"].append({
-            "name": row[2],
-            "type": row[3],
-            "description": row[4],
-        })
-
-    return json.dumps({"tables": list(tables.values())}, indent=2, default=str)
+    doc = build_schema_doc()
+    return json.dumps(doc, indent=2, default=str)
 
 
 _CORE_NAMESPACE_DESCRIPTIONS: dict[str, str] = {

--- a/src/moneybin/mcp/tools/sql.py
+++ b/src/moneybin/mcp/tools/sql.py
@@ -26,6 +26,9 @@ def sql_query(query: str) -> ResponseEnvelope:
     Use this for ad-hoc analysis not covered by other tools. Results
     are limited to the configured maximum row count.
 
+    For schema, columns, and example queries, read resource
+    `moneybin://schema` before composing non-trivial queries.
+
     Args:
         query: The SQL query to execute.
     """
@@ -55,5 +58,6 @@ def register_sql_tools(mcp: FastMCP) -> None:
         sql_query,
         "sql_query",
         "Execute a read-only SQL query against the database. "
-        "Supports SELECT, WITH, DESCRIBE, SHOW, PRAGMA, EXPLAIN.",
+        "Supports SELECT, WITH, DESCRIBE, SHOW, PRAGMA, EXPLAIN. "
+        "Read resource moneybin://schema for tables, columns, and example queries.",
     )

--- a/src/moneybin/seeds.py
+++ b/src/moneybin/seeds.py
@@ -50,6 +50,7 @@ def materialize_seeds(db: Database) -> None:
 
 def refresh_views(db: Database) -> None:
     """Create or replace the app views that expose seeds + user data."""
+    # Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict)
     sql = f"""
         CREATE OR REPLACE VIEW {CATEGORIES.full_name} AS
         SELECT

--- a/src/moneybin/services/schema_catalog.py
+++ b/src/moneybin/services/schema_catalog.py
@@ -50,12 +50,13 @@ EXAMPLES: dict[str, list[Example]] = {
             """,
         ),
         Example(
-            question="Transactions for an account in a date range",
+            question="Transactions for one account within a date range "
+            "(substitute YOUR_ACCOUNT_ID and the real dates)",
             sql="""
                 SELECT transaction_date, description, amount, category
                 FROM core.fct_transactions
-                WHERE account_id = ?
-                  AND transaction_date BETWEEN ? AND ?
+                WHERE account_id = 'YOUR_ACCOUNT_ID'
+                  AND transaction_date BETWEEN DATE '2024-01-01' AND DATE '2024-12-31'
                 ORDER BY transaction_date DESC
             """,
         ),
@@ -124,11 +125,12 @@ EXAMPLES: dict[str, list[Example]] = {
     ],
     "app.transaction_notes": [
         Example(
-            question="All notes on a specific transaction",
+            question="Notes for a specific transaction "
+            "(substitute YOUR_TRANSACTION_ID)",
             sql="""
                 SELECT transaction_id, note, created_at
                 FROM app.transaction_notes
-                WHERE transaction_id = ?
+                WHERE transaction_id = 'YOUR_TRANSACTION_ID'
                 ORDER BY created_at
             """,
         ),
@@ -235,7 +237,7 @@ def build_schema_doc() -> dict[str, Any]:
     return {
         "version": 1,
         "generated_at": datetime.now(UTC).isoformat(),
-        "conventions": CONVENTIONS,
+        "conventions": dict(CONVENTIONS),
         "tables": tables,
         "beyond_the_interface": {
             "note": _BEYOND_NOTE,

--- a/src/moneybin/services/schema_catalog.py
+++ b/src/moneybin/services/schema_catalog.py
@@ -7,7 +7,15 @@ declared in `moneybin.tables`.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from moneybin.database import get_database
+from moneybin.tables import INTERFACE_TABLES
+
+logger = logging.getLogger(__name__)
 
 CONVENTIONS: dict[str, str] = {
     "amount_sign": "negative = expense, positive = income",
@@ -158,3 +166,81 @@ EXAMPLES: dict[str, list[Example]] = {
         ),
     ],
 }
+
+_BEYOND_NOTE = (
+    "The tables above are the curated query surface. Other schemas exist "
+    "for raw ingest (raw), staging (prep), provenance (meta), and seed "
+    "data (seeds). Use them only when the curated tables cannot answer "
+    "the question."
+)
+_BEYOND_QUERY = (
+    "SELECT table_schema, table_name, comment FROM duckdb_tables() "
+    "WHERE table_schema NOT IN ('main', 'pg_catalog') ORDER BY 1, 2"
+)
+
+
+def build_schema_doc() -> dict[str, Any]:
+    """Return the schema document for the LLM-facing catalog.
+
+    Reads `duckdb_tables()` and `duckdb_columns()` for every interface
+    table that exists in the live database; missing tables are silently
+    skipped (the test/dev DB may not have every interface table).
+    """
+    db = get_database()
+
+    interface_names = [t.full_name for t in INTERFACE_TABLES]
+    placeholders = ",".join(["?"] * len(interface_names))
+    table_rows = db.execute(
+        f"""
+        SELECT schema_name || '.' || table_name AS full_name,
+               COALESCE(comment, '') AS comment
+        FROM duckdb_tables()
+        WHERE schema_name || '.' || table_name IN ({placeholders})
+        ORDER BY schema_name, table_name
+        """,  # noqa: S608  # INTERFACE_TABLES is a compile-time allowlist, not user input
+        interface_names,
+    ).fetchall()
+
+    tables: list[dict[str, Any]] = []
+    for full_name, table_comment in table_rows:
+        schema_name, table_name = full_name.split(".", 1)
+        col_rows = db.execute(
+            """
+            SELECT column_name, data_type, is_nullable,
+                   COALESCE(comment, '') AS comment
+            FROM duckdb_columns()
+            WHERE schema_name = ? AND table_name = ?
+            ORDER BY column_index
+            """,
+            [schema_name, table_name],
+        ).fetchall()
+        tables.append({
+            "name": full_name,
+            "purpose": table_comment,
+            "columns": [
+                {
+                    "name": name,
+                    "type": dtype,
+                    "nullable": bool(nullable),
+                    "comment": comment,
+                }
+                for name, dtype, nullable, comment in col_rows
+            ],
+            "examples": [
+                {"question": ex.question, "sql": ex.sql}
+                for ex in EXAMPLES.get(full_name, [])
+            ],
+        })
+
+    logger.info(f"Schema doc built: {len(tables)} interface tables present")
+
+    return {
+        "version": 1,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "conventions": dict(CONVENTIONS),
+        "tables": tables,
+        "beyond_the_interface": {
+            "note": _BEYOND_NOTE,
+            "catalog_query": _BEYOND_QUERY,
+        },
+    }

--- a/src/moneybin/services/schema_catalog.py
+++ b/src/moneybin/services/schema_catalog.py
@@ -176,8 +176,8 @@ _BEYOND_NOTE = (
     "the question."
 )
 _BEYOND_QUERY = (
-    "SELECT table_schema, table_name, comment FROM duckdb_tables() "
-    "WHERE table_schema NOT IN ('main', 'pg_catalog') ORDER BY 1, 2"
+    "SELECT schema_name, table_name, comment FROM duckdb_tables() "
+    "WHERE schema_name NOT IN ('main', 'pg_catalog') ORDER BY 1, 2"
 )
 
 
@@ -192,8 +192,18 @@ def build_schema_doc() -> dict[str, Any]:
 
     interface_names = [t.full_name for t in INTERFACE_TABLES]
     placeholders = ",".join(["?"] * len(interface_names))
+    # Union tables and views — `duckdb_tables()` excludes views, but
+    # interface objects like `app.categories` are views (see seeds.py).
     rows = db.execute(
         f"""
+        WITH interface_objects AS (
+            SELECT schema_name, table_name, comment
+            FROM duckdb_tables()
+            UNION ALL
+            SELECT schema_name, view_name AS table_name, comment
+            FROM duckdb_views()
+            WHERE NOT internal
+        )
         SELECT
             t.schema_name || '.' || t.table_name AS full_name,
             COALESCE(t.comment, '') AS table_comment,
@@ -201,7 +211,7 @@ def build_schema_doc() -> dict[str, Any]:
             c.data_type,
             c.is_nullable,
             COALESCE(c.comment, '') AS column_comment
-        FROM duckdb_tables() t
+        FROM interface_objects t
         JOIN duckdb_columns() c
           ON t.schema_name = c.schema_name AND t.table_name = c.table_name
         WHERE t.schema_name || '.' || t.table_name IN ({placeholders})

--- a/src/moneybin/services/schema_catalog.py
+++ b/src/moneybin/services/schema_catalog.py
@@ -1,0 +1,160 @@
+"""Schema catalog service — produces the LLM-facing schema document.
+
+Joins live DuckDB catalog metadata (table/column types and comments) with
+hand-authored example queries, filtered to the curated interface tables
+declared in `moneybin.tables`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+CONVENTIONS: dict[str, str] = {
+    "amount_sign": "negative = expense, positive = income",
+    "currency": "DECIMAL(18,2); ISO 4217 codes in currency_code columns",
+    "dates": "DATE type; transaction_date is the canonical posting date",
+    "ids": (
+        "Deterministic SHA-256 truncated to 16 hex chars; "
+        "see core.fct_transactions.transaction_id"
+    ),
+}
+
+
+@dataclass(frozen=True)
+class Example:
+    """A single example query for a table."""
+
+    question: str
+    sql: str
+
+
+EXAMPLES: dict[str, list[Example]] = {
+    "core.fct_transactions": [
+        Example(
+            question="Total spending by category last month",
+            sql="""
+                SELECT category, SUM(amount_absolute) AS total
+                FROM core.fct_transactions
+                WHERE transaction_direction = 'expense'
+                  AND transaction_year_month = STRFTIME(CURRENT_DATE - INTERVAL 1 MONTH, '%Y-%m')
+                GROUP BY category
+                ORDER BY total DESC
+            """,
+        ),
+        Example(
+            question="Transactions for an account in a date range",
+            sql="""
+                SELECT transaction_date, description, amount, category
+                FROM core.fct_transactions
+                WHERE account_id = ?
+                  AND transaction_date BETWEEN ? AND ?
+                ORDER BY transaction_date DESC
+            """,
+        ),
+        Example(
+            question="Monthly spending trend (last 12 months)",
+            sql="""
+                SELECT transaction_year_month, SUM(amount_absolute) AS total_spent
+                FROM core.fct_transactions
+                WHERE transaction_direction = 'expense'
+                  AND transaction_date >= CURRENT_DATE - INTERVAL 12 MONTH
+                GROUP BY transaction_year_month
+                ORDER BY transaction_year_month
+            """,
+        ),
+    ],
+    "core.dim_accounts": [
+        Example(
+            question="List all accounts with their institution",
+            sql="""
+                SELECT account_id, account_type, institution_name, source_type
+                FROM core.dim_accounts
+                ORDER BY institution_name, account_type
+            """,
+        ),
+        Example(
+            question="Join accounts to transactions to label by institution",
+            sql="""
+                SELECT a.institution_name, COUNT(*) AS txn_count,
+                       SUM(t.amount_absolute) AS total_volume
+                FROM core.fct_transactions t
+                JOIN core.dim_accounts a USING (account_id)
+                GROUP BY a.institution_name
+                ORDER BY total_volume DESC
+            """,
+        ),
+    ],
+    "core.bridge_transfers": [
+        Example(
+            question="Confirmed transfer pairs with debit and credit transaction IDs",
+            sql="""
+                SELECT b.transfer_id, b.debit_transaction_id,
+                       b.credit_transaction_id, b.amount, b.date_offset_days
+                FROM core.bridge_transfers b
+                ORDER BY b.transfer_id
+            """,
+        ),
+    ],
+    "app.categories": [
+        Example(
+            question="All active categories",
+            sql="""
+                SELECT category_id, category, subcategory, description
+                FROM app.categories
+                WHERE is_active
+                ORDER BY category, subcategory
+            """,
+        ),
+    ],
+    "app.budgets": [
+        Example(
+            question="Active budgets with their target amounts",
+            sql="""
+                SELECT * FROM app.budgets ORDER BY category
+            """,
+        ),
+    ],
+    "app.transaction_notes": [
+        Example(
+            question="All notes on a specific transaction",
+            sql="""
+                SELECT transaction_id, note, created_at
+                FROM app.transaction_notes
+                WHERE transaction_id = ?
+                ORDER BY created_at
+            """,
+        ),
+    ],
+    "app.merchants": [
+        Example(
+            question="Merchants with their canonical names",
+            sql="""
+                SELECT merchant_id, canonical_name, raw_pattern
+                FROM app.merchants
+                ORDER BY canonical_name
+            """,
+        ),
+    ],
+    "app.categorization_rules": [
+        Example(
+            question="Active categorization rules",
+            sql="""
+                SELECT rule_id, merchant_pattern, category, subcategory, priority
+                FROM app.categorization_rules
+                WHERE is_active
+                ORDER BY priority DESC
+            """,
+        ),
+    ],
+    "app.transaction_categories": [
+        Example(
+            question="Per-transaction category assignments",
+            sql="""
+                SELECT transaction_id, category, subcategory, categorized_by
+                FROM app.transaction_categories
+                ORDER BY categorized_at DESC
+                LIMIT 100
+            """,
+        ),
+    ],
+}

--- a/src/moneybin/services/schema_catalog.py
+++ b/src/moneybin/services/schema_catalog.py
@@ -190,54 +190,52 @@ def build_schema_doc() -> dict[str, Any]:
 
     interface_names = [t.full_name for t in INTERFACE_TABLES]
     placeholders = ",".join(["?"] * len(interface_names))
-    table_rows = db.execute(
+    rows = db.execute(
         f"""
-        SELECT schema_name || '.' || table_name AS full_name,
-               COALESCE(comment, '') AS comment
-        FROM duckdb_tables()
-        WHERE schema_name || '.' || table_name IN ({placeholders})
-        ORDER BY schema_name, table_name
+        SELECT
+            t.schema_name || '.' || t.table_name AS full_name,
+            COALESCE(t.comment, '') AS table_comment,
+            c.column_name,
+            c.data_type,
+            c.is_nullable,
+            COALESCE(c.comment, '') AS column_comment
+        FROM duckdb_tables() t
+        JOIN duckdb_columns() c
+          ON t.schema_name = c.schema_name AND t.table_name = c.table_name
+        WHERE t.schema_name || '.' || t.table_name IN ({placeholders})
+        ORDER BY t.schema_name, t.table_name, c.column_index
         """,  # noqa: S608  # INTERFACE_TABLES is a compile-time allowlist, not user input
         interface_names,
     ).fetchall()
 
-    tables: list[dict[str, Any]] = []
-    for full_name, table_comment in table_rows:
-        schema_name, table_name = full_name.split(".", 1)
-        col_rows = db.execute(
-            """
-            SELECT column_name, data_type, is_nullable,
-                   COALESCE(comment, '') AS comment
-            FROM duckdb_columns()
-            WHERE schema_name = ? AND table_name = ?
-            ORDER BY column_index
-            """,
-            [schema_name, table_name],
-        ).fetchall()
-        tables.append({
-            "name": full_name,
-            "purpose": table_comment,
-            "columns": [
-                {
-                    "name": name,
-                    "type": dtype,
-                    "nullable": bool(nullable),
-                    "comment": comment,
-                }
-                for name, dtype, nullable, comment in col_rows
-            ],
-            "examples": [
-                {"question": ex.question, "sql": ex.sql}
-                for ex in EXAMPLES.get(full_name, [])
-            ],
+    tables_by_name: dict[str, dict[str, Any]] = {}
+    for full_name, table_comment, col_name, dtype, nullable, col_comment in rows:
+        entry = tables_by_name.setdefault(
+            full_name,
+            {
+                "name": full_name,
+                "purpose": table_comment,
+                "columns": [],
+                "examples": [
+                    {"question": ex.question, "sql": ex.sql}
+                    for ex in EXAMPLES.get(full_name, [])
+                ],
+            },
+        )
+        entry["columns"].append({
+            "name": col_name,
+            "type": dtype,
+            "nullable": bool(nullable),
+            "comment": col_comment,
         })
 
+    tables = list(tables_by_name.values())
     logger.info(f"Schema doc built: {len(tables)} interface tables present")
 
     return {
         "version": 1,
         "generated_at": datetime.now(UTC).isoformat(),
-        "conventions": dict(CONVENTIONS),
+        "conventions": CONVENTIONS,
         "tables": tables,
         "beyond_the_interface": {
             "note": _BEYOND_NOTE,

--- a/src/moneybin/sql/schema/app_budgets.sql
+++ b/src/moneybin/sql/schema/app_budgets.sql
@@ -1,4 +1,5 @@
 /* Monthly spending budget targets by category; each record defines a spending limit for a category over a date range */
+-- Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict)
 CREATE TABLE IF NOT EXISTS app.budgets (
     budget_id VARCHAR PRIMARY KEY, -- Unique identifier for this budget record
     category VARCHAR NOT NULL, -- Spending category this budget applies to; matches app.categories.category

--- a/src/moneybin/sql/schema/app_categorization_rules.sql
+++ b/src/moneybin/sql/schema/app_categorization_rules.sql
@@ -1,4 +1,5 @@
 /* Auto-categorization rules evaluated in priority order; assign categories based on description patterns, amount bounds, and account filters */
+-- Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict)
 CREATE TABLE IF NOT EXISTS app.categorization_rules (
     rule_id VARCHAR PRIMARY KEY, -- Unique identifier for this rule
     name VARCHAR NOT NULL, -- Human-readable label for this rule, e.g. Starbucks coffee purchases

--- a/src/moneybin/sql/schema/app_merchants.sql
+++ b/src/moneybin/sql/schema/app_merchants.sql
@@ -1,4 +1,5 @@
 /* Merchant normalization patterns matched against transaction descriptions to canonicalize merchant names and cache category assignments */
+-- Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict)
 CREATE TABLE IF NOT EXISTS app.merchants (
     merchant_id VARCHAR PRIMARY KEY, -- Unique identifier for this merchant record
     raw_pattern VARCHAR NOT NULL, -- Pattern matched against fct_transactions.description to identify this merchant

--- a/src/moneybin/sql/schema/app_transaction_categories.sql
+++ b/src/moneybin/sql/schema/app_transaction_categories.sql
@@ -1,4 +1,5 @@
 /* Category assignments for transactions; written by the rules engine, AI model, or user; one record per transaction */
+-- Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict)
 CREATE TABLE IF NOT EXISTS app.transaction_categories (
     transaction_id VARCHAR PRIMARY KEY, -- Foreign key to core.fct_transactions; one categorization record per transaction
     category VARCHAR NOT NULL, -- Assigned spending category

--- a/src/moneybin/sql/schema/app_transaction_notes.sql
+++ b/src/moneybin/sql/schema/app_transaction_notes.sql
@@ -1,4 +1,5 @@
 /* Free-form user notes on individual transactions; one note per transaction */
+-- Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict)
 CREATE TABLE IF NOT EXISTS app.transaction_notes (
     transaction_id VARCHAR PRIMARY KEY, -- Foreign key to core.fct_transactions; one note per transaction
     note VARCHAR NOT NULL, -- Free-form text note added by the user about this transaction

--- a/src/moneybin/tables.py
+++ b/src/moneybin/tables.py
@@ -44,9 +44,7 @@ TABULAR_ACCOUNTS = TableRef("raw", "tabular_accounts")
 IMPORT_LOG = TableRef("raw", "import_log")
 
 # -- App tables (application-managed data) --
-TRANSACTION_CATEGORIES = TableRef(
-    "app", "transaction_categories", audience="interface"
-)
+TRANSACTION_CATEGORIES = TableRef("app", "transaction_categories", audience="interface")
 BUDGETS = TableRef("app", "budgets", audience="interface")
 TRANSACTION_NOTES = TableRef("app", "transaction_notes", audience="interface")
 # view: seeds.categories ∪ app.user_categories, with overrides applied
@@ -54,9 +52,7 @@ CATEGORIES = TableRef("app", "categories", audience="interface")
 USER_CATEGORIES = TableRef("app", "user_categories")
 CATEGORY_OVERRIDES = TableRef("app", "category_overrides")
 MERCHANTS = TableRef("app", "merchants", audience="interface")
-CATEGORIZATION_RULES = TableRef(
-    "app", "categorization_rules", audience="interface"
-)
+CATEGORIZATION_RULES = TableRef("app", "categorization_rules", audience="interface")
 PROPOSED_RULES = TableRef("app", "proposed_rules")
 RULE_DEACTIVATIONS = TableRef("app", "rule_deactivations")
 SCHEMA_MIGRATIONS = TableRef("app", "schema_migrations")

--- a/src/moneybin/tables.py
+++ b/src/moneybin/tables.py
@@ -3,7 +3,14 @@
 All consumers (MCP server, CLI, services) import table constants from here.
 """
 
-from typing import NamedTuple
+from __future__ import annotations
+
+import sys
+from typing import Literal, NamedTuple
+
+# When adding a new TableRef constant: if it should be visible to MCP
+# clients via the curated `moneybin://schema` resource, pass
+# audience="interface". Otherwise it stays internal (default).
 
 
 class TableRef(NamedTuple):
@@ -11,6 +18,7 @@ class TableRef(NamedTuple):
 
     schema: str
     name: str
+    audience: Literal["interface", "internal"] = "internal"
 
     @property
     def full_name(self) -> str:
@@ -19,9 +27,9 @@ class TableRef(NamedTuple):
 
 
 # -- Core layer (canonical tables built by SQLMesh transforms) --
-DIM_ACCOUNTS = TableRef("core", "dim_accounts")
-FCT_TRANSACTIONS = TableRef("core", "fct_transactions")
-BRIDGE_TRANSFERS = TableRef("core", "bridge_transfers")
+DIM_ACCOUNTS = TableRef("core", "dim_accounts", audience="interface")
+FCT_TRANSACTIONS = TableRef("core", "fct_transactions", audience="interface")
+BRIDGE_TRANSFERS = TableRef("core", "bridge_transfers", audience="interface")
 
 # -- Raw tables (used until core models are built for these entities) --
 OFX_ACCOUNTS = TableRef("raw", "ofx_accounts")
@@ -36,16 +44,19 @@ TABULAR_ACCOUNTS = TableRef("raw", "tabular_accounts")
 IMPORT_LOG = TableRef("raw", "import_log")
 
 # -- App tables (application-managed data) --
-TRANSACTION_CATEGORIES = TableRef("app", "transaction_categories")
-BUDGETS = TableRef("app", "budgets")
-TRANSACTION_NOTES = TableRef("app", "transaction_notes")
-CATEGORIES = TableRef(
-    "app", "categories"
-)  # view: seeds.categories ∪ app.user_categories, with overrides applied
+TRANSACTION_CATEGORIES = TableRef(
+    "app", "transaction_categories", audience="interface"
+)
+BUDGETS = TableRef("app", "budgets", audience="interface")
+TRANSACTION_NOTES = TableRef("app", "transaction_notes", audience="interface")
+# view: seeds.categories ∪ app.user_categories, with overrides applied
+CATEGORIES = TableRef("app", "categories", audience="interface")
 USER_CATEGORIES = TableRef("app", "user_categories")
 CATEGORY_OVERRIDES = TableRef("app", "category_overrides")
-MERCHANTS = TableRef("app", "merchants")
-CATEGORIZATION_RULES = TableRef("app", "categorization_rules")
+MERCHANTS = TableRef("app", "merchants", audience="interface")
+CATEGORIZATION_RULES = TableRef(
+    "app", "categorization_rules", audience="interface"
+)
 PROPOSED_RULES = TableRef("app", "proposed_rules")
 RULE_DEACTIVATIONS = TableRef("app", "rule_deactivations")
 SCHEMA_MIGRATIONS = TableRef("app", "schema_migrations")
@@ -69,3 +80,20 @@ FCT_TRANSACTION_PROVENANCE = TableRef("meta", "fct_transaction_provenance")
 
 # -- Synthetic tables (created on demand by the generator) --
 GROUND_TRUTH = TableRef("synthetic", "ground_truth")
+
+
+def _all_table_refs() -> tuple[TableRef, ...]:
+    """Collect every TableRef constant defined at module scope.
+
+    Walks this module's globals so the interface set is derived from
+    the constant declarations rather than maintained as a parallel list.
+    """
+    module = sys.modules[__name__]
+    return tuple(
+        value for value in vars(module).values() if isinstance(value, TableRef)
+    )
+
+
+INTERFACE_TABLES: tuple[TableRef, ...] = tuple(
+    t for t in _all_table_refs() if t.audience == "interface"
+)

--- a/tests/moneybin/conftest.py
+++ b/tests/moneybin/conftest.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import moneybin.database as db_module
 from moneybin.config import (
     clear_settings_cache,
     get_base_dir,
@@ -19,6 +20,7 @@ from moneybin.config import (
     set_current_profile,
 )
 from moneybin.database import Database
+from tests.moneybin.db_helpers import apply_core_table_comments, create_core_tables_raw
 
 
 @contextmanager
@@ -110,6 +112,26 @@ def mock_secret_store() -> MagicMock:
     store = MagicMock()
     store.get_key.return_value = "test-encryption-key-for-unit-tests"
     return store
+
+
+@pytest.fixture()
+def schema_catalog_db(
+    tmp_path: Path, mock_secret_store: MagicMock
+) -> Generator[Database, None, None]:
+    """Database with core tables + comments applied; for schema-catalog tests."""
+    database = Database(
+        tmp_path / "schema_catalog.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+    )
+    create_core_tables_raw(database.conn)
+    apply_core_table_comments(database)
+    db_module._database_instance = database  # type: ignore[attr-defined]
+    try:
+        yield database
+    finally:
+        db_module._database_instance = None  # type: ignore[attr-defined]
+        database.close()
 
 
 @pytest.fixture()

--- a/tests/moneybin/db_helpers.py
+++ b/tests/moneybin/db_helpers.py
@@ -29,6 +29,16 @@ CREATE TABLE IF NOT EXISTS core.dim_accounts (
 );
 """
 
+CORE_BRIDGE_TRANSFERS_DDL = """\
+CREATE TABLE IF NOT EXISTS core.bridge_transfers (
+    transfer_id VARCHAR PRIMARY KEY,
+    debit_transaction_id VARCHAR,
+    credit_transaction_id VARCHAR,
+    date_offset_days INTEGER,
+    amount DECIMAL(18, 2)
+);
+"""
+
 CORE_FCT_TRANSACTIONS_DDL = """\
 CREATE TABLE IF NOT EXISTS core.fct_transactions (
     transaction_id VARCHAR,
@@ -83,6 +93,7 @@ def create_core_tables(db: Database) -> None:
     """
     db.execute(CORE_DIM_ACCOUNTS_DDL)
     db.execute(CORE_FCT_TRANSACTIONS_DDL)
+    db.execute(CORE_BRIDGE_TRANSFERS_DDL)
 
 
 def create_core_tables_raw(conn: duckdb.DuckDBPyConnection) -> None:
@@ -96,6 +107,7 @@ def create_core_tables_raw(conn: duckdb.DuckDBPyConnection) -> None:
     """
     conn.execute(CORE_DIM_ACCOUNTS_DDL)
     conn.execute(CORE_FCT_TRANSACTIONS_DDL)
+    conn.execute(CORE_BRIDGE_TRANSFERS_DDL)
 
 
 # Table and column comments for core tables — mirror the SQLMesh model

--- a/tests/moneybin/db_helpers.py
+++ b/tests/moneybin/db_helpers.py
@@ -96,3 +96,55 @@ def create_core_tables_raw(conn: duckdb.DuckDBPyConnection) -> None:
     """
     conn.execute(CORE_DIM_ACCOUNTS_DDL)
     conn.execute(CORE_FCT_TRANSACTIONS_DDL)
+
+
+# Table and column comments for core tables — mirror the SQLMesh model
+# headers and inline column comments. Applied separately because the
+# minimal CREATE TABLE DDL above does not embed them.
+CORE_TABLE_COMMENTS: dict[str, str] = {
+    "core.fct_transactions": (
+        "Canonical transactions fact view; reads from the deduplicated "
+        "merged layer with categorization and merchant joins; "
+        "negative amount = expense, positive = income"
+    ),
+    "core.dim_accounts": (
+        "Canonical accounts dimension; one row per account across sources"
+    ),
+}
+
+CORE_COLUMN_COMMENTS: dict[str, dict[str, str]] = {
+    "core.fct_transactions": {
+        "transaction_id": (
+            "Gold key: deterministic SHA-256 hash, unique per real-world transaction"
+        ),
+        "amount": "Transaction amount; negative = expense, positive = income",
+        "transaction_direction": ("Derived from amount sign: expense, income, or zero"),
+        "category": (
+            "Spending category; from app.transaction_categories when "
+            "categorized, else source value"
+        ),
+    },
+    "core.dim_accounts": {
+        "account_id": "Stable per-source account identifier",
+        "institution_name": "Display name of the issuing institution",
+    },
+}
+
+
+def apply_core_table_comments(database: Database) -> None:
+    """Apply COMMENT ON TABLE/COLUMN for core test tables.
+
+    Production comments are applied by SQLMesh's `register_comments`;
+    tests need to mirror that for the schema catalog tests to see prose.
+    """
+    for table, comment in CORE_TABLE_COMMENTS.items():
+        escaped = comment.replace("'", "''")
+        database.execute(  # noqa: S608  # static module constants, not user input
+            f"COMMENT ON TABLE {table} IS '{escaped}'"
+        )
+    for table, cols in CORE_COLUMN_COMMENTS.items():
+        for col, comment in cols.items():
+            escaped = comment.replace("'", "''")
+            database.execute(  # noqa: S608  # static module constants, not user input
+                f"COMMENT ON COLUMN {table}.{col} IS '{escaped}'"
+            )

--- a/tests/moneybin/db_helpers.py
+++ b/tests/moneybin/db_helpers.py
@@ -122,6 +122,10 @@ CORE_TABLE_COMMENTS: dict[str, str] = {
     "core.dim_accounts": (
         "Canonical accounts dimension; one row per account across sources"
     ),
+    "core.bridge_transfers": (
+        "Confirmed transfer pairs linking two fct_transactions rows; "
+        "derived from app.match_decisions where match_type = 'transfer'"
+    ),
 }
 
 CORE_COLUMN_COMMENTS: dict[str, dict[str, str]] = {

--- a/tests/moneybin/test_mcp/test_resources.py
+++ b/tests/moneybin/test_mcp/test_resources.py
@@ -10,7 +10,6 @@ import pytest
 from moneybin.mcp.resources import (
     resource_accounts,
     resource_privacy,
-    resource_schema,
     resource_status,
     resource_tools,
 )
@@ -135,48 +134,6 @@ class TestResourcePrivacy:
         result = resource_privacy()
         data: dict[str, Any] = json.loads(result)
         assert data["unmask_critical"] is False
-
-
-# ---------------------------------------------------------------------------
-# moneybin://schema
-# ---------------------------------------------------------------------------
-
-
-class TestResourceSchema:
-    """Tests for moneybin://schema resource."""
-
-    @pytest.mark.unit
-    def test_returns_tables_list(self) -> None:
-        result = resource_schema()
-        data: dict[str, Any] = json.loads(result)
-        assert "tables" in data
-        assert isinstance(data["tables"], list)
-
-    @pytest.mark.unit
-    def test_tables_have_required_fields(self) -> None:
-        result = resource_schema()
-        data: dict[str, Any] = json.loads(result)
-        if data["tables"]:
-            table = data["tables"][0]
-            assert "schema" in table
-            assert "table" in table
-            assert "columns" in table
-
-    @pytest.mark.unit
-    def test_columns_have_name_and_type(self) -> None:
-        result = resource_schema()
-        data: dict[str, Any] = json.loads(result)
-        for table in data["tables"]:
-            for col in table["columns"]:
-                assert "name" in col
-                assert "type" in col
-
-    @pytest.mark.unit
-    def test_core_schema_included(self) -> None:
-        result = resource_schema()
-        data: dict[str, Any] = json.loads(result)
-        schemas = {t["schema"] for t in data["tables"]}
-        assert "core" in schemas
 
 
 # ---------------------------------------------------------------------------

--- a/tests/moneybin/test_mcp/test_schema_resource.py
+++ b/tests/moneybin/test_mcp/test_schema_resource.py
@@ -3,40 +3,16 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Generator
-from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
-import moneybin.database as db_module
 from moneybin.database import Database
 from moneybin.mcp.resources import resource_schema
-from tests.moneybin.db_helpers import apply_core_table_comments, create_core_tables_raw
+
+pytestmark = pytest.mark.unit
 
 
-@pytest.fixture()
-def schema_mcp_db(tmp_path: Path) -> Generator[Database, None, None]:
-    """Database with core tables and comments applied, singleton patched."""
-    mock_store = MagicMock()
-    mock_store.get_key.return_value = "test-encryption-key-256bit-placeholder"
-    database = Database(
-        tmp_path / "schema_mcp.duckdb",
-        secret_store=mock_store,
-        no_auto_upgrade=True,
-    )
-    create_core_tables_raw(database.conn)
-    apply_core_table_comments(database)
-    db_module._database_instance = database  # type: ignore[attr-defined]
-    try:
-        yield database
-    finally:
-        db_module._database_instance = None  # type: ignore[attr-defined]
-        database.close()
-
-
-@pytest.mark.unit
-def test_resource_schema_returns_valid_json(schema_mcp_db: Database) -> None:
+def test_resource_schema_returns_valid_json(schema_catalog_db: Database) -> None:
     """Parsed JSON must have version, tables, conventions, and beyond_the_interface."""
     result = resource_schema()
     data = json.loads(result)
@@ -46,9 +22,8 @@ def test_resource_schema_returns_valid_json(schema_mcp_db: Database) -> None:
     assert "beyond_the_interface" in data
 
 
-@pytest.mark.unit
 def test_resource_schema_contains_core_interface_tables(
-    schema_mcp_db: Database,
+    schema_catalog_db: Database,
 ) -> None:
     """core.fct_transactions and core.dim_accounts must appear in tables[].name."""
     result = resource_schema()
@@ -58,9 +33,8 @@ def test_resource_schema_contains_core_interface_tables(
     assert "core.dim_accounts" in names
 
 
-@pytest.mark.unit
 def test_resource_schema_tables_have_required_fields(
-    schema_mcp_db: Database,
+    schema_catalog_db: Database,
 ) -> None:
     """Each table entry has the expected top-level keys."""
     data = json.loads(resource_schema())
@@ -72,9 +46,8 @@ def test_resource_schema_tables_have_required_fields(
         assert "examples" in table
 
 
-@pytest.mark.unit
 def test_resource_schema_columns_have_name_and_type(
-    schema_mcp_db: Database,
+    schema_catalog_db: Database,
 ) -> None:
     """Each column entry has at least name and type."""
     data = json.loads(resource_schema())

--- a/tests/moneybin/test_mcp/test_schema_resource.py
+++ b/tests/moneybin/test_mcp/test_schema_resource.py
@@ -1,0 +1,85 @@
+"""Tests for the moneybin://schema MCP resource."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import moneybin.database as db_module
+from moneybin.database import Database
+from moneybin.mcp.resources import resource_schema
+from tests.moneybin.db_helpers import apply_core_table_comments, create_core_tables_raw
+
+
+@pytest.fixture()
+def schema_mcp_db(tmp_path: Path) -> Generator[Database, None, None]:
+    """Database with core tables and comments applied, singleton patched."""
+    mock_store = MagicMock()
+    mock_store.get_key.return_value = "test-encryption-key-256bit-placeholder"
+    database = Database(
+        tmp_path / "schema_mcp.duckdb",
+        secret_store=mock_store,
+        no_auto_upgrade=True,
+    )
+    create_core_tables_raw(database.conn)
+    apply_core_table_comments(database)
+    db_module._database_instance = database  # type: ignore[attr-defined]
+    try:
+        yield database
+    finally:
+        db_module._database_instance = None  # type: ignore[attr-defined]
+        database.close()
+
+
+@pytest.mark.unit
+def test_resource_schema_returns_valid_json(schema_mcp_db: Database) -> None:
+    """Parsed JSON must have version, tables, conventions, and beyond_the_interface."""
+    result = resource_schema()
+    data = json.loads(result)
+    assert data["version"] == 1
+    assert isinstance(data["tables"], list)
+    assert "conventions" in data
+    assert "beyond_the_interface" in data
+
+
+@pytest.mark.unit
+def test_resource_schema_contains_core_interface_tables(
+    schema_mcp_db: Database,
+) -> None:
+    """core.fct_transactions and core.dim_accounts must appear in tables[].name."""
+    result = resource_schema()
+    data = json.loads(result)
+    names = {t["name"] for t in data["tables"]}
+    assert "core.fct_transactions" in names
+    assert "core.dim_accounts" in names
+
+
+@pytest.mark.unit
+def test_resource_schema_tables_have_required_fields(
+    schema_mcp_db: Database,
+) -> None:
+    """Each table entry has the expected top-level keys."""
+    data = json.loads(resource_schema())
+    assert data["tables"], "fixture should have seeded core tables"
+    for table in data["tables"]:
+        assert "name" in table
+        assert "purpose" in table
+        assert "columns" in table
+        assert "examples" in table
+
+
+@pytest.mark.unit
+def test_resource_schema_columns_have_name_and_type(
+    schema_mcp_db: Database,
+) -> None:
+    """Each column entry has at least name and type."""
+    data = json.loads(resource_schema())
+    assert data["tables"], "fixture should have seeded core tables"
+    for table in data["tables"]:
+        for col in table["columns"]:
+            assert "name" in col
+            assert "type" in col

--- a/tests/moneybin/test_services/test_schema_catalog.py
+++ b/tests/moneybin/test_services/test_schema_catalog.py
@@ -108,12 +108,13 @@ def test_build_schema_doc_includes_examples_for_present_tables(
 def test_interface_tables_present_in_catalog(schema_catalog_db: Database) -> None:
     """Stale-entry drift: an interface-tagged table is missing from the DB.
 
-    Only checks tables the test DB actually creates (core.*); the assertion
-    here is that nothing tagged interface in the *core* schema is missing.
+    Coverage gap: filters to core.* because the fixture only seeds core
+    tables — the six app.* interface tables (categories, budgets, notes,
+    merchants, categorization_rules, transaction_categories) are not
+    presence-checked or example-executed here. See docs/followups.md
+    "MCP schema discoverability — app.* drift coverage".
     """
     present = _present_tables(schema_catalog_db)
-    # Filter to core.* — the test fixture only seeds core tables.
-    # Broaden this filter when app.* gets seeded.
     missing_core = [
         t.full_name
         for t in INTERFACE_TABLES
@@ -128,17 +129,12 @@ def test_examples_parse_and_execute(schema_catalog_db: Database) -> None:
     """Examples must parse and execute against the live schema.
 
     Catches column-renamed-but-example-not-updated drift. Skips examples
-    for tables not present in the test DB (app.* tables not seeded here).
-    Parameterized examples (containing '?') are validated via PREPARE
-    instead of execution.
+    for tables not present in the test DB (app.* tables — see the
+    coverage-gap note on test_interface_tables_present_in_catalog).
     """
     present = _present_tables(schema_catalog_db)
     for table_name, examples in EXAMPLES.items():
         if table_name not in present:
             continue
         for ex in examples:
-            if "?" in ex.sql:
-                schema_catalog_db.execute(f"PREPARE schema_catalog_probe AS {ex.sql}")
-                schema_catalog_db.execute("DEALLOCATE schema_catalog_probe")
-            else:
-                schema_catalog_db.execute(ex.sql).fetchall()
+            schema_catalog_db.execute(ex.sql).fetchall()

--- a/tests/moneybin/test_services/test_schema_catalog.py
+++ b/tests/moneybin/test_services/test_schema_catalog.py
@@ -2,12 +2,25 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import moneybin.database as db_module
+from moneybin.database import Database
 from moneybin.services.schema_catalog import (
     CONVENTIONS,
     EXAMPLES,
     Example,
+    build_schema_doc,
 )
 from moneybin.tables import INTERFACE_TABLES
+from tests.moneybin.db_helpers import (
+    apply_core_table_comments,
+    create_core_tables_raw,
+)
 
 
 def test_conventions_has_required_keys() -> None:
@@ -41,3 +54,71 @@ def test_every_interface_table_has_at_least_one_example() -> None:
     interface_names = {t.full_name for t in INTERFACE_TABLES}
     missing = interface_names - set(EXAMPLES.keys())
     assert not missing, f"Interface tables missing examples: {sorted(missing)}"
+
+
+@pytest.fixture()
+def schema_db(tmp_path: Path) -> Generator[Database, None, None]:
+    """Database with core tables created and comments applied."""
+    mock_store = MagicMock()
+    mock_store.get_key.return_value = "test-encryption-key-256bit-placeholder"
+    database = Database(
+        tmp_path / "schema.duckdb",
+        secret_store=mock_store,
+        no_auto_upgrade=True,
+    )
+    create_core_tables_raw(database.conn)
+    apply_core_table_comments(database)
+    db_module._database_instance = database  # type: ignore[attr-defined]
+    try:
+        yield database
+    finally:
+        db_module._database_instance = None  # type: ignore[attr-defined]
+        database.close()
+
+
+def test_build_schema_doc_top_level_keys(schema_db: Database) -> None:
+    """The returned dict must have all expected top-level keys with correct types."""
+    doc = build_schema_doc()
+    assert doc["version"] == 1
+    assert "generated_at" in doc
+    assert doc["conventions"]["amount_sign"].startswith("negative")
+    assert isinstance(doc["tables"], list)
+    assert "beyond_the_interface" in doc
+    assert "catalog_query" in doc["beyond_the_interface"]
+
+
+def test_build_schema_doc_includes_present_interface_tables(
+    schema_db: Database,
+) -> None:
+    """Core interface tables present in the DB must appear in the output."""
+    doc = build_schema_doc()
+    names = {t["name"] for t in doc["tables"]}
+    # The test DB only creates core.* via create_core_tables_raw; app tables
+    # are absent, so build_schema_doc should silently skip them rather than
+    # error. Core interface tables must be present.
+    assert "core.fct_transactions" in names
+    assert "core.dim_accounts" in names
+
+
+def test_build_schema_doc_columns_carry_type_and_comment(
+    schema_db: Database,
+) -> None:
+    """Each column entry must include data_type and the applied comment."""
+    doc = build_schema_doc()
+    fct = next(t for t in doc["tables"] if t["name"] == "core.fct_transactions")
+    cols_by_name = {c["name"]: c for c in fct["columns"]}
+    assert "amount" in cols_by_name
+    assert "DECIMAL" in cols_by_name["amount"]["type"].upper()
+    assert "negative" in cols_by_name["amount"]["comment"].lower()
+
+
+def test_build_schema_doc_includes_examples_for_present_tables(
+    schema_db: Database,
+) -> None:
+    """Each table entry must carry at least one example with question and sql."""
+    doc = build_schema_doc()
+    fct = next(t for t in doc["tables"] if t["name"] == "core.fct_transactions")
+    assert len(fct["examples"]) >= 1
+    first = fct["examples"][0]
+    assert "question" in first
+    assert "sql" in first

--- a/tests/moneybin/test_services/test_schema_catalog.py
+++ b/tests/moneybin/test_services/test_schema_catalog.py
@@ -2,13 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
-from pathlib import Path
-from unittest.mock import MagicMock
-
 import pytest
 
-import moneybin.database as db_module
 from moneybin.database import Database
 from moneybin.services.schema_catalog import (
     CONVENTIONS,
@@ -17,10 +12,8 @@ from moneybin.services.schema_catalog import (
     build_schema_doc,
 )
 from moneybin.tables import INTERFACE_TABLES
-from tests.moneybin.db_helpers import (
-    apply_core_table_comments,
-    create_core_tables_raw,
-)
+
+pytestmark = pytest.mark.unit
 
 
 def test_conventions_has_required_keys() -> None:
@@ -64,27 +57,7 @@ def _present_tables(db: Database) -> set[str]:
     return {r[0] for r in rows}
 
 
-@pytest.fixture()
-def schema_db(tmp_path: Path) -> Generator[Database, None, None]:
-    """Database with core tables created and comments applied."""
-    mock_store = MagicMock()
-    mock_store.get_key.return_value = "test-encryption-key-256bit-placeholder"
-    database = Database(
-        tmp_path / "schema.duckdb",
-        secret_store=mock_store,
-        no_auto_upgrade=True,
-    )
-    create_core_tables_raw(database.conn)
-    apply_core_table_comments(database)
-    db_module._database_instance = database  # type: ignore[attr-defined]
-    try:
-        yield database
-    finally:
-        db_module._database_instance = None  # type: ignore[attr-defined]
-        database.close()
-
-
-def test_build_schema_doc_top_level_keys(schema_db: Database) -> None:
+def test_build_schema_doc_top_level_keys(schema_catalog_db: Database) -> None:
     """The returned dict must have all expected top-level keys with correct types."""
     doc = build_schema_doc()
     assert doc["version"] == 1
@@ -96,7 +69,7 @@ def test_build_schema_doc_top_level_keys(schema_db: Database) -> None:
 
 
 def test_build_schema_doc_includes_present_interface_tables(
-    schema_db: Database,
+    schema_catalog_db: Database,
 ) -> None:
     """Core interface tables present in the DB must appear in the output."""
     doc = build_schema_doc()
@@ -109,7 +82,7 @@ def test_build_schema_doc_includes_present_interface_tables(
 
 
 def test_build_schema_doc_columns_carry_type_and_comment(
-    schema_db: Database,
+    schema_catalog_db: Database,
 ) -> None:
     """Each column entry must include data_type and the applied comment."""
     doc = build_schema_doc()
@@ -121,7 +94,7 @@ def test_build_schema_doc_columns_carry_type_and_comment(
 
 
 def test_build_schema_doc_includes_examples_for_present_tables(
-    schema_db: Database,
+    schema_catalog_db: Database,
 ) -> None:
     """Each table entry must carry at least one example with question and sql."""
     doc = build_schema_doc()
@@ -132,13 +105,13 @@ def test_build_schema_doc_includes_examples_for_present_tables(
     assert "sql" in first
 
 
-def test_interface_tables_present_in_catalog(schema_db: Database) -> None:
+def test_interface_tables_present_in_catalog(schema_catalog_db: Database) -> None:
     """Stale-entry drift: an interface-tagged table is missing from the DB.
 
     Only checks tables the test DB actually creates (core.*); the assertion
     here is that nothing tagged interface in the *core* schema is missing.
     """
-    present = _present_tables(schema_db)
+    present = _present_tables(schema_catalog_db)
     # Filter to core.* — the test fixture only seeds core tables.
     # Broaden this filter when app.* gets seeded.
     missing_core = [
@@ -151,7 +124,7 @@ def test_interface_tables_present_in_catalog(schema_db: Database) -> None:
     )
 
 
-def test_examples_parse_and_execute(schema_db: Database) -> None:
+def test_examples_parse_and_execute(schema_catalog_db: Database) -> None:
     """Examples must parse and execute against the live schema.
 
     Catches column-renamed-but-example-not-updated drift. Skips examples
@@ -159,13 +132,13 @@ def test_examples_parse_and_execute(schema_db: Database) -> None:
     Parameterized examples (containing '?') are validated via PREPARE
     instead of execution.
     """
-    present = _present_tables(schema_db)
+    present = _present_tables(schema_catalog_db)
     for table_name, examples in EXAMPLES.items():
         if table_name not in present:
             continue
         for ex in examples:
             if "?" in ex.sql:
-                schema_db.execute(f"PREPARE schema_catalog_probe AS {ex.sql}")
-                schema_db.execute("DEALLOCATE schema_catalog_probe")
+                schema_catalog_db.execute(f"PREPARE schema_catalog_probe AS {ex.sql}")
+                schema_catalog_db.execute("DEALLOCATE schema_catalog_probe")
             else:
-                schema_db.execute(ex.sql).fetchall()
+                schema_catalog_db.execute(ex.sql).fetchall()

--- a/tests/moneybin/test_services/test_schema_catalog.py
+++ b/tests/moneybin/test_services/test_schema_catalog.py
@@ -56,6 +56,14 @@ def test_every_interface_table_has_at_least_one_example() -> None:
     assert not missing, f"Interface tables missing examples: {sorted(missing)}"
 
 
+def _present_tables(db: Database) -> set[str]:
+    """Return fully-qualified names of all tables in the test DB."""
+    rows = db.execute(
+        "SELECT schema_name || '.' || table_name FROM duckdb_tables()"
+    ).fetchall()
+    return {r[0] for r in rows}
+
+
 @pytest.fixture()
 def schema_db(tmp_path: Path) -> Generator[Database, None, None]:
     """Database with core tables created and comments applied."""
@@ -122,3 +130,42 @@ def test_build_schema_doc_includes_examples_for_present_tables(
     first = fct["examples"][0]
     assert "question" in first
     assert "sql" in first
+
+
+def test_interface_tables_present_in_catalog(schema_db: Database) -> None:
+    """Stale-entry drift: an interface-tagged table is missing from the DB.
+
+    Only checks tables the test DB actually creates (core.*); the assertion
+    here is that nothing tagged interface in the *core* schema is missing.
+    """
+    present = _present_tables(schema_db)
+    # Filter to core.* — the test fixture only seeds core tables.
+    # Broaden this filter when app.* gets seeded.
+    missing_core = [
+        t.full_name
+        for t in INTERFACE_TABLES
+        if t.schema == "core" and t.full_name not in present
+    ]
+    assert not missing_core, (
+        f"INTERFACE_TABLES core entries missing from catalog: {missing_core}"
+    )
+
+
+def test_examples_parse_and_execute(schema_db: Database) -> None:
+    """Examples must parse and execute against the live schema.
+
+    Catches column-renamed-but-example-not-updated drift. Skips examples
+    for tables not present in the test DB (app.* tables not seeded here).
+    Parameterized examples (containing '?') are validated via PREPARE
+    instead of execution.
+    """
+    present = _present_tables(schema_db)
+    for table_name, examples in EXAMPLES.items():
+        if table_name not in present:
+            continue
+        for ex in examples:
+            if "?" in ex.sql:
+                schema_db.execute(f"PREPARE schema_catalog_probe AS {ex.sql}")
+                schema_db.execute("DEALLOCATE schema_catalog_probe")
+            else:
+                schema_db.execute(ex.sql).fetchall()

--- a/tests/moneybin/test_services/test_schema_catalog.py
+++ b/tests/moneybin/test_services/test_schema_catalog.py
@@ -81,6 +81,41 @@ def test_build_schema_doc_includes_present_interface_tables(
     assert "core.dim_accounts" in names
 
 
+def test_build_schema_doc_includes_interface_views(
+    schema_catalog_db: Database,
+) -> None:
+    """Interface objects that are views (not tables) must appear too.
+
+    Regression test: `duckdb_tables()` excludes views, so the catalog
+    query must union it with `duckdb_views()` to surface objects like
+    `app.categories` (created via CREATE OR REPLACE VIEW in seeds.py).
+    """
+    schema_catalog_db.execute("CREATE SCHEMA IF NOT EXISTS app")
+    schema_catalog_db.execute(
+        "CREATE OR REPLACE VIEW app.categories AS "
+        "SELECT 'X' AS category_id, 'X' AS category, "
+        "NULL::VARCHAR AS subcategory, NULL::VARCHAR AS description, "
+        "true AS is_active"
+    )
+    doc = build_schema_doc()
+    names = {t["name"] for t in doc["tables"]}
+    assert "app.categories" in names
+
+
+def test_beyond_the_interface_query_executes(
+    schema_catalog_db: Database,
+) -> None:
+    """The catalog query in the footer must run via the same connection.
+
+    Regression test: previously used `table_schema` (an information_schema
+    column), which fails on `duckdb_tables()`. The query must use
+    `schema_name` so power users / LLMs copying it can run it directly.
+    """
+    doc = build_schema_doc()
+    query = doc["beyond_the_interface"]["catalog_query"]
+    schema_catalog_db.execute(query).fetchall()
+
+
 def test_build_schema_doc_columns_carry_type_and_comment(
     schema_catalog_db: Database,
 ) -> None:

--- a/tests/moneybin/test_services/test_schema_catalog.py
+++ b/tests/moneybin/test_services/test_schema_catalog.py
@@ -1,0 +1,43 @@
+"""Tests for the schema catalog service."""
+
+from __future__ import annotations
+
+from moneybin.services.schema_catalog import (
+    CONVENTIONS,
+    EXAMPLES,
+    Example,
+)
+from moneybin.tables import INTERFACE_TABLES
+
+
+def test_conventions_has_required_keys() -> None:
+    """CONVENTIONS must define exactly the four canonical keys."""
+    assert set(CONVENTIONS.keys()) == {
+        "amount_sign",
+        "currency",
+        "dates",
+        "ids",
+    }
+
+
+def test_example_dataclass_shape() -> None:
+    """Example is a frozen dataclass with question and sql fields."""
+    ex = Example(question="q?", sql="SELECT 1")
+    assert ex.question == "q?"
+    assert ex.sql == "SELECT 1"
+
+
+def test_examples_only_reference_interface_tables() -> None:
+    """Every key in EXAMPLES must be a known interface table."""
+    interface_names = {t.full_name for t in INTERFACE_TABLES}
+    for table_name in EXAMPLES.keys():
+        assert table_name in interface_names, (
+            f"EXAMPLES key {table_name!r} is not an interface table"
+        )
+
+
+def test_every_interface_table_has_at_least_one_example() -> None:
+    """Every interface table must have at least one entry in EXAMPLES."""
+    interface_names = {t.full_name for t in INTERFACE_TABLES}
+    missing = interface_names - set(EXAMPLES.keys())
+    assert not missing, f"Interface tables missing examples: {sorted(missing)}"

--- a/tests/moneybin/test_tables.py
+++ b/tests/moneybin/test_tables.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from moneybin.tables import (
     BRIDGE_TRANSFERS,
     BUDGETS,
@@ -16,6 +18,8 @@ from moneybin.tables import (
     TRANSACTION_NOTES,
     TableRef,
 )
+
+pytestmark = pytest.mark.unit
 
 EXPECTED_INTERFACE = {
     FCT_TRANSACTIONS.full_name,

--- a/tests/moneybin/test_tables.py
+++ b/tests/moneybin/test_tables.py
@@ -1,0 +1,59 @@
+"""Tests for the TableRef registry and INTERFACE_TABLES derivation."""
+
+from __future__ import annotations
+
+from moneybin.tables import (
+    BRIDGE_TRANSFERS,
+    BUDGETS,
+    CATEGORIES,
+    CATEGORIZATION_RULES,
+    DIM_ACCOUNTS,
+    FCT_TRANSACTIONS,
+    INTERFACE_TABLES,
+    MERCHANTS,
+    OFX_TRANSACTIONS,
+    TRANSACTION_CATEGORIES,
+    TRANSACTION_NOTES,
+    TableRef,
+)
+
+EXPECTED_INTERFACE = {
+    FCT_TRANSACTIONS.full_name,
+    DIM_ACCOUNTS.full_name,
+    BRIDGE_TRANSFERS.full_name,
+    CATEGORIES.full_name,
+    BUDGETS.full_name,
+    TRANSACTION_NOTES.full_name,
+    MERCHANTS.full_name,
+    CATEGORIZATION_RULES.full_name,
+    TRANSACTION_CATEGORIES.full_name,
+}
+
+
+def test_audience_defaults_to_internal() -> None:
+    """Audience field defaults to "internal" when not specified."""
+    t = TableRef("foo", "bar")
+    assert t.audience == "internal"
+
+
+def test_interface_tables_set_matches_expected() -> None:
+    """INTERFACE_TABLES contains exactly the expected set of full names."""
+    full_names = {t.full_name for t in INTERFACE_TABLES}
+    assert full_names == EXPECTED_INTERFACE
+
+
+def test_interface_tables_all_carry_interface_audience() -> None:
+    """Every entry in INTERFACE_TABLES has audience="interface"."""
+    for t in INTERFACE_TABLES:
+        assert t.audience == "interface"
+
+
+def test_internal_tables_excluded_from_interface() -> None:
+    """Raw tables are not present in INTERFACE_TABLES."""
+    assert OFX_TRANSACTIONS not in INTERFACE_TABLES
+    assert OFX_TRANSACTIONS.audience == "internal"
+
+
+def test_full_name_unchanged() -> None:
+    """full_name property returns schema.name as before."""
+    assert FCT_TRANSACTIONS.full_name == "core.fct_transactions"


### PR DESCRIPTION
## Summary

Adds a new MCP resource `moneybin://schema` that returns a curated, structured schema document — interface tables, columns with types/comments, hand-authored example queries, and shared conventions — so an LLM connected via MCP can write accurate `sql_query` calls on the first try without per-session DESCRIBE/SHOW reconnaissance. Replaces a primitive raw-catalog dump that had previously been registered at the same URI.

## Impact

- MCP clients that read `moneybin://schema` now receive a richer, more useful payload (curated 9-table set, per-column prose, example queries, conventions block, "beyond the interface" footer pointing at the full catalog).
- `sql_query` tool description gains a one-line pointer to the resource for clients that don't auto-load resources.
- New `audience` field on `TableRef` (default `"internal"`) — fully backward compatible with all existing `TableRef("schema", "name")` call sites.
- No CLI changes, no schema migrations, no consent changes (resource is `low` sensitivity).

## Changes

### Spec & plan
Brainstormed design lives in `docs/specs/mcp-sql-discoverability.md` (status: implemented). Implementation plan in `docs/superpowers/plans/2026-05-01-mcp-sql-discoverability.md`. Followup note in `docs/followups.md` flags the sibling-`.examples.sql` co-location option for future reconsideration if drift becomes a real problem. README roadmap entry flipped 📐 → ✅.

### Interface-table tagging
Extended `TableRef` `NamedTuple` with `audience: Literal["interface", "internal"] = "internal"`. Tagged 9 tables as interface (3 core + 6 app). New `INTERFACE_TABLES` tuple is derived from the registry via `_all_table_refs()` walking module globals — no parallel allowlist to maintain.

### Schema catalog service
New `src/moneybin/services/schema_catalog.py` houses:
- `CONVENTIONS` dict (sign convention, money type, date type, ID strategy)
- `Example` frozen dataclass
- `EXAMPLES` dict mapping each interface table to 1-3 hand-authored queries chosen to teach idioms (period grouping, sign filtering, joins)
- `build_schema_doc()` joins `duckdb_tables()` and `duckdb_columns()` in a single query, groups columns per table, attaches examples, returns a JSON-serializable dict

### MCP integration
- `moneybin://schema` registered in `src/moneybin/mcp/resources.py` as a thin wrapper around `build_schema_doc()`
- `sql_query` docstring + registration description point at the resource
- One-line `-- Query examples ...` pointer comments added to each interface-table DDL/model file (8 SQL files + the `app.categories` view in `seeds.py`)

### Tests
- `tests/moneybin/test_tables.py` — 5 tests for `audience` field and `INTERFACE_TABLES` derivation
- `tests/moneybin/test_services/test_schema_catalog.py` — 10 tests covering structure, presence drift, and example parse-and-execute (the drift test caught a missing `bridge_transfers` DDL in test helpers, fixed in the same commit)
- `tests/moneybin/test_mcp/test_schema_resource.py` — 4 tests covering JSON shape and table coverage
- Shared `schema_catalog_db` fixture in `tests/moneybin/conftest.py` consumed by both test modules
- `tests/moneybin/db_helpers.py` extended with `apply_core_table_comments()` so tests see the same comment metadata production gets via SQLMesh's `register_comments`

## Testing

- `make check test` clean: 0 lint, 0 type errors, **1431 tests passing**
- End-to-end exercise against a temp DB confirms all 9 interface tables present, 95+ columns total with types/comments, examples per table, conventions and `beyond_the_interface` footer populated
- Drift tests verify: every interface table exists in the catalog (presence drift); every example for a present table parses+executes (column drift, via `PREPARE`/`DEALLOCATE` for parameterized examples)

## Notes

- The previous `resource_schema` in `mcp/resources.py` did raw `duckdb_columns()` introspection and is fully replaced (the old shape is incompatible with the new curated dict). The corresponding `TestResourceSchema` class in `test_resources.py` was removed; coverage moved to `test_schema_resource.py`.
- The `app.categories` pointer comment lives in `seeds.py` (next to the `CREATE OR REPLACE VIEW` statement) rather than in `app_categories.sql` — that DDL file now contains `app.user_categories` and `app.category_overrides`, neither of which is an interface table.
- A `/simplify` pass collapsed the build_schema_doc N+1 query into a single JOIN, consolidated duplicate test fixtures into `conftest.py`, and added missing `pytestmark = pytest.mark.unit` markers to the new test files.