### PR TITLE
Fix invalid MCP tool names rejected by Anthropic/OpenAI clients

### DIFF
--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -36,7 +36,7 @@ Single source of truth for spec status. Update this table when a spec's status c
 | [Overview](smart-import-overview.md) | Umbrella | ready | Six-pillar initiative: smart tabular detection, PDF, ML categorization, auto-rules, AI-assisted parsing |
 | [Tabular Import](smart-import-tabular.md) | Feature | implemented | Universal tabular importer (CSV, TSV, Excel, Parquet, Feather); heuristic detection engine, multi-account support, migration formats (Tiller, Mint, YNAB, Maybe). Supersedes archived `csv-import` spec. |
 | [Tabular Cleanup](tabular-import-cleanup.md) | Feature | implemented | Post-ship cleanup: ResolvedMapping dataclass, Literal types, config params, DatabaseKeyError handler, Decimal correctness, N+1 merchant batch optimization, account matching wiring |
-| [Smart Import Inbox](smart-import-inbox.md) | Feature | implemented | Watched-folder import UX: drop files in `~/Documents/MoneyBin/<profile>/inbox/`, run `moneybin import inbox` (or `import.inbox_sync` MCP), files move to `processed/YYYY-MM/` or `failed/YYYY-MM/` with YAML error sidecar. Per-profile lockfile + crash-recovery via staging-rename. |
+| [Smart Import Inbox](smart-import-inbox.md) | Feature | implemented | Watched-folder import UX: drop files in `~/Documents/MoneyBin/<profile>/inbox/`, run `moneybin import inbox` (or `import_inbox_sync` MCP), files move to `processed/YYYY-MM/` or `failed/YYYY-MM/` with YAML error sidecar. Per-profile lockfile + crash-recovery via staging-rename. |
 | `smart-import-pdf.md` | Feature | planned | Pillar C: native-text PDF import |
 | `smart-import-ai-parsing.md` | Feature | planned | Pillar F: LLM fallback for file parsing |
 

--- a/docs/specs/smart-import-inbox.md
+++ b/docs/specs/smart-import-inbox.md
@@ -48,7 +48,7 @@ The existing `~/.moneybin/` location is the older Unix dotdir form of platform c
 9. **Atomic file movement.** Each file is processed in three filesystem steps: source → staging path inside the destination directory → final destination. Movement uses `os.rename` (atomic on the same filesystem). A crash mid-import leaves the file either in `inbox/` (not yet moved), in a discoverable `staging-*` path inside `processed/` or `failed/`, or at its final destination — never partially written or duplicated. A startup recovery pass (run at the start of every sync) cleans up stale `staging-*` entries by reverting them to `inbox/`.
 10. **Out-of-scope on inbox/processed/failed boundaries.** Sync only acts on regular files directly inside `inbox/` (root) or directly inside `inbox/<single-subfolder>/`. Nested subfolders deeper than one level, symlinks, and hidden files (starting with `.`) are skipped with an `ignored` entry in the response. This rules out sync recursing into `processed/`, `failed/`, or accidentally following a symlink out of the home directory.
 11. **CLI surface.** `moneybin import inbox` drains the active profile's inbox. `moneybin import inbox list` previews without moving. `moneybin import inbox path` prints the active profile's inbox parent (`<inbox_root>/<profile>/`). All three live under the existing `import` group per `cli-restructure.md` and respect the global `--profile` flag.
-12. **MCP surface.** `import.inbox_sync` drains. `import.inbox_list` previews. Both are `low` sensitivity (return aggregate counts, filenames, and error codes — never file contents).
+12. **MCP surface.** `import_inbox_sync` drains. `import_inbox_list` previews. Both are `low` sensitivity (return aggregate counts, filenames, and error codes — never file contents).
 
 ### Non-Functional
 
@@ -73,7 +73,7 @@ Existing tables touched indirectly via `ImportService`:
 
 - `src/moneybin/services/inbox_service.py` — `InboxService` class encapsulating directory layout, locking, the recovery pass, file movement, and the sync/list operations. Calls `ImportService.import_file()` for each file. Returns a dataclass result (`InboxSyncResult`) with `processed`, `failed`, `skipped`, `ignored` lists.
 - `src/moneybin/cli/import_inbox.py` — Typer subcommands `inbox`, `inbox list`, `inbox path` registered under the existing `import` group.
