### PR TITLE
Expand MCP client install support and add concurrency guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # MoneyBin Development Makefile
 # This Makefile provides development commands for the MoneyBin project
 
-.PHONY: help setup clean install install-dev test test-cov lint format type-check pre-commit venv activate status install-uv test-e2e test-scenarios
+.PHONY: help setup clean install install-dev test test-cov lint format type-check pre-commit venv activate status install-uv test-e2e test-scenarios claude-mcp
 
 # Default target
 .DEFAULT_GOAL := help
@@ -179,6 +179,9 @@ type-check: venv ## Development: Type check with pyright
 
 check: format lint type-check ## Development: Run all code quality checks
 	@echo "$(GREEN)✅ All code quality checks complete$(RESET)"
+
+claude-mcp: venv ## Development: Launch Claude Code with the MoneyBin MCP server (PROFILE=name to override active profile)
+	@exec ./scripts/claude-mcp.sh $(PROFILE)
 
 
 clean-cache: ## Utility: Clean Python cache files

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ moneybin import status
 moneybin mcp config generate --client claude-desktop --install
 ```
 
+Supported clients: **claude-desktop**, **claude-code**, **cursor**, **windsurf**, **vscode**, **gemini-cli**, **codex** (CLI / Desktop app / IDE extension), **chatgpt-desktop**. MoneyBin's single-writer DuckDB lock means only one MCP session per profile can run at a time — see [Configuring MCP Clients](docs/guides/mcp-clients.md) for the concurrency model, per-client behavior, and per-session opt-in for Claude Code (`make claude-mcp`).
+
 `import file` is the golden path: extract → load → transform → categorize, in one command. See the [Data Import guide](docs/guides/data-import.md) for formats, batch management, and migration profiles (Tiller, Mint, YNAB, Maybe).
 
 Once connected, ask things like:

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -1,0 +1,105 @@
+# Configuring MCP Clients
+
+This guide covers wiring MoneyBin's MCP server into AI clients. For what the server *exposes* (tools, prompts, resources), see [MCP Server](mcp-server.md).
+
+## Quickstart
+
+```bash
+# Print a snippet (default client: claude-desktop)
+moneybin mcp config generate
+
+# Install directly into a client's config file
+moneybin mcp config generate --client claude-desktop --install --yes
+
+# Profile-aware: install for a specific MoneyBin profile
+moneybin mcp config generate --client cursor --profile alice --install --yes
+```
+
+Each invocation prints the JSON or TOML snippet first; `--install` then merges it into the client's canonical config (creating the file if absent). Existing settings — including unrelated MCP servers, comments, and key ordering — are preserved.
+
+## Supported clients
+
+| Client | Format | Install path | Notes |
+|---|---|---|---|
+| `claude-desktop` | JSON `mcpServers` | `~/Library/Application Support/Claude/claude_desktop_config.json` | One server process per app, shared across all chats |
+| `claude-code` | JSON `mcpServers` | `<base>/profiles/<profile>/claude-code-mcp.json` | Per-profile file; loaded only when launched with `--strict-mcp-config --mcp-config <file>` (see [Per-session opt-in](#per-session-opt-in-claude-code)) |
+| `cursor` | JSON `mcpServers` | `~/.cursor/mcp.json` | One server process per Cursor instance |
+| `windsurf` | JSON `mcpServers` | `~/.codeium/windsurf/mcp_config.json` | One server process per Windsurf instance |
+| `vscode` | JSON `servers` (with `"type": "stdio"`) | `<repo>/.vscode/mcp.json` | Workspace-local; only loads when the workspace is open in VS Code |
+| `gemini-cli` | JSON `mcpServers` | `~/.gemini/settings.json` | Auto-loads on every `gemini` invocation |
+| `codex` | TOML `[mcp_servers.<name>]` | `~/.codex/config.toml` | Shared across **Codex CLI**, **Codex Desktop app**, and the **Codex IDE extension** |
+| `chatgpt-desktop` | n/a (UI) | n/a | Uses the in-app **Connectors** UI; `--install` is unsupported. The command prints step-by-step setup instructions |
+
+## Concurrency model
+
+MoneyBin stores each profile's data in a single-writer DuckDB file. **Only one MCP server (or any other process) can hold the database open against a given profile at a time.** A second connection on the same profile fails to acquire the write lock and exits.
+
+How that interacts with each client depends on its server-lifecycle model:
+
+| Pattern | Clients | Behavior |
+|---|---|---|
+| **App-shared connection** | Claude Desktop, ChatGPT Desktop, Cursor, VS Code, Windsurf | One server process per app instance, spawned at launch and reused across all chats. Opening "New chat" doesn't start another connection. |
+| **Per-invocation** | Claude Code, Codex CLI, Gemini CLI | One server process per CLI invocation. Each new shell session spawns a fresh server, and each one tries to claim the lock. |
+
+Different *profiles* never collide — each has its own DB and lock — so you can install `MoneyBin (alice)` and `MoneyBin (bob)` side-by-side in the same client without issue. The lock fight is only between concurrent sessions on the **same** profile.
+
+### What this means in practice
+
+- **Pick one app-based client per profile** as the primary MoneyBin host. If you keep Claude Desktop and Cursor both running with `MoneyBin (alice)`, the second one to start will fail to load.
+- **Avoid running MoneyBin CLI commands while a desktop client is using the same profile.** The CLI opens its own DB connection and will collide with whichever app is holding the lock. Quit the client first, or run the CLI against a different profile.
+- **CLI clients (codex, gemini-cli) auto-load on every invocation.** If you `--install` MoneyBin into them, every `codex` or `gemini` command in any terminal will try to spawn the server. For occasional use, prefer pasting the snippet manually instead of `--install`. (Claude Code is the exception; see below.)
+
+## Per-session opt-in (Claude Code)
+
+Claude Code is the only client that supports a true per-launch MCP config override. You can install MoneyBin without forcing it to start in every Claude Code session.
+
+```bash
+# One-time setup
+moneybin profile create <name>
+moneybin mcp config generate --client claude-code --profile <name> --install --yes
+
+# Launch a Claude Code session with MoneyBin loaded
+make claude-mcp                       # uses the active profile
+make claude-mcp PROFILE=<name>        # explicit profile
+./scripts/claude-mcp.sh <name>        # equivalent, no Make
+```
+
+`make claude-mcp` runs `claude --strict-mcp-config --mcp-config <profile-config-path>`, which tells Claude Code to ignore every other configured MCP server and load only MoneyBin for that one session. Plain `claude` invocations don't include MoneyBin and don't take the lock.
+
+This is the recommended setup if you do non-MoneyBin work in Claude Code on the same machine — it keeps the server (and its lock) off until you ask for it.
+
+## Codex (CLI, Desktop, IDE)
+
+OpenAI's Codex products share `~/.codex/config.toml`. A single `--install --client codex` covers all three:
+
+- **Codex CLI** — `codex` command in the terminal
+- **Codex Desktop app** — macOS / Windows app from [developers.openai.com/codex/app](https://developers.openai.com/codex/app)
+- **Codex IDE extension** — VS Code / JetBrains
+
+There's no per-launch override flag. Once installed, Codex auto-loads MoneyBin every time. As an alternative install path, OpenAI also documents `codex mcp add` for managing servers from the CLI; `moneybin mcp config generate --client codex --install` produces an equivalent TOML block via tomlkit (which preserves any inline comments and unrelated settings in your `config.toml`).
+
+## ChatGPT Desktop
+
+ChatGPT Desktop adds MCP servers through **Settings → Connectors** (Developer Mode), not a JSON config file we can write. Running:
+
+```bash
+moneybin mcp config generate --client chatgpt-desktop --profile <name>
+```
+
+prints the canonical snippet plus a numbered checklist for the Connectors UI: which fields to fill (Name, Command, Arguments, env vars), where to paste them, and a fallback for builds that only accept HTTP connectors (`moneybin mcp serve --transport streamable-http` + tunnel URL).
+
+## Switching profiles
+
+Re-running `--install` for a different profile **adds an additional entry** rather than replacing the previous one. So `moneybin mcp config generate --client cursor --profile alice --install` followed by `moneybin mcp config generate --client cursor --profile bob --install` leaves both `MoneyBin (alice)` and `MoneyBin (bob)` in `~/.cursor/mcp.json`. That's safe — different profiles don't collide on the lock — and lets you see all configured profiles in the client's UI.
+
+If you'd rather have a single MoneyBin entry, edit the client's config file directly to remove the stale entry. We don't auto-replace because losing access to the previous profile silently is worse than leaving it visible.
+
+## Troubleshooting
+
+**"Database is locked" / MCP server exits immediately on startup.** Another process is holding the same profile's DB. Most common causes: (a) a desktop client (Claude Desktop, Cursor, VS Code) is already running with the same profile installed; (b) you ran a `moneybin` CLI command in another terminal and it's still holding the connection; (c) two `claude`/`codex`/`gemini` invocations are racing. Quit the offender or switch to a different `--profile`.
+
+**Install command says "Cannot parse existing config".** The target file has invalid JSON or TOML. Open it in your editor, fix the syntax, then re-run `--install`.
+
+**`make claude-mcp` reports "No active profile and --profile not supplied".** Either run `moneybin profile create <name>` first, or pass `PROFILE=<name>` to the make target.
+
+**MCP server starts but the client doesn't see any tools.** Verify the client is actually pointing at the right config: `moneybin mcp config path --client <name> [--profile <name>]` prints the resolved install path. Cross-check that the file exists, contains a `MoneyBin` entry, and that the entry's `command` and `args` are runnable from the client's launch context.

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -12,7 +12,7 @@ moneybin mcp config generate --client claude-desktop
 moneybin mcp config generate --client claude-desktop --install
 ```
 
