### PR TITLE
Add sql_schema MCP tool for hosts without resource support

### DIFF
--- a/src/moneybin/mcp/tools/sql.py
+++ b/src/moneybin/mcp/tools/sql.py
@@ -3,6 +3,7 @@
 
 Tools:
     - sql_query — Execute a read-only SQL query (medium sensitivity)
+    - sql_schema — Return the curated schema doc (low sensitivity)
 """
 
 from __future__ import annotations
@@ -14,6 +15,7 @@ from moneybin.mcp._registration import register
 from moneybin.mcp.decorator import mcp_tool
 from moneybin.mcp.privacy import get_max_rows, validate_read_only_query
 from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
+from moneybin.services.schema_catalog import build_schema_doc
 
 
 @mcp_tool(sensitivity="medium")
@@ -51,6 +53,18 @@ def sql_query(query: str) -> ResponseEnvelope:
     return build_envelope(data=records, sensitivity="medium")
 
 
+@mcp_tool(sensitivity="low")
+def sql_schema() -> ResponseEnvelope:
+    """Return the curated database schema for ad-hoc SQL composition.
+
+    Equivalent to reading the ``moneybin://schema`` MCP resource. Provided
+    as a tool for hosts that don't surface MCP resources to the model
+    (e.g. Claude.ai chat). Returns interface tables, columns, comments,
+    conventions, and example queries.
+    """
+    return build_envelope(data=build_schema_doc(), sensitivity="low")
+
+
 def register_sql_tools(mcp: FastMCP) -> None:
     """Register all sql namespace tools with the FastMCP server."""
     register(
@@ -59,5 +73,14 @@ def register_sql_tools(mcp: FastMCP) -> None:
         "sql_query",
         "Execute a read-only SQL query against the database. "
         "Supports SELECT, WITH, DESCRIBE, SHOW, PRAGMA, EXPLAIN. "
-        "Read resource moneybin://schema for tables, columns, and example queries.",
+        "Call sql_schema (or read resource moneybin://schema) for tables, "
+        "columns, and example queries.",
+    )
+    register(
+        mcp,
+        sql_schema,
+        "sql_schema",
+        "Return the curated database schema: interface tables, columns, "
+        "comments, conventions, and example queries. Mirrors the "
+        "moneybin://schema resource for hosts that don't expose MCP resources.",
     )

--- a/tests/moneybin/test_mcp/test_tools.py
+++ b/tests/moneybin/test_mcp/test_tools.py
@@ -10,7 +10,7 @@ from fastmcp import FastMCP
 
 from moneybin.mcp.tools.accounts import accounts_list, register_accounts_tools
 from moneybin.mcp.tools.spending import register_spending_tools
-from moneybin.mcp.tools.sql import register_sql_tools, sql_query
+from moneybin.mcp.tools.sql import register_sql_tools, sql_query, sql_schema
 
 pytestmark = pytest.mark.usefixtures("mcp_db")
 
@@ -78,3 +78,14 @@ class TestV1ToolRegistration:
         parsed = result.to_dict()
         assert "summary" in parsed
         assert parsed["data"][0]["cnt"] == 2
+
+    @pytest.mark.unit
+    def test_sql_schema_returns_envelope(self, mcp_db: object) -> None:
+        result = sql_schema()
+        parsed = result.to_dict()
+        assert parsed["summary"]["sensitivity"] == "low"
+        data = parsed["data"]
+        assert data["version"] == 1
+        names = {t["name"] for t in data["tables"]}
+        assert "core.fct_transactions" in names
+        assert "core.dim_accounts" in names


### PR DESCRIPTION
### Summary
Adds an `sql_schema` MCP tool that returns the same curated schema document as the existing `moneybin://schema` resource. Many MCP hosts (notably Claude.ai chat) only plumb tools through to the model — resources are silently dropped — so the schema doc was effectively invisible there. A thin tool wrapper makes the server fully usable in any host.

### Impact
- New tool in the `sql` namespace: `sql_schema` (low sensitivity, no consent required).
- `sql_query`'s tool description now references both `sql_schema` and the `moneybin://schema` resource.
- No behavior change for hosts that already supported resources (Claude Code).

### Changes

#### MCP tool
- Add `sql_schema()` in `src/moneybin/mcp/tools/sql.py` — wraps `build_schema_doc()` and returns the result via `build_envelope` at sensitivity `low`.
- Register the tool alongside `sql_query`.

#### Tests
- Add `test_sql_schema_returns_envelope` verifying envelope shape, sensitivity tier, schema version, and presence of `core.fct_transactions` / `core.dim_accounts`.

### Testing
- `make check` — format, lint, pyright all clean.
- `uv run pytest tests/moneybin/test_mcp/test_tools.py -v` — 5 passed.