### PR TITLE
Fix app table purpose strings overwritten by boilerplate comment

### DIFF
--- a/src/moneybin/sql/schema/app_budgets.sql
+++ b/src/moneybin/sql/schema/app_budgets.sql
@@ -1,5 +1,4 @@
 /* Monthly spending budget targets by category; each record defines a spending limit for a category over a date range */
--- Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict)
 CREATE TABLE IF NOT EXISTS app.budgets (
     budget_id VARCHAR PRIMARY KEY, -- Unique identifier for this budget record
     category VARCHAR NOT NULL, -- Spending category this budget applies to; matches app.categories.category

--- a/src/moneybin/sql/schema/app_categorization_rules.sql
+++ b/src/moneybin/sql/schema/app_categorization_rules.sql
@@ -1,5 +1,4 @@
 /* Auto-categorization rules evaluated in priority order; assign categories based on description patterns, amount bounds, and account filters */
--- Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict)
 CREATE TABLE IF NOT EXISTS app.categorization_rules (
     rule_id VARCHAR PRIMARY KEY, -- Unique identifier for this rule
     name VARCHAR NOT NULL, -- Human-readable label for this rule, e.g. Starbucks coffee purchases

--- a/src/moneybin/sql/schema/app_merchants.sql
+++ b/src/moneybin/sql/schema/app_merchants.sql
@@ -1,5 +1,4 @@
 /* Merchant normalization patterns matched against transaction descriptions to canonicalize merchant names and cache category assignments */
--- Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict)
 CREATE TABLE IF NOT EXISTS app.merchants (
     merchant_id VARCHAR PRIMARY KEY, -- Unique identifier for this merchant record
     raw_pattern VARCHAR NOT NULL, -- Pattern matched against fct_transactions.description to identify this merchant

--- a/src/moneybin/sql/schema/app_transaction_categories.sql
+++ b/src/moneybin/sql/schema/app_transaction_categories.sql
@@ -1,5 +1,4 @@
 /* Category assignments for transactions; written by the rules engine, AI model, or user; one record per transaction */
--- Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict)
 CREATE TABLE IF NOT EXISTS app.transaction_categories (
     transaction_id VARCHAR PRIMARY KEY, -- Foreign key to core.fct_transactions; one categorization record per transaction
     category VARCHAR NOT NULL, -- Assigned spending category

--- a/src/moneybin/sql/schema/app_transaction_notes.sql
+++ b/src/moneybin/sql/schema/app_transaction_notes.sql
@@ -1,5 +1,4 @@
 /* Free-form user notes on individual transactions; one note per transaction */
--- Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict)
 CREATE TABLE IF NOT EXISTS app.transaction_notes (
     transaction_id VARCHAR PRIMARY KEY, -- Foreign key to core.fct_transactions; one note per transaction
     note VARCHAR NOT NULL, -- Free-form text note added by the user about this transaction


### PR DESCRIPTION
### Summary
The schema catalog exposed via `moneybin://schema` was reporting a placeholder string ("Query examples for the LLM: see ...") as the `purpose` for five `app.*` tables instead of the real descriptions. Removing a stale `--` pointer line above each `CREATE TABLE` lets the real `/* */` block comment register as the table's DuckDB catalog comment.

### Impact
- LLM clients consuming `moneybin://schema` (and the `sql_schema` MCP tool) will now see meaningful purpose strings for `app.budgets`, `app.categorization_rules`, `app.merchants`, `app.transaction_categories`, and `app.transaction_notes`.
- No workflow changes for developers. New table comments take effect on next app startup (when `init_schemas` reapplies them).

### Changes

#### Schema DDL cleanup
`schema.py:_apply_comments()` uses sqlglot to parse each schema file and registers the comment closest to `CREATE TABLE` as the table comment. When both a `/* purpose */` block and a `-- Query examples...` line preceded `CREATE TABLE`, sqlglot's `[-1]` (closest) selection picked the boilerplate `--` line, overwriting the real description.

- Deleted the `-- Query examples for the LLM: see src/moneybin/services/schema_catalog.py (EXAMPLES dict)` line from the five affected files. The pointer was redundant — `EXAMPLES` in `schema_catalog.py` is the source of truth and is already wired into the catalog output.

### Testing
- `uv run pytest tests/moneybin/test_schema.py tests/moneybin/test_services/test_schema_catalog.py tests/moneybin/test_mcp/test_schema_resource.py` — 17 passed
- `make format lint` — clean

### Notes
A similar `# Query examples for the LLM:` comment lives in `src/moneybin/seeds.py:53` above the `app.categories` view definition, but it's a Python comment, not a SQL one — it never reached the DuckDB catalog and isn't part of this fix.