### PR TITLE
Fix silent migration skip + surface inbox import error details

### DIFF
--- a/docs/followups.md
+++ b/docs/followups.md
@@ -276,3 +276,28 @@ and extend the `schema_catalog_db` fixture to call it. The DDL exists in
 `src/moneybin/sql/schema/app_*.sql` and could be loaded directly via
 `schema.py:init_schemas()` if a non-private interface is exposed, or
 mirrored as Python constants like the core helpers do today.
+
+## Revisit migration auto-apply gate closer to MVP
+
+`Database.__init__` now applies pending migrations whenever
+`MigrationRunner(self).pending()` is non-empty, instead of gating on
+`stored_pkg_version != current_pkg_version`. The previous gate was
+silently broken — `pyproject.toml` `version` was static at `0.1.0`, so
+DBs created pre-V003 never re-entered the migration runner on subsequent
+opens, and the V003 column adds (e.g. `raw.ofx_institutions.import_id`)
+never landed on existing personal DBs. The pending-based gate fixes that
+without requiring a manual version bump.
+
+Trade-off to revisit before MVP / first non-author user: the new gate
+removes the implicit "migrations only run when I cut a release" boundary.
+For single-user personal MoneyBin that's a feature; for a packaged
+release where users may have read-only DB snapshots, copy on drag, or
+multiple processes opening the same DB, we may want migration application
+to be an explicit step (e.g. `moneybin db migrate` at install time, with
+the runtime gate being either advisory or off). Decide based on the
+deploy model we settle on for MVP — keeping pending-driven, switching to
+explicit-only, or some both/and (apply automatically if exactly one
+process owns the file, otherwise warn).
+
+Touchpoint: `src/moneybin/database.py` `__init__` migration block, around
+the `runner.pending()` check.

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -174,16 +174,26 @@ class Database:
             stored_versions = get_current_versions(self)
             stored_pkg_version = stored_versions.get("moneybin")
 
-            # Check MoneyBin schema migrations
-            if stored_pkg_version != current_pkg_version:
-                if stored_pkg_version is not None:
+            # Gate on pending migrations, not pkg version. The version string in
+            # pyproject.toml is bumped by hand and was previously the only
+            # trigger — so a DB opened pre-V003 stayed pre-V003 forever if the
+            # version hadn't moved between releases. Any unapplied migration
+            # (or a version mismatch) drives the runner.
+            runner = MigrationRunner(self)
+            pending = runner.pending()
+            if pending or stored_pkg_version != current_pkg_version:
+                if stored_pkg_version is not None and (
+                    stored_pkg_version != current_pkg_version
+                ):
                     logger.info(
                         f"⚙️  MoneyBin upgraded ({stored_pkg_version} → {current_pkg_version}). "
                         f"Applying updates..."
                     )
+                elif pending:
+                    logger.info(
+                        f"⚙️  {len(pending)} pending migration(s) detected. Applying..."
+                    )
 
-                # Run pending schema migrations
-                runner = MigrationRunner(self)
                 result = runner.apply_all()
 
                 if result.failed:

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -182,14 +182,15 @@ class Database:
             runner = MigrationRunner(self)
             pending = runner.pending()
             if pending or stored_pkg_version != current_pkg_version:
-                if stored_pkg_version is not None and (
-                    stored_pkg_version != current_pkg_version
-                ):
+                if stored_pkg_version is None:
+                    # First-ever open of this DB — schema initialization.
+                    logger.info("⚙️  Initializing MoneyBin schema...")
+                elif stored_pkg_version != current_pkg_version:
                     logger.info(
                         f"⚙️  MoneyBin upgraded ({stored_pkg_version} → {current_pkg_version}). "
                         f"Applying updates..."
                     )
-                elif pending:
+                else:
                     logger.info(
                         f"⚙️  {len(pending)} pending migration(s) detected. Applying..."
                     )

--- a/src/moneybin/services/inbox_service.py
+++ b/src/moneybin/services/inbox_service.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Literal
 from urllib.parse import quote, unquote
 