-- `src/moneybin/mcp/tools/import_inbox.py` — `import.inbox_sync` and `import.inbox_list` MCP tools (or extend `import_tools.py` if it stays small).
+- `src/moneybin/mcp/tools/import_inbox.py` — `import_inbox_sync` and `import_inbox_list` MCP tools (or extend `import_tools.py` if it stays small).
 - `tests/services/test_inbox_service.py` — service-level unit + integration tests.
 - `tests/cli/test_import_inbox.py` — CLI subprocess tests.
 - `tests/mcp/test_import_inbox_tools.py` — MCP tool tests.
@@ -132,7 +132,7 @@ Done: 1 imported, 1 failed.
 
 Two new tools under the existing `import.*` namespace.
 
-### `import.inbox_sync`
+### `import_inbox_sync`
 
 - **Sensitivity:** `low` (returns counts, filenames, error codes; never file contents)
 - **Args:** none
@@ -153,9 +153,9 @@ Two new tools under the existing `import.*` namespace.
     "ignored": [{"path": ".DS_Store", "reason": "hidden_file"}]
   }
   ```
-- **Actions hints:** `"Move failed files into inbox/<account-slug>/ and re-run import.inbox_sync"` when any failures are returned.
+- **Actions hints:** `"Move failed files into inbox/<account-slug>/ and re-run import_inbox_sync"` when any failures are returned.
 
-### `import.inbox_list`
+### `import_inbox_list`
 
 - **Sensitivity:** `low`
 - **Args:** none

--- a/src/moneybin/mcp/tools/import_inbox.py
+++ b/src/moneybin/mcp/tools/import_inbox.py
@@ -25,7 +25,7 @@ def inbox_sync() -> ResponseEnvelope:
     if result["failed"]:
         actions.insert(
             0,
-            "Move failed files into inbox/<account-slug>/ and re-run import.inbox_sync",
+            "Move failed files into inbox/<account-slug>/ and re-run import_inbox_sync",
         )
     return build_envelope(data=result, sensitivity="low", actions=actions)
 
@@ -38,7 +38,7 @@ def inbox_list() -> ResponseEnvelope:
     return build_envelope(
         data=result,
         sensitivity="low",
-        actions=["Use import.inbox_sync to drain the inbox"],
+        actions=["Use import_inbox_sync to drain the inbox"],
     )
 
 
@@ -47,13 +47,13 @@ def register_inbox_tools(mcp: FastMCP) -> None:
     register(
         mcp,
         inbox_sync,
-        "import.inbox_sync",
+        "import_inbox_sync",
         "Drain the active profile's import inbox; move successes to "
         "processed/ and failures to failed/ with structured error sidecars.",
     )
     register(
         mcp,
         inbox_list,
-        "import.inbox_list",
+        "import_inbox_list",
         "Preview the active profile's import inbox without moving anything.",
     )

--- a/tests/moneybin/test_mcp/test_import_inbox_tools.py
+++ b/tests/moneybin/test_mcp/test_import_inbox_tools.py
@@ -1,4 +1,4 @@
-"""Tests for import.inbox_sync / import.inbox_list MCP tools."""
+"""Tests for import_inbox_sync / import_inbox_list MCP tools."""
 
 from __future__ import annotations
 
@@ -37,7 +37,7 @@ def patch_service(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> MagicMock:
 
 
 class TestInboxSyncTool:
-    """import.inbox_sync envelope shape and actions."""
+    """import_inbox_sync envelope shape and actions."""
 
     def test_returns_low_sensitivity_envelope(self, patch_service: MagicMock) -> None:
         patch_service.sync.return_value = InboxSyncResult(
@@ -63,7 +63,7 @@ class TestInboxSyncTool:
 
 
 class TestInboxListTool:
-    """import.inbox_list envelope shape."""
+    """import_inbox_list envelope shape."""
 
     def test_returns_would_process_shape(self, patch_service: MagicMock) -> None:
         patch_service.enumerate.return_value = InboxListResult(

--- a/tests/moneybin/test_mcp/test_visibility.py
+++ b/tests/moneybin/test_mcp/test_visibility.py
@@ -164,6 +164,31 @@ async def test_full_discover_reveals_every_extended_tool() -> None:
 
 
 @pytest.mark.asyncio
+async def test_every_tool_name_matches_anthropic_openai_pattern() -> None:
+    """Every registered tool name must match ``^[a-zA-Z0-9_-]{1,64}$``.
+
+    Why: Anthropic and OpenAI clients reject tool definitions whose names
+    don't match this regex (FastMCP/MCP SDK itself does not enforce it, so a
+    bad name boots fine and only fails at the frontend on connect). See
+    ``.claude/rules/mcp-server.md`` — "we use the portable subset."
+    """
+    import re
+
+    from moneybin.mcp.server import mcp
+
+    pattern = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+    names = [
+        t.name
+        for t in await mcp._list_tools()  # noqa: SLF001  # public list_tools() filters by visibility  # pyright: ignore[reportPrivateUsage]
+    ]
+    bad = [n for n in names if not pattern.match(n)]
+    assert not bad, (
+        f"Tool names violate ^[a-zA-Z0-9_-]{{1,64}}$ (Anthropic/OpenAI "
+        f"frontend regex): {bad}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_hidden_tool_is_uncallable_via_tools_call() -> None:
     """Hidden tools must be uncallable.
 

--- a/tests/moneybin/test_mcp/test_visibility.py
+++ b/tests/moneybin/test_mcp/test_visibility.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 import pytest
@@ -172,14 +173,12 @@ async def test_every_tool_name_matches_anthropic_openai_pattern() -> None:
     bad name boots fine and only fails at the frontend on connect). See
     ``.claude/rules/mcp-server.md`` — "we use the portable subset."
     """
-    import re
-
     from moneybin.mcp.server import mcp
 
     pattern = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
     names = [
         t.name
-        for t in await mcp._list_tools()  # noqa: SLF001  # public list_tools() filters by visibility  # pyright: ignore[reportPrivateUsage]
+        for t in await mcp._list_tools()  # noqa: SLF001  # fastmcp internal — public list_tools() filters by visibility  # pyright: ignore[reportPrivateUsage]
     ]
     bad = [n for n in names if not pattern.match(n)]
     assert not bad, (


### PR DESCRIPTION
### Summary
Two MCP tools registered with dotted names (`import.inbox_sync`, `import.inbox_list`) that violate the `^[a-zA-Z0-9_-]{1,64}$` regex enforced by Anthropic and OpenAI clients, causing `FrontendRemoteMcpToolDefinition.name` validation errors at MCP startup. Renames them to underscore form and adds a unit test that catches any future regression.

### Impact
- **MCP users:** the tools are now `import_inbox_sync` and `import_inbox_list`. The old dotted names never worked end-to-end (frontend rejected them), so this is a fix, not a breaking rename of a working surface.
- **No workflow changes.**

### Changes

#### MCP tool name fix
The `mcp-server.md` rule already calls out: *"Anthropic and OpenAI clients enforce `^[a-zA-Z0-9_-]{1,64}$`, so we use the portable subset."* These two tools slipped through.
- `src/moneybin/mcp/tools/import_inbox.py` — registered names and the action-hint strings updated to underscore form.
- `docs/specs/smart-import-inbox.md`, `docs/specs/INDEX.md` — references updated.
- `tests/moneybin/test_mcp/test_import_inbox_tools.py` — docstrings updated.

#### Regression test
- `tests/moneybin/test_mcp/test_visibility.py` — new `test_every_tool_name_matches_anthropic_openai_pattern` iterates `mcp._list_tools()` and asserts each name matches the regex. Runs in normal `make test`, so future bad names fail before reaching CI's e2e tier or the frontend.

### Testing
- `uv run pytest tests/moneybin/test_mcp/test_visibility.py tests/moneybin/test_mcp/test_import_inbox_tools.py -v` — all pass.
- `make format lint` — clean.

### Notes
The existing `tests/e2e/test_e2e_mcp.py` smoke test missed this because the MCP Python SDK client does not enforce the frontend regex — `list_tools()` succeeds with any string. The new unit test closes that gap.