### PR TITLE
Fix MCP server crash on existing DB with stale schema

### DIFF
--- a/src/moneybin/schema.py
+++ b/src/moneybin/schema.py
@@ -119,10 +119,13 @@ def _apply_comments(conn: duckdb.DuckDBPyConnection, sql: str) -> None:
                     f"COMMENT ON COLUMN {table_name}.{col_def.name} IS '{safe_comment}'"
                 )
                 logger.debug(f"Applied column comment to {table_name}.{col_def.name}")
-            except duckdb.CatalogException:
+            except (duckdb.CatalogException, duckdb.BinderException):
+                # Column may not exist yet — either the table is created later
+                # (e.g. SQLMesh-managed core tables) or a pending migration will
+                # add the column. Comments will reapply on the next startup.
                 logger.debug(
                     f"Skipping column comment for {table_name}.{col_def.name}"
-                    " — table does not exist yet"
+                    " — column or table does not exist yet"
                 )
 
 

--- a/tests/moneybin/test_schema.py
+++ b/tests/moneybin/test_schema.py
@@ -1,0 +1,45 @@
+"""Tests for schema initialization and inline-comment application."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from moneybin.database import Database
+
+
+def test_init_does_not_fail_when_existing_table_missing_new_columns(
+    tmp_path: Path, mock_secret_store: MagicMock
+) -> None:
+    """Reopening a stale DB must not crash during schema-comment application.
+
+    Reopening a DB whose live table is missing columns added by a later
+    migration must not raise BinderException during schema-comment application.
+
+    Reproduces the bug where Database.__init__ ran _apply_comments BEFORE
+    migrations: a pre-V003 ofx_institutions table (no import_id, no
+    source_type) caused COMMENT ON COLUMN to fail because the column did
+    not yet exist on the live table — even though V003 would add it
+    moments later.
+    """
+    db_path = tmp_path / "moneybin.duckdb"
+
+    db = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
+    try:
+        db.execute("ALTER TABLE raw.ofx_institutions DROP COLUMN import_id")
+        db.execute("ALTER TABLE raw.ofx_institutions DROP COLUMN source_type")
+        db.execute("DELETE FROM app.schema_migrations WHERE version >= 3")
+    finally:
+        db.close()
+
+    db2 = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=False)
+    try:
+        cols = {
+            row[0]
+            for row in db2.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_schema = 'raw' AND table_name = 'ofx_institutions'"
+            ).fetchall()
+        }
+        assert "import_id" in cols
+        assert "source_type" in cols
+    finally:
+        db2.close()


### PR DESCRIPTION
### Summary
`Database.__init__` runs `init_schemas` (which applies inline column comments) *before* migrations, so on an existing DB whose live tables predate a column-adding migration, `COMMENT ON COLUMN` raised `BinderException` and crashed the MCP server at startup. This widens the silent-skip path to cover that case.

### Impact
- Users on a pre-V003 DB can now start `moneybin mcp serve` without hitting `Binder Error: Table "ofx_institutions" does not have a column with name "import_id"`.
- No workflow changes.

### Changes

#### `src/moneybin/schema.py`
Catch `duckdb.BinderException` in addition to `CatalogException` when applying column comments. The skipped comment will reapply on the next startup once the pending migration has added the column.

#### `tests/moneybin/test_schema.py` (new)
Reproducer: open a fresh DB, drop `import_id`/`source_type` from `raw.ofx_institutions`, delete the V003 migration record, then reopen with auto-upgrade enabled. Pre-fix: raises `BinderException`. Post-fix: passes and migrations re-add the columns.

### Testing
- New `tests/moneybin/test_schema.py` passes
- `tests/moneybin/test_database.py`, `test_migrations.py`, `test_migration_v003.py` all pass
- `tests/e2e/test_e2e_mcp.py` (real `moneybin mcp serve` subprocess) passes

### Notes
The existing e2e MCP suite only boots against a fresh profile, which is why the bug slipped through — the new test specifically covers the "live DB shape lags schema files" gap.