+import duckdb
 import yaml
 
 from moneybin.config import MoneyBinSettings
@@ -388,6 +389,9 @@ class InboxService:
     ) -> None:
         """Move failed file to failed/ and write YAML sidecar."""
         error_code, stage = self._classify_error(error)
+        error_class = type(error).__name__
+        message = str(error)[:_SIDECAR_MESSAGE_MAX]
+        log_line = f"Inbox import failed: {rel_filename} → {error_code} ({error_class})"
         if not src.exists():
             # File vanished between enumerate() and import — nothing to move.
             # Record the failure but continue draining remaining files.
@@ -395,9 +399,11 @@ class InboxService:
                 "filename": rel_filename,
                 "error_code": error_code,
                 "stage": stage,
+                "error_class": error_class,
+                "message": message,
             })
             INBOX_SYNC_TOTAL.labels(outcome="failed").inc()
-            logger.warning(f"Inbox import failed: {rel_filename} → {error_code}")
+            logger.warning(log_line)
             return
         try:
             moved = self.move_to_outcome(src, outcome="failed", year_month=year_month)
@@ -409,29 +415,36 @@ class InboxService:
                 "filename": rel_filename,
                 "error_code": error_code,
                 "stage": stage,
+                "error_class": error_class,
+                "message": message,
             })
             INBOX_SYNC_TOTAL.labels(outcome="failed").inc()
             logger.warning(
-                f"Inbox import failed: {rel_filename} → {error_code} "
-                f"(could not move to failed/: {move_err.__class__.__name__})"
+                f"{log_line} (could not move to failed/: {move_err.__class__.__name__})"
             )
             return
+        suggestion = self._suggestion_for(error_code)
         sidecar = self.write_error_sidecar(
             moved,
             error_code=error_code,
             stage=stage,
-            message=str(error)[:_SIDECAR_MESSAGE_MAX],
-            suggestion=self._suggestion_for(error_code),
+            message=message,
+            suggestion=suggestion,
         )
-        result.failed.append({
+        entry: dict[str, object] = {
             "filename": rel_filename,
             "error_code": error_code,
             "stage": stage,
+            "error_class": error_class,
+            "message": message,
             "moved_to": str(moved.relative_to(self.root)),
             "sidecar": str(sidecar.relative_to(self.root)),
-        })
+        }
+        if suggestion is not None:
+            entry["suggestion"] = suggestion
+        result.failed.append(entry)
         INBOX_SYNC_TOTAL.labels(outcome="failed").inc()
-        logger.warning(f"Inbox import failed: {rel_filename} → {error_code}")
+        logger.warning(log_line)
 
     @staticmethod
     def _classify_error(error: Exception) -> tuple[str, str]:
@@ -446,6 +459,12 @@ class InboxService:
                 if needle in msg:
                     return (code, stage)
             return ("value_error", "import")
+        # DuckDB binder/catalog errors signal a stale schema (e.g. table
+        # missing a column the loader expects). Almost always means a
+        # migration hasn't been applied to this DB; the suggestion below
+        # tells the operator how to fix it.
+        if isinstance(error, duckdb.BinderException | duckdb.CatalogException):
+            return ("schema_mismatch", "load")
         return ("import_error", "import")
 
     @staticmethod
@@ -467,6 +486,11 @@ class InboxService:
             "permission_error": (
                 "Check file ownership and permissions "
                 "(e.g., chmod 644 or chown to your user)."
+            ),
+            "schema_mismatch": (
+                "Database schema is out of date. Run "
+                "'moneybin db migrate' to apply pending migrations, then "
+                "re-run sync."
             ),
         }.get(error_code)
 

--- a/src/moneybin/services/inbox_service.py
+++ b/src/moneybin/services/inbox_service.py
@@ -391,17 +391,25 @@ class InboxService:
         error_code, stage = self._classify_error(error)
         error_class = type(error).__name__
         message = str(error)[:_SIDECAR_MESSAGE_MAX]