-Supported clients: **Claude Desktop**, **Cursor**, **Windsurf**. Works with any MCP-compatible client that accepts stdio transport config.
+Supported clients: Claude Desktop, Claude Code, Cursor, Windsurf, VS Code, Gemini CLI, Codex (CLI / Desktop / IDE), and ChatGPT Desktop. See [Configuring MCP Clients](mcp-clients.md) for install paths, the concurrency model, and Claude Code's per-session opt-in.
 
 After connecting, you can ask your AI assistant things like:
 - *"What's my spending by category this month?"*

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -74,6 +74,7 @@ Single source of truth for spec status. Update this table when a spec's status c
 | [Architecture & Design](mcp-architecture.md) | Architecture | in-progress | MCP v1 design philosophy, tool taxonomy, privacy integration, CLI symmetry, Apps readiness. Supersedes archived `mcp-read-tools` and `mcp-write-tools` specs. |
 | [Tool Surface](mcp-tool-surface.md) | Architecture | in-progress | Concrete tool, prompt, resource, and service layer definitions for MCP v1 (46 tools, 4 prompts, 4 resources) |
 | [SQL Schema Discoverability](mcp-sql-discoverability.md) | Feature | implemented | `moneybin://schema` resource exposes curated interface tables (core + select app) with columns, comments, and example queries; eliminates per-session schema reconnaissance |
+| [Tool Timeouts & Cancellation](mcp-tool-timeouts.md) | Feature | draft | Global 30s wall-clock cap on every tool dispatch with DuckDB `interrupt()` + connection close on timeout, so a hung call can't wedge the server's write lock |
 
 ## Sync
 

