### PR TITLE
docs: cli-restructure v2 — unified CLI / MCP / HTTP taxonomy

### DIFF
--- a/.claude/rules/mcp-server.md
+++ b/.claude/rules/mcp-server.md
@@ -78,6 +78,32 @@ Tools without consent return **degraded responses** (aggregates instead of row-l
 
 The `detail` parameter (`summary`, `standard`, `full`) lets the AI self-select verbosity. `detail=summary` always returns aggregates without triggering consent.
 
+## When CLI-only is justified
+
+Default: every operation is MCP-exposed. CLI-only status requires a justified exception. Two acceptable justifications:
+
+1. **Secret material through the LLM context window.** Tools that accept passphrases or encryption keys (`db_unlock`, `db_rotate_key`, `sync_rotate_key`, `db_init`). Routing those through an LLM-mediated channel is a security model violation, not a capability gap.
+2. **Hands-on operator territory.** Bootstrapping, troubleshooting, and developer-tooling operations that require physical operator presence (`db_init/lock/ps/kill/migrate/shell/ui`, `mcp_serve`, `mcp_config_*`, `profile_*`, `transform_restate`). The MCP server can't even start when the database is locked, so exposing recovery/lifecycle tools to MCP would be meaningless.
+
+What is NOT a valid CLI-only justification:
+- "Long-running" — MCP supports progress notifications.
+- "Needs OAuth / browser" — tools can return redirect URLs; clients open them.
+- "Destructive" — use a `confirm` parameter or elicitation; the AI must obtain explicit user agreement.
+- "Interactive" — split into a list-tool (read) and act-tools (write); the AI orchestrates the loop.
+- "Writes to scheduler / filesystem" — server has filesystem access; routine.
+
+When adding a new operation, the default is "expose to MCP." Apply this filter at design time, not after the fact.
+
+## Server Instructions Field
+
+The `FastMCP(instructions=...)` argument in `src/moneybin/mcp/server.py` is the canonical onboarding text injected into the LLM's system prompt at session start. Treat it as a load-bearing surface, not a comment.
+
+- **Keep in sync with taxonomy.** Any rename, new top-level group, or change to orientation tools (`system_status`, `reports_health`) must update the instructions text in the same change.
+- **Required content:** one-line product description, top-level group enumeration, naming convention with examples, orientation pointers, response envelope shape, bulk-tool preference, sensitivity tiers / degraded-response behavior.
+- **Length budget:** ~150–300 tokens. Loaded once per session, but competes with conversation and tool descriptions for working memory.
+- **Style:** triple-quoted string via `textwrap.dedent(...)` — not concatenated string literals.
+- See [`docs/specs/mcp-tool-surface.md`](../../docs/specs/mcp-tool-surface.md) §1 for required-content rationale.
+
 ## Connection Model
 
 All tools use `get_database()` from `src/moneybin/database.py` — a single long-lived read-write connection per process. The `Database` class handles encryption, schema init, and migrations transparently. See [`privacy-data-protection.md`](../../docs/specs/privacy-data-protection.md).

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -2,6 +2,33 @@
 
 Tracking deferred work and known limitations from shipped features.
 
+## Draft `account-management.md` spec (post-cli-restructure v2)
+
+The v2 CLI restructure places the `accounts` top-level entity namespace but no spec owns it. Net-worth.md owns balance/networth surfaces; asset-tracking.md owns assets; nothing owns the entity-management surface (`list`, `show`, `rename`, `archive`, `include`).
+
+Surfaces left without a home:
+- `accounts list / show / rename / archive / include` CLI commands
+- `accounts_list / accounts_get / accounts_rename / accounts_archive / accounts_include` MCP tools
+- `app.account_settings` table (currently specced inside `net-worth.md` but conceptually broader than net-worth inclusion)
+- Account merging workflow (when import discovers the same account from two sources)
+- Per-account display preferences (color, icon, display order) — future, not yet specced anywhere
+
+Plan:
+1. Write `docs/specs/account-management.md` covering the scope above.
+2. Move `app.account_settings` ownership from `net-worth.md` to the new spec; net-worth.md continues to read `include_in_net_worth` from it.
+3. Update INDEX.md status `planned` → `draft` once written.
+
+## Dynamic MCP server instructions for progressive disclosure (post-cli-restructure v2)
+
+The MCP `FastMCP(instructions=...)` text in `src/moneybin/mcp/server.py` is currently static. v1 advertised `moneybin_discover` for loading extended namespaces, but progressive disclosure (per-session tag-based tool visibility) is not honored by all MCP clients. v2 leaves the discover advertisement out of the instructions to keep the message correct across clients.
+
+When client support for FastMCP visibility transforms broadens — or when we identify the connecting client by name on `initialize` — revisit:
+
+- **Conditional injection.** Inspect the connecting client (FastMCP exposes the client name) and append a "Load extended namespaces via `moneybin_discover`" line only for clients that honor visibility transforms.
+- **Static re-add.** If the broader ecosystem catches up, just put the line back and drop the conditional.
+
+The `moneybin_discover` tool itself remains active and discoverable via `mcp list-tools`; this is purely about whether the instructions field calls it out at session start.
+
 ## Auto-rule splitting (post-PR #58)
 
 The current auto-rule generator proposes one `(merchant_pattern, category, subcategory)` per

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -71,7 +71,7 @@ Single source of truth for spec status. Update this table when a spec's status c
 | Spec | Type | Status | Summary |
 |---|---|---|---|
 | [Architecture & Design](mcp-architecture.md) | Architecture | in-progress | MCP v1 design philosophy, tool taxonomy, privacy integration, CLI symmetry, Apps readiness. Supersedes archived `mcp-read-tools` and `mcp-write-tools` specs. |
-| [Tool Surface](mcp-tool-surface.md) | Architecture | in-progress | Concrete tool, prompt, resource, and service layer definitions for MCP v1 (46 tools, 4 prompts, 4 resources) |
+| [Tool Surface](mcp-tool-surface.md) | Architecture | ready | Concrete tool, prompt, resource, and service layer definitions for MCP. v2 (2026-05-02) aligns naming with `cli-restructure.md` v2 taxonomy (path-prefix-verb-suffix), adds `reports_*` namespace, exposes sync + transform to MCP under the v2 exposure principle. |
 | [SQL Schema Discoverability](mcp-sql-discoverability.md) | Feature | implemented | `moneybin://schema` resource exposes curated interface tables (core + select app) with columns, comments, and example queries; eliminates per-session schema reconnaissance |
 
 ## Sync
@@ -102,7 +102,7 @@ Single source of truth for spec status. Update this table when a spec's status c
 
 | Spec | Type | Status | Summary |
 |---|---|---|---|
-| [CLI Restructure](cli-restructure.md) | Architecture | implemented | Target CLI command tree: profiles as first-class, `import` as golden path, domain commands top-level. Reference spec for all other specs' CLI sections. |
+| [CLI Restructure](cli-restructure.md) | Architecture | ready | Target command taxonomy across CLI / MCP / future HTTP. v1 implemented; v2 (2026-05-02, status `ready`) dissolves `track`, introduces entity groups (`accounts`, `transactions`), adds `categories`, `merchants`, `assets`, `reports`, `system` top-level groups, separates `tax`, codifies MCP exposure principle, renames MCP tools. Reference spec for all other specs' surface placement. |
 | [Observability](observability.md) | Feature | implemented | Logging consolidation, `prometheus_client` metrics with DuckDB persistence, instrumentation API (`@tracked`, `track_duration`), log/stats CLI commands |
 | [Database Migration](database-migration.md) | Feature | implemented | Dual-path schema migration system: auto-upgrade on first invocation, SQL/Python migrations, rebaseline, SQLMesh version detection |
 | `export.md` | Feature | planned | Export analysis results to CSV, Excel, Google Sheets |
@@ -116,6 +116,7 @@ Single source of truth for spec status. Update this table when a spec's status c
 | [Data Pipeline Reconciliation](data-reconciliation.md) | Feature | draft | Automated pipeline integrity checks: raw→prep→core row accounting, import batch validation, temporal coverage gaps, orphan detection. Complements financial balance reconciliation in `net-worth.md`. |
 
 ## Standalone
-| [Net Worth & Balance Tracking](net-worth.md) | Feature | draft | Authoritative balance tracking per account, daily carry-forward interpolation, reconciliation deltas, `agg_net_worth` aggregation; cash-only v1. CLI updated by `cli-restructure.md`: `track balance` and `track networth` replace top-level `balance`/`networth`/`reconciliation`. |
-| [Asset Tracking](asset-tracking.md) | Feature | draft | Physical asset registry (real estate, vehicles, valuables) with periodic valuations, staleness warnings, liability linking, and net worth integration. CLI namespace: `track asset` per `cli-restructure.md`. |
-| [Budget Tracking](budget-tracking.md) | Feature | draft | Monthly budgets with target-vs-actual and rollovers. CLI namespace: `track budget` per `cli-restructure.md`. |
+| `account-management.md` | Feature | planned | Owns the `accounts` entity namespace: list/show/rename/archive/include, account merging, per-account settings (`app.account_settings`), display preferences. CLI per `cli-restructure.md` v2: top-level `accounts` (entity ops; balance lives nested under `accounts balance` per `net-worth.md`). |
+| [Net Worth & Balance Tracking](net-worth.md) | Feature | draft | Authoritative balance tracking per account, daily carry-forward interpolation, reconciliation deltas, `agg_net_worth` aggregation; cash-only v1. CLI per `cli-restructure.md` v2: `accounts balance` (per-account workflow), `reports networth` (cross-domain rollup). |
+| [Asset Tracking](asset-tracking.md) | Feature | draft | Physical asset registry (real estate, vehicles, valuables) with periodic valuations, staleness warnings, liability linking, and net worth integration. CLI namespace: top-level `assets` per `cli-restructure.md` v2 (parallel to `accounts`). |
+| [Budget Tracking](budget-tracking.md) | Feature | draft | Monthly budgets with target-vs-actual and rollovers. CLI namespace: top-level `budget` (mutation) + `reports budget` (vs-actual) per `cli-restructure.md` v2. |

--- a/docs/specs/asset-tracking.md
+++ b/docs/specs/asset-tracking.md
@@ -15,7 +15,7 @@ The dividing line between assets and investments: **if the value comes from a ma
 
 Related specs and docs:
 - [`net-worth.md`](net-worth.md) — balance tracking and `agg_net_worth`; this spec extends it to include physical assets
-- [`cli-restructure.md`](cli-restructure.md) — target CLI command tree; asset commands live under `track asset`
+- [`cli-restructure.md`](cli-restructure.md) v2 — assets are a **top-level command group** (`moneybin assets …`), parallel to `accounts`. The full asset workflow (registration, valuation, liability linking, staleness) is owned by this spec. Net worth contribution flows through `core.agg_net_worth`, surfaced via `reports networth`. CLI examples below already use the v2 path.
 - [`privacy-data-protection.md`](privacy-data-protection.md) — asset data encrypted at rest via `Database` class
 - [`database-migration.md`](database-migration.md) — migration infrastructure for new tables
 - [`mcp-architecture.md`](mcp-architecture.md) — tool taxonomy and response envelope conventions
@@ -33,7 +33,7 @@ Related specs and docs:
 9. **Staleness warnings.** Each valuation in `fct_asset_valuations_daily` tracks days since the last real observation. Warnings surface in CLI output and MCP responses when a valuation exceeds its staleness threshold. Warnings are informational only — stale values are still included in net worth.
 10. **Staleness threshold resolution:** per-asset override → per-type default → global config default.
 11. **Asset disposal.** Assets can be marked as sold with a date and sale amount. Disposed assets stop contributing to net worth but their history is preserved.
-12. **CLI commands** under `track asset` (see CLI Interface section).
+12. **CLI commands** under `assets` (see CLI Interface section).
 13. **MCP tools:** `assets.list`, `assets.detail`, `assets.summary` (see MCP Interface section).
 14. **All commands support `--output json`** for non-interactive parity.
 15. **Source precedence within a day.** When multiple valuation sources exist for the same asset on the same date: manual (user assertion) > appraisal > automated estimate (Zillow/KBB).
@@ -42,7 +42,7 @@ Related specs and docs:
 
 ### New table: `app.assets`
 
-User-created asset registry. Managed via CLI (`track asset add/update/sell/remove`).
+User-created asset registry. Managed via CLI (`assets add/update/sell/remove`).
 
 ```sql
 CREATE TABLE IF NOT EXISTS app.assets (
@@ -64,7 +64,7 @@ CREATE TABLE IF NOT EXISTS app.assets (
 
 ### New table: `app.asset_valuations`
 
-User-entered valuations. Managed via CLI (`track asset value set/unset`).
+User-entered valuations. Managed via CLI (`assets valuation set/unset`).
 
 ```sql
 CREATE TABLE IF NOT EXISTS app.asset_valuations (
@@ -230,7 +230,7 @@ asset_staleness_default_days: int = (
 
 ### Where staleness surfaces
 
-- **`track asset list`** — warning indicator next to stale assets with days since last valuation
+- **`assets list`** — warning indicator next to stale assets with days since last valuation
 - **`track networth show`** — summary note: "N assets have stale valuations" with asset names
 - **MCP tools** — `summary.warnings` array includes stale asset notices
 
@@ -238,12 +238,12 @@ Staleness is informational only — never blocks queries or omits stale assets f
 
 ## CLI Interface
 
-All commands under `track asset`, following [`cli-restructure.md`](cli-restructure.md). All support `--output json` for non-interactive parity.
+All commands under `assets`, following [`cli-restructure.md`](cli-restructure.md). All support `--output json` for non-interactive parity.
 
 ### Asset management
 
 ```
-moneybin track asset add --name "123 Main St" --type real_estate \
+moneybin assets add --name "123 Main St" --type real_estate \
     [--description "Primary residence"] \
     [--acquisition-date 2020-03-15] [--acquisition-cost 450000] \
     [--liability-account-id <account_id>] [--staleness-days 180]
@@ -252,31 +252,31 @@ moneybin track asset add --name "123 Main St" --type real_estate \
 - `--type` validates against the four known types (`real_estate`, `vehicle`, `valuable`, `other`)
 
 ```
-moneybin track asset list [--type real_estate] [--include-disposed] [--output json|table]
+moneybin assets list [--type real_estate] [--include-disposed] [--output json|table]
 ```
 - Default: active assets only (no `disposal_date`)
 - Shows: name, type, latest valuation, days since valuation, staleness warning if applicable
 
 ```
-moneybin track asset show <asset_id> [--output json|table]
+moneybin assets show <asset_id> [--output json|table]
 ```
 - Detail view: all asset fields, valuation history, linked liability balance if present, gain/loss vs acquisition cost
 
 ```
-moneybin track asset update <asset_id> [--name "..."] [--description "..."] \
+moneybin assets update <asset_id> [--name "..."] [--description "..."] \
     [--liability-account-id <id>] [--staleness-days 90]
 ```
 - Updates any mutable field on the asset
 
 ```
-moneybin track asset sell <asset_id> --date 2025-06-01 --amount 35000 [--notes "Trade-in"] [--yes]
+moneybin assets sell <asset_id> --date 2025-06-01 --amount 35000 [--notes "Trade-in"] [--yes]
 ```
 - Sets `disposal_date` and `disposal_amount`
 - Asset stops contributing to net worth after disposal date
 - History preserved; asset visible with `--include-disposed`
 
 ```
-moneybin track asset remove <asset_id> [--yes]
+moneybin assets remove <asset_id> [--yes]
 ```
 - Hard delete of asset and all its valuations
 - Confirmation required
@@ -285,24 +285,24 @@ moneybin track asset remove <asset_id> [--yes]
 ### Valuation management
 
 ```
-moneybin track asset value set <asset_id> --date 2025-01-15 --value 475000 [--notes "Zillow estimate"]
+moneybin assets value set <asset_id> --date 2025-01-15 --value 475000 [--notes "Zillow estimate"]
 ```
 - Inserts or updates a row in `app.asset_valuations` (upsert on `asset_id + valuation_date`)
 
 ```
-moneybin track asset value history <asset_id> [--from DATE] [--to DATE] [--output json|table]
+moneybin assets value history <asset_id> [--from DATE] [--to DATE] [--output json|table]
 ```
 - Shows valuation history for an asset over time
 
 ```
-moneybin track asset value unset <asset_id> --date 2025-01-15 [--yes]
+moneybin assets value unset <asset_id> --date 2025-01-15 [--yes]
 ```
 - Removes a specific manual valuation
 
 ### Example output
 
 ```
-$ moneybin track asset list
+$ moneybin assets list
 
 Name                Type          Value        Last Valued    Status
 123 Main St         real_estate   $475,000     2025-01-15     ✅ Current
@@ -311,7 +311,7 @@ Grandma's Ring      valuable      $12,000      2024-03-01     ✅ Current
 ```
 
 ```
-$ moneybin track networth show
+$ moneybin reports networth show
 
 Net Worth: $347,250 as of 2025-04-23
 
@@ -354,13 +354,13 @@ Follows the standard envelope from [`mcp-architecture.md`](mcp-architecture.md):
     "warnings": ["1 asset has a stale valuation: 2021 Tesla Model 3 (234 days)"]
   },
   "data": [...],
-  "actions": ["Use assets.detail for full history", "Use 'track asset value set' to update stale valuations"]
+  "actions": ["Use assets.detail for full history", "Use 'assets value set' to update stale valuations"]
 }
 ```
 
 ### Write tools
 
-Deferred to v2, same as balance assertion write tools in the net worth spec. The `track asset` CLI handles the low-frequency asset management workflow for v1.
+Deferred to v2, same as balance assertion write tools in the net worth spec. The `assets` CLI handles the low-frequency asset management workflow for v1.
 
 ### Net worth tools (existing, extended)
 
@@ -390,17 +390,17 @@ Deferred to v2, same as balance assertion write tools in the net worth spec. The
 
 ### Tier 3 — Integration
 
-- End-to-end: `track asset add` → `track asset value set` → `sqlmesh run` → `track networth show` → verify asset included in net worth.
-- Disposal flow: `track asset sell` → `sqlmesh run` → verify asset excluded from net worth after disposal date.
-- Liability linking: add asset with `--liability-account-id` → `track asset show` → verify equity display.
-- Staleness surfacing: set an old valuation → `track asset list` → verify warning appears.
+- End-to-end: `assets add` → `assets value set` → `sqlmesh run` → `track networth show` → verify asset included in net worth.
+- Disposal flow: `assets sell` → `sqlmesh run` → verify asset excluded from net worth after disposal date.
+- Liability linking: add asset with `--liability-account-id` → `assets show` → verify equity display.
+- Staleness surfacing: set an old valuation → `assets list` → verify warning appears.
 
 ## Dependencies
 
 - [`net-worth.md`](net-worth.md) — `agg_net_worth` view is extended; this spec cannot ship before or independently of net worth
 - [`database-migration.md`](database-migration.md) — new tables (`app.assets`, `app.asset_valuations`) require migration infrastructure
 - [`privacy-data-protection.md`](privacy-data-protection.md) — asset data is sensitive; encrypted at rest via `Database` class
-- [`cli-restructure.md`](cli-restructure.md) — `track asset` namespace defined by the CLI structure spec
+- [`cli-restructure.md`](cli-restructure.md) — `assets` namespace defined by the CLI structure spec
 - `core.dim_accounts` — liability linking references existing dimension
 
 ## Out of Scope
@@ -422,13 +422,13 @@ Deferred to v2, same as balance assertion write tools in the net worth spec. The
 - `sqlmesh/models/core/fct_asset_valuations.sql` — VIEW unioning all valuation sources
 - `sqlmesh/models/core/fct_asset_valuations_daily.sql` — TABLE with daily carry-forward logic (may be Python model)
 - `src/moneybin/services/asset_service.py` — business logic for asset CRUD and valuation management
-- `src/moneybin/cli/commands/asset.py` — `track asset` command group
+- `src/moneybin/cli/commands/asset.py` — `assets` command group
 - `tests/test_asset_service.py` — unit tests for asset service
 - `tests/test_cli_asset.py` — CLI integration tests
 
 ### Files to Modify
 
-- `src/moneybin/cli/main.py` — register `track asset` command group
+- `src/moneybin/cli/main.py` — register `assets` command group
 - `src/moneybin/sql/schema.py` — register new DDL files for `app.assets` and `app.asset_valuations`
 - `src/moneybin/config.py` — add `asset_staleness_default_days` to `MoneyBinSettings`
 - `sqlmesh/models/core/agg_net_worth.sql` — extend to include asset valuations (created by net worth spec, modified here)

--- a/docs/specs/categorization-auto-rules.md
+++ b/docs/specs/categorization-auto-rules.md
@@ -34,7 +34,7 @@ This spec adds auto-rule generation — pillar E from the [categorization umbrel
 
 ### Proposal generation
 
-1. After any categorization event (`categorize_bulk` MCP tool or `moneybin categorize` CLI), the system checks each categorized transaction for a potential auto-rule proposal.
+1. After any categorization event (`transactions_categorize_bulk_apply` MCP tool or `moneybin categorize` CLI), the system checks each categorized transaction for a potential auto-rule proposal.
 2. A proposal is generated when no active rule or merchant mapping already covers the transaction's pattern AND no pending proposal for the same pattern exists (if a pending proposal exists, its `trigger_count` is incremented instead).
 3. The proposal threshold is configurable (`categorization.auto_rule_proposal_threshold`, default 1). A value of 1 means propose on first categorization; a value of 3 means propose after three matching categorizations.
 4. Pattern extraction uses the merchant-first strategy: canonical merchant name when a `merchant_id` exists, cleaned description otherwise.
@@ -138,7 +138,7 @@ The auto-rule engine hooks into the categorization service layer, which is share
 
 | Hook point | Trigger |
 |---|---|
-| `CategorizationService.bulk_categorize()` | Batch categorization via `categorize_bulk` MCP tool or `moneybin categorize` CLI |
+| `CategorizationService.bulk_categorize()` | Batch categorization via `transactions_categorize_bulk_apply` MCP tool or `moneybin categorize` CLI |
 
 **CLI parity:** CLI commands use the same service layer as MCP tools. Same code path, not a separate implementation.
 
@@ -158,12 +158,12 @@ The hook is lightweight: one SELECT each against rules, merchants, and proposals
 
 | Command | Description |
 |---|---|
-| `moneybin categorize auto review` | Table of pending proposals with sample transactions, trigger counts, and pattern details |
-| `moneybin categorize auto confirm --approve <id> [<id>...] --reject <id> [<id>...]` | Batch approve/reject proposals |
-| `moneybin categorize auto confirm --approve-all` | Approve all pending proposals |
-| `moneybin categorize auto confirm --reject-all` | Reject all pending proposals |
-| `moneybin categorize auto stats` | Auto-rule health: active count, proposal count, override rate, top-performing rules |
-| `moneybin categorize auto rules` | List active auto-rules (equivalent to `list-rules --created-by auto_rule`) |
+| `moneybin transactions categorize auto review` | Table of pending proposals with sample transactions, trigger counts, and pattern details |
+| `moneybin transactions categorize auto confirm --approve <id> [<id>...] --reject <id> [<id>...]` | Batch approve/reject proposals |
+| `moneybin transactions categorize auto confirm --approve-all` | Approve all pending proposals |
+| `moneybin transactions categorize auto confirm --reject-all` | Reject all pending proposals |
+| `moneybin transactions categorize auto stats` | Auto-rule health: active count, proposal count, override rate, top-performing rules |
+| `moneybin transactions categorize auto rules` | List active auto-rules (equivalent to `list-rules --created-by auto_rule`) |
 
 ### Import-time output
 
@@ -178,18 +178,18 @@ Imported 120 transactions from chase_checking.csv
      8 by ML (high confidence)
   35 uncategorized
   4 new rules proposed
-  Run 'moneybin categorize auto review' to review proposed rules
+  Run 'moneybin transactions categorize auto review' to review proposed rules
 ```
 
 ### Non-interactive parity
 
 | Interactive | Flag equivalent |
 |---|---|
-| Review table | `moneybin categorize auto review --output json` |
-| Approve specific | `moneybin categorize auto confirm --approve ar_001 ar_002` |
-| Reject specific | `moneybin categorize auto confirm --reject ar_003` |
-| Approve all | `moneybin categorize auto confirm --approve-all` |
-| Reject all | `moneybin categorize auto confirm --reject-all` |
+| Review table | `moneybin transactions categorize auto review --output json` |
+| Approve specific | `moneybin transactions categorize auto confirm --approve ar_001 ar_002` |
+| Reject specific | `moneybin transactions categorize auto confirm --reject ar_003` |
+| Approve all | `moneybin transactions categorize auto confirm --approve-all` |
+| Reject all | `moneybin transactions categorize auto confirm --reject-all` |
 
 ## MCP Interface
 
@@ -197,9 +197,9 @@ Imported 120 transactions from chase_checking.csv
 
 | Tool | Type | Description |
 |---|---|---|
-| `categorize_auto_review` | Read | List pending proposals with sample transactions, trigger counts, and pattern details |
-| `categorize_auto_confirm` | Write | Batch approve/reject proposals by ID. Approved proposals are promoted to active rules. |
-| `categorize_auto_stats` | Read | Auto-rule health: active count, proposal count, override rate, top-performing rules by match count |
+| `transactions_categorize_auto_review` | Read | List pending proposals with sample transactions, trigger counts, and pattern details |
+| `transactions_categorize_auto_confirm` | Write | Batch approve/reject proposals by ID. Approved proposals are promoted to active rules. |
+| `transactions_categorize_auto_stats` | Read | Auto-rule health: active count, proposal count, override rate, top-performing rules by match count |
 
 ### Prompt
 
@@ -256,7 +256,7 @@ Env var overrides:
 ### Integration tests
 
 - **End-to-end**: import -> bulk categorize -> verify proposals created -> approve -> re-import -> verify new transactions auto-categorized by the promoted rule
-- **Hook fires on all paths**: `categorize_bulk` MCP tool and CLI categorization both trigger proposal generation (same service layer)
+- **Hook fires on all paths**: `transactions_categorize_bulk_apply` MCP tool and CLI categorization both trigger proposal generation (same service layer)
 - **Immediate effect**: approve a proposal, verify existing uncategorized transactions matching the pattern are categorized immediately
 - **Priority hierarchy**: transaction categorized by user rule -> auto-rule hook does not propose (pattern already covered)
 - **Hook idempotency**: categorize same transaction twice -> no duplicate proposal
@@ -272,7 +272,7 @@ Env var overrides:
 
 - Existing rule engine (`app.categorization_rules`, rule evaluation logic)
 - Existing merchant normalization (`app.merchants`, canonical name resolution)
-- Existing categorization service layer (`CategorizationService.bulk_categorize()`, backing `categorize_bulk` MCP tool)
+- Existing categorization service layer (`CategorizationService.bulk_categorize()`, backing `transactions_categorize_bulk_apply` MCP tool)
 - Database migration system (`database-migration.md`) for `app.proposed_rules` table creation
 
 ## Out of Scope

--- a/docs/specs/categorization-overview.md
+++ b/docs/specs/categorization-overview.md
@@ -84,11 +84,11 @@ When a user categorizes a transaction, the system identifies the pattern and pro
 
 **Key design decisions** (full detail in [`categorization-auto-rules.md`](categorization-auto-rules.md)):
 
-- **Trigger:** After any categorization event (`categorize_bulk` or CLI categorization), for each categorized transaction, check whether an active rule or merchant mapping already covers the pattern. If not, create or reinforce a proposal.
+- **Trigger:** After any categorization event (`transactions_categorize_bulk_apply` or CLI categorization), for each categorized transaction, check whether an active rule or merchant mapping already covers the pattern. If not, create or reinforce a proposal.
 - **Pattern extraction:** Merchant-first — use the canonical merchant name when a `merchant_id` exists, fall back to `normalize_description()` cleanup otherwise. Reuses the existing description normalization code.
 - **Proposal lifecycle:** `pending` → `approved` (promoted to `app.categorization_rules` with `created_by='auto_rule'`, `priority=200`) or `rejected` or `superseded` (when the user corrects the category).
 - **Correction handling:** Single user overrides don't affect the rule. After `auto_rule_override_threshold` (default 2) overrides, the rule is deactivated and a new proposal is created with the corrected category.
-- **UX:** Proposals accumulate silently. `categorize_bulk` response includes a `rules_proposed` count and review hint. User reviews in batch via `categorize_auto_review` and `categorize_auto_confirm`. Approved rules take effect immediately against existing uncategorized transactions (synchronous promotion).
+- **UX:** Proposals accumulate silently. `transactions_categorize_bulk_apply` response includes a `rules_proposed` count and review hint. User reviews in batch via `transactions_categorize_auto_review` and `transactions_categorize_auto_confirm`. Approved rules take effect immediately against existing uncategorized transactions (synchronous promotion).
 - **Conflicting categorizations:** Amount/account-aware rule proposals are deferred to future enhancements (see Future Directions).
 
 ---
@@ -120,7 +120,7 @@ The v1 implementation uses TF-IDF (term frequency–inverse document frequency) 
 
 - **Minimum training samples:** configurable, default 50 categorized transactions.
 - **Features:** TF-IDF on normalized transaction description (v1). Amount as an optional second feature for experimentation.
-- **Retraining:** auto-retrains when statistically significant new categorizations exist (threshold relative to training set size, configurable via `categorization.ml_retrain_threshold`). `categorize_ml_train` remains as a manual escape hatch but is not part of the standard workflow.
+- **Retraining:** auto-retrains when statistically significant new categorizations exist (threshold relative to training set size, configurable via `categorization.ml_retrain_threshold`). `transactions_categorize_ml_train` remains as a manual escape hatch but is not part of the standard workflow.
 
 ### Model storage
 
@@ -170,13 +170,13 @@ User-facing surfaces (CLI, MCP responses) display **qualitative confidence tiers
 | Moderate | "moderate confidence" | Between `ml_review_threshold` and `ml_auto_apply_threshold` |
 | Low | "low confidence" | Below `ml_review_threshold` |
 
-`categorize_ml_status` and `detail=full` on transaction queries always expose the numeric score for power users. The qualitative tiers are the default presentation — they hide calibration noise while the model matures and communicate the system's certainty in terms that don't require ML background.
+`transactions_categorize_ml_status` and `detail=full` on transaction queries always expose the numeric score for power users. The qualitative tiers are the default presentation — they hide calibration noise while the model matures and communicate the system's certainty in terms that don't require ML background.
 
 ### Accuracy measurement
 
 Model accuracy is measured by K-fold cross-validation (default K=5) on the user's categorized transaction history. The reported accuracy represents how often the model correctly predicts the category for transactions it wasn't trained on. Accuracy improves as more categorized transactions accumulate.
 
-`categorize_ml_status` reports overall accuracy and a per-category breakdown with precision, recall, and support:
+`transactions_categorize_ml_status` reports overall accuracy and a per-category breakdown with precision, recall, and support:
 
 - **Precision** for a category = when the model predicts this category, how often is it correct? Low precision means false positives.
 - **Recall** for a category = of all transactions that actually belong to this category, how many did the model find? Low recall means missed predictions.
@@ -197,9 +197,9 @@ This gives the user actionable insight: "Shopping is noisy — maybe I should ad
 
 | Tool | Purpose |
 |---|---|
-| `categorize_ml_status` | Model health: trained/untrained, sample count, accuracy, per-category precision/recall/support, confidence distribution |
-| `categorize_ml_train` | Trigger training or retraining, returns accuracy metrics |
-| `categorize_ml_apply` | Run predictions manually with configurable threshold and dry-run mode |
+| `transactions_categorize_ml_status` | Model health: trained/untrained, sample count, accuracy, per-category precision/recall/support, confidence distribution |
+| `transactions_categorize_ml_train` | Trigger training or retraining, returns accuracy metrics |
+| `transactions_categorize_ml_apply` | Run predictions manually with configurable threshold and dry-run mode |
 
 ---
 
@@ -258,7 +258,7 @@ Every categorization is traceable to its origin. No black boxes.
 
 ### System-level statistics
 
-`categorize_stats` extended with auto-rule and ML breakdowns:
+`transactions_categorize_stats` extended with auto-rule and ML breakdowns:
 
 - Total/categorized/uncategorized counts with percentage
 - Breakdown by `categorized_by` source
@@ -402,7 +402,7 @@ Not pillars, not designed in detail. Architectural constraints noted so the curr
 
 Decisions made during spec review, preserved for context.
 
-- **ML retraining trigger.** Auto-retrain when statistically significant new categorizations exist. The ML prediction step checks whether retraining is warranted before running predictions. Threshold is relative to training set size and configurable via `categorization.ml_retrain_threshold`. `categorize_ml_train` remains as a manual escape hatch but is not part of the standard workflow. The import summary notes when retraining occurred. The system should feel like it's learning from the user — "accuracy over automation" does not override the "system learns" commitment.
+- **ML retraining trigger.** Auto-retrain when statistically significant new categorizations exist. The ML prediction step checks whether retraining is warranted before running predictions. Threshold is relative to training set size and configurable via `categorization.ml_retrain_threshold`. `transactions_categorize_ml_train` remains as a manual escape hatch but is not part of the standard workflow. The import summary notes when retraining occurred. The system should feel like it's learning from the user — "accuracy over automation" does not override the "system learns" commitment.
 - **Auto-rule deduplication.** Both proposals survive independently; user decides during review. See `categorization-auto-rules.md` Deduplication table and Out of Scope section. Intelligent merging of overlapping patterns is a future enhancement.
 - **ML confidence calibration.** Always use Platt scaling (`CalibratedClassifierCV`). Raw SVM distances are not meaningful as thresholds. Calibrated probabilities are noisier on small datasets but still more useful than uncalibrated scores. Progressive confidence disclosure (qualitative tiers instead of numeric scores) hides calibration noise from users until the model matures. See Confidence Calibration and Progressive Confidence Disclosure sections under Pillar D.
 - **Interaction with Smart Import pillar F.** ML training weights are determined by `categorized_by`, not `source_type`. No interaction. A transaction's label quality depends on who categorized it (user, rule, AI), not how the transaction entered the system (CSV, Plaid, AI-parsed PDF). If AI-parsed transactions have unreliable descriptions, that's a pillar F quality concern at parse time, not a training weight concern.

--- a/docs/specs/categorize-bulk.md
+++ b/docs/specs/categorize-bulk.md
@@ -5,20 +5,20 @@ implemented
 
 ## Goal
 
-Add a `moneybin categorize bulk` CLI command that mirrors the existing `categorize_bulk` MCP tool, and eliminate per-item duplicate DB lookups inside `CategorizationService.bulk_categorize` by threading a shared `BulkRecordingContext` through `AutoRuleService.record_categorization`. Tighten the bulk-categorize input contract by replacing untyped dicts with a shared Pydantic model validated at every boundary.
+Add a `moneybin transactions categorize bulk` CLI command that mirrors the existing `transactions_categorize_bulk_apply` MCP tool, and eliminate per-item duplicate DB lookups inside `CategorizationService.bulk_categorize` by threading a shared `BulkRecordingContext` through `AutoRuleService.record_categorization`. Tighten the bulk-categorize input contract by replacing untyped dicts with a shared Pydantic model validated at every boundary.
 
 ## Background
 
-- `mcp-architecture.md` §5 (CLI Symmetry) requires every MCP tool to have a CLI equivalent. `categorize_bulk` is the largest remaining gap.
+- `mcp-architecture.md` §5 (CLI Symmetry) requires every MCP tool to have a CLI equivalent. `transactions_categorize_bulk_apply` is the largest remaining gap.
 - `private/followups.md` items: "No `categorize bulk` CLI command", "Cache active-rule patterns and merchant pairs across `bulk_categorize` loop", "Avoid duplicate description SELECT in `bulk_categorize`".
 - Auto-rule learning is *triggered* by `bulk_categorize`. Without a CLI surface, there is no honest end-to-end CLI path through the auto-rule pipeline. `tests/e2e/test_e2e_workflows.py::TestAutoRulePipeline::test_import_then_promote_proposal` currently seeds `app.proposed_rules` via raw `db query` SQL as a workaround.
 - Today's hot path: `AutoRuleService.record_categorization` runs ~5 DB queries per item (description SELECT, rule-engine evaluation queries, merchants table SELECT) — many of which duplicate state the bulk loop already fetched.
 
 ## Requirements
 
-1. New CLI command `moneybin categorize bulk` accepts a JSON array of categorization items from a file (`--input <path>`) or stdin (sentinel `-`), with `--output {table,json}` mirroring sibling commands.
+1. New CLI command `moneybin transactions categorize bulk` accepts a JSON array of categorization items from a file (`--input <path>`) or stdin (sentinel `-`), with `--output {table,json}` mirroring sibling commands.
 2. `CategorizationService.bulk_categorize` requires `Sequence[BulkCategorizationItem]` (Pydantic model). No untyped-dict input path.
-3. The Pydantic model is shared between the CLI command and the `categorize_bulk` MCP tool. Both surfaces validate per-item, accumulate validation failures into the existing `BulkCategorizationResult.error_details`, and never short-circuit a partially-valid batch.
+3. The Pydantic model is shared between the CLI command and the `transactions_categorize_bulk_apply` MCP tool. Both surfaces validate per-item, accumulate validation failures into the existing `BulkCategorizationResult.error_details`, and never short-circuit a partially-valid batch.
 4. CLI exit code is `1` when any item failed to apply (`errors > 0` or `skipped > 0`), `0` otherwise.
 5. `bulk_categorize` builds one `BulkRecordingContext` (txn-row map with `description`/`amount`/`account_id`, active-rule rows, merchant rows) before the per-item loop and threads it into every `record_categorization` call. Context owns merchant-cache invalidation when the loop creates a new merchant.
 6. `AutoRuleService.record_categorization` accepts an optional `context: BulkRecordingContext | None`. When provided, helpers consult the context instead of issuing DB queries. When `None`, behavior is unchanged for non-bulk callers.
@@ -66,7 +66,7 @@ No schema changes. New in-memory types only:
 - `tests/moneybin/test_categorization_service.py`, `tests/moneybin/test_auto_rule_service.py`
   - Migrate dict-based bulk tests to construct `BulkCategorizationItem`. Add coverage for context-routed paths and assertions that DB queries are not issued when the context is provided.
 - `docs/specs/INDEX.md` — add this spec under Categorization.
-- `docs/specs/mcp-architecture.md` §5 — note that `categorize_bulk` now has CLI parity.
+- `docs/specs/mcp-architecture.md` §5 — note that `transactions_categorize_bulk_apply` now has CLI parity.
 - `private/followups.md` — remove the three resolved items.
 - `README.md` — per `.claude/rules/shipping.md`: update CLI section / categorization roadmap.
 
@@ -82,13 +82,13 @@ No schema changes. New in-memory types only:
 
 ```bash
 # From a JSON file
-moneybin categorize bulk --input categorizations.json
+moneybin transactions categorize bulk --input categorizations.json
 
 # From stdin (pipe-friendly)
-cat categorizations.json | moneybin categorize bulk -
+cat categorizations.json | moneybin transactions categorize bulk -
 
 # JSON output for scripts
-moneybin categorize bulk --input cats.json --output json
+moneybin transactions categorize bulk --input cats.json --output json
 ```
 
 Input format (bare JSON array):
@@ -114,7 +114,7 @@ Exit code: `0` if every item applied cleanly, `1` if any item failed parse, vali
 
 ## MCP Interface
 
-`categorize_bulk` tool — no signature change at the protocol level. Internally:
+`transactions_categorize_bulk_apply` tool — no signature change at the protocol level. Internally:
 
 - Same `_validate_items()` helper as the CLI; validation failures accumulate to `error_details`.
 - Result envelope unchanged: `{summary, data, actions}` with the existing `BulkCategorizationResult` fields under `data`.

--- a/docs/specs/cli-restructure.md
+++ b/docs/specs/cli-restructure.md
@@ -2,11 +2,13 @@
 
 ## Status
 <!-- draft | ready | in-progress | implemented -->
-implemented
+ready
+
+> **v2 revision (2026-05-02):** v1 of this spec is implemented. v2 (status: `ready`) supersedes the taxonomy decisions (dissolves the `track` group, introduces entity groups `accounts` and `transactions`, adds top-level `categories`, `merchants`, `assets`, `reports`, `system`, separates `tax`, unifies the rule across CLI / MCP / future HTTP). Profile system, pipeline orchestration, and infrastructure command groups are unchanged. Implementation pass moves status `ready` → `in-progress`. See [Revision History](#revision-history) and [Migration v1 → v2](#migration-v1--v2).
 
 ## Goal
 
-Redesign MoneyBin's CLI command tree to reflect the product's matured architecture: profiles as first-class entities, `import` as the magical golden path, domain commands (`matches`, `categorize`, `track`) as top-level citizens, and a structure that every future spec can reference for "where does my CLI surface go?"
+Define a single command taxonomy that holds across MoneyBin's three primary interfaces (CLI, MCP, future HTTP). Specifically: profiles as first-class entities, `import` as the magical golden path, **entity groups** (`accounts`, `transactions`) that own their per-instance workflows and aggregations, a **reports** group for cross-cutting analytical views, and infrastructure commands as top-level peers. Every future spec references this document for "where does my surface go?" — and the answer is the same shape regardless of which interface is being designed.
 
 ## Background
 
@@ -27,7 +29,7 @@ Related specs and docs:
 - [`sync-overview.md`](sync-overview.md) — `sync` subcommands
 - [`matching-same-record-dedup.md`](matching-same-record-dedup.md) / [`matching-transfer-detection.md`](matching-transfer-detection.md) — `matches` commands
 - [`categorization-auto-rules.md`](categorization-auto-rules.md) — `categorize auto-*` commands
-- [`net-worth.md`](net-worth.md) — `track balance/networth` commands (updated from original `balance`/`reconciliation`/`networth` top-level placement)
+- [`net-worth.md`](net-worth.md) — `accounts balance` / `accounts networth` commands (v2)
 - [`observability.md`](observability.md) — `logs` and `stats` commands
 - [`database-migration.md`](database-migration.md) — `db migrate` commands
 - [`mcp-architecture.md`](mcp-architecture.md) / [`mcp-tool-surface.md`](mcp-tool-surface.md) — MCP tool/prompt enumeration
@@ -48,9 +50,21 @@ The global `--profile` flag provides ephemeral override without changing the def
 
 Individual commands (`matches run`, `categorize apply-rules`, `transform apply`) exist for configuration, troubleshooting, and power-user control — not as steps in a manual pipeline.
 
-### Domain commands are top-level
+### Entity groups own their workflows and aggregations
 
-Major feature domains that have user-facing review workflows and will grow across multiple specs deserve top-level placement: `matches`, `categorize`, `track`. Infrastructure commands (`db`, `transform`, `mcp`) are also top-level but are used less frequently.
+Top-level groups represent **entities** (`accounts`, `transactions`) or **cross-cutting concerns** (`reports`, `import`, `sync`, `export`, infrastructure). Per-instance workflows and aggregations live *under* their entity, not as siblings. This applies uniformly across CLI, MCP, and HTTP.
+
+Concretely:
+
+- `accounts` owns its per-account workflows (`balance`) and its aggregation (`networth`)
+- `transactions` owns its per-transaction workflows (`matches`, `categorize`) and entity ops (`list`, `show`, `search`)
+- `reports` holds analytical lenses on transaction-level data (spending, cashflow, tax, budget vs actual) — cross-cutting, read-only
+
+The rule replaces v1's "domain commands are top-level" principle, which produced a flat surface (`matches`, `categorize`, `track`) that hid the entity hierarchy and forced unrelated things (balance, budget, recurring) into one bucket.
+
+### Sub-group naming
+
+Sub-group names are the natural English name for the workflow or concept. Usually a noun (`balance`, `networth`, `matches`); a verb-form is fine when it names the workflow more clearly than the equivalent noun (`categorize` rather than `categorization`). Action verbs at the leaf are always imperative single-word: `list`, `show`, `assert`, `accept`, `reject`, `apply`, `delete`.
 
 ### Universal flags
 
@@ -109,50 +123,88 @@ moneybin [--profile NAME] [--verbose] [--output json|table] [--yes]
 |   |   +-- remove                 -- Uninstall scheduled job
 |   +-- rotate-key                 -- Rotate E2E encryption key pair
 |
-+-- matches
-|   +-- run [--type transfer|dedup] -- Run matcher + SQLMesh
-|   +-- review                     -- Interactive: accept/reject/skip/quit
-|   |     [--type transfer|dedup]    Filter by match type
-|   |     [--accept <match_id>]      Non-interactive: accept specific
-|   |     [--reject <match_id>]      Non-interactive: reject specific
-|   |     [--accept-all]             Non-interactive: accept all pending
-|   +-- log                        -- Show recent match decisions
-|   |     [--type transfer|dedup]    Filter by type
-|   |     [--status rejected]        Filter by status
-|   |     [--debug]                  Show below-threshold pairs
-|   +-- undo <match_id>            -- Reverse a match decision
-|   +-- backfill                   -- One-time scan of all existing transactions
-|
-+-- categorize
-|   +-- apply-rules                -- Run all rules against uncategorized txns
-|   +-- seed                       -- Initialize default categories
-|   +-- stats                      -- Coverage statistics
-|   +-- list-rules                 -- List all active rules (manual + auto)
-|   +-- auto-review                -- Table of pending proposals
-|   +-- auto-confirm               -- Act on proposals
-|   |     [--approve <id> ...]       Approve specific
-|   |     [--reject <id> ...]        Reject specific
-|   |     [--approve-all]            Approve all pending
-|   |     [--reject-all]             Reject all pending
-|   +-- auto-stats                 -- Auto-rule health metrics
-|   +-- auto-rules                 -- List active auto-generated rules
-|
-+-- track
-|   +-- balance
++-- accounts
+|   +-- list                       -- List accounts
+|   +-- show <account_id>          -- Show one account
+|   +-- rename <account_id> <name> -- Rename an account
+|   +-- include <account_id>       -- Toggle include_in_net_worth [--no]
+|   +-- balance                    -- Per-account balance workflow (net-worth.md)
 |   |   +-- show [--account ID] [--as-of DATE]
 |   |   +-- assert <account_id> <date> <amount> [--notes] [--yes]
 |   |   +-- list [--account ID]
 |   |   +-- delete <account_id> <date> [--yes]
 |   |   +-- reconcile [--account ID] [--threshold AMOUNT]
 |   |   +-- history [--from DATE] [--to DATE] [--interval]
-|   +-- networth
+|   +-- investments                -- (future spec, gated on investment-tracking.md)
+|
++-- assets                         -- (future spec) Physical assets (real estate, vehicles, valuables)
+|                                     Workflows defined in asset-tracking.md.
+|                                     Contributes to reports networth alongside accounts.
+|
++-- transactions
+|   +-- list                       -- List transactions [--account ID] [--from] [--to]
+|   +-- show <txn_id>              -- Show one transaction
+|   +-- search <query>             -- Full-text / structured search
+|   +-- review                     -- Unified review queue (matches + categorize)
+|   |     [--type matches|categorize|all]   Default all; walks matches first then categorize
+|   |     [--status]                        Counts only, no interactive loop
+|   |     [--confirm <id>]                  Non-interactive: confirm one (auto-detects type by ID)
+|   |     [--reject <id>]                   Non-interactive: reject one
+|   |     [--confirm-all]                   Non-interactive: confirm all in scope
+|   |     [--limit N]                       Cap items per session
+|   +-- matches                    -- Transfer detection + dedup workflow (no review — see transactions review)
+|   |   +-- run [--type transfer|dedup]
+|   |   +-- log [--type] [--status] [--debug]
+|   |   +-- undo <match_id>
+|   |   +-- backfill
+|   +-- categorize                 -- Categorization workflow + rules (taxonomy/merchants live in top-level groups; review lives at transactions review)
+|   |   +-- bulk <category_id> --txn-ids ...
+|   |   +-- stats                  -- Coverage metrics
+|   |   +-- rules                  -- Rule management (list, create, apply, delete)
+|   |   |   +-- list
+|   |   |   +-- create <pattern> <category_id>
+|   |   |   +-- apply               -- Run rules against uncategorized
+|   |   |   +-- delete <rule_id>
+|   |   +-- auto                    -- Auto-rule proposals workflow
+|   |   |   +-- review
+|   |   |   +-- confirm [--approve ID ...] [--reject ID ...] [--approve-all] [--reject-all]
+|   |   |   +-- stats
+|   |   +-- ml                      -- ML-assisted categorization
+|   |       +-- status
+|   |       +-- train
+|   |       +-- apply
+|   +-- recurring                  -- (future spec) Recurring transaction detection
+|
++-- categories                     -- Category taxonomy (reference data)
+|   +-- list
+|   +-- create <name> [--parent] [--icon]
+|   +-- toggle <category_id>       -- Enable / disable
+|   +-- delete <category_id>
+|
++-- merchants                      -- Merchant mappings (reference data)
+|   +-- list
+|   +-- create <pattern> <canonical_name> [--default-category]
+|
++-- reports                        -- Cross-domain analytical and aggregation views (read-only)
+|   +-- networth                   -- Cross-domain net worth aggregation (accounts + assets)
 |   |   +-- show [--as-of DATE]
 |   |   +-- history [--from DATE] [--to DATE] [--interval]
-|   +-- budget                     -- (CLI TBD when budget-tracking spec matures)
-|   +-- recurring                  -- (future spec)
-|   +-- investments                -- (future spec)
+|   +-- spending                   -- (future spec)
+|   +-- cashflow                   -- (future spec)
+|   +-- budget                     -- (future spec) Budget vs actual report
+|   +-- health                     -- Cross-domain financial snapshot (was overview health)
 |
-+-- export                         -- (future spec)
++-- tax                            -- Tax domain (forms, deductions, capital gains, estimates)
+|   +-- w2 <year>                  -- W-2 form data
+|   +-- deductions <year>          -- Categorized deductible expenses
+|                                     Future: 1099, capital_gains, estimate, carryforward
+|
++-- system                         -- System / data status meta-view
+|   +-- status                     -- What data exists, freshness, pending review queues
+|
++-- budget                         -- (future spec) Budget target management (mutation)
+|
++-- export                         -- (future spec) Export to CSV / Excel / Sheets
 |
 +-- logs
 |   +-- clean --older-than <duration> [--dry-run]
@@ -199,17 +251,71 @@ moneybin [--profile NAME] [--verbose] [--output json|table] [--yes]
 ### Mental model
 
 ```
+Entity groups:  accounts (+ balance), transactions (+ matches, categorize), assets
+Reference data: categories, merchants (taxonomies that transactions reference)
+Reports:        reports (networth, spending, cashflow, financial health, budget vs actual — cross-domain read-only)
+Tax:            tax (forms, deductions, future capital gains)
+System:         system (data status meta-view)
 Data in:        import, sync
-Data quality:   matches, categorize
-Tracking:       track (balance, networth, budget, recurring, investments)
 Data out:       export
+Mutation:       budget (target management; vs-actual report lives under reports/budget)
 Operational:    logs, stats
 Infrastructure: profile, db, mcp, transform
 ```
 
-### Top-level command count: 12
+### Top-level command count: 18
 
-`profile`, `import`, `sync`, `matches`, `categorize`, `track`, `export`, `logs`, `stats`, `db`, `mcp`, `transform`
+`profile`, `import`, `sync`, `accounts`, `transactions`, `assets`, `categories`, `merchants`, `reports`, `tax`, `system`, `budget`, `export`, `logs`, `stats`, `db`, `mcp`, `transform`
+
+## Cross-Interface Taxonomy
+
+The same hierarchy expresses across CLI, MCP, and (future) HTTP. Each protocol encodes the hierarchy in its native idiom; the noun ordering is identical, only the verb position and separators differ.
+
+### The unified rule
+
+> Hierarchy is the entity path. Verb is the leaf action. Aggregations live with their entity. Workflows live with the entity they operate on. Reports are cross-cutting analytical views.
+
+### Encoding per protocol
+
+| Protocol | Hierarchy | Verb position | Example |
+|---|---|---|---|
+| CLI | space-separated path | trailing word | `accounts balance assert <id> <date> <amt>` |
+| MCP | underscore prefix | trailing token | `accounts_balance_assert` |
+| HTTP | URL path | HTTP method + sub-path for non-CRUD | `POST /accounts/{id}/balances` |
+
+### Naming examples
+
+| Concept | CLI | MCP | HTTP |
+|---|---|---|---|
+| List accounts | `accounts list` | `accounts_list` | `GET /accounts` |
+| Show one account | `accounts show <id>` | `accounts_get` | `GET /accounts/{id}` |
+| Show current balances | `accounts balance show` | `accounts_balance_list` | `GET /accounts/balances` |
+| Assert a balance | `accounts balance assert ...` | `accounts_balance_assert` | `POST /accounts/{id}/balances` |
+| Balance history | `accounts balance history` | `accounts_balance_history` | `GET /accounts/{id}/balances/history` |
+| Net worth now | `accounts networth show` | `accounts_networth_get` | `GET /accounts/networth` |
+| List matches | `transactions matches list` | `transactions_matches_list` | `GET /transactions/matches` |
+| Confirm a match | `transactions matches confirm <id>` | `transactions_matches_confirm` | `POST /transactions/matches/{id}/confirm` |
+| Spending report | `reports spending` | `reports_spending_get` | `GET /reports/spending` |
+
+### Pluralization
+
+Pluralization is the one place clean symmetry breaks down — each protocol uses its own idiom:
+
+| Protocol | Convention |
+|---|---|
+| CLI | Top-level groups plural (`accounts`, `transactions`, `reports`); sub-resource nouns named for the *concept* (singular for types: `balance`, `networth`; plural for relationship collections: `matches`); verbs always singular |
+| MCP | Mirrors CLI exactly (just swap spaces for underscores) |
+| HTTP | Standard REST: plural for collections (`/accounts/{id}/balances`), singular for single instances (`/accounts/{id}/balances/{date}`) |
+
+The structural symmetry (entity → sub-resource → action ordering) holds across all three. The asymmetry — `balance` (CLI/MCP) vs `balances` (REST sub-resource) — is documented and intentional. REST readers expect plural collection paths; CLI/MCP readers don't.
+
+### Why this rule
+
+Three justifications:
+
+1. **Learn-once-use-everywhere.** A user who knows `accounts balance list` already knows `accounts_balance_list` and `GET /accounts/balances`. Web UI navigation maps the same way. One mental model across four surfaces.
+2. **Discoverability scales with catalog.** As MoneyBin's MCP catalog grows beyond ~30 tools, prefix-clustered names (`accounts_balance_*`, `transactions_matches_*`) sort related operations together in `mcp list-tools` output, helping both humans and LLMs scan the surface.
+3. **Future HTTP is a free win.** When MoneyBin adds an HTTP layer (web UI backend, third-party integrations), the URL paths are already designed.
 
 ## Profile System
 
@@ -362,7 +468,52 @@ Interactive mode (no `--client` flag) prompts the user to select a client and pr
 
 Scope: generate and install only. Does not edit or remove existing entries — that's the user's responsibility.
 
-## Migration Table
+## Migration v1 → v2
+
+This is a hard cut. No aliases, no deprecation period. v1 paths break in the same release that ships v2. MoneyBin is pre-1.0 single-user; the cost of clean is small and one-time.
+
+### CLI moves
+
+| v1 path | v2 path | Notes |
+|---|---|---|
+| `track balance show` | `accounts balance show` | Same surface, new parent |
+| `track balance assert` | `accounts balance assert` | |
+| `track balance list` | `accounts balance list` | |
+| `track balance delete` | `accounts balance delete` | |
+| `track balance reconcile` | `accounts balance reconcile` | |
+| `track balance history` | `accounts balance history` | |
+| `track networth show` | `reports networth show` | Cross-domain rollup (accounts + assets) — moved out of `accounts` to honor that it aggregates more than accounts |
+| `track networth history` | `reports networth history` | |
+| `track budget *` | `budget *` | Top-level (mutation); reports → `reports budget` |
+| `track recurring *` | `transactions recurring *` | Pattern detection on transactions |
+| `track investments *` | `accounts investments *` | Holdings as account-typed entity |
+| `matches *` | `transactions matches *` | Workflow on transactions |
+| `categorize *` (workflow + rules + auto + ml) | `transactions categorize *` | Workflow on transactions |
+| `categorize categories / create-category / toggle-category` | `categories list / create / toggle / delete` | Reference-data taxonomy → top-level entity group |
+| `categorize merchants / create-merchants` | `merchants list / create` | Reference-data taxonomy → top-level entity group |
+| (none) | `accounts list / show / rename / include` | New entity ops |
+| (none) | `transactions list / show / search` | New entity ops |
+| (none) | `reports {spending, cashflow, tax, budget}` | New analytical group (subcommands future) |
+
+The `track` group is dissolved entirely.
+
+### MCP renames
+
+MCP tool names migrate to the path-prefix-verb-suffix convention. As with CLI, hard cut: rename in place, update tool registry, update any client configs that reference old names.
+
+| v1 tool name | v2 tool name |
+|---|---|
+| `get_net_worth` | `accounts_networth_get` |
+| `get_net_worth_history` | `accounts_networth_history` |
+| `get_balances` | `accounts_balance_list` |
+| `get_balance_assertions` | `accounts_balance_assertions_list` |
+| (existing transaction tools) | `transactions_*` prefix |
+| (existing match tools) | `transactions_matches_*` prefix |
+| (existing categorize tools) | `transactions_categorize_*` prefix |
+
+Specific existing-tool renames are enumerated in `mcp-tool-surface.md` as part of v2 implementation.
+
+## Migration Table (v0 → v1, historical)
 
 ### Removed commands
 
@@ -399,7 +550,42 @@ The `config` and `data` command groups are fully dissolved. `config` is replaced
 
 ## Implementation Phasing
 
-### Phase 1: Implement now (this spec)
+### v2 implementation pass (current)
+
+Restructure-only. Move and rename existing commands to the new tree; rename MCP tools to the new convention. **No new functionality** — that stays with the owning specs.
+
+| Change | Scope |
+|---|---|
+| Create `accounts` group with `list`, `show`, `rename`, `include` (thin entity ops) | New CLI module |
+| Move `track balance` → `accounts balance` (preserve subcommands as stubs where they were) | Rename + reparent |
+| Move `track networth` → `reports networth` (preserve subcommands as stubs) | Rename + reparent into reports group |
+| Add top-level `assets` group (placeholder; workflows owned by `asset-tracking.md`) | New CLI module, all stubs |
+| Keep `tax` top-level (not nested in `reports`) | Stub initially; tools added by `tax-*.md` specs |
+| Create `transactions` group with `list`, `show`, `search` (thin entity ops) | New CLI module |
+| Move `matches` → `transactions matches` (existing functionality preserved) | Reparent + update tests |
+| Move `categorize` → `transactions categorize` (workflow tools + rules + auto + ml) | Reparent + update tests |
+| Pull `categorize categories *` and `categorize create-category` / `categorize toggle-category` → top-level `categories` group | Promote to entity group |
+| Pull `categorize merchants *` and `categorize create-merchants` → top-level `merchants` group | Promote to entity group |
+| Move `track budget` → `budget` (top-level, still stub) | Rename + flatten |
+| Move `track recurring` → `transactions recurring` (still stub) | Reparent |
+| Move `track investments` → `accounts investments` (still stub) | Reparent |
+| Dissolve `track` group | Delete CLI module |
+| Add `reports` group with stubbed subcommands (`spending`, `cashflow`, `tax`, `budget`) | New CLI module, all stubs |
+| Rename MCP tools to path-prefix-verb-suffix convention | Update tool registry, regenerate client configs |
+| Collapse `transactions matches review` and `transactions categorize review` into unified `transactions review` (CLI). Add MCP `transactions_review_status` orientation tool | New CLI command + new MCP tool |
+| Rename `import_csv_preview` → `import_file_preview` (format-agnostic) | MCP tool rename + service method rename |
+| Expose `sync_*` to MCP (all except `sync_rotate_key`) — login, logout, connect, disconnect, pull, status, schedule_set/show/remove | New MCP tools wrapping existing CLI sync surface |
+| Expose `transform_*` to MCP (all except `transform_restate`) — status, plan, validate, audit, apply | New MCP tools wrapping existing CLI transform surface |
+| Update `mcp-tool-surface.md` with new names + new MCP exposures | Doc edit |
+| Update specs that reference v1 CLI paths | Doc edits across specs (see [Specs Requiring CLI Section Updates](#specs-requiring-cli-section-updates)) |
+
+Hard cut. v1 paths break in the same release. Tests, scripts, docs, and `mcp config generate` output all update together.
+
+### v1 phasing (historical, completed)
+
+The following phases describe the original v1 implementation (completed 2026-04-20). Retained for reference; the v2 implementation pass above supersedes Phase 2/3 entries that touched `track`, `matches`, `categorize`.
+
+#### Phase 1 (v1, historical)
 
 Structural changes, profile system, and thin wrappers around existing tools.
 
@@ -423,7 +609,7 @@ Structural changes, profile system, and thin wrappers around existing tools.
 | `transform restate` | Thin wrapper: `sqlmesh restate` (with confirmation) |
 | `logs clean` / `logs path` / `logs tail` | File system operations on log directory |
 
-### Phase 2: Stub now ("not implemented" message)
+#### Phase 2 (v1, historical) — Stub now ("not implemented" message)
 
 Reserve the namespace. Users see the command in `--help` but get a clear message directing them to the relevant spec or future release.
 
@@ -439,7 +625,7 @@ Reserve the namespace. Users see the command in `--help` but get a clear message
 | `stats` | `observability.md` (depends on metrics tables) |
 | `db migrate` | `database-migration.md` |
 
-### Phase 3: Defer to owning spec
+#### Phase 3 (v1, historical) — Defer to owning spec
 
 These commands are fully implemented when their owning spec is implemented. The owning spec should reference this document for command placement and flag conventions.
 
@@ -460,15 +646,20 @@ These commands are fully implemented when their owning spec is implemented. The 
 
 ## Specs Requiring CLI Section Updates
 
-These existing specs define CLI commands that should be updated to reflect the new command tree structure established by this spec:
+These existing specs define CLI commands that need updates to reflect v2's taxonomy:
 
-| Spec | CLI change needed |
-|---|---|
-| `net-worth.md` | Move `balance`, `reconciliation`, `networth` from top-level to `track balance` and `track networth`. `reconciliation show` becomes `track balance reconcile`. |
-| `observability.md` | No structural change needed — `logs` and `stats` are already top-level. Verify command signatures match. |
-| `privacy-data-protection.md` | `db lock`/`unlock`/`rotate-key` already match. Add `db ps`/`db kill` references. |
-| `database-migration.md` | Verify `db migrate apply/status` matches (currently specced as `data migrate apply/status`). |
-| `budget-tracking.md` | Update CLI to `track budget *` when spec is rewritten. |
+| Spec | CLI change needed (v2) | MCP change needed (v2) |
+|---|---|---|
+| `net-worth.md` | `track balance` → `accounts balance`. `track networth` → `reports networth` (cross-domain rollup, accounts + assets). `reconciliation show` → `accounts balance reconcile`. | `get_balances` → `accounts_balance_list`, etc. `get_net_worth` → `reports_networth_get`. |
+| `asset-tracking.md` | CLI namespace: top-level `assets` group (parallel to `accounts`). Net worth contribution flows through `core.agg_net_worth` consumed by `reports networth`. | Asset MCP tools take `assets_*` prefix (path-prefix-verb-suffix per v2). |
+| `account-management.md` (planned) | Owns the `accounts` namespace entity ops (`list`, `show`, `rename`, `archive`, `include`). Balance subcommands stay nested per `net-worth.md`. Drafted as a separate spec to give per-account configuration, merging, and archival their own design space. | Owns `accounts_list`, `accounts_get`, `accounts_rename`, `accounts_archive`, `accounts_include`. |
+| `matching-same-record-dedup.md` / `matching-transfer-detection.md` | `matches *` → `transactions matches *` | Match-related tools take `transactions_matches_*` prefix |
+| `categorization-overview.md` / `categorization-auto-rules.md` / `categorize-bulk.md` | `categorize *` workflow → `transactions categorize *`. Pull category-taxonomy and merchant-mapping commands to top-level `categories *` and `merchants *` groups | Categorize workflow tools take `transactions_categorize_*` prefix; category and merchant CRUD become `categories_*` / `merchants_*` top-level |
+| `budget-tracking.md` | `track budget *` → `budget *`; budget-vs-actual report goes under `reports budget` | When MCP tools are added, follow new naming |
+| `mcp-tool-surface.md` | n/a | Adopt path-prefix-verb-suffix convention; enumerate all existing tool renames |
+| `observability.md` | No structural change. Verify command signatures match. | n/a |
+| `privacy-data-protection.md` | `db lock`/`unlock`/`rotate-key` already match. | n/a |
+| `database-migration.md` | Verify `db migrate apply/status` matches. | n/a |
 
 ## Future Specs to Add
 
@@ -531,3 +722,12 @@ These were identified during design and should be added to the spec index:
 - **MCP UX standards** (tool naming, error surfaces, prompt design). Deferred to `mcp-ux-standards.md`.
 - **`stats` implementation.** Depends on `observability.md` metrics tables. Stubbed only.
 - **`db migrate` implementation.** Depends on `database-migration.md` migration framework. Stubbed only.
+- **MCP and HTTP UX standards.** Naming and hierarchy are settled here. Tool-level error surfaces, prompt design, response envelopes, content negotiation, auth, and rate limiting belong in `mcp-tool-surface.md`, `mcp-ux-standards.md`, and a future `http-api.md`. v2 only mandates the naming convention.
+- **Future HTTP layer.** No HTTP server is built or designed in v2. The cross-interface taxonomy reserves the URL paths and naming so future HTTP work inherits a coherent surface.
+
+## Revision History
+
+| Date | Version | Summary |
+|---|---|---|
+| 2026-05-02 | v2 | Dissolved `track`; introduced entity groups (`accounts`, `transactions`); added `reports` group; unified taxonomy across CLI / MCP / future HTTP; renamed MCP tools to path-prefix-verb-suffix convention. Hard cut, no aliases. |
+| 2026-04-20 (orig) | v1 | Initial restructure: profile system, dissolved `config`/`data`, top-level `matches`/`categorize`/`track`. Implemented. |

--- a/docs/specs/data-reconciliation.md
+++ b/docs/specs/data-reconciliation.md
@@ -142,7 +142,7 @@ moneybin reconciliation check --layer import [--import-id UUID]
 ```
 - Filter to a specific import batch
 
-The financial balance reconciliation command (`moneybin reconciliation show`) is defined in [`net-worth.md`](net-worth.md) and covers the institution-balance-vs-transactions concern. Both commands live under the same `reconciliation` group.
+The financial balance reconciliation command (`moneybin accounts balance reconcile`) is defined in [`net-worth.md`](net-worth.md) and covers the institution-balance-vs-transactions concern. The financial reconciliation lives under `accounts balance reconcile` (per `net-worth.md` v2 + `cli-restructure.md` v2).
 
 ## MCP Interface
 

--- a/docs/specs/mcp-architecture.md
+++ b/docs/specs/mcp-architecture.md
@@ -476,7 +476,7 @@ The `categorize_bulk` MCP tool has CLI parity via `moneybin categorize bulk`. Bo
 ### What symmetry does NOT mean
 
 - **Not identical UX.** The CLI uses tables, progress bars, and icons. MCP returns structured data. Same data, different presentation.
-- **Not identical invocation.** `moneybin spending summary --months 3` vs `spending_summary(months=3)`. The CLI uses Typer's conventions; MCP uses tool-call conventions.
+- **Not identical invocation.** `moneybin reports spending summary --months 3` vs `reports_spending_summary(months=3)`. The CLI uses Typer's conventions; MCP uses tool-call conventions.
 - **Not a generated surface.** The CLI is hand-crafted for human ergonomics. It's not auto-generated from MCP tool schemas. Both surfaces are independently authored but share the service layer.
 
 ### CLI command structure
@@ -537,7 +537,7 @@ Both surfaces carry enough metadata for AI tools (Claude Code, Codex) to use the
 - **Structured output flag** — `--output json` on any CLI command returns the same response envelope as the MCP tool, enabling AI tools that prefer CLI to parse results programmatically.
 - **Exit codes** are consistent and documented: 0 = success, 1 = error, 2 = consent required.
 
-`--output json` means an AI using Claude Code can call `moneybin spending summary --months 3 --output json` and get the exact same response envelope as the MCP tool. No parsing heuristics needed.
+`--output json` means an AI using Claude Code can call `moneybin reports spending summary --months 3 --output json` and get the exact same response envelope as the MCP tool. No parsing heuristics needed.
 
 ---
 

--- a/docs/specs/mcp-tool-surface.md
+++ b/docs/specs/mcp-tool-surface.md
@@ -25,6 +25,8 @@ Together they replace the prototype-era MCP specs (read tools, write tools) with
 
 ready
 
+> **v2 revision (2026-05-02):** Aligns MCP tool naming with the unified taxonomy in [`cli-restructure.md`](cli-restructure.md) v2. The convention is path-prefix-verb-suffix (`accounts_balance_list`), with cross-domain reports moving under a new `reports_*` namespace. v1 tool names existed before the cross-interface rule was settled and used noun-collection-as-list (`accounts_balances`) and standalone analytical domains (`spending_*`, `cashflow_*`, `tax_*`). v2 makes the verb explicit and groups analytical lenses under `reports`. Sync (9 tools) and transform (5 tools) gain MCP exposure under the v2 exposure principle. See [§16b. Rename Map (v1 → v2)](#16b-rename-map-v1--v2). Hard cut: no aliases. Implementation pass moves status `ready` → `in-progress`.
+
 ---
 
 ## 1. Conventions (quick reference)
@@ -46,7 +48,7 @@ Every tool returns:
     "display_currency": "USD"
   },
   "data": [ ... ],
-  "actions": ["Use spending_by_category for category breakdown"]
+  "actions": ["Use reports_spending_by_category for category breakdown"]
 }
 ```
 
@@ -74,9 +76,17 @@ These apply to all tools that accept them and are not repeated per tool:
 
 `detail=summary` on a `medium` tool returns aggregates without triggering consent. Degraded responses use the same envelope with `summary.degraded: true`.
 
-### Namespace conventions
+### Namespace conventions (v2)
 
-Two segments by default (`domain_action`, e.g. `spending_summary`). Three segments when a sub-domain has a distinct workflow identity (e.g., `transactions_matches_pending`). Tool names are lowercase with underscore separators — no dots, since Anthropic's and OpenAI's MCP clients enforce `^[a-zA-Z0-9_-]{1,64}$` regardless of what the spec permits. Noun = query, verb = action.
+Path-prefix-verb-suffix. Tool names mirror the CLI hierarchy with underscores instead of spaces, ending in an explicit verb.
+
+- **Pattern:** `<entity_or_domain>[_<sub_resource>]_<verb>`
+- **Examples:** `accounts_list`, `accounts_balance_list`, `accounts_balance_assert`, `reports_networth_get`, `transactions_matches_confirm`, `reports_spending_summary`
+- **Verbs:** `_list` (collection get), `_get` (single instance), `_assert`, `_confirm`, `_reject`, `_apply`, `_delete`, `_create`, `_update`, plus domain-natural verbs (`_reconcile`, `_run`, `_train`).
+- **Pluralization:** singular for resource types (`balance`, `networth`, `category`); plural for relationship collections (`matches`); verb-suffix carries the list/single distinction so the noun stays consistent.
+- **Encoding constraint:** lowercase ASCII with underscores, ≤64 chars (`^[a-zA-Z0-9_-]{1,64}$` per Anthropic and OpenAI MCP client regex).
+
+This mirrors the CLI taxonomy in `cli-restructure.md` v2. A user who knows `accounts balance list` already knows `accounts_balance_list` and `GET /accounts/balances`.
 
 ### Service layer convention
 
@@ -86,13 +96,46 @@ Each namespace maps to a service class. Tools and CLI commands are thin wrappers
 
 CLI mirrors MCP namespaces as command groups. `--output json` on any command returns the same response envelope as the MCP tool. Default output is human-readable (tables, summary lines, icons per `cli.md` rules).
 
+### When CLI-only is justified (v2 MCP exposure principle)
+
+Default: every operation is MCP-exposed. CLI-only status requires a justified exception. Acceptable exceptions are narrow:
+
+1. **Secret material through the LLM context window.** Tools that accept passphrases or encryption keys (`db_unlock`, `db_rotate_key`, `sync_rotate_key`, `db_init`) — passing those through an LLM-mediated channel is a security model violation, not a capability gap.
+2. **Hands-on operator territory.** Bootstrapping, troubleshooting, and developer-tooling operations that require physical operator presence (`db_init`, `db_lock`, `db_ps`, `db_kill`, `db_migrate apply/status`, `db_shell`, `db_ui`, `mcp_serve`, `mcp_config_*`, `profile_*`, `transform_restate`). MCP can't even start if the database is locked, so exposing recovery/lifecycle tools to MCP would be meaningless.
+
+What is NOT a valid CLI-only justification:
+- "Long-running" — MCP supports progress notifications.
+- "Needs OAuth / browser" — tools can return redirect URLs; clients open them.
+- "Destructive" — use a `confirm` parameter or elicitation; the AI must obtain explicit user agreement.
+- "Interactive" — split into a list-tool (read) and act-tools (write); the AI orchestrates the loop.
+- "Writes to scheduler / filesystem" — server has filesystem access; routine.
+
+Apply this filter when adding any new tool. The default answer is "expose to MCP."
+
+### Server `instructions` field
+
+The MCP `initialize` response includes an `instructions` string that compatible clients inject into the LLM's system prompt at session start. The canonical text lives in `src/moneybin/mcp/server.py` (the `FastMCP(instructions=...)` argument) — this spec describes what it should *cover*, not the literal text.
+
+Required content:
+- One-line product description (local-first, on-device DuckDB)
+- Top-level group enumeration with brief domain hint (entity groups, reference data, reports, system, pipeline, privacy)
+- Naming convention reminder (path-prefix-verb-suffix, with 2–3 examples)
+- Orientation pointers — which tool to call to "get oriented" for both new (`system_status`) and returning (`reports_health`) sessions
+- Response envelope shape (`{summary, data, actions}`) and pagination convention
+- Bulk-tool preference
+- Sensitivity tiers and degraded-response behavior
+
+Length budget: ~150–300 tokens. The text is loaded once per session, so the cost is amortized — but it competes with conversation and tool descriptions for working memory.
+
+Keep the text in sync with the spec. Renames and new top-level groups must update both.
+
 ---
 
 ## 2. Exemplars
 
 These three tools demonstrate every pattern in full detail. Subsequent namespace sections use a compact format and reference these for shared patterns.
 
-### 2.1 `spending_summary` — low sensitivity, time-series, no degradation
+### 2.1 `reports_spending_summary` — low sensitivity, time-series, no degradation
 
 **Service layer**
 
@@ -112,7 +155,7 @@ class SpendingService:
 
 **MCP tool**
 
-- **Name:** `spending_summary`
+- **Name:** `reports_spending_summary`
 - **Description:** "Get income vs expense totals by month. Returns time-series data suitable for charting. Use `months` for recent history or `start_date`/`end_date` for a specific range."
 - **Sensitivity:** `low` — returns aggregates only, no row-level data at any detail level.
 - **Parameters:**
@@ -136,12 +179,12 @@ class SpendingService:
 ```
 
 - **Degraded response:** N/A — this tool is `low` sensitivity and already returns aggregates. The response is identical regardless of consent status.
-- **Actions:** `["Use spending_by_category for category breakdown", "Use spending_compare to compare periods"]`
+- **Actions:** `["Use reports_spending_by_category for category breakdown", "Use reports_spending_compare to compare periods"]`
 
 **CLI command**
 
 ```
-moneybin spending summary [--months 3] [--start-date DATE] [--end-date DATE]
+moneybin reports spending summary [--months 3] [--start-date DATE] [--end-date DATE]
                           [--account-id ID ...] [--detail standard] [--output json]
 ```
 
@@ -165,8 +208,8 @@ Default output is a table with period, income, expenses, net, and count columns.
     {"period": "2026-02", "income": 5200.00, "expenses": 3654.90, "net": 1545.10, "transaction_count": 78}
   ],
   "actions": [
-    "Use spending_by_category for category breakdown",
-    "Use spending_compare to compare periods"
+    "Use reports_spending_by_category for category breakdown",
+    "Use reports_spending_compare to compare periods"
   ]
 }
 ```
@@ -258,7 +301,7 @@ class TransactionService:
 }
 ```
 
-- **Actions (consented):** `["Use categorize_bulk to categorize selected transactions", "Use transactions_correct to fix a transaction's amount or description"]`
+- **Actions (consented):** `["Use transactions_categorize_bulk_apply to categorize selected transactions", "Use transactions_correct to fix a transaction's amount or description"]`
 
 **CLI command**
 
@@ -273,7 +316,7 @@ Default output is a table with date, amount, description, category, and account 
 
 ---
 
-### 2.3 `categorize_bulk` — write tool, batch semantics, paired read tool
+### 2.3 `transactions_categorize_bulk_apply` — write tool, batch semantics, paired read tool
 
 **Service layer**
 
@@ -292,8 +335,8 @@ When `create_merchant_mappings` is true, the service normalizes each transaction
 
 **MCP tool**
 
-- **Name:** `categorize_bulk`
-- **Description:** "Apply categories to multiple transactions at once. Pair with `categorize_uncategorized` to fetch candidates first. Optionally auto-creates merchant mappings so future imports are categorized automatically."
+- **Name:** `transactions_categorize_bulk_apply`
+- **Description:** "Apply categories to multiple transactions at once. Pair with `transactions_categorize_pending_list` to fetch candidates first. Optionally auto-creates merchant mappings so future imports are categorized automatically."
 - **Sensitivity:** `medium` — reads transaction descriptions to create merchant mappings.
 - **Parameters:**
 
@@ -320,27 +363,27 @@ When `create_merchant_mappings` is true, the service normalizes each transaction
 Note: for write tools, `data` is a result object, not an array. The envelope still wraps it — `summary.total_count` reflects the input list size.
 
 - **Degraded response:** Write tools require consent unconditionally. If consent is not granted, the tool returns an error-style envelope with `summary.degraded: true` and an action pointing to the consent grant command. No partial execution.
-- **Actions:** `["Use categorize_rules to review auto-created rules", "Use categorize_uncategorized to fetch the next batch"]`
+- **Actions:** `["Use transactions_categorize_rules_list to review auto-created rules", "Use transactions_categorize_pending_list to fetch the next batch"]`
 
 **CLI command**
 
 ```
-moneybin categorize bulk --file categorizations.json [--no-merchant-mappings] [--output json]
+moneybin transactions categorize bulk --file categorizations.json [--no-merchant-mappings] [--output json]
 ```
 
 The CLI accepts a JSON file (or stdin) since batch data doesn't work as flags. `--no-merchant-mappings` disables the auto-create side-effect. Default output is a summary line: "Applied 48, skipped 0, errors 2, merchants created 12."
 
 ---
 
-## 3. `spending.*` — Expense analysis
+## 3. `reports_spending_*` — Expense analysis (v2: moved into reports namespace)
 
 **Service class:** `SpendingService`
 
-### `spending_summary`
+### `reports_spending_summary`
 
 *Exemplar — see section 2.1.*
 
-### `spending_by_category`
+### `reports_spending_by_category`
 
 Income vs expense totals broken down by category for a period. Requires transactions to be categorized.
 
@@ -348,9 +391,9 @@ Income vs expense totals broken down by category for a period. Requires transact
 - **Unique parameters:** `top_n: int = 10` — limit to top N categories by total. `include_uncategorized: bool = true` — whether to include an "Uncategorized" rollup row.
 - **Behavior:** Returns array of `{category, subcategory, total, transaction_count, percent_of_total}` sorted by total descending. At `detail=full`, includes per-month breakdown within each category.
 - **Service:** `SpendingService.by_category() -> CategoryBreakdown`
-- **CLI:** `moneybin spending by-category [--top-n 10] [--include-uncategorized]`
+- **CLI:** `moneybin reports spending by-category [--top-n 10] [--include-uncategorized]`
 
-### `spending_merchants`
+### `reports_spending_merchants`
 
 Top merchants by spending for a period.
 
@@ -358,9 +401,9 @@ Top merchants by spending for a period.
 - **Unique parameters:** `top_n: int = 20`
 - **Behavior:** Returns array of `{merchant_name, total, transaction_count, category, last_seen}`. Merchants without mappings appear by raw description. Degraded response returns category totals instead.
 - **Service:** `SpendingService.merchants() -> MerchantBreakdown`
-- **CLI:** `moneybin spending merchants [--top-n 20]`
+- **CLI:** `moneybin reports spending merchants [--top-n 20]`
 
-### `spending_compare`
+### `reports_spending_compare`
 
 Compare spending between two periods (month-over-month, year-over-year).
 
@@ -368,25 +411,25 @@ Compare spending between two periods (month-over-month, year-over-year).
 - **Unique parameters:** `period_a: str` (required, YYYY-MM), `period_b: str` (required, YYYY-MM).
 - **Behavior:** Returns array of `{category, period_a_total, period_b_total, change_amount, change_percent}`. No `months`/`start_date`/`end_date` — this tool uses explicit period comparison. At `detail=summary`, returns only the overall totals for each period.
 - **Service:** `SpendingService.compare() -> PeriodComparison`
-- **CLI:** `moneybin spending compare --period-a 2026-03 --period-b 2026-04`
+- **CLI:** `moneybin reports spending compare --period-a 2026-03 --period-b 2026-04`
 
 ---
 
-## 4. `cashflow.*` — Money movement
+## 4. `reports_cashflow_*` — Money movement (v2: moved into reports namespace)
 
 **Service class:** `CashflowService`
 
-### `cashflow_summary`
+### `reports_cashflow_summary`
 
 Net cash flow by period — income, outflows, and net position.
 
 - **Sensitivity:** `low`
 - **Unique parameters:** None beyond shared conventions.
-- **Behavior:** Similar shape to `spending_summary` but focused on the cash flow framing: `{period, inflows, outflows, net, running_balance}`. `running_balance` is cumulative net across the returned periods. Chart-ready time-series.
+- **Behavior:** Similar shape to `reports_spending_summary` but focused on the cash flow framing: `{period, inflows, outflows, net, running_balance}`. `running_balance` is cumulative net across the returned periods. Chart-ready time-series.
 - **Service:** `CashflowService.summary() -> CashflowSummary`
-- **CLI:** `moneybin cashflow summary`
+- **CLI:** `moneybin reports cashflow summary`
 
-### `cashflow_income`
+### `reports_cashflow_income`
 
 Income sources breakdown for a period.
 
@@ -394,11 +437,11 @@ Income sources breakdown for a period.
 - **Unique parameters:** `top_n: int = 10`
 - **Behavior:** Returns array of `{source, total, transaction_count, frequency, last_seen}`. Groups by normalized description. Degraded response returns a single total income figure.
 - **Service:** `CashflowService.income() -> IncomeBreakdown`
-- **CLI:** `moneybin cashflow income [--top-n 10]`
+- **CLI:** `moneybin reports cashflow income [--top-n 10]`
 
 ---
 
-## 5. `accounts.*` — Account management
+## 5. `accounts.*` — Account management and per-account workflows
 
 **Service class:** `AccountService`
 
@@ -412,7 +455,7 @@ List all known accounts with type and institution.
 - **Service:** `AccountService.list() -> list[Account]`
 - **CLI:** `moneybin accounts list`
 
-### `accounts_balances`
+### `accounts_balance_list`
 
 Most recent balance for each account.
 
@@ -420,9 +463,9 @@ Most recent balance for each account.
 - **Unique parameters:** None beyond `account_id` filter.
 - **Behavior:** Returns array of `{account_id, institution_name, account_type, ledger_balance, available_balance, as_of_date}`. Degraded response returns total across all accounts without per-account breakdown.
 - **Service:** `AccountService.balances() -> list[AccountBalance]`
-- **CLI:** `moneybin accounts balances`
+- **CLI:** `moneybin accounts balance show`
 
-### `accounts_details`
+### `accounts_get`
 
 Full account details including routing/account numbers.
 
@@ -430,9 +473,9 @@ Full account details including routing/account numbers.
 - **Unique parameters:** `account_id: str` (required — single account, not a list; this is an exception to the batch-first principle because requesting full PII details for multiple accounts in one call is not a natural workflow and would complicate audit logging).
 - **Behavior:** Returns single account object with all fields including masked `routing_number` and `account_number` (e.g., `...1234`). Unmasked only in verified-local mode with `LOCAL_UNMASK_CRITICAL`. Degraded response returns the `accounts_list` view for that account (metadata only).
 - **Service:** `AccountService.details() -> AccountDetail`
-- **CLI:** `moneybin accounts details --account-id ID`
+- **CLI:** `moneybin accounts show --account-id ID`
 
-### `accounts_networth`
+### `reports_networth_get`
 
 Net worth across all accounts over time.
 
@@ -444,7 +487,7 @@ Net worth across all accounts over time.
 
 ---
 
-## 6. `transactions.*` — Transaction-level operations
+## 6. `transactions.*` — Transaction-level operations (matches and categorize workflows nested)
 
 **Service class:** `TransactionService` (search, correct, annotate, recurring), `MatchService` (matches sub-domain)
 
@@ -474,7 +517,7 @@ Add tags, notes, or cash breakdowns to transactions. Annotations are metadata �
 - **CLI:** `moneybin transactions annotate --file annotations.json`
 - **Dependency:** Annotations table schema (new).
 
-### `transactions_recurring`
+### `transactions_recurring_list`
 
 Detect recurring transactions (subscriptions, regular charges).
 
@@ -482,7 +525,7 @@ Detect recurring transactions (subscriptions, regular charges).
 - **Unique parameters:** `min_occurrences: int = 3` — minimum times a pattern must appear. `active_only: bool = true` — only show patterns with activity in the last 60 days.
 - **Behavior:** Groups by normalized description and rounded amount. Returns array of `{description, merchant_name, avg_amount, frequency_days, occurrence_count, first_seen, last_seen, is_active}`. Degraded response returns count of recurring patterns and total monthly recurring spend without itemization.
 - **Service:** `TransactionService.recurring() -> list[RecurringPattern]`
-- **CLI:** `moneybin transactions recurring [--min-occurrences 3] [--all]`
+- **CLI:** `moneybin transactions recurring list [--min-occurrences 3] [--all]`
 
 ### `transactions_matches.*` — Transaction matching sub-domain
 
@@ -522,7 +565,7 @@ Reject one or more match proposals.
 - **Service:** `MatchService.reject() -> BulkActionResult`
 - **CLI:** `moneybin transactions matches reject --match-ids ID [ID ...] [--permanent]`
 
-#### `transactions_matches_revoke`
+#### `transactions_matches_undo`
 
 Un-merge a previously confirmed match.
 
@@ -589,15 +632,15 @@ Batch import a directory of mixed file types.
 - **CLI:** `moneybin import folder PATH [--account-id ID] [--recursive]`
 - **Dependency:** Smart Import Pillar A.
 
-### `import_csv_preview`
+### `import_file_preview`
 
-Preview a CSV file's headers and sample rows before importing.
+Preview a tabular file's headers and sample rows before importing. Format-agnostic (CSV, Excel, etc.).
 
 - **Sensitivity:** `low` — structural metadata only.
 - **Unique parameters:** `file_path: str` (required).
 - **Behavior:** Returns `{file_name, headers, column_count, sample_rows}` with 3 sample rows as dicts keyed by header. Does not import or modify anything.
-- **Service:** `ImportService.csv_preview() -> CSVPreview`
-- **CLI:** `moneybin import csv-preview PATH`
+- **Service:** `ImportService.file_preview() -> FilePreview`
+- **CLI:** `moneybin import file-preview PATH`
 
 ### `import_list_formats`
 
@@ -633,11 +676,11 @@ Confirm and execute AI-assisted parsing for a file.
 
 ---
 
-## 8. `categorize.*` — Categorization pipeline
+## 8. `transactions_categorize_*`, `categories_*`, `merchants_*` — Categorization pipeline + reference data (v2: split into workflow + taxonomy + merchant mapping namespaces)
 
 **Service class:** `CategorizationService`
 
-### `categorize_uncategorized`
+### `transactions_categorize_pending_list`
 
 Fetch transactions that haven't been categorized yet. The read side of the categorize-then-bulk workflow.
 
@@ -645,13 +688,13 @@ Fetch transactions that haven't been categorized yet. The read side of the categ
 - **Unique parameters:** `suggest: bool = false` — when true, include AI-suggested categories based on merchant mappings and existing rules (does not apply them).
 - **Behavior:** Returns array of `{transaction_id, date, amount, description, account_id, suggested_category?, suggested_subcategory?, suggestion_source?}`. Degraded response returns uncategorized count by account and time period.
 - **Service:** `CategorizationService.uncategorized() -> TransactionSearchResult`
-- **CLI:** `moneybin categorize uncategorized [--suggest] [--limit 50]`
+- **CLI:** `moneybin transactions categorize pending [--suggest] [--limit 50]`
 
-### `categorize_bulk`
+### `transactions_categorize_bulk_apply`
 
 *Exemplar — see section 2.3.*
 
-### `categorize_rules`
+### `transactions_categorize_rules_list`
 
 List active categorization rules.
 
@@ -659,9 +702,9 @@ List active categorization rules.
 - **Unique parameters:** None.
 - **Behavior:** Returns array of `{rule_id, name, merchant_pattern, match_type, category, subcategory, min_amount, max_amount, account_id, priority, created_by}` sorted by priority.
 - **Service:** `CategorizationService.rules() -> list[CategorizationRule]`
-- **CLI:** `moneybin categorize rules`
+- **CLI:** `moneybin transactions categorize rules list`
 
-### `categorize_create_rules`
+### `transactions_categorize_rules_create`
 
 Create one or more categorization rules.
 
@@ -669,9 +712,9 @@ Create one or more categorization rules.
 - **Unique parameters:** `rules: list[object]` (required) — list of `{name, merchant_pattern, category, subcategory?, match_type?, min_amount?, max_amount?, account_id?, priority?}`.
 - **Behavior:** Validates patterns and categories. Returns `{created, skipped, errors, error_details}`.
 - **Service:** `CategorizationService.create_rules() -> BulkCreateResult`
-- **CLI:** `moneybin categorize create-rules --file rules.json`
+- **CLI:** `moneybin transactions categorize rules create --file rules.json`
 
-### `categorize_delete_rule`
+### `transactions_categorize_rule_delete`
 
 Delete a categorization rule.
 
@@ -679,9 +722,9 @@ Delete a categorization rule.
 - **Unique parameters:** `rule_id: str` (required).
 - **Behavior:** Deletes the rule. Returns confirmation with the deleted rule's name.
 - **Service:** `CategorizationService.delete_rule() -> DeleteResult`
-- **CLI:** `moneybin categorize delete-rule --rule-id ID`
+- **CLI:** `moneybin transactions categorize rules delete --rule-id ID`
 
-### `categorize_merchants`
+### `merchants_list`
 
 List merchant name mappings.
 
@@ -689,9 +732,9 @@ List merchant name mappings.
 - **Unique parameters:** None.
 - **Behavior:** Returns array of `{merchant_id, raw_pattern, match_type, canonical_name, category, subcategory, created_by}`.
 - **Service:** `CategorizationService.merchants() -> list[MerchantMapping]`
-- **CLI:** `moneybin categorize merchants`
+- **CLI:** `moneybin merchants list`
 
-### `categorize_create_merchants`
+### `merchants_create`
 
 Create one or more merchant name mappings.
 
@@ -699,9 +742,9 @@ Create one or more merchant name mappings.
 - **Unique parameters:** `mappings: list[object]` (required) — list of `{raw_pattern, canonical_name, match_type?, category?, subcategory?}`.
 - **Behavior:** Returns `{created, skipped, errors, error_details}`.
 - **Service:** `CategorizationService.create_merchants() -> BulkCreateResult`
-- **CLI:** `moneybin categorize create-merchants --file mappings.json`
+- **CLI:** `moneybin merchants create --file mappings.json`
 
-### `categorize_categories`
+### `categories_list`
 
 List the category taxonomy.
 
@@ -709,9 +752,9 @@ List the category taxonomy.
 - **Unique parameters:** `include_inactive: bool = false`.
 - **Behavior:** Returns array of `{category_id, category, subcategory, description, is_default, is_active}`.
 - **Service:** `CategorizationService.categories() -> list[Category]`
-- **CLI:** `moneybin categorize categories [--include-inactive]`
+- **CLI:** `moneybin categories list [--include-inactive]`
 
-### `categorize_create_category`
+### `categories_create`
 
 Create a custom category.
 
@@ -719,9 +762,9 @@ Create a custom category.
 - **Unique parameters:** `category: str` (required), `subcategory: str?`, `description: str?`.
 - **Behavior:** Generates a category ID, returns the created category.
 - **Service:** `CategorizationService.create_category() -> Category`
-- **CLI:** `moneybin categorize create-category --category NAME [--subcategory NAME]`
+- **CLI:** `moneybin categories create --category NAME [--subcategory NAME]`
 
-### `categorize_toggle_category`
+### `categories_toggle`
 
 Enable or disable a category.
 
@@ -729,9 +772,9 @@ Enable or disable a category.
 - **Unique parameters:** `category_id: str` (required), `is_active: bool` (required).
 - **Behavior:** Toggles the active flag. Existing categorizations are preserved.
 - **Service:** `CategorizationService.toggle_category() -> ToggleResult`
-- **CLI:** `moneybin categorize toggle-category --category-id ID --active/--inactive`
+- **CLI:** `moneybin categories toggle --category-id ID --active/--inactive`
 
-### `categorize_stats`
+### `transactions_categorize_stats`
 
 Categorization coverage statistics.
 
@@ -739,9 +782,9 @@ Categorization coverage statistics.
 - **Unique parameters:** None.
 - **Behavior:** Returns `{total_transactions, categorized, uncategorized, percent_categorized, by_source}` where `by_source` breaks down by categorization source (user, rule, ai, plaid).
 - **Service:** `CategorizationService.stats() -> CategorizationStats`
-- **CLI:** `moneybin categorize summary`
+- **CLI:** `moneybin transactions categorize stats`
 
-### `categorize_apply_rules`
+### `transactions_categorize_rules_apply`
 
 Run the rule engine against uncategorized transactions.
 
@@ -749,10 +792,10 @@ Run the rule engine against uncategorized transactions.
 - **Unique parameters:** `dry_run: bool = false` — preview what would be categorized without applying.
 - **Behavior:** Applies active rules in priority order to uncategorized transactions. Returns `{applied, skipped, already_categorized}`. With `dry_run`, returns the proposed categorizations without applying them.
 - **Service:** `CategorizationService.apply_rules() -> RuleApplicationResult`
-- **CLI:** `moneybin categorize apply-rules [--dry-run]`
+- **CLI:** `moneybin transactions categorize rules apply [--dry-run]`
 - **Dependency:** Categorization umbrella spec.
 
-### `categorize_auto_review`
+### `transactions_categorize_auto_review`
 
 List auto-generated rules pending user approval.
 
@@ -760,10 +803,10 @@ List auto-generated rules pending user approval.
 - **Unique parameters:** None.
 - **Behavior:** Returns array of `{proposed_rule_id, merchant_pattern, category, subcategory, source, trigger_count, sample_transactions}` where `source` indicates how the rule was generated (ml, pattern_detection).
 - **Service:** `CategorizationService.auto_review() -> list[ProposedRule]`
-- **CLI:** `moneybin categorize auto review`
+- **CLI:** `moneybin transactions categorize auto review`
 - **Dependency:** [Categorization overview](categorization-overview.md) (Pillar E: auto-rule generation), [Auto-rule generation](categorization-auto-rules.md).
 
-### `categorize_auto_confirm`
+### `transactions_categorize_auto_confirm`
 
 Approve or reject proposed auto-generated rules.
 
@@ -771,10 +814,10 @@ Approve or reject proposed auto-generated rules.
 - **Unique parameters:** `approvals: list[object]` (required) — list of `{proposed_rule_id, action}` where action is `approve` or `reject`.
 - **Behavior:** Approved rules are promoted to active categorization rules in `app.categorization_rules` with `created_by='auto_rule'` and immediately evaluated against uncategorized transactions. Rejected rules are not re-proposed for the same pattern. Returns `{approved, rejected, errors}`.
 - **Service:** `CategorizationService.auto_confirm() -> BulkActionResult`
-- **CLI:** `moneybin categorize auto confirm --approve <id> [<id>...] --reject <id> [<id>...]`
+- **CLI:** `moneybin transactions categorize auto confirm --approve <id> [<id>...] --reject <id> [<id>...]`
 - **Dependency:** [Categorization overview](categorization-overview.md) (Pillar E: auto-rule generation), [Auto-rule generation](categorization-auto-rules.md).
 
-### `categorize_auto_stats`
+### `transactions_categorize_auto_stats`
 
 Auto-rule health metrics.
 
@@ -782,10 +825,10 @@ Auto-rule health metrics.
 - **Unique parameters:** None.
 - **Behavior:** Returns `{active_rules, pending_proposals, rejected_proposals, override_rate, top_rules}` where `top_rules` is an array of the most-matched auto-rules with match counts. `override_rate` is the percentage of auto-rule categorizations that were later overridden by the user.
 - **Service:** `CategorizationService.auto_stats() -> AutoRuleStats`
-- **CLI:** `moneybin categorize auto stats`
+- **CLI:** `moneybin transactions categorize auto stats`
 - **Dependency:** [Categorization overview](categorization-overview.md) (Pillar E: auto-rule generation), [Auto-rule generation](categorization-auto-rules.md).
 
-### `categorize_ml_status`
+### `transactions_categorize_ml_status`
 
 ML model status and accuracy metrics.
 
@@ -793,10 +836,10 @@ ML model status and accuracy metrics.
 - **Unique parameters:** None.
 - **Behavior:** Returns `{status, last_trained, training_samples, accuracy, confidence_distribution}` where `status` is `untrained`, `training`, or `ready`. `confidence_distribution` shows how many transactions fall in each confidence tier (high/moderate/low). Confidence scores are Platt-calibrated probabilities; user-facing output uses qualitative tiers (see [categorization overview](categorization-overview.md) Progressive Confidence Disclosure).
 - **Service:** `CategorizationService.ml_status() -> MLModelStatus`
-- **CLI:** `moneybin categorize ml-status`
+- **CLI:** `moneybin transactions categorize ml status`
 - **Dependency:** [Categorization overview](categorization-overview.md) (Pillar D: ML categorization).
 
-### `categorize_ml_train`
+### `transactions_categorize_ml_train`
 
 Trigger model training or retraining on current categorization history.
 
@@ -804,10 +847,10 @@ Trigger model training or retraining on current categorization history.
 - **Unique parameters:** None.
 - **Behavior:** Trains the model synchronously. Returns `{status, training_samples, accuracy, duration_seconds}`. Requires minimum number of categorized transactions to produce a useful model. Note: the pipeline auto-retrains when statistically significant new categorizations exist (see [categorization overview](categorization-overview.md)); this tool is a manual escape hatch.
 - **Service:** `CategorizationService.ml_train() -> MLTrainResult`
-- **CLI:** `moneybin categorize ml-train`
+- **CLI:** `moneybin transactions categorize ml train`
 - **Dependency:** [Categorization overview](categorization-overview.md) (Pillar D: ML categorization).
 
-### `categorize_ml_apply`
+### `transactions_categorize_ml_apply`
 
 Run ML categorization at a given confidence threshold.
 
@@ -815,12 +858,12 @@ Run ML categorization at a given confidence threshold.
 - **Unique parameters:** `min_confidence: float = 0.9` — only apply predictions above this threshold. `dry_run: bool = false`.
 - **Behavior:** Applies ML predictions to uncategorized transactions above the confidence threshold. Returns `{applied, below_threshold, already_categorized}`. With `dry_run`, returns predictions without applying.
 - **Service:** `CategorizationService.ml_apply() -> MLApplyResult`
-- **CLI:** `moneybin categorize ml-apply [--min-confidence 0.9] [--dry-run]`
+- **CLI:** `moneybin transactions categorize ml apply [--min-confidence 0.9] [--dry-run]`
 - **Dependency:** [Categorization overview](categorization-overview.md) (Pillar D: ML categorization).
 
 ---
 
-## 9. `budget.*` — Budget tracking
+## 9. `budget_*` (mutation) and `reports_budget_*` (vs-actual reads) — Budget tracking (v2: split)
 
 **Service class:** `BudgetService`
 
@@ -834,7 +877,7 @@ Create or update a monthly budget for a category.
 - **Service:** `BudgetService.set() -> Budget`
 - **CLI:** `moneybin budget set --category NAME --amount N [--start-month YYYY-MM]`
 
-### `budget_status`
+### `reports_budget_status`
 
 Budget vs actual spending comparison for a month.
 
@@ -842,9 +885,9 @@ Budget vs actual spending comparison for a month.
 - **Unique parameters:** `month: str?` (YYYY-MM, defaults to current month).
 - **Behavior:** Returns array of `{category, budget, spent, remaining, percent_used, status}` where status is `OK`, `WARNING` (>90%), or `OVER`. Includes only categories with active budgets. At `detail=full`, includes per-week spending pace within the month.
 - **Service:** `BudgetService.status() -> list[BudgetStatus]`
-- **CLI:** `moneybin budget status [--month YYYY-MM]`
+- **CLI:** `moneybin reports budget status [--month YYYY-MM]`
 
-### `budget_summary`
+### `reports_budget_summary`
 
 Budget performance over multiple months — trend view.
 
@@ -852,7 +895,7 @@ Budget performance over multiple months — trend view.
 - **Unique parameters:** Shared `months`/date conventions.
 - **Behavior:** Returns array of `{month, total_budget, total_spent, total_remaining, categories_over, categories_on_track}`. Chart-ready time-series for budget adherence over time.
 - **Service:** `BudgetService.summary() -> list[BudgetMonthlySummary]`
-- **CLI:** `moneybin budget summary [--months 6]`
+- **CLI:** `moneybin reports budget summary [--months 6]`
 
 ### `budget_delete`
 
@@ -941,11 +984,11 @@ Query the AI audit log.
 
 ---
 
-## 12. `overview.*` — Cross-domain summaries
+## 12. `system_*` and `reports_health` — Data status meta-view + financial health snapshot (v2: split from `overview.*`)
 
 **Service class:** `OverviewService`
 
-### `overview_status`
+### `system_status`
 
 Data status dashboard — what data exists, how fresh it is, what's pending action.
 
@@ -953,9 +996,9 @@ Data status dashboard — what data exists, how fresh it is, what's pending acti
 - **Unique parameters:** None.
 - **Behavior:** Returns `{accounts, transactions, categorization, imports, matching, budgets}` where each section has relevant counts and dates. E.g., `transactions: {total: 4230, date_range: "2024-01 to 2026-04", last_import: "2026-04-15"}`, `categorization: {categorized: 3890, uncategorized: 340, percent: 92}`, `matching: {pending_review: 5}`. This is the tool version of the `moneybin://status` resource with richer detail.
 - **Service:** `OverviewService.status() -> SystemStatus`
-- **CLI:** `moneybin overview status`
+- **CLI:** `moneybin system status`
 
-### `overview_health`
+### `reports_health`
 
 Financial health snapshot — high-level summary across all domains.
 
@@ -963,7 +1006,7 @@ Financial health snapshot — high-level summary across all domains.
 - **Unique parameters:** `months: int = 1` (period to summarize).
 - **Behavior:** Returns `{net_worth, monthly_income, monthly_expenses, monthly_net, savings_rate, top_spending_categories, budget_compliance, recurring_total}`. Designed as a conversation opener — gives the AI enough context to ask informed follow-up questions.
 - **Service:** `OverviewService.health() -> FinancialHealth`
-- **CLI:** `moneybin overview health [--months 1]`
+- **CLI:** `moneybin reports health [--months 1]`
 
 ---
 
@@ -1000,7 +1043,7 @@ Four goal-oriented workflow templates. Each defines the goal, relevant tools, gu
 
 **Parameters:** `month: str?` (YYYY-MM, defaults to current month).
 
-**Relevant tools:** `spending_summary`, `spending_by_category`, `spending_compare`, `cashflow_summary`, `budget_status`, `transactions_recurring`, `overview_health`
+**Relevant tools:** `reports_spending_summary`, `reports_spending_by_category`, `reports_spending_compare`, `reports_cashflow_summary`, `reports_budget_status`, `transactions_recurring_list`, `reports_health`
 
 **Guardrails:**
 
@@ -1017,7 +1060,7 @@ Four goal-oriented workflow templates. Each defines the goal, relevant tools, gu
 
 **Goal:** Work through uncategorized transactions in batches, applying categories, creating merchant mappings, and building rules so future imports require less manual work.
 
-**Relevant tools:** `categorize_stats`, `categorize_categories`, `categorize_uncategorized`, `categorize_bulk`, `categorize_create_rules`, `categorize_create_merchants`, `categorize_create_category`
+**Relevant tools:** `transactions_categorize_stats`, `categories_list`, `transactions_categorize_pending_list`, `transactions_categorize_bulk_apply`, `transactions_categorize_rules_create`, `merchants_create`, `categories_create`
 
 **Guardrails:**
 
@@ -1027,20 +1070,20 @@ Four goal-oriented workflow templates. Each defines the goal, relevant tools, gu
 - Present proposed categorizations to the user for confirmation before applying
 - After applying, propose merchant mappings and rules for patterns that appeared multiple times
 - Track progress: "X of Y categorized, Z remaining"
-- If `categorize_ml_status` shows a trained model, use `suggest=true` to leverage ML suggestions
+- If `transactions_categorize_ml_status` shows a trained model, use `suggest=true` to leverage ML suggestions
 - Stop when the user says stop, not when the queue is empty
 
-**Decision points:** User confirms each batch of categorizations before `categorize_bulk` is called. User confirms proposed rules before `categorize_create_rules` is called.
+**Decision points:** User confirms each batch of categorizations before `transactions_categorize_bulk_apply` is called. User confirms proposed rules before `transactions_categorize_rules_create` is called.
 
 ### `onboarding` (Setup)
 
 **Goal:** Guide a first-time user from empty database to imported, transformed, and categorized data.
 
-**Relevant tools:** `overview_status`, `import_file`, `import_csv_preview`, `import_list_formats`, `categorize_stats`
+**Relevant tools:** `system_status`, `import_file`, `import_file_preview`, `import_list_formats`, `transactions_categorize_stats`
 
 **Guardrails:**
 
-- Start by checking `overview_status` — if data already exists, acknowledge and ask what the user wants to do next rather than re-running onboarding
+- Start by checking `system_status` — if data already exists, acknowledge and ask what the user wants to do next rather than re-running onboarding
 - Ask the user for file paths — don't assume locations
 - For tabular files, guide through the format creation flow if auto-detection fails
 - After import, explain what happened (records loaded, accounts discovered) and what's available next
@@ -1055,7 +1098,7 @@ Four goal-oriented workflow templates. Each defines the goal, relevant tools, gu
 
 **Parameters:** `tax_year: str` (defaults to prior year).
 
-**Relevant tools:** `tax_w2`, `tax_deductions`, `spending_by_category`, `cashflow_income`, `transactions_search`
+**Relevant tools:** `tax_w2`, `tax_deductions`, `reports_spending_by_category`, `reports_cashflow_income`, `transactions_search`
 
 **Guardrails:**
 
@@ -1135,9 +1178,9 @@ Always registered regardless of namespace configuration. Enables progressive dis
 {
   "namespace": "categorize",
   "tools_loaded": [
-    {"name": "categorize_uncategorized", "description": "Fetch transactions that haven't been categorized yet"},
-    {"name": "categorize_bulk", "description": "Apply categories to multiple transactions at once"},
-    {"name": "categorize_rules", "description": "List active categorization rules"}
+    {"name": "transactions_categorize_pending_list", "description": "Fetch transactions that haven't been categorized yet"},
+    {"name": "transactions_categorize_bulk_apply", "description": "Apply categories to multiple transactions at once"},
+    {"name": "transactions_categorize_rules_list", "description": "List active categorization rules"}
   ],
   "already_loaded": false
 }
@@ -1202,6 +1245,185 @@ All prototype prompts are replaced by the four v1 prompts. The prototype's step-
 
 ---
 
+## 16b. Rename Map (v1 → v2)
+
+Per [`cli-restructure.md`](cli-restructure.md) v2. Hard cut: rename in place, no aliases. Update the tool registry, regenerate `mcp config generate` output for all client configs, and update any AI agent prompts or external references.
+
+### `accounts_*`
+
+| v1 | v2 | Notes |
+|---|---|---|
+| `accounts_list` | `accounts_list` | Unchanged |
+| `accounts_details` | `accounts_get` | Single-instance get |
+| `accounts_balances` | `accounts_balance_list` | Singular type + explicit `_list` |
+| `accounts_networth` | `reports_networth_get` | **Moves to `reports_*`** — cross-domain rollup (accounts + assets), no longer scoped to `accounts` namespace |
+| (new — `net-worth.md`) | `accounts_balance_assert` | |
+| (new) | `accounts_balance_history` | |
+| (new) | `accounts_balance_reconcile` | |
+| (new) | `accounts_balance_assertions_list` | |
+| (new) | `accounts_balance_assertion_delete` | |
+| (new) | `reports_networth_history` | Moved out of `accounts_*` |
+
+### `transactions_*` (entity ops)
+
+| v1 | v2 | Notes |
+|---|---|---|
+| `transactions_search` | `transactions_search` | Verb already trailing |
+| `transactions_correct` | `transactions_correct` | Verb already trailing |
+| `transactions_annotate` | `transactions_annotate` | Verb already trailing |
+| `transactions_recurring` | `transactions_recurring_list` | Add explicit `_list` |
+| (new) | `transactions_review_status` | Returns counts of both review queues (matches pending + categorize pending). Orientation tool for "anything to review?" check; AI then calls `transactions_matches_pending` or `transactions_categorize_pending_list` to fetch items |
+
+### `transactions_matches_*` (workflow under transactions)
+
+| v1 | v2 | Notes |
+|---|---|---|
+| `transactions_matches_pending` | `transactions_matches_pending` | Unchanged — kept specialized; review queue is the dominant call. See judgment call #1 |
+| `transactions_matches_confirm` | `transactions_matches_confirm` | Unchanged. CLI v2 also uses `matches confirm` for symmetry — see judgment call #2 |
+| `transactions_matches_reject` | `transactions_matches_reject` | Unchanged |
+| `transactions_matches_revoke` | `transactions_matches_undo` | Align verb with CLI (`matches undo`) |
+| `transactions_matches_log` | `transactions_matches_log` | Noun "log" reads as the resource; keep |
+| `transactions_matches_run` | `transactions_matches_run` | Unchanged |
+
+### `transactions_categorize_*` (was `categorize_*` workflow + rules + auto + ml)
+
+Workflow tools that operate on transaction state stay nested under `transactions_categorize_*`. Reference-data tools (categories, merchants) split into their own top-level groups — see `categories_*` and `merchants_*` below.
+
+| v1 | v2 |
+|---|---|
+| `categorize_uncategorized` | `transactions_categorize_pending_list` |
+| `categorize_bulk` | `transactions_categorize_bulk_apply` |
+| `categorize_apply_rules` | `transactions_categorize_rules_apply` |
+| `categorize_rules` | `transactions_categorize_rules_list` |
+| `categorize_create_rules` | `transactions_categorize_rules_create` |
+| `categorize_delete_rule` | `transactions_categorize_rule_delete` |
+| `categorize_stats` | `transactions_categorize_stats` |
+| `categorize_auto_review` | `transactions_categorize_auto_review` |
+| `categorize_auto_confirm` | `transactions_categorize_auto_confirm` |
+| `categorize_auto_stats` | `transactions_categorize_auto_stats` |
+| `categorize_ml_status` | `transactions_categorize_ml_status` |
+| `categorize_ml_train` | `transactions_categorize_ml_train` |
+| `categorize_ml_apply` | `transactions_categorize_ml_apply` |
+
+### `categories_*` (new top-level — taxonomy reference data)
+
+Categories are reference data that transactions reference, not a workflow on transactions. Promoted to a top-level entity group so taxonomy management is independent of the categorization workflow.
+
+| v1 | v2 |
+|---|---|
+| `categorize_categories` | `categories_list` |
+| `categorize_create_category` | `categories_create` |
+| `categorize_toggle_category` | `categories_toggle` |
+| (new) | `categories_delete` |
+
+### `merchants_*` (new top-level — merchant mapping reference data)
+
+Merchants are reference data (canonical names + default categories). Same logic as categories: promoted to a top-level entity group.
+
+| v1 | v2 |
+|---|---|
+| `categorize_merchants` | `merchants_list` |
+| `categorize_create_merchants` | `merchants_create` |
+
+### `reports_*` (new namespace — cross-domain analytical and aggregation views)
+
+`spending_*` and `cashflow_*` tools move under `reports_*`. Read-only `budget_*` tools also move; mutation `budget_*` tools stay top-level. `accounts_networth_*` moves here too — net worth aggregates across accounts + assets, so it's structurally a cross-domain report.
+
+`tax_*` does **not** move here — see "Unchanged top-level domains" below.
+
+| v1 | v2 |
+|---|---|
+| `spending_summary` | `reports_spending_summary` |
+| `spending_by_category` | `reports_spending_by_category` |
+| `spending_merchants` | `reports_spending_merchants` |
+| `spending_compare` | `reports_spending_compare` |
+| `cashflow_summary` | `reports_cashflow_summary` |
+| `cashflow_income` | `reports_cashflow_income` |
+| `budget_status` | `reports_budget_status` |
+| `budget_summary` | `reports_budget_summary` |
+| `accounts_networth` (v1: `accounts_networth`, then proposed `accounts_networth_get`) | `reports_networth_get` |
+| (new) | `reports_networth_history` |
+| (new) | `reports_health` (was `overview_health`) |
+
+### `budget_*` (mutation, stays top-level)
+
+| v1 | v2 |
+|---|---|
+| `budget_set` | `budget_set` |
+| `budget_delete` | `budget_delete` |
+
+### `system_*` and split of `overview_*`
+
+The v1 `overview_*` namespace bundled two conceptually different tools:
+- `overview_status` — operational meta-view: data freshness, counts, pending queues
+- `overview_health` — analytical financial summary (net worth + spending + budget compliance)
+
+v2 splits them by their actual content. Status is a system meta-view; health is a cross-domain financial report.
+
+| v1 | v2 | Rationale |
+|---|---|---|
+| `overview_status` | `system_status` | Operational/system meta — distinct from analytical reports |
+| `overview_health` | `reports_health` | Cross-domain financial summary — sibling of `reports_spending_summary` |
+
+`system_*` is a new top-level namespace for system meta-information. Currently a single tool; future system observability or diagnostics tools can land here.
+
+### Unchanged top-level domains
+
+| Namespace | Tools | Rationale |
+|---|---|---|
+| `import_*` | 6 of 7 unchanged; `import_csv_preview` → `import_file_preview` (format-agnostic) | Pipeline action, not entity-scoped |
+| `privacy_*` | All 4 privacy tools unchanged | Cross-cutting consent/audit domain |
+| `sql_*` | `sql_query` unchanged | Infrastructure escape hatch |
+| `tax_*` | `tax_w2`, `tax_deductions` unchanged | Tax is its own domain — workflow that crosses spending, income, deductions, forms. Future tools (`tax_1099`, `tax_capital_gains`, `tax_estimate`) land here. |
+
+### `assets_*` (new top-level — physical assets)
+
+Reserved namespace for `asset-tracking.md`. Workflows (registration, valuation, liability linking, staleness) defined there. Initial v2 implementation creates the namespace with stubs only; full tool surface lands when `asset-tracking.md` is implemented.
+
+### `sync_*` (new MCP exposure — was CLI-only)
+
+Per the v2 MCP exposure principle, sync becomes nearly fully MCP-exposed. The AI may want to proactively pull recent data, check sync status, or initiate a connection — these are legitimate user-workflow operations. OAuth flows return redirect URLs; the client opens them.
+
+| v2 tool | Behavior |
+|---|---|
+| `sync_login` | Initiates device-code flow with moneybin-server. Returns `{device_code, user_code, verification_url, polling_token}`. Client displays URL + code; tool polls until completion |
+| `sync_logout` | Clears stored JWT |
+| `sync_connect [--institution]` | Initiates OAuth with bank/aggregator. Returns redirect URL; tool polls for completion |
+| `sync_disconnect <institution>` | Removes institution; idempotent |
+| `sync_pull [--institution] [--force]` | Triggers sync for one or all institutions; runs full pipeline |
+| `sync_status` | Read-only: connected institutions, last-sync times, errors |
+| `sync_schedule_set --time HH:MM` | Installs daily sync (launchd/cron); writes scheduler entry |
+| `sync_schedule_show` | Read-only schedule details |
+| `sync_schedule_remove` | Uninstalls scheduled job |
+
+**CLI-only (security-justified):** `sync_rotate_key` — passphrase material through LLM context window is a security model violation.
+
+### `transform_*` (new MCP exposure — was CLI-only)
+
+Routine pipeline operations the AI legitimately needs (e.g., ensure pipeline is up to date after a manual data change). Full surface except `_restate`.
+
+| v2 tool | Behavior |
+|---|---|
+| `transform_status` | Current model state, environment |
+| `transform_plan` | Preview pending SQLMesh changes (read-only) |
+| `transform_validate` | Check model SQL parses and resolves |
+| `transform_audit` | Run data quality assertions |
+| `transform_apply` | Execute SQLMesh changes |
+
+**CLI-only (operator-territory):** `transform_restate` — destructive force-recompute for a date range, used for bug fixes / late-data backfill / schema reinterpretation. Power-user / data-engineering territory; preceded by code changes the AI doesn't drive.
+
+### Judgment calls flagged for review
+
+A few renames make minor judgment calls. Flagged here so they can be revisited if needed:
+
+1. **`transactions_matches_pending` → `transactions_matches_list` + `status` param.** Consolidates a status-filter into a parameter. Alternative: keep `_pending` as a specialized tool. Pro-consolidation: matches the v2 rule (one list operation per sub-resource). Pro-specialized: `pending` is the dominant query in practice and a dedicated tool reads cleaner.
+2. **`transactions_matches_confirm` stays `_confirm`; CLI verb aligned to `confirm`.** Resolved. Both interfaces use `confirm` because it more accurately describes ratifying a system-proposed match (vs. picking from options).
+3. **`overview_*` split into `system_status` and `reports_health`.** v1 bundled operational meta and financial summary under one namespace. v2 separates them by content type. Resolved.
+4. **`tax_*` stays its own top-level domain.** Resolved. Tax is a workflow that crosses spending, income, deductions, and forms; future tools (1099, capital gains, estimates, carryforward) need a stable home. Two tools today, but the namespace is reserved for natural growth.
+5. **`categorize_uncategorized` → `transactions_categorize_pending_list`.** Resolved. Symmetry with `transactions_matches_pending` — both are review queues, both read the same shape.
+
+---
+
 ## 17. Dependency tracker
 
 Tools that depend on unbuilt subsystems are included in the full catalog with dependency markers. They ship with stub or no-op behavior until their dependency is implemented.
@@ -1210,16 +1432,16 @@ Tools that depend on unbuilt subsystems are included in the full catalog with de
 |---|---|---|
 | **Consent management spec** | Not written | `privacy_grant`, `privacy_revoke`, `privacy_status`; all degraded response behavior across the surface |
 | **Audit log spec** | Not written | `privacy_audit`; audit logging in middleware |
-| **Redaction engine spec** | Not written | `accounts_details` field masking; `high` sensitivity behavior |
+| **Redaction engine spec** | Not written | `accounts_get` field masking; `high` sensitivity behavior |
 | **Provider profiles spec** | Not written | Verified-local bypass; `privacy_status` backend info |
 | **Transaction matching (Pillars A+C)** | Draft (umbrella) | All `transactions_matches.*` tools |
 | **Transaction matching (Pillar B)** | Draft (umbrella) | `transactions_matches.*` transfer-type filtering |
-| **[Categorization overview](categorization-overview.md)** | Draft | `categorize_apply_rules`, `categorize_auto_review`, `categorize_auto_confirm`, `categorize_auto_stats`, `categorize_ml_status`, `categorize_ml_train`, `categorize_ml_apply` |
+| **[Categorization overview](categorization-overview.md)** | Draft | `transactions_categorize_rules_apply`, `transactions_categorize_auto_review`, `transactions_categorize_auto_confirm`, `transactions_categorize_auto_stats`, `transactions_categorize_ml_status`, `transactions_categorize_ml_train`, `transactions_categorize_ml_apply` |
 | **Smart Import (Pillar A)** | Not written | `import_folder` |
 | **Smart Import (Pillar F) + Privacy** | Not written | `import_ai_preview`, `import_ai_parse` |
 | **Corrections table schema** | Not written | `transactions_correct` |
 | **Annotations table schema** | Not written | `transactions_annotate` |
-| **Budget tracking spec** | Draft | `budget_summary` rollover behavior |
+| **Budget tracking spec** | Draft | `reports_budget_summary` rollover behavior |
 
 ### Tools shippable without dependencies
 

--- a/docs/specs/net-worth.md
+++ b/docs/specs/net-worth.md
@@ -31,10 +31,10 @@ Related specs and docs:
 5. **Aggregate to `core.agg_net_worth`** — a SQLMesh VIEW that sums `fct_balances_daily` across all included accounts per day.
 6. **Account inclusion/exclusion:** All accounts in `core.dim_accounts` are included by default. Users can exclude accounts via `app.account_settings` (new table with `include_in_net_worth BOOLEAN DEFAULT TRUE`). Excluded accounts still have daily balances computed but are omitted from `agg_net_worth`.
 7. **Reconciliation deltas:** When the transaction-derived balance at a given date doesn't match the next authoritative observation, compute and surface the delta. Deltas are informational (not blocking) and self-heal — they are recomputed on every `sqlmesh run`, so reimporting missing transactions resolves them naturally.
-8. **Manual balance assertions:** Users can assert a known balance via `moneybin balance assert <account_id> <date> <amount>`. Stored in `app.balance_assertions`. Serves as an authoritative observation alongside institution-provided balances.
+8. **Manual balance assertions:** Users can assert a known balance via `moneybin accounts balance assert <account_id> <date> <amount>`. Stored in `app.balance_assertions`. Serves as an authoritative observation alongside institution-provided balances.
 9. **No balance without an anchor:** Accounts with zero balance observations produce no `fct_balances_daily` rows. The system does not estimate an opening balance from transactions alone.
-10. **CLI commands:** `moneybin networth show`, `moneybin networth history`, `moneybin balance show`, `moneybin balance assert`, `moneybin balance list`, `moneybin balance delete`, `moneybin reconciliation show`.
-11. **MCP tools:** `get_net_worth`, `get_net_worth_history`, `get_balances`, `get_balance_assertions`.
+10. **CLI commands:** `moneybin reports networth show`, `moneybin reports networth history`, `moneybin accounts balance show`, `moneybin accounts balance assert`, `moneybin accounts balance list`, `moneybin accounts balance delete`, `moneybin accounts balance reconcile`.
+11. **MCP tools:** `reports_networth_get`, `reports_networth_history`, `accounts_balance_list`, `accounts_balance_assertions_list`.
 12. **All commands support `--output json`** for non-interactive parity.
 13. **Cash-only v1.** Investment holdings and multi-currency conversion are future extensions (Level 2 and Level 3 respectively). Net worth v1 covers cash accounts only.
 
@@ -42,7 +42,7 @@ Related specs and docs:
 
 ### New table: `app.balance_assertions`
 
-User-entered balance anchors. Managed via CLI (`moneybin balance assert/list/delete`).
+User-entered balance anchors. Managed via CLI (`moneybin accounts balance assert/list/delete`).
 
 ```sql
 CREATE TABLE IF NOT EXISTS app.balance_assertions (
@@ -165,50 +165,50 @@ GROUP BY d.balance_date
 
 All commands support `--output json` for non-interactive parity.
 
-### `networth` command group
+### `accounts networth` / `reports networth` commands
 
 ```
-moneybin networth show [--as-of DATE] [--account ACCOUNT_ID] [--output json|table]
+moneybin reports networth show [--as-of DATE] [--account ACCOUNT_ID] [--output json|table]
 ```
 - Default: net worth as of today (latest available date)
 - `--as-of`: historical point-in-time lookup
 - `--account`: filter to specific account(s), repeatable
 
 ```
-moneybin networth history [--from DATE] [--to DATE] [--interval daily|weekly|monthly] [--output json|table]
+moneybin reports networth history [--from DATE] [--to DATE] [--interval daily|weekly|monthly] [--output json|table]
 ```
 - Default interval: monthly
 - Shows net worth over time with period-over-period change (absolute and percentage)
 
-### `balance` command group
+### `accounts balance` commands
 
 ```
-moneybin balance show [--account ACCOUNT_ID] [--as-of DATE] [--output json|table]
+moneybin accounts balance show [--account ACCOUNT_ID] [--as-of DATE] [--output json|table]
 ```
 - Default: latest known balance per account
 - Shows: account name, balance, date of last observation, source (OFX/CSV/Plaid/assertion)
 
 ```
-moneybin balance assert <account_id> <date> <amount> [--notes "reason"] [--yes]
+moneybin accounts balance assert <account_id> <date> <amount> [--notes "reason"] [--yes]
 ```
 - Inserts or updates a row in `app.balance_assertions`
 - Validates `account_id` exists in `dim_accounts`
 
 ```
-moneybin balance list [--account ACCOUNT_ID] [--output json|table]
+moneybin accounts balance list [--account ACCOUNT_ID] [--output json|table]
 ```
 - Shows all balance assertions, optionally filtered by account
 
 ```
-moneybin balance delete <account_id> <date> [--yes]
+moneybin accounts balance delete <account_id> <date> [--yes]
 ```
 - Removes a manual assertion
 - `--yes` for non-interactive confirmation
 
-### `reconciliation` command group
+### `accounts balance reconcile` command
 
 ```
-moneybin reconciliation show [--account ACCOUNT_ID] [--threshold AMOUNT] [--output json|table]
+moneybin accounts balance reconcile [--account ACCOUNT_ID] [--threshold AMOUNT] [--output json|table]
 ```
 - Shows all accounts with non-zero reconciliation deltas
 - `--threshold`: only show deltas exceeding this amount (default: $0.01)
@@ -217,19 +217,19 @@ moneybin reconciliation show [--account ACCOUNT_ID] [--threshold AMOUNT] [--outp
 
 ### Tools
 
-**`get_net_worth`** — Returns current or historical net worth.
+**`reports_networth_get`** — Returns current or historical net worth.
 - Params: `as_of_date` (optional DATE), `account_ids` (optional list of VARCHAR)
 - Returns: total net worth, per-account breakdown with balance and source, currency
 
-**`get_net_worth_history`** — Returns net worth time series.
+**`reports_networth_history`** — Returns net worth time series.
 - Params: `from_date` (DATE), `to_date` (DATE), `interval` (daily|weekly|monthly, default monthly)
 - Returns: time series with net worth, period-over-period change (absolute and percentage), account count
 
-**`get_balances`** — Returns current balance per account.
+**`accounts_balance_list`** — Returns current balance per account.
 - Params: `account_ids` (optional list), `as_of_date` (optional DATE)
 - Returns: per-account balance with date of last observation and source attribution
 
-**`get_balance_assertions`** — Returns manual balance assertions.
+**`accounts_balance_assertions_list`** — Returns manual balance assertions.
 - Params: `account_id` (optional VARCHAR)
 - Returns: list of assertions with dates, amounts, and notes
 
@@ -278,8 +278,8 @@ This lets the scenario suite (`make test-scenarios`) validate that `fct_balances
 
 ### Tier 3 — Integration
 
-- End-to-end: import OFX file → `sqlmesh run` → `moneybin networth show` → verify output matches expected values.
-- Manual assertion flow: `moneybin balance assert` → `sqlmesh run` → verify balance updated in `fct_balances_daily`.
+- End-to-end: import OFX file → `sqlmesh run` → `moneybin reports networth show` → verify output matches expected values.
+- Manual assertion flow: `moneybin accounts balance assert` → `sqlmesh run` → verify balance updated in `fct_balances_daily`.
 - Intra-day re-sync: import twice on the same day → verify latest observation wins in `fct_balances_daily`.
 - Reconciliation self-healing: import with gap → observe delta → reimport with missing data → verify delta resolves.
 
@@ -311,9 +311,8 @@ This lets the scenario suite (`make test-scenarios`) validate that `fct_balances
 - `sqlmesh/models/core/fct_balances.sql` — VIEW unioning all balance sources
 - `sqlmesh/models/core/fct_balances_daily.sql` — TABLE with daily carry-forward logic (may be Python model)
 - `sqlmesh/models/core/agg_net_worth.sql` — VIEW aggregating across accounts
-- `src/moneybin/cli/commands/networth.py` — `networth show`, `networth history`
-- `src/moneybin/cli/commands/balance.py` — `balance show`, `balance assert`, `balance list`, `balance delete`
-- `src/moneybin/cli/commands/reconciliation.py` — `reconciliation show`
+- `src/moneybin/cli/commands/reports/networth.py` — `reports networth show / history`
+- `src/moneybin/cli/commands/accounts/balance.py` — `accounts balance show / assert / list / delete / reconcile / history`
 - `src/moneybin/services/balance_service.py` — business logic for balance queries, assertions, reconciliation
 - `src/moneybin/services/networth_service.py` — business logic for net worth queries
 - `tests/test_balance_service.py` — unit tests for balance logic
@@ -325,7 +324,7 @@ This lets the scenario suite (`make test-scenarios`) validate that `fct_balances
 
 - `src/moneybin/cli/main.py` — register `networth`, `balance`, `reconciliation` command groups
 - `src/moneybin/sql/schema.py` — register new DDL files for `app.balance_assertions` and `app.account_settings`
-- `src/moneybin/mcp/tools/` — add `get_net_worth`, `get_net_worth_history`, `get_balances`, `get_balance_assertions` tools
+- `src/moneybin/mcp/tools/` — add `reports_networth_get`, `reports_networth_history`, `accounts_balance_list`, `accounts_balance_assertions_list` tools
 - `src/moneybin/mcp/resources/` — add `net-worth://summary` resource
 
 ### Key Decisions

--- a/src/moneybin/mcp/server.py
+++ b/src/moneybin/mcp/server.py
@@ -12,6 +12,7 @@ Documentation: https://modelcontextprotocol.github.io/python-sdk/
 from __future__ import annotations
 
 import logging
+import textwrap
 from pathlib import Path
 
 import duckdb
@@ -40,17 +41,32 @@ EXTENDED_DOMAINS: frozenset[str] = frozenset(EXTENDED_DOMAIN_DESCRIPTIONS)
 # Global server instance — tools/resources/prompts register against this
 mcp = FastMCP(
     "MoneyBin",
-    instructions=(
-        "MoneyBin is an AI-powered personal finance app. Tools use "
-        "underscore-joined namespaces (spending_summary, accounts_balances, etc.). "
-        "Core tools are available immediately. Extended namespaces "
-        "(categorize, budget, tax, privacy) can be loaded with "
-        "moneybin_discover. All data stays local in DuckDB.\n\n"
-        "IMPORTANT: Prefer bulk tools (categorize_bulk, categorize_create_rules) "
-        "over single-item operations. Fetch a batch, reason about all items, "
-        "then submit in one call.\n\n"
-        "Every tool returns {summary, data, actions}. Check summary.has_more "
-        "for pagination and actions[] for suggested next steps."
+    instructions=textwrap.dedent(
+        """\
+        MoneyBin is a local-first personal finance platform. All data lives in DuckDB on the user's machine.
+
+        Top-level groups:
+        - accounts (balance) — financial accounts and per-account workflows
+        - transactions (matches, categorize) — transactions and workflows on them
+        - assets — physical assets (real estate, vehicles, valuables)
+        - categories, merchants — taxonomy reference data
+        - reports — cross-domain analytical and aggregation views (networth, spending, cashflow, financial health, budget vs actual)
+        - tax — tax forms, deductions, future capital gains
+        - system — data status
+        - import, sync — data ingestion (sync_pull/status/connect available; OAuth flows return URLs the client opens)
+        - privacy — consent and audit
+
+        Tool names mirror the hierarchy with underscores, verb at end: accounts_balance_assert, transactions_matches_accept, reports_networth_get, reports_spending_summary.
+
+        Getting oriented:
+        - system_status — what data exists, freshness, pending review queues
+        - reports_health — financial snapshot (net worth, income/expenses, savings rate)
+
+        Conventions:
+        - Every tool returns {summary, data, actions}. Check summary.has_more for pagination; actions[] suggests next steps.
+        - Prefer bulk tools (transactions_categorize_bulk_apply, transactions_categorize_rules_create).
+        - Sensitivity tiers: low / medium / high. Without consent, tools degrade to aggregates — they never fail.
+        """
     ),
     # mask_error_details wraps unclassified exceptions in a generic ToolError.
     # Classified domain exceptions are caught by mcp_tool and returned as error


### PR DESCRIPTION
## Summary

Brings the CLI restructure spec to a v2 design that unifies the command taxonomy across CLI, MCP, and a future HTTP surface. Dissolves the `track` group, promotes entity-and-workflow groups (`accounts`, `transactions`) plus reference-data and reports groups, and codifies a default-expose-to-MCP principle. Comprehensive ~50-tool MCP rename map and cascading updates to all downstream specs that reference v1 paths.

## Impact

- The CLI implementation pass that follows this spec is a hard cut: `track balance/networth/budget/recurring/investments`, top-level `matches`/`categorize`, and ~30 MCP tool names are renamed in one release with no aliases.
- Downstream specs (`net-worth.md`, `asset-tracking.md`, all `categorization-*.md`) now reference v2 paths and will need code follow-up when their owning features are implemented.
- A new project rule (`.claude/rules/mcp-server.md`) makes "expose to MCP" the default for new operations and documents the narrow CLI-only exemptions.
- The MCP `instructions` field is now load-bearing for AI orientation and must be kept in sync with the spec — codified as a project rule.

## Changes

### Spec — `cli-restructure.md` v2

- Status flipped `implemented` → `in-progress` → `ready` to reflect the v2 design pass.
- New design principle: **entity groups own their workflows and aggregations** (replaces v1's "domain commands are top-level").
- Final taxonomy: 18 top-level groups — `profile`, `import`, `sync`, `accounts`, `transactions`, `assets`, `categories`, `merchants`, `reports`, `tax`, `system`, `budget`, `export`, `logs`, `stats`, `db`, `mcp`, `transform`.
- New section: **Cross-Interface Taxonomy** with the unified rule, encoding-per-protocol table, naming examples, and pluralization conventions.
- New section: **Migration v1 → v2** with the full CLI move table and MCP rename callouts.
- Updated v2 implementation pass (restructure-only; no new functionality).
- Revision History added.

### Spec — `mcp-tool-surface.md` v2

- Status `ready`. Comprehensive **§16b. Rename Map (v1 → v2)** covering every tool.
- Path-prefix-verb-suffix naming codified in §1 Conventions.
- New **MCP exposure principle** section: defaults to expose, narrow exemptions documented.
- New **Server `instructions` field** intent section (canonical text lives in code, spec describes required content).
- New `sync_*` (9 tools) and `transform_*` (5 tools) MCP exposure sections.
- New `categories_*` and `merchants_*` top-level reference-data namespaces (split out of `categorize_*`).
- New `system_*` namespace + `reports_health` (split from `overview_*`).
- ~30 per-tool section headings renamed in place to v2 names; CLI examples and inline references rewritten outside protected migration tables.
- 5 judgment calls resolved with rationale.

### Cascading downstream-spec updates

- `net-worth.md` — CLI moves to `accounts balance` + `reports networth`; MCP tool names updated; implementation file paths reorganized.
- `asset-tracking.md` — CLI surface flipped from `track asset` to top-level `assets`.
- `categorize-bulk.md`, `categorization-auto-rules.md`, `categorization-overview.md` — `categorize *` workflow under `transactions categorize *`; taxonomy/merchant CRUD lifted to top-level `categories` / `merchants`; MCP tool names updated.
- `data-reconciliation.md` — `reconciliation` references redirected to `accounts balance reconcile`.
- `mcp-architecture.md` — example tool/CLI references updated.

### Code

- `src/moneybin/mcp/server.py` — `FastMCP(instructions=...)` rewritten in v2 taxonomy via `textwrap.dedent("""...""")`. Length ~345 tokens. Server loads cleanly.

### Project rules and follow-ups

- `.claude/rules/mcp-server.md` — added "When CLI-only is justified" and "Server Instructions Field" sections.
- `docs/followups.md` — entries for `account-management.md` drafting plan and dynamic instructions for client-conditional progressive disclosure.
- `docs/specs/INDEX.md` — `account-management.md` planned, `cli-restructure.md` and `mcp-tool-surface.md` flipped to `ready`, downstream spec entries refreshed.

## Test plan

- [x] Server import smoke check (`uv run python -c "from moneybin.mcp.server import mcp"`) confirms `instructions` field rewrites cleanly via `textwrap.dedent` and the module imports without error.
- [x] Final v1-leakage scan across all `docs/specs/*.md` returns zero matches outside protected migration tables and the v2 callout.
- [ ] Reviewer: skim `cli-restructure.md` and `mcp-tool-surface.md` end-to-end.
- [ ] Reviewer: spot-check a few CLI examples and MCP tool names in the cascaded downstream specs.

## Notes

- Implementation of the CLI/MCP renames lands in a follow-up `refactor/cli-restructure-v2` branch — this PR is design-only.
- `account-management.md` remains unwritten and is captured in `followups.md` with a 3-step drafting plan; net-worth.md continues to own `app.account_settings` until the new spec absorbs it.
- The MCP exposure principle (`mcp-tool-surface.md` §1 + `.claude/rules/mcp-server.md`) is the rule going forward — applies to new tools, not retroactive to all existing ones.