+        suggestion = self._suggestion_for(error_code)
         log_line = f"Inbox import failed: {rel_filename} → {error_code} ({error_class})"
-        if not src.exists():
-            # File vanished between enumerate() and import — nothing to move.
-            # Record the failure but continue draining remaining files.
-            result.failed.append({
+
+        def _base_entry() -> dict[str, object]:
+            entry: dict[str, object] = {
                 "filename": rel_filename,
                 "error_code": error_code,
                 "stage": stage,
                 "error_class": error_class,
                 "message": message,
-            })
+            }
+            if suggestion is not None:
+                entry["suggestion"] = suggestion
+            return entry
+
+        if not src.exists():
+            # File vanished between enumerate() and import — nothing to move.
+            # Record the failure but continue draining remaining files.
+            result.failed.append(_base_entry())
             INBOX_SYNC_TOTAL.labels(outcome="failed").inc()
             logger.warning(log_line)
             return
@@ -411,19 +419,12 @@ class InboxService:
             # Disk full, cross-device, permission, etc. Don't let a failed
             # move-to-failed/ abort the whole drain — record what we know and
             # continue to the next file.
-            result.failed.append({
-                "filename": rel_filename,
-                "error_code": error_code,
-                "stage": stage,
-                "error_class": error_class,
-                "message": message,
-            })
+            result.failed.append(_base_entry())
             INBOX_SYNC_TOTAL.labels(outcome="failed").inc()
             logger.warning(
                 f"{log_line} (could not move to failed/: {move_err.__class__.__name__})"
             )
             return
-        suggestion = self._suggestion_for(error_code)
         sidecar = self.write_error_sidecar(
             moved,
             error_code=error_code,
@@ -431,17 +432,9 @@ class InboxService:
             message=message,
             suggestion=suggestion,
         )
-        entry: dict[str, object] = {
-            "filename": rel_filename,
-            "error_code": error_code,
-            "stage": stage,
-            "error_class": error_class,
-            "message": message,
-            "moved_to": str(moved.relative_to(self.root)),
-            "sidecar": str(sidecar.relative_to(self.root)),
-        }
-        if suggestion is not None:
-            entry["suggestion"] = suggestion
+        entry = _base_entry()
+        entry["moved_to"] = str(moved.relative_to(self.root))
+        entry["sidecar"] = str(sidecar.relative_to(self.root))
         result.failed.append(entry)
         INBOX_SYNC_TOTAL.labels(outcome="failed").inc()
         logger.warning(log_line)

--- a/tests/moneybin/test_migrations.py
+++ b/tests/moneybin/test_migrations.py
@@ -580,6 +580,55 @@ class TestAutoUpgrade:
         finally:
             db2.close()
 