--- a/docs/specs/mcp-tool-timeouts.md
+++ b/docs/specs/mcp-tool-timeouts.md
@@ -1,0 +1,125 @@
+# Feature: MCP Tool Timeouts and Cancellation
+
+## Status
+
+draft
+
+## Goal
+
+Guarantee every MCP tool call returns within a bounded wall-clock time with a structured error rather than hanging the client indefinitely. Timeouts must release the underlying DuckDB connection so subsequent calls aren't wedged behind a stale write lock.
+
+## Background
+
+A `import_inbox_sync` call hung the MoneyBin MCP server for 30+ minutes against a profile with five Wells Fargo QBO files in the inbox. The client (Claude Code) had no way to recover — MCP tool calls are synchronous from the agent's perspective, so the agent blocked on a response that never arrived. Worse, the first interrupted call appears to have left a DuckDB transaction open, so the reconnected server's next call immediately deadlocked behind the orphaned write lock.
+
+Realistic SQLMesh-on-DuckDB workloads at personal-finance scale (tens of thousands to low millions of rows) complete in 1–10 seconds, with 30 seconds being a generous worst case. A multi-minute response means the server is deadlocked or in a runaway loop, not doing legitimate work.
+
+Related code: `src/moneybin/mcp/` (tool registration and dispatch), `src/moneybin/database.py` (DuckDB connection management).
+
+## Requirements
+
+1. Every MCP tool dispatch is wrapped in a hard wall-clock timeout. Default: **30 seconds**, configurable via `MoneyBinSettings`.
+2. On timeout, the server attempts to interrupt the running DuckDB statement (`connection.interrupt()`) and force-close the connection, releasing any held write lock.
+3. The client receives a structured timeout response — not a hang, not a transport error. The envelope follows the standard MCP tool response shape: `{summary, data: null, actions: [], error: {kind: "timed_out", tool: "<name>", elapsed_s: <float>, timeout_s: <float>}}`.
+4. The server logs a single structured line per timeout including tool name, elapsed seconds, and configured cap. No PII or query payloads in the log.
+5. The next tool call after a timeout must succeed (assuming the underlying issue is transient) — i.e., no orphaned connection or transaction state survives the timeout path.
+6. The cap is global (one value applies to all tools). No per-tool overrides in this iteration.
+7. Tools that already complete in well under the cap are unchanged in behavior; the timeout is invisible on the happy path.
+
+## Data Model
+
+No schema changes. One new configuration field:
+
+- `MoneyBinSettings.mcp.tool_timeout_seconds: float = 30.0` (env: `MONEYBIN_MCP__TOOL_TIMEOUT_SECONDS`)
+
+## Implementation Plan
+
+### Files to Create
+
+- `tests/moneybin/test_mcp/test_tool_timeouts.py` — unit + integration coverage for the timeout path.
+
+### Files to Modify
+
+- `src/moneybin/config.py` — add `tool_timeout_seconds` to the MCP settings group.
+- `src/moneybin/mcp/server.py` (or wherever tool dispatch lives) — wrap every registered tool handler in a timeout guard.
+- `src/moneybin/mcp/responses.py` (or equivalent envelope helper) — extend the error envelope schema to carry `kind`, `tool`, `elapsed_s`, `timeout_s`.
+- `src/moneybin/database.py` — expose a context manager that yields a connection and guarantees `interrupt()` + `close()` on cancellation.
+
+### Key Decisions
+
+- **One global cap, not per-tool.** YAGNI: a single 30s value catches every realistic deadlock without a registry, decorators, or config sprawl. Promote to per-tool only if a specific tool proves it needs a different value.
+- **Cancellation must reach DuckDB.** Naive `asyncio.wait_for` cancels the future but leaves the worker thread running and the connection held. The dispatch layer must (a) hold a reference to the active `DuckDBPyConnection`, (b) call `interrupt()` on timeout, and (c) force-close the connection in a `finally` block so the lock is released even if `interrupt()` is a no-op for the current statement (e.g., mid-`COPY`).
+- **Connection-per-call as the cleanup fallback.** Each tool dispatch acquires a fresh connection from the connection manager. On timeout, that connection is closed, which aborts the transaction and releases the lock. Long-lived shared connections are not used in the MCP path.
+- **No background continuation.** A timed-out call does not silently keep running. The work is cancelled. If a tool legitimately needs longer than the cap (today, none should), it must be redesigned — e.g., `import_inbox_sync` decomposed into per-file calls. Background-job semantics are explicitly out of scope for this iteration.
+- **Logging stays low-cardinality.** Log tool name, elapsed seconds, configured cap. Do not log arguments — they may contain account IDs, search strings, or other sensitive context.
+
+```mermaid
+sequenceDiagram
+    participant Client as MCP Client
+    participant Dispatch as Tool Dispatch
+    participant Conn as DuckDB Connection
+    participant Tool as Tool Handler
+
+    Client->>Dispatch: call_tool(name, args)
+    Dispatch->>Conn: acquire()
+    Dispatch->>Tool: run with 30s deadline
+    alt Completes within cap
+        Tool-->>Dispatch: result
+        Dispatch->>Conn: release()
+        Dispatch-->>Client: {summary, data, actions}
+    else Exceeds cap
+        Dispatch->>Conn: interrupt() + force_close()
+        Dispatch->>Tool: cancel()
+        Dispatch-->>Client: {error: timed_out, elapsed_s, ...}
+    end
+```
+
+## CLI Interface
+
+No CLI changes. The new settings field is reachable via the standard `MONEYBIN_MCP__TOOL_TIMEOUT_SECONDS` env var.
+
+## MCP Interface
+
+No new tools. The error envelope gains a structured `error` object on the timeout path:
+
+```json
+{
+  "summary": null,
+  "data": null,
+  "actions": [],
+  "error": {
+    "kind": "timed_out",
+    "tool": "import_inbox_sync",
+    "elapsed_s": 30.0,
+    "timeout_s": 30.0
+  }
+}
+```
+
+Existing tools that return `error: null` on success are unaffected.
+
+## Testing Strategy
+
+- **Unit**: a fake tool handler that sleeps 60s returns the structured timeout envelope within ~30s wall-clock.
+- **Unit**: a fake tool handler that holds a DuckDB connection and runs a long query — verify `interrupt()` is called and the connection is closed on timeout.
+- **Integration**: two back-to-back calls where the first times out — the second must succeed against the same profile (proves the lock was released).
+- **Regression**: existing fast tools (e.g., `accounts_list`, `spending_summary`) complete unchanged and well under the cap on the standard test fixture.
+
+## Synthetic Data Requirements
+
+None. The timeout mechanism is data-agnostic; existing test fixtures are sufficient.
+
+## Dependencies
+
+- DuckDB Python API: `connection.interrupt()` (already available, no version bump).
+- Python `asyncio.wait_for` (stdlib).
+- No new third-party packages.
+
+## Out of Scope
+
+- Per-tool timeout overrides.
+- Background continuation / job-handle pattern (`job_status` / `job_result` tools). If a future tool legitimately needs longer than the cap, that's the time to design this — not now.
+- Streaming progress updates from long-running tools.
+- Decomposing `import_inbox_sync` into per-file calls. The timeout will surface that this tool needs redesign; the redesign itself is a separate spec.
+- Recovery from corrupted on-disk state caused by an unclean DuckDB shutdown. The contract is "release the lock" not "guarantee transactional consistency under SIGKILL."
+- Client-side MCP request timeouts (e.g., Claude Code's per-call deadline). Those live in the client and vary across MCP hosts. This spec ensures the server always responds within the cap so a client-side timeout isn't load-bearing for correctness.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ dependencies = [
     "fastexcel>=0.19.0",
     # MCP server — primary AI assistant interface
     "fastmcp>=3.1,<4",
+    # TOML round-trip writer for codex config installs (preserves comments/formatting)
+    "tomlkit>=0.13.2",
 ]
 
 [tool.setuptools]

--- a/scripts/claude-mcp.sh
+++ b/scripts/claude-mcp.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Launch Claude Code with the MoneyBin MCP server for a single session.
+#
+# Resolves the per-profile claude-code-mcp.json path, verifies prerequisites,
+# then execs `claude --strict-mcp-config --mcp-config <path>` so the user's
+# shell becomes the controlling process of the TUI. This must run from a
+# real shell (not as a Make recipe) so claude can grab the TTY directly.
+#
+# Usage:
+#   scripts/claude-mcp.sh                  # uses active MoneyBin profile
+#   scripts/claude-mcp.sh <profile-name>   # uses a specific profile
+#   PROFILE=<name> scripts/claude-mcp.sh   # same, via env
+
+set -u
+
+profile="${1:-${PROFILE:-}}"
+profile_arg=()
+if [[ -n "$profile" ]]; then
+  profile_arg=(--profile "$profile")
+fi
+
+err=$(mktemp)
+trap 'rm -f "$err"' EXIT
+
+config_path=$(uv run --quiet moneybin mcp config path --client claude-code "${profile_arg[@]}" 2>"$err")
+rc=$?
+
+if [[ $rc -ne 0 || -z "$config_path" ]]; then
+  echo "❌ Could not resolve MoneyBin MCP config path." >&2
+  cat "$err" >&2
+  echo "" >&2
+  echo "Hint: moneybin profile create <name>   (if no profile exists)" >&2
+  echo "      moneybin mcp config generate --client claude-code --install --yes --profile <name>" >&2
+  echo "      $0 <name>   (or PROFILE=<name> make claude-mcp)" >&2
+  exit 1
+fi
+
+if [[ ! -f "$config_path" ]]; then
+  echo "❌ MoneyBin MCP config not found at $config_path." >&2
+  echo "Run: moneybin mcp config generate --client claude-code --install --yes${profile:+ --profile $profile}" >&2
+  exit 1
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "❌ 'claude' CLI not found on PATH." >&2
+  echo "Install Claude Code first: https://docs.claude.com/en/docs/claude-code" >&2
+  exit 1
+fi
+
+echo "🚀 Launching Claude Code with MoneyBin MCP ($config_path)"
+exec claude --strict-mcp-config --mcp-config "$config_path"

--- a/scripts/claude-mcp.sh
+++ b/scripts/claude-mcp.sh
@@ -37,7 +37,7 @@ fi
 
 if [[ ! -f "$config_path" ]]; then
   echo "❌ MoneyBin MCP config not found at $config_path." >&2
-  echo "Run: moneybin mcp config generate --client claude-code --install --yes${profile:+ --profile $profile}" >&2
+  echo "Run: moneybin mcp config generate --client claude-code --install --yes${profile:+ --profile \"$profile\"}" >&2
   exit 1
 fi
 

--- a/src/moneybin/cli/commands/mcp.py
+++ b/src/moneybin/cli/commands/mcp.py
@@ -1,8 +1,10 @@
 """MCP server commands for MoneyBin CLI.
 
-This module provides the `moneybin mcp serve` command that starts the
-Model Context Protocol server, exposing DuckDB financial data to AI
-assistants like Cursor, Claude Desktop, and ChatGPT Desktop.
+`moneybin mcp serve` starts the Model Context Protocol server that exposes
+DuckDB financial data to MCP-compatible clients. `moneybin mcp config
+generate --client <c>` produces install snippets for the supported clients
+(see `_SUPPORTED_CLIENTS`); `docs/guides/mcp-clients.md` documents per-client
+behavior, the concurrency model, and per-session opt-in for Claude Code.
 """
 
 import asyncio
@@ -210,7 +212,7 @@ def config_generate(
     if client not in _SUPPORTED_CLIENTS:
         supported = ", ".join(_SUPPORTED_CLIENTS)
         logger.error(f"❌ Unknown client '{client}'. Supported: {supported}")
-        raise typer.Exit(1)
+        raise typer.Exit(2)  # usage error — matches `mcp config path` convention
 
     resolved_profile = profile or get_current_profile()
 
@@ -336,33 +338,32 @@ def _build_snippet(
         snippet: dict[str, Any] = {"servers": {entry_name: vscode_entry}}
         return snippet, json.dumps(snippet, indent=2)
     if client == "codex":
-        text = _render_codex_toml(entry_name, server_entry)
-        # Codex never writes via _merge_client_config, but return a stable
-        # dict so the caller's contract holds.
-        return {"mcp_servers": {entry_name: server_entry}}, text
+        snippet = {"mcp_servers": {entry_name: server_entry}}
+        return snippet, _render_codex_toml(snippet)
     snippet = {"mcpServers": {entry_name: server_entry}}
     return snippet, json.dumps(snippet, indent=2)
 
 
-def _render_codex_toml(entry_name: str, server_entry: dict[str, Any]) -> str:
-    """Render an MCP server as a Codex `[mcp_servers.<name>]` TOML block.
+def _render_codex_toml(snippet: dict[str, Any]) -> str:
+    """Render the codex snippet via tomlkit so display matches what we install.
 
-    Hand-formatted to avoid pulling in a TOML-writer dependency for one block.
-    Quoting matches what `tomli`/`tomli_w` would produce for the field types we
-    emit (strings, lists of strings, flat string→string env tables).
+    Using the same TOML writer for both the printed snippet and the
+    `_merge_toml_config` write guarantees byte-identical output, eliminating
+    any divergence in quoting, escaping, or whitespace between what the user
+    sees and what lands in `config.toml`.
     """
-    safe_name = entry_name.replace('"', '\\"')
-    lines = [f'[mcp_servers."{safe_name}"]']
-    lines.append(f"command = {json.dumps(server_entry['command'])}")
-    args = server_entry.get("args", [])
-    if args:
-        rendered_args = ", ".join(json.dumps(a) for a in args)
-        lines.append(f"args = [{rendered_args}]")
-    env_pairs = server_entry.get("env", {})
-    if env_pairs:
-        rendered_env = ", ".join(f"{k} = {json.dumps(v)}" for k, v in env_pairs.items())
-        lines.append(f"env = {{ {rendered_env} }}")
-    return "\n".join(lines)
+    import tomlkit
+
+    doc = tomlkit.document()
+    for top_key, top_val in snippet.items():
+        if isinstance(top_val, dict):
+            section = tomlkit.table()
+            for entry_name, entry_val in top_val.items():
+                section[entry_name] = entry_val  # type: ignore[index]  # tomlkit table behaves as MutableMapping at runtime; stub omits __setitem__
+            doc[top_key] = section
+        else:
+            doc[top_key] = top_val
+    return tomlkit.dumps(doc).rstrip()  # pyright: ignore[reportUnknownMemberType]  # tomlkit.dumps stub returns Unknown
 
 
 def _confirm_and_merge(
@@ -417,11 +418,11 @@ def _merge_toml_config(config_path: Path, patch: dict[str, Any]) -> None:
                 section = tomlkit.table()
                 doc[top_key] = section
             for entry_name, entry_val in top_val.items():
-                section[entry_name] = entry_val  # type: ignore[index]
+                section[entry_name] = entry_val  # type: ignore[index]  # tomlkit table behaves as MutableMapping at runtime; stub omits __setitem__
         else:
             doc[top_key] = top_val
 
-    config_path.write_text(tomlkit.dumps(doc))  # pyright: ignore[reportUnknownMemberType]
+    config_path.write_text(tomlkit.dumps(doc))  # pyright: ignore[reportUnknownMemberType]  # tomlkit.dumps stub returns Unknown
 
 
 def _get_client_config_path(client: str) -> Path:

--- a/src/moneybin/cli/commands/mcp.py
+++ b/src/moneybin/cli/commands/mcp.py
@@ -17,7 +17,7 @@ import typer
 
 from moneybin.cli.output import OutputFormat, output_option, quiet_option
 from moneybin.cli.utils import emit_json
-from moneybin.config import find_repo_root
+from moneybin.config import find_repo_root, get_base_dir
 from moneybin.mcp.server import mcp as mcp_server
 
 app = typer.Typer(help="MCP server for AI assistant integration", no_args_is_help=True)
@@ -27,7 +27,10 @@ logger = logging.getLogger(__name__)
 TransportType = Literal["stdio", "sse", "streamable-http"]
 _VALID_TRANSPORTS: tuple[str, ...] = get_args(TransportType)
 
-# Supported MCP client config file locations
+# MCP client config file locations for clients that auto-load from a fixed path.
+# claude-code uses a per-profile path resolved at runtime (see _client_install_path).
+# vscode uses a workspace-local path (.vscode/mcp.json) resolved at runtime.
+# chatgpt-desktop has no config file — servers are added via the Connectors UI.
 _CLIENT_CONFIG_PATHS: dict[str, Path] = {
     "claude-desktop": Path.home()
     / "Library"
@@ -36,7 +39,21 @@ _CLIENT_CONFIG_PATHS: dict[str, Path] = {
     / "claude_desktop_config.json",
     "cursor": Path.home() / ".cursor" / "mcp.json",
     "windsurf": Path.home() / ".codeium" / "windsurf" / "mcp_config.json",
+    "gemini-cli": Path.home() / ".gemini" / "settings.json",
+    "codex": Path.home() / ".codex" / "config.toml",
 }
+
+# Clients that don't write to a fixed path. Listed for help text and validation.
+_PROFILE_SCOPED_CLIENTS: tuple[str, ...] = ("claude-code",)
+_WORKSPACE_SCOPED_CLIENTS: tuple[str, ...] = ("vscode",)
+_NO_INSTALL_CLIENTS: tuple[str, ...] = ("chatgpt-desktop",)
+
+_SUPPORTED_CLIENTS: tuple[str, ...] = (
+    *_CLIENT_CONFIG_PATHS,
+    *_PROFILE_SCOPED_CLIENTS,
+    *_WORKSPACE_SCOPED_CLIENTS,
+    *_NO_INSTALL_CLIENTS,
+)
 
 _DEFAULT_CLIENT = "claude-desktop"
 
@@ -69,6 +86,57 @@ def config_show(ctx: typer.Context) -> None:
     typer.echo(f"max_chars:  {settings.mcp.max_chars}")
 
 
+@config_app.command("path")
+def config_path(
+    client: Annotated[
+        str,
+        typer.Option(
+            "--client",
+            "-c",
+            help=f"MCP client. Supported: {', '.join(_SUPPORTED_CLIENTS)}",
+        ),
+    ] = _DEFAULT_CLIENT,
+    profile: Annotated[
+        str | None,
+        typer.Option("--profile", "-p", help="MoneyBin profile (default: active)."),
+    ] = None,
+) -> None:
+    """Print the install path of an MCP client's config file.
+
+    Used by `make claude-mcp` to locate the per-profile Claude Code config.
+    Exits non-zero with no output for clients that don't have a JSON config
+    file (e.g. chatgpt-desktop).
+
+    Profile resolution is non-interactive: if no profile is set and `--profile`
+    is not given, this exits with a clear error instead of starting the
+    first-run wizard. The wizard's stdin prompts would hang under any
+    `$(...)` command substitution that captures stdout.
+    """
+    from moneybin.config import get_current_profile
+
+    if client not in _SUPPORTED_CLIENTS:
+        supported = ", ".join(_SUPPORTED_CLIENTS)
+        logger.error(f"❌ Unknown client '{client}'. Supported: {supported}")
+        raise typer.Exit(2)
+
+    if profile:
+        resolved_profile = profile
+    else:
+        try:
+            resolved_profile = get_current_profile(auto_resolve=False)
+        except RuntimeError as e:
+            logger.error(
+                "❌ No active profile and --profile not supplied. "
+                "Run `moneybin profile create <name>` or pass `--profile <name>`."
+            )
+            raise typer.Exit(1) from e
+
+    path = _client_install_path(client, resolved_profile)
+    if path is None:
+        raise typer.Exit(1)
+    typer.echo(str(path))
+
+
 @config_app.command("generate")
 def config_generate(
     client: Annotated[
@@ -76,7 +144,7 @@ def config_generate(
         typer.Option(
             "--client",
             "-c",
-            help=f"MCP client to generate config for. Supported: {', '.join(_CLIENT_CONFIG_PATHS)}",
+            help=f"MCP client to generate config for. Supported: {', '.join(_SUPPORTED_CLIENTS)}",
         ),
     ] = _DEFAULT_CLIENT,
     profile: Annotated[
@@ -121,8 +189,28 @@ def config_generate(
 
         # Install directly without prompting
         moneybin mcp config generate --client claude-desktop --install --yes
+
+        # Profile-scoped Claude Code config (loaded only with `claude --mcp-config`)
+        moneybin mcp config generate --client claude-code --install --yes
+
+        # Print snippet + step-by-step Connector setup for ChatGPT Desktop
+        moneybin mcp config generate --client chatgpt-desktop
+
+        # Codex (CLI / Desktop app / IDE extension all share ~/.codex/config.toml)
+        moneybin mcp config generate --client codex --install --yes
+
+        # Workspace-local .vscode/mcp.json
+        moneybin mcp config generate --client vscode --install --yes
+
+        # User-level ~/.gemini/settings.json
+        moneybin mcp config generate --client gemini-cli --install --yes
     """
     from moneybin.config import get_current_profile
+
+    if client not in _SUPPORTED_CLIENTS:
+        supported = ", ".join(_SUPPORTED_CLIENTS)
+        logger.error(f"❌ Unknown client '{client}'. Supported: {supported}")
+        raise typer.Exit(1)
 
     resolved_profile = profile or get_current_profile()
 
@@ -158,49 +246,271 @@ def config_generate(
         if resolved_profile != "default"
         else "MoneyBin"
     )
-    snippet = {"mcpServers": {entry_name: server_entry}}
-    snippet_json = json.dumps(snippet, indent=2)
+    snippet, snippet_text = _build_snippet(client, entry_name, server_entry)
+    typer.echo(snippet_text)
 
-    typer.echo(snippet_json)
+    if client == "chatgpt-desktop":
+        if install:
+            logger.error(
+                "❌ --install is not supported for chatgpt-desktop. "
+                "ChatGPT Desktop adds MCP servers through its Connectors UI, "
+                "not a JSON config file. Follow the instructions below to add "
+                "MoneyBin as a custom connector."
+            )
+            _print_chatgpt_desktop_instructions(server_entry, entry_name)
+            raise typer.Exit(1)
+        _print_chatgpt_desktop_instructions(server_entry, entry_name)
+        return
+
+    if client == "claude-code":
+        config_path = _client_install_path(client, resolved_profile)
+        if config_path is None:  # unreachable — claude-code always resolves a path
+            raise typer.Exit(1)
+        if not install:
+            _print_claude_code_launch_hint(config_path)
+            return
+        _confirm_and_merge(config_path, snippet, yes=yes)
+        _print_claude_code_launch_hint(config_path)
+        return
+
+    if client == "vscode":
+        vscode_path = _client_install_path(client, resolved_profile)
+        if vscode_path is None:
+            logger.error(
+                "❌ vscode --install requires running inside a repo "
+                "(creates .vscode/mcp.json in the repo root)."
+            )
+            raise typer.Exit(1)
+        if not install:
+            return
+        _confirm_and_merge(vscode_path, snippet, yes=yes)
+        return
 
     if not install:
         return
 
     config_path = _get_client_config_path(client)
-
-    if not yes:
-        confirmed = typer.confirm(
-            f"\nInstall into {config_path}?",
-            default=False,
-        )
-        if not confirmed:
-            logger.info("Installation cancelled.")
-            return
-
-    _merge_client_config(config_path, snippet)
-    logger.info(f"✅ Config written to {config_path}")
+    _confirm_and_merge(config_path, snippet, yes=yes)
+    _maybe_warn_auto_load(client, resolved_profile)
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 
+def _client_install_path(client: str, profile: str) -> Path | None:
+    """Resolve the install path for a client, or None if it has no config file.
+
+    Claude Code is the only client with per-launch MCP override support, so we
+    keep its config in a per-profile file (`<base>/profiles/<profile>/...`) and
+    leave it un-auto-loaded; `make claude-mcp` opts in via
+    `claude --strict-mcp-config --mcp-config <path>`. The other clients all
+    auto-load their canonical config — see docs/guides/mcp-clients.md for the
+    concurrency model. VS Code uses a workspace-local `.vscode/mcp.json`
+    resolved from the current repo root; returns None when not in a repo.
+    """
+    if client in _CLIENT_CONFIG_PATHS:
+        return _CLIENT_CONFIG_PATHS[client]
+    if client == "claude-code":
+        return get_base_dir() / "profiles" / profile / "claude-code-mcp.json"
+    if client == "vscode":
+        repo = find_repo_root()
+        if repo is None:
+            return None
+        return repo / ".vscode" / "mcp.json"
+    return None
+
+
+def _build_snippet(
+    client: str, entry_name: str, server_entry: dict[str, Any]
+) -> tuple[dict[str, Any], str]:
+    """Build the (parsed-snippet-dict, rendered-text) pair for a client.
+
+    Most clients use the canonical `{"mcpServers": {<name>: {...}}}` JSON shape.
+    VS Code's workspace `.vscode/mcp.json` uses `{"servers": {...}}` with an
+    explicit `"type": "stdio"` field. Codex uses TOML under `[mcp_servers.<name>]`.
+    The dict half is what `_merge_client_config` writes; the text half is what
+    we echo to the user.
+    """
+    if client == "vscode":
+        vscode_entry = {"type": "stdio", **server_entry}
+        snippet: dict[str, Any] = {"servers": {entry_name: vscode_entry}}
+        return snippet, json.dumps(snippet, indent=2)
+    if client == "codex":
+        text = _render_codex_toml(entry_name, server_entry)
+        # Codex never writes via _merge_client_config, but return a stable
+        # dict so the caller's contract holds.
+        return {"mcp_servers": {entry_name: server_entry}}, text
+    snippet = {"mcpServers": {entry_name: server_entry}}
+    return snippet, json.dumps(snippet, indent=2)
+
+
+def _render_codex_toml(entry_name: str, server_entry: dict[str, Any]) -> str:
+    """Render an MCP server as a Codex `[mcp_servers.<name>]` TOML block.
+
+    Hand-formatted to avoid pulling in a TOML-writer dependency for one block.
+    Quoting matches what `tomli`/`tomli_w` would produce for the field types we
+    emit (strings, lists of strings, flat string→string env tables).
+    """
+    safe_name = entry_name.replace('"', '\\"')
+    lines = [f'[mcp_servers."{safe_name}"]']
+    lines.append(f"command = {json.dumps(server_entry['command'])}")
+    args = server_entry.get("args", [])
+    if args:
+        rendered_args = ", ".join(json.dumps(a) for a in args)
+        lines.append(f"args = [{rendered_args}]")
+    env_pairs = server_entry.get("env", {})
+    if env_pairs:
+        rendered_env = ", ".join(f"{k} = {json.dumps(v)}" for k, v in env_pairs.items())
+        lines.append(f"env = {{ {rendered_env} }}")
+    return "\n".join(lines)
+
+
+def _confirm_and_merge(
+    config_path: Path, snippet: dict[str, Any], *, yes: bool
+) -> None:
+    """Confirm with the user (unless --yes) and merge the snippet into the file.
+
+    Dispatches by file suffix: `.toml` files are round-tripped through tomlkit
+    so existing comments and key ordering survive the merge. JSON files use
+    the simpler shallow-merge path.
+    """
+    if not yes:
+        confirmed = typer.confirm(f"\nInstall into {config_path}?", default=False)
+        if not confirmed:
+            logger.info("Installation cancelled.")
+            return
+    if config_path.suffix == ".toml":
+        _merge_toml_config(config_path, snippet)
+    else:
+        _merge_client_config(config_path, snippet)
+    logger.info(f"✅ Config written to {config_path}")
+
+
+def _merge_toml_config(config_path: Path, patch: dict[str, Any]) -> None:
+    """Merge `patch` into a TOML file, preserving comments and key ordering.
+
+    `patch` follows the same nested-dict shape as JSON snippets (e.g.
+    `{"mcp_servers": {"<name>": {...}}}`). Only the leaf entries we own are
+    overwritten — sibling keys, comments, and formatting are left intact.
+    """
+    import tomlkit
+    from tomlkit.exceptions import TOMLKitError
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if config_path.exists():
+        try:
+            doc = tomlkit.parse(config_path.read_text())
+        except TOMLKitError:
+            logger.error(
+                f"❌ Cannot parse existing TOML at {config_path}. "
+                "Fix the file manually before running --install again."
+            )
+            raise typer.Exit(1) from None
+    else:
+        doc = tomlkit.document()
+
+    for top_key, top_val in patch.items():
+        if isinstance(top_val, dict):
+            section = doc.get(top_key)  # pyright: ignore[reportUnknownMemberType]
+            if not isinstance(section, dict):
+                section = tomlkit.table()
+                doc[top_key] = section
+            for entry_name, entry_val in top_val.items():
+                section[entry_name] = entry_val  # type: ignore[index]
+        else:
+            doc[top_key] = top_val
+
+    config_path.write_text(tomlkit.dumps(doc))  # pyright: ignore[reportUnknownMemberType]
+
+
 def _get_client_config_path(client: str) -> Path:
-    """Return the config file path for the given MCP client.
+    """Return the fixed-path config file for clients in `_CLIENT_CONFIG_PATHS`.
 
-    Args:
-        client: Client identifier (e.g. "claude-desktop").
-
-    Returns:
-        Absolute path to the client's config file.
-
-    Raises:
-        typer.Exit: If the client is not recognized.
+    Profile-scoped (`claude-code`) and no-install (`chatgpt-desktop`) clients are
+    handled inline in `config_generate` and never reach this helper.
     """
     if client not in _CLIENT_CONFIG_PATHS:
         supported = ", ".join(_CLIENT_CONFIG_PATHS)
         logger.error(f"❌ Unknown client '{client}'. Supported: {supported}")
         raise typer.Exit(1)
     return _CLIENT_CONFIG_PATHS[client]
+
+
+# Per-invocation CLI clients: every shell command spawns a fresh server.
+# Surface this so users understand the "always-on" install semantics.
+_PER_INVOCATION_CLIENTS: frozenset[str] = frozenset({"codex", "gemini-cli"})
+
+
+def _maybe_warn_auto_load(client: str, profile: str) -> None:
+    """Warn after install when the client auto-loads on every invocation.
+
+    For codex (CLI/Desktop/IDE) and gemini-cli, install means MoneyBin starts on
+    every shell launch of that tool — same profile from two terminals will fight
+    over the lock. Surface this so users can choose paste-only instead.
+    """
+    if client not in _PER_INVOCATION_CLIENTS:
+        return
+    surface = (
+        "the Codex CLI, Desktop app, and IDE extension"
+        if client == "codex"
+        else "every `gemini` invocation"
+    )
+    typer.echo("")
+    typer.echo(
+        f"⚠️  {client} auto-loads MoneyBin on {surface}. Two concurrent "
+        f"sessions on profile '{profile}' will fight over the DB write lock — "
+        "the second exits. See docs/guides/mcp-clients.md."
+    )
+
+
+def _print_claude_code_launch_hint(config_path: Path) -> None:
+    """Tell the user how to launch Claude Code with the generated config."""
+    typer.echo("")
+    typer.echo("Launch Claude Code with this MCP server only:")
+    typer.echo(f"  claude --strict-mcp-config --mcp-config {config_path}")
+    typer.echo("")
+    typer.echo(
+        "Or run `make claude-mcp` from the repo to launch with the active profile."
+    )
+
+
+def _print_chatgpt_desktop_instructions(
+    server_entry: dict[str, Any], entry_name: str
+) -> None:
+    """Print step-by-step Connector setup for ChatGPT Desktop.
+
+    ChatGPT Desktop installs MCP servers through Settings → Connectors (Developer
+    Mode), not a JSON config file we can write. The snippet above is informational
+    — copy individual fields into the connector form.
+    """
+    command = server_entry["command"]
+    args_str = " ".join(server_entry.get("args", []))
+    env_pairs = server_entry.get("env", {})
+
+    typer.echo("")
+    typer.echo("ChatGPT Desktop install steps:")
+    typer.echo("  1. Open ChatGPT → Settings → Connectors.")
+    typer.echo(
+        "     If you don't see 'Add custom connector', enable Developer Mode "
+        "under Settings → Advanced first."
+    )
+    typer.echo("  2. Click 'Add custom connector' → choose the local/stdio option.")
+    typer.echo(f"  3. Name: {entry_name}")
+    typer.echo(f"     Command: {command}")
+    typer.echo(f"     Arguments: {args_str}")
+    if env_pairs:
+        typer.echo("     Environment variables:")
+        for key, value in env_pairs.items():
+            typer.echo(f"       {key}={value}")
+    typer.echo("  4. Save. ChatGPT will spawn the server on demand.")
+    typer.echo("")
+    typer.echo(
+        "Note: ChatGPT Desktop's MCP support is gated by version and plan. "
+        "If your build only accepts HTTP connectors, run "
+        "`moneybin mcp serve --transport streamable-http` and add the resulting "
+        "URL as a custom connector instead."
+    )
 
 
 def _merge_client_config(config_path: Path, patch: dict[str, Any]) -> None:

--- a/src/moneybin/cli/commands/mcp.py
+++ b/src/moneybin/cli/commands/mcp.py
@@ -121,9 +121,13 @@ def config_path(
         logger.error(f"❌ Unknown client '{client}'. Supported: {supported}")
         raise typer.Exit(2)
 
+    # Profile resolution only matters for profile-scoped clients (claude-code).
+    # Fixed-path and workspace-scoped clients have profile-independent paths,
+    # so skip the lookup and let an unset profile produce a placeholder.
+    needs_profile = client in _PROFILE_SCOPED_CLIENTS
     if profile:
         resolved_profile = profile
-    else:
+    elif needs_profile:
         try:
             resolved_profile = get_current_profile(auto_resolve=False)
         except RuntimeError as e:
@@ -132,9 +136,16 @@ def config_path(
                 "Run `moneybin profile create <name>` or pass `--profile <name>`."
             )
             raise typer.Exit(1) from e
+    else:
+        resolved_profile = ""  # unused for non-profile-scoped clients
 
     path = _client_install_path(client, resolved_profile)
     if path is None:
+        if client in _WORKSPACE_SCOPED_CLIENTS:
+            logger.error(
+                f"❌ {client} config path requires running inside a repo "
+                "(no git root found from current directory)."
+            )
         raise typer.Exit(1)
     typer.echo(str(path))
 
@@ -292,8 +303,8 @@ def config_generate(
         return
 
     config_path = _get_client_config_path(client)
-    _confirm_and_merge(config_path, snippet, yes=yes)
-    _maybe_warn_auto_load(client, resolved_profile)
+    if _confirm_and_merge(config_path, snippet, yes=yes):
+        _maybe_warn_auto_load(client, resolved_profile)
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
@@ -368,23 +379,29 @@ def _render_codex_toml(snippet: dict[str, Any]) -> str:
 
 def _confirm_and_merge(
     config_path: Path, snippet: dict[str, Any], *, yes: bool
-) -> None:
+) -> bool:
     """Confirm with the user (unless --yes) and merge the snippet into the file.
 
     Dispatches by file suffix: `.toml` files are round-tripped through tomlkit
     so existing comments and key ordering survive the merge. JSON files use
     the simpler shallow-merge path.
+
+    Returns True if the file was written, False if the user declined the
+    confirmation prompt. Callers gate post-install side effects (e.g. the
+    auto-load warning) on the return value so users who decline don't get
+    warnings about a server they didn't install.
     """
     if not yes:
         confirmed = typer.confirm(f"\nInstall into {config_path}?", default=False)
         if not confirmed:
             logger.info("Installation cancelled.")
-            return
+            return False
     if config_path.suffix == ".toml":
         _merge_toml_config(config_path, snippet)
     else:
         _merge_client_config(config_path, snippet)
     logger.info(f"✅ Config written to {config_path}")
+    return True
 
 
 def _merge_toml_config(config_path: Path, patch: dict[str, Any]) -> None:
@@ -467,9 +484,13 @@ def _maybe_warn_auto_load(client: str, profile: str) -> None:
 
 def _print_claude_code_launch_hint(config_path: Path) -> None:
     """Tell the user how to launch Claude Code with the generated config."""
+    import shlex
+
     typer.echo("")
     typer.echo("Launch Claude Code with this MCP server only:")
-    typer.echo(f"  claude --strict-mcp-config --mcp-config {config_path}")
+    typer.echo(
+        f"  claude --strict-mcp-config --mcp-config {shlex.quote(str(config_path))}"
+    )
     typer.echo("")
     typer.echo(
         "Or run `make claude-mcp` from the repo to launch with the active profile."

--- a/tests/moneybin/test_cli/test_cli_mcp_enhancements.py
+++ b/tests/moneybin/test_cli/test_cli_mcp_enhancements.py
@@ -200,9 +200,9 @@ class TestMCPConfigGenerate:
     def test_generate_unknown_client_errors(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Unknown clients exit non-zero with a helpful log message."""
+        """Unknown client → usage error (exit 2), matching `mcp config path`."""
         result = runner.invoke(app, ["config", "generate", "--client", "bogus"])
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert "Unknown client" in caplog.text
 
     def test_generate_claude_code_prints_launch_hint(self, tmp_path: Path) -> None:
@@ -291,6 +291,16 @@ class TestMCPConfigPath:
         result = runner.invoke(app, ["config", "path", "--client", "bogus"])
         assert result.exit_code == 2
 
+    def test_path_fixed_path_client_returns_canonical_location(self) -> None:
+        """Fixed-path clients (e.g. cursor) resolve to their `_CLIENT_CONFIG_PATHS` entry."""
+        result = runner.invoke(
+            app, ["config", "path", "--client", "cursor", "--profile", "alice"]
+        )
+        assert result.exit_code == 0
+        # Cursor's canonical install path is ~/.cursor/mcp.json — independent of profile.
+        assert ".cursor" in result.output
+        assert "mcp.json" in result.output
+
 
 class TestMCPConfigGenerateCodex:
     """Codex emits a TOML [mcp_servers] block and installs via tomlkit round-trip."""
@@ -338,6 +348,8 @@ class TestMCPConfigGenerateCodex:
         entry = parsed["mcp_servers"]["MoneyBin (alice)"]
         assert entry["command"] == "uv"
         assert "moneybin" in entry["args"]
+        # Concurrency guardrail must fire on per-invocation client installs.
+        assert "auto-loads" in result.output
 
     def test_generate_codex_install_preserves_existing_keys_and_comments(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -471,3 +483,5 @@ class TestMCPConfigGenerateGeminiCLI:
 
         payload = _json.loads(target.read_text())
         assert "mcpServers" in payload
+        # Concurrency guardrail must fire on per-invocation client installs.
+        assert "auto-loads" in result.output

--- a/tests/moneybin/test_cli/test_cli_mcp_enhancements.py
+++ b/tests/moneybin/test_cli/test_cli_mcp_enhancements.py
@@ -301,6 +301,22 @@ class TestMCPConfigPath:
         assert ".cursor" in result.output
         assert "mcp.json" in result.output
 
+    def test_path_fixed_path_client_no_profile_required(self) -> None:
+        """Fixed-path clients work without --profile and without an active profile."""
+        result = runner.invoke(app, ["config", "path", "--client", "cursor"])
+        assert result.exit_code == 0
+        assert "mcp.json" in result.output
+
+    def test_path_vscode_outside_repo_exits_one(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Vscode config path errors with a diagnostic when no repo root is found."""
+        monkeypatch.setattr("moneybin.cli.commands.mcp.find_repo_root", lambda: None)
+        result = runner.invoke(
+            app, ["config", "path", "--client", "vscode", "--profile", "alice"]
+        )
+        assert result.exit_code == 1
+
 
 class TestMCPConfigGenerateCodex:
     """Codex emits a TOML [mcp_servers] block and installs via tomlkit round-trip."""
@@ -350,6 +366,33 @@ class TestMCPConfigGenerateCodex:
         assert "moneybin" in entry["args"]
         # Concurrency guardrail must fire on per-invocation client installs.
         assert "auto-loads" in result.output
+
+    def test_generate_codex_install_cancelled_skips_warning(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Declining the install prompt suppresses the auto-load warning."""
+        target = tmp_path / "config.toml"
+        monkeypatch.setattr(
+            "moneybin.cli.commands.mcp._get_client_config_path",
+            lambda client: target,  # type: ignore[reportUnknownLambdaType]
+        )
+        result = runner.invoke(
+            app,
+            [
+                "config",
+                "generate",
+                "--client",
+                "codex",
+                "--profile",
+                "alice",
+                "--install",
+            ],
+            input="n\n",
+        )
+        assert result.exit_code == 0
+        # User declined → file not written, warning suppressed.
+        assert not target.exists()
+        assert "auto-loads" not in result.output
 
     def test_generate_codex_install_preserves_existing_keys_and_comments(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/moneybin/test_cli/test_cli_mcp_enhancements.py
+++ b/tests/moneybin/test_cli/test_cli_mcp_enhancements.py
@@ -196,3 +196,278 @@ class TestMCPConfigGenerate:
             ["config", "generate", "--client", "claude-desktop", "--profile", "work"],
         )
         assert result.exit_code == 0
+
+    def test_generate_unknown_client_errors(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Unknown clients exit non-zero with a helpful log message."""
+        result = runner.invoke(app, ["config", "generate", "--client", "bogus"])
+        assert result.exit_code == 1
+        assert "Unknown client" in caplog.text
+
+    def test_generate_claude_code_prints_launch_hint(self, tmp_path: Path) -> None:
+        """claude-code emits the snippet plus the `claude --mcp-config` launch line."""
+        result = runner.invoke(app, ["config", "generate", "--client", "claude-code"])
+        assert result.exit_code == 0
+        assert "mcpServers" in result.output
+        assert "--strict-mcp-config" in result.output
+        assert "--mcp-config" in result.output
+        assert "claude-code-mcp.json" in result.output
+
+    def test_generate_claude_code_install_writes_to_profile_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """claude-code --install writes to <base>/profiles/<profile>/claude-code-mcp.json."""
+        monkeypatch.setattr("moneybin.cli.commands.mcp.get_base_dir", lambda: tmp_path)
+        result = runner.invoke(
+            app,
+            [
+                "config",
+                "generate",
+                "--client",
+                "claude-code",
+                "--profile",
+                "work",
+                "--install",
+                "--yes",
+            ],
+        )
+        assert result.exit_code == 0
+        expected = tmp_path / "profiles" / "work" / "claude-code-mcp.json"
+        assert expected.exists()
+        import json as _json
+
+        payload = _json.loads(expected.read_text())
+        assert "mcpServers" in payload
+
+    def test_generate_chatgpt_desktop_prints_instructions(self) -> None:
+        """chatgpt-desktop emits the snippet plus Connector setup steps."""
+        result = runner.invoke(
+            app, ["config", "generate", "--client", "chatgpt-desktop"]
+        )
+        assert result.exit_code == 0
+        assert "mcpServers" in result.output
+        assert "Connectors" in result.output
+        assert "Command:" in result.output
+        assert "Arguments:" in result.output
+
+    def test_generate_chatgpt_desktop_install_errors(self) -> None:
+        """chatgpt-desktop --install exits non-zero (no JSON file to write)."""
+        result = runner.invoke(
+            app,
+            ["config", "generate", "--client", "chatgpt-desktop", "--install", "--yes"],
+        )
+        assert result.exit_code == 1
+        assert (
+            "not supported" in result.output.lower()
+            or "connectors" in result.output.lower()
+        )
+
+
+class TestMCPConfigPath:
+    """Tests for the `mcp config path` command."""
+
+    def test_path_claude_code_under_profile(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """claude-code path is <base>/profiles/<profile>/claude-code-mcp.json."""
+        monkeypatch.setattr("moneybin.cli.commands.mcp.get_base_dir", lambda: tmp_path)
+        result = runner.invoke(
+            app, ["config", "path", "--client", "claude-code", "--profile", "alice"]
+        )
+        assert result.exit_code == 0
+        assert (
+            str(tmp_path / "profiles" / "alice" / "claude-code-mcp.json")
+            in result.output
+        )
+
+    def test_path_chatgpt_desktop_exits_one(self) -> None:
+        """chatgpt-desktop has no JSON config file — exit 1, no output."""
+        result = runner.invoke(app, ["config", "path", "--client", "chatgpt-desktop"])
+        assert result.exit_code == 1
+
+    def test_path_unknown_client_exits_two(self) -> None:
+        """Unknown client → usage error (exit 2)."""
+        result = runner.invoke(app, ["config", "path", "--client", "bogus"])
+        assert result.exit_code == 2
+
+
+class TestMCPConfigGenerateCodex:
+    """Codex emits a TOML [mcp_servers] block and installs via tomlkit round-trip."""
+
+    def test_generate_codex_emits_toml_block(self) -> None:
+        result = runner.invoke(
+            app, ["config", "generate", "--client", "codex", "--profile", "alice"]
+        )
+        assert result.exit_code == 0
+        assert "[mcp_servers." in result.output
+        assert 'command = "uv"' in result.output
+        assert "args = [" in result.output
+        # No mcpServers JSON header — codex output is TOML, not JSON.
+        assert "mcpServers" not in result.output
+
+    def test_generate_codex_install_writes_toml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / "config.toml"
+        monkeypatch.setattr(
+            "moneybin.cli.commands.mcp._get_client_config_path",
+            lambda client: target,  # type: ignore[reportUnknownLambdaType]
+        )
+        result = runner.invoke(
+            app,
+            [
+                "config",
+                "generate",
+                "--client",
+                "codex",
+                "--profile",
+                "alice",
+                "--install",
+                "--yes",
+            ],
+        )
+        assert result.exit_code == 0
+        assert target.exists()
+
+        import tomllib
+
+        parsed = tomllib.loads(target.read_text())
+        assert "mcp_servers" in parsed
+        assert "MoneyBin (alice)" in parsed["mcp_servers"]
+        entry = parsed["mcp_servers"]["MoneyBin (alice)"]
+        assert entry["command"] == "uv"
+        assert "moneybin" in entry["args"]
+
+    def test_generate_codex_install_preserves_existing_keys_and_comments(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Round-trip merge keeps unrelated settings and inline comments intact."""
+        target = tmp_path / "config.toml"
+        target.write_text(
+            "# user preference\n"
+            'model = "gpt-5"  # default model\n'
+            "\n"
+            "[mcp_servers.other]\n"
+            'command = "node"\n'
+            'args = ["server.js"]\n'
+        )
+        monkeypatch.setattr(
+            "moneybin.cli.commands.mcp._get_client_config_path",
+            lambda client: target,  # type: ignore[reportUnknownLambdaType]
+        )
+        result = runner.invoke(
+            app,
+            [
+                "config",
+                "generate",
+                "--client",
+                "codex",
+                "--profile",
+                "alice",
+                "--install",
+                "--yes",
+            ],
+        )
+        assert result.exit_code == 0
+        text = target.read_text()
+        # Pre-existing comments and the unrelated server entry survive.
+        assert "# user preference" in text
+        assert "# default model" in text
+        assert "[mcp_servers.other]" in text
+        # New entry is present.
+        assert "MoneyBin (alice)" in text or '"MoneyBin (alice)"' in text
+
+
+class TestMCPConfigGenerateVSCode:
+    """VS Code uses workspace-local .vscode/mcp.json with `servers` key."""
+
+    def test_generate_vscode_uses_servers_key(self) -> None:
+        result = runner.invoke(
+            app, ["config", "generate", "--client", "vscode", "--profile", "alice"]
+        )
+        assert result.exit_code == 0
+        assert '"servers"' in result.output
+        assert '"type": "stdio"' in result.output
+        # Standard `mcpServers` key must NOT be present in vscode output.
+        assert "mcpServers" not in result.output
+
+    def test_generate_vscode_install_writes_workspace_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "moneybin.cli.commands.mcp.find_repo_root", lambda: tmp_path
+        )
+        result = runner.invoke(
+            app,
+            [
+                "config",
+                "generate",
+                "--client",
+                "vscode",
+                "--profile",
+                "alice",
+                "--install",
+                "--yes",
+            ],
+        )
+        assert result.exit_code == 0
+        target = tmp_path / ".vscode" / "mcp.json"
+        assert target.exists()
+        import json as _json
+
+        payload = _json.loads(target.read_text())
+        assert "servers" in payload
+        entry = next(iter(payload["servers"].values()))
+        assert entry["type"] == "stdio"
+        assert entry["command"] == "uv"
+
+    def test_generate_vscode_install_outside_repo_errors(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("moneybin.cli.commands.mcp.find_repo_root", lambda: None)
+        result = runner.invoke(
+            app,
+            ["config", "generate", "--client", "vscode", "--install", "--yes"],
+        )
+        assert result.exit_code == 1
+
+
+class TestMCPConfigGenerateGeminiCLI:
+    """gemini-cli installs to a fixed user-level path with the standard `mcpServers` shape."""
+
+    def test_generate_gemini_cli_emits_mcp_servers(self) -> None:
+        result = runner.invoke(
+            app,
+            ["config", "generate", "--client", "gemini-cli", "--profile", "alice"],
+        )
+        assert result.exit_code == 0
+        assert "mcpServers" in result.output
+
+    def test_generate_gemini_cli_install_writes_settings(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / "settings.json"
+        monkeypatch.setattr(
+            "moneybin.cli.commands.mcp._get_client_config_path",
+            lambda client: target,  # type: ignore[reportUnknownLambdaType]
+        )
+        result = runner.invoke(
+            app,
+            [
+                "config",
+                "generate",
+                "--client",
+                "gemini-cli",
+                "--profile",
+                "alice",
+                "--install",
+                "--yes",
+            ],
+        )
+        assert result.exit_code == 0
+        assert target.exists()
+        import json as _json
+
+        payload = _json.loads(target.read_text())
+        assert "mcpServers" in payload

--- a/uv.lock
+++ b/uv.lock
@@ -1587,6 +1587,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "sqlmesh" },
+    { name = "tomlkit" },
     { name = "typer" },
 ]
 
@@ -1644,6 +1645,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "requests", specifier = ">=2.33.1" },
     { name = "sqlmesh", extras = ["duckdb"], specifier = ">=0.200.0" },
+    { name = "tomlkit", specifier = ">=0.13.2" },
     { name = "typer", specifier = ">=0.24.1" },
 ]
 
@@ -3323,6 +3325,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Broadens `moneybin mcp config generate --client …` from three install targets to seven (plus one instructions-only client), with per-session opt-in for Claude Code. Adds a new `docs/guides/mcp-clients.md` explaining MoneyBin's single-writer-per-profile concurrency model, per-client server-lifecycle behavior, and how to avoid lock fights in practice.

## Impact

- New supported clients: `claude-code`, `vscode`, `gemini-cli`, `codex` (covers CLI / Desktop app / IDE extension), `chatgpt-desktop`
- New developer command: `make claude-mcp [PROFILE=name]` launches Claude Code with MoneyBin's MCP server loaded only for that session
- Per-profile Claude Code configs now live at `<base>/profiles/<profile>/claude-code-mcp.json`
- Codex installs are now round-trip-safe (preserve hand-edited TOML)
- One new dependency: `tomlkit>=0.13.2`

## Changes

### CLI install targets
- **claude-code**: per-profile JSON at `<base>/profiles/<profile>/claude-code-mcp.json`. Loaded only via `claude --strict-mcp-config --mcp-config <file>`; not auto-started.
- **vscode**: workspace-local `.vscode/mcp.json` with the `servers` schema and `"type": "stdio"`. Errors out cleanly when `--install` is run outside a repo.
- **gemini-cli**: user-level `~/.gemini/settings.json`, standard `mcpServers` shape.
- **codex**: `~/.codex/config.toml` (shared across CLI, Desktop app, and IDE extension). Round-tripped via tomlkit so user comments / model settings / plugins / marketplaces survive.
- **chatgpt-desktop**: prints snippet plus step-by-step Connectors UI instructions; `--install` is unsupported (no JSON file we can write).

### Per-session opt-in for Claude Code
- New `scripts/claude-mcp.sh` resolves the per-profile config path and `exec`s `claude --strict-mcp-config --mcp-config <path>` so Claude Code becomes the foreground TTY job (Make recipes don't pass job control cleanly).
- New `make claude-mcp` target that delegates to the script with `PROFILE=` override support.
- New `moneybin mcp config path --client <c> [--profile <p>]` subcommand for non-interactive path lookup.

### Auto-load warning
After installing into per-invocation CLI clients (codex, gemini-cli), the command prints a one-line warning that every shell invocation will spawn a server and concurrent same-profile sessions will fight over the lock — with a pointer to the new guide.

### Docs
- New `docs/guides/mcp-clients.md`: quickstart, supported-clients table, concurrency model (app-shared vs per-invocation), per-session opt-in for Claude Code, Codex shared-config note, ChatGPT Desktop UI flow, profile switching semantics, troubleshooting checklist.
- README MCP callout reduced to a one-liner naming all eight clients and linking to the new guide.
- `docs/guides/mcp-server.md` updated to point at the new guide.

### Separately-scoped (included for staging)
- `docs/specs/mcp-tool-timeouts.md` — draft spec for global 30s wall-clock cap on tool dispatch with DuckDB `interrupt()` on timeout. Indexed in `docs/specs/INDEX.md` as `draft`. No implementation in this PR.

## Test plan

- [ ] 31 cases in `tests/moneybin/test_cli/test_cli_mcp_enhancements.py` covering each new client's snippet shape, install behavior, and (for codex) round-trip preservation of existing keys and comments
- [ ] Full CLI test suite green: `uv run pytest tests/moneybin/test_cli/ -n auto` → 297 passed
- [ ] `make format lint` and `pyright` clean on changed files
- [ ] Real-world round-trip verified against a live `~/.codex/config.toml`: MoneyBin entry added without disturbing model setting, notify hook, marketplaces, or plugins
- [ ] Smoke-test `make claude-mcp PROFILE=<name>` launches Claude Code with MoneyBin loaded only for that session

## Notes

- Cross-client lock collisions (e.g., Cursor + Claude Desktop both running with the same profile) are runtime-only — no install-time fix possible. The new guide documents this clearly.
- Codex CLI / Gemini CLI cannot do per-session opt-in: neither supports a per-launch MCP-config override flag. Verified against [developers.openai.com/codex/mcp](https://developers.openai.com/codex/mcp) and the Gemini CLI MCP docs. Users who want occasional MoneyBin in those clients should skip `--install` and paste the snippet manually.
- The `mcp-tool-timeouts.md` spec is included because it was already in the working tree; it's labeled `draft` and not part of this branch's logical scope. Easy to split into its own PR if you'd rather review separately.