+    def test_pending_migrations_apply_without_version_change(
+        self, tmp_path: Path, mock_secret_store: MagicMock
+    ) -> None:
+        """Pending migrations apply on reopen even when pkg version is unchanged.
+
+        Regression: the gate was previously `stored_pkg != current_pkg`, so a DB
+        opened before a migration was added stayed un-migrated forever unless
+        someone bumped pyproject.toml. The fix gates on `runner.pending()`.
+        """
+        db_path = tmp_path / "test.duckdb"
+
+        # First open at 1.0.0 — records version, applies any baseline migrations.
+        with patch(
+            "moneybin.database.importlib.metadata.version", return_value="1.0.0"
+        ):
+            db1 = Database(db_path, secret_store=mock_secret_store)
+            # Simulate "a migration was never recorded" by deleting one applied
+            # row from schema_migrations. On next open the runner.pending()
+            # check should re-apply it without any version bump.
+            row = db1.execute(
+                "SELECT version FROM app.schema_migrations "
+                "ORDER BY version DESC LIMIT 1"
+            ).fetchone()
+            assert row is not None, "expected at least one applied migration"
+            removed_version = row[0]
+            db1.execute(
+                "DELETE FROM app.schema_migrations WHERE version = ?",
+                [removed_version],
+            )
+            db1.close()
+
+        # Second open at the *same* version. Pre-fix this was a no-op.
+        with patch(
+            "moneybin.database.importlib.metadata.version", return_value="1.0.0"
+        ):
+            db2 = Database(db_path, secret_store=mock_secret_store)
+        try:
+            count = db2.execute(
+                "SELECT COUNT(*) FROM app.schema_migrations WHERE version = ?",
+                [removed_version],
+            ).fetchone()
+            assert count is not None
+            assert count[0] == 1, (
+                "pending migration should have been re-applied on reopen "
+                "even though the package version did not change"
+            )
+        finally:
+            db2.close()
+
     def test_no_auto_upgrade_skips_migrations(
         self,
         tmp_path: Path,

--- a/tests/moneybin/test_services/test_inbox_service.py
+++ b/tests/moneybin/test_services/test_inbox_service.py
@@ -376,6 +376,65 @@ class TestSyncFailure:
         result = svc.sync(year_month="2026-05")
         assert result.failed[0]["error_code"] == "import_error"
 
+    def test_failed_entry_includes_message_and_class(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Failed result entries surface error_class + message to MCP/CLI callers."""
+        from moneybin.services import inbox_service as mod
+
+        class FakeImportService:
+            def __init__(self, db: object) -> None:
+                pass
+
+            def import_file(self, path: str, **kwargs: object) -> object:
+                raise RuntimeError("something specific went wrong")
+
+        monkeypatch.setattr(mod, "ImportService", FakeImportService)
+
+        db = MagicMock(spec=Database)
+        svc = InboxService(db=db, settings=_make_settings(tmp_path))
+        svc.ensure_layout()
+        (svc.inbox_dir / "x.csv").write_text("a\n1\n")
+
+        entry = svc.sync(year_month="2026-05").failed[0]
+        assert entry["error_class"] == "RuntimeError"
+        assert entry["message"] == "something specific went wrong"
+
+    def test_duckdb_binder_error_classified_as_schema_mismatch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """DuckDB binder errors map to schema_mismatch with a migrate suggestion.
+
+        Covers the failure mode where a raw.* table is missing a column that
+        the loader writes (e.g. import_id pre-V003) — the user-visible error
+        should tell them to run db migrate, not surface as generic import_error.
+        """
+        import duckdb
+
+        from moneybin.services import inbox_service as mod
+
+        class FakeImportService:
+            def __init__(self, db: object) -> None:
+                pass
+
+            def import_file(self, path: str, **kwargs: object) -> object:
+                raise duckdb.BinderException(
+                    "Referenced update column import_id not found in table!"
+                )
+
+        monkeypatch.setattr(mod, "ImportService", FakeImportService)
+
+        db = MagicMock(spec=Database)
+        svc = InboxService(db=db, settings=_make_settings(tmp_path))
+        svc.ensure_layout()
+        (svc.inbox_dir / "x.qfx").write_text("not really qfx\n")
+
+        entry = svc.sync(year_month="2026-05").failed[0]
+        assert entry["error_code"] == "schema_mismatch"
+        assert entry["stage"] == "load"
+        assert entry["error_class"] == "BinderException"
+        assert "moneybin db migrate" in str(entry["suggestion"])
+
 
 class TestSyncBusy:
     """Concurrent sync returns inbox_busy in result instead of raising."""

--- a/tests/moneybin/test_services/test_inbox_service.py
+++ b/tests/moneybin/test_services/test_inbox_service.py
@@ -435,6 +435,40 @@ class TestSyncFailure:
         assert entry["error_class"] == "BinderException"
         assert "moneybin db migrate" in str(entry["suggestion"])
 
+    def test_suggestion_preserved_when_source_vanishes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Vanished-source early-exit path still surfaces the suggestion.
+
+        Regression: PR #93 originally hoisted error_class/message into the
+        early-exit dicts but left suggestion in the success-only branch, so
+        a schema_mismatch error during a flaky import would silently drop
+        the "run moneybin db migrate" hint.
+        """
+        import duckdb
+
+        from moneybin.services import inbox_service as mod
+
+        class FakeImportService:
+            def __init__(self, db: object) -> None:
+                pass
+
+            def import_file(self, path: str, **kwargs: object) -> object:
+                Path(path).unlink()
+                raise duckdb.BinderException("import_id not found")
+
+        monkeypatch.setattr(mod, "ImportService", FakeImportService)
+
+        db = MagicMock(spec=Database)
+        svc = InboxService(db=db, settings=_make_settings(tmp_path))
+        svc.ensure_layout()
+        (svc.inbox_dir / "x.qfx").write_text("not really qfx\n")
+
+        entry = svc.sync(year_month="2026-05").failed[0]
+        assert entry["error_code"] == "schema_mismatch"
+        assert "moneybin db migrate" in str(entry["suggestion"])
+        assert "sidecar" not in entry  # vanished — no sidecar written
+
 
 class TestSyncBusy:
     """Concurrent sync returns inbox_busy in result instead of raising."""


### PR DESCRIPTION
## Summary

The migration auto-apply gate compared `pyproject.toml`'s static `0.1.0` version against the stored DB version, so DBs created before any new migration was added never re-entered the runner — V003's column adds (e.g. `raw.ofx_institutions.import_id`) silently never landed, and OFX/QFX imports failed with an opaque `import_error` whose detail lived only in a YAML sidecar on disk. This PR fixes the gate to trigger on `runner.pending()` and surfaces the exception class + message on failed inbox results so callers (LLM via MCP, CLI) can see what actually broke.

## Impact

- Existing personal DBs will auto-apply pending migrations on next open instead of staying frozen at the schema state of their first launch — no manual `moneybin db migrate` needed for the V003 hole.
- MCP `import_inbox_sync` and CLI `inbox sync` failed entries now include `error_class`, `message`, and (when known) `suggestion` fields. Existing fields are unchanged; this is purely additive for callers.
- No workflow changes required of teammates.

## Changes

### Migration gate fix (`src/moneybin/database.py`)
Replaces the version-equality gate with a pending-migrations check. Logs separately for "upgraded" vs. "pending detected" cases so the operator can tell which path fired.

### Inbox failure surfacing (`src/moneybin/services/inbox_service.py`)
`_handle_failure` now records `error_class` and a truncated `message` on every failed result entry (vanished-source, move-failed, and normal paths) and propagates the suggestion text. Adds a `duckdb.BinderException | CatalogException` → `("schema_mismatch", "load")` branch in `_classify_error`, with a suggestion pointing at `moneybin db migrate`. The sidecar YAML format is unchanged.

### Tests
- `tests/moneybin/test_migrations.py::TestAutoUpgrade::test_pending_migrations_apply_without_version_change` — locks in the regression: delete an applied migration row, reopen at the same package version, verify it gets re-applied.
- `tests/moneybin/test_services/test_inbox_service.py` — two new tests: failed entries include `error_class`/`message`, and DuckDB binder errors classify as `schema_mismatch` with the migrate suggestion.

### Follow-ups (`docs/followups.md`)
Adds a section flagging the auto-apply gate trade-off to reconsider before MVP — pending-driven is right for single-user; a packaged release with read-only snapshots or multi-process opens may want explicit-only application.

## Testing

- [x] `uv run ruff format` + `uv run ruff check` clean on edited files
- [x] `uv run pyright` clean on edited files
- [x] `uv run pytest tests/ -m "not integration and not e2e"` — 1524 passed
- [x] Targeted runs of `test_migrations.py`, `test_database.py`, `test_services/test_inbox_service.py` — 105 passed

Reviewer should sanity-check the gate change in `database.py` (ensure `runner.pending()` is safe to call on every open — it's already called inside the existing branch, just hoisted) and the `BinderException | CatalogException` branch — both are public DuckDB exception types per their package.

## Notes

After merging, anyone whose DB was stuck pre-V003 will get migrations applied on the next process start. No data migration risk: V003 only ALTERs ADD nullable columns; existing rows get NULL `import_id` (documented as "pre-batch-tracking rows that cannot be reverted").