### PR TITLE
Add MCP tool wall-clock timeouts with DuckDB lock release

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Once connected, ask things like:
 | AES-256-GCM encryption at rest, key management, automatic schema migrations | [Database & Security](docs/guides/database-security.md) |
 | Multi-profile isolation (per-profile DB, config, logs) | [Profiles](docs/guides/profiles.md) |
 | MCP server: 9 tool domains, prompt templates, resources, `--output json` parity with CLI | [MCP Server](docs/guides/mcp-server.md) |
+| MCP tool timeouts: every tool returns within a configurable wall-clock cap (default 30 s); timeouts release the DuckDB lock so the next call succeeds | [Spec](docs/specs/mcp-tool-timeouts.md) |
 | Direct SQL: shell, DuckDB UI, key tables documented | [SQL Access](docs/guides/sql-access.md) |
 | Synthetic data generator (3 personas, ~200 merchants, ground-truth labels) | [Synthetic Data](docs/guides/synthetic-data.md) |
 | Scenario test suite (10 scenarios, five-tier taxonomy, bug-report recipe) | [Scenario Authoring](docs/guides/scenario-authoring.md) |
@@ -125,6 +126,7 @@ Full command reference: [CLI Reference](docs/guides/cli-reference.md).
 | Investment tracking (holdings, cost basis) | 🗓️ |
 | Privacy tiers & consent model | 📐 |
 | MCP SQL schema discoverability (curated `moneybin://schema` resource) | ✅ |
+| MCP tool timeouts (configurable 30 s cap, DuckDB lock released on timeout) | ✅ |
 | Export (CSV, Excel, Google Sheets) | 🗓️ |
 
 Per-feature design specs live in [`docs/specs/`](docs/specs/INDEX.md).

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -74,7 +74,7 @@ Single source of truth for spec status. Update this table when a spec's status c
 | [Architecture & Design](mcp-architecture.md) | Architecture | in-progress | MCP v1 design philosophy, tool taxonomy, privacy integration, CLI symmetry, Apps readiness. Supersedes archived `mcp-read-tools` and `mcp-write-tools` specs. |
 | [Tool Surface](mcp-tool-surface.md) | Architecture | ready | Concrete tool, prompt, resource, and service layer definitions for MCP. v2 (2026-05-02) aligns naming with `cli-restructure.md` v2 taxonomy (path-prefix-verb-suffix), adds `reports_*` namespace, exposes sync + transform to MCP under the v2 exposure principle. |
 | [SQL Schema Discoverability](mcp-sql-discoverability.md) | Feature | implemented | `moneybin://schema` resource exposes curated interface tables (core + select app) with columns, comments, and example queries; eliminates per-session schema reconnaissance |
-| [Tool Timeouts & Cancellation](mcp-tool-timeouts.md) | Feature | draft | Global 30s wall-clock cap on every tool dispatch with DuckDB `interrupt()` + connection close on timeout, so a hung call can't wedge the server's write lock |
+| [Tool Timeouts & Cancellation](mcp-tool-timeouts.md) | Feature | implemented | Global 30s wall-clock cap on every tool dispatch with DuckDB `interrupt()` + connection close on timeout, so a hung call can't wedge the server's write lock |
 
 ## Sync
 

--- a/docs/specs/mcp-tool-timeouts.md
+++ b/docs/specs/mcp-tool-timeouts.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-draft
+implemented
 
 ## Goal
 

--- a/docs/superpowers/plans/2026-05-02-mcp-tool-timeouts.md
+++ b/docs/superpowers/plans/2026-05-02-mcp-tool-timeouts.md
@@ -1,0 +1,805 @@
+# MCP Tool Timeouts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wrap every MCP tool dispatch in a hard wall-clock timeout that returns a structured error envelope and releases any held DuckDB write lock so the next call succeeds.
+
+**Architecture:** A new timeout guard inside the `@mcp_tool` decorator runs every tool under `asyncio.wait_for(..., timeout=settings.mcp.tool_timeout_seconds)`. Sync tool bodies are dispatched to a worker thread via `asyncio.to_thread`. On timeout, a new `Database.interrupt_and_reset()` helper calls `connection.interrupt()`, closes the connection, and clears the singleton so the next call reopens cleanly. The error envelope grows a structured `kind="timed_out"` shape with `tool`, `elapsed_s`, `timeout_s`. Default cap: 30s, configurable via `MoneyBinSettings.mcp.tool_timeout_seconds`.
+
+**Tech Stack:** Python 3.12+, FastMCP, DuckDB Python API, `asyncio` (stdlib), Pydantic Settings, pytest.
+
+---
+
+## File Structure
+
+**Create:**
+- `tests/moneybin/test_mcp/test_tool_timeouts.py` — unit + integration coverage for the timeout path.
+
+**Modify:**
+- `src/moneybin/config.py` — add `tool_timeout_seconds` field to `MCPConfig`.
+- `src/moneybin/errors.py` — add `TimeoutError` UserError + classification.
+- `src/moneybin/protocol/envelope.py` — extend error payload to support `{kind, tool, elapsed_s, timeout_s}` for timeouts.
+- `src/moneybin/database.py` — add `interrupt_and_reset()` method on `Database` and `interrupt_and_reset_database()` module-level helper.
+- `src/moneybin/mcp/decorator.py` — wrap every decorated tool in an async timeout guard; on timeout, call `interrupt_and_reset_database()` and return a structured timeout envelope.
+- `tests/moneybin/test_mcp/test_decorator.py` — extend with envelope-shape regression for the new error fields (no behavior break).
+
+---
+
+## Task 1: Add `tool_timeout_seconds` to MCPConfig
+
+**Files:**
+- Modify: `src/moneybin/config.py:228-255` (extend `MCPConfig`)
+- Test: `tests/moneybin/test_config.py` (locate the existing MCPConfig tests; add one)
+
+- [ ] **Step 1: Locate existing MCPConfig tests**
+
+Run: `grep -rn "MCPConfig\|tool_timeout" tests/moneybin/test_config.py 2>/dev/null | head -20`
+
+If `tests/moneybin/test_config.py` doesn't exist, search broader: `grep -rln "MCPConfig" tests/`. Use whatever file the existing config tests live in. If none exists, create `tests/moneybin/test_config.py` with the test below.
+
+- [ ] **Step 2: Write failing test for the new field**
+
+Add to the file located in Step 1:
+
+```python
+import pytest
+
+from moneybin.config import MCPConfig
+
+
+@pytest.mark.unit
+def test_mcp_tool_timeout_default() -> None:
+    cfg = MCPConfig()
+    assert cfg.tool_timeout_seconds == 30.0
+
+
+@pytest.mark.unit
+def test_mcp_tool_timeout_must_be_positive() -> None:
+    with pytest.raises(ValueError):
+        MCPConfig(tool_timeout_seconds=0.0)
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `uv run pytest tests/moneybin/test_config.py -v -k tool_timeout`
+Expected: FAIL with `AttributeError: ... tool_timeout_seconds` or unexpected default.
+
+- [ ] **Step 4: Add the field to MCPConfig**
+
+In `src/moneybin/config.py`, inside the `MCPConfig` class (after `progressive_disclosure`), add:
+
+```python
+    tool_timeout_seconds: float = Field(
+        default=30.0,
+        gt=0.0,
+        description=(
+            "Hard wall-clock cap for any single MCP tool dispatch. On timeout, "
+            "the active DuckDB statement is interrupted and the connection is "
+            "reset so subsequent calls aren't wedged behind a stale write lock."
+        ),
+    )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/moneybin/test_config.py -v -k tool_timeout`
+Expected: PASS (2 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/moneybin/config.py tests/moneybin/test_config.py
+git commit -m "Add tool_timeout_seconds setting to MCPConfig"
+```
+
+---
+
+## Task 2: Add `interrupt_and_reset` to Database
+
+**Files:**
+- Modify: `src/moneybin/database.py:475-485` (add method on `Database`); append module-level helper near line 539.
+- Test: `tests/moneybin/test_database.py` (or whichever existing file holds Database tests — search if unsure).
+
+- [ ] **Step 1: Locate existing Database tests**
+
+Run: `grep -rln "class TestDatabase\|def test_database\|from moneybin.database" tests/moneybin/ | head`
+
+Use the matching file. If none, create `tests/moneybin/test_database_interrupt.py`.
+
+- [ ] **Step 2: Write failing test for `interrupt_and_reset`**
+
+```python
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from moneybin.database import Database, get_database, interrupt_and_reset_database
+import moneybin.database as db_module
+
+
+@pytest.mark.unit
+def test_interrupt_and_reset_calls_interrupt_then_closes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mock_store = MagicMock()
+    mock_store.get_key.return_value = "test-key-32-bytes-padding-padding-pad"
+    db = Database(tmp_path / "t.duckdb", secret_store=mock_store, no_auto_upgrade=True)
+
+    raw_conn = db._conn
+    assert raw_conn is not None
+    raw_conn.interrupt = MagicMock(wraps=raw_conn.interrupt)  # type: ignore[method-assign]
+
+    db.interrupt_and_reset()
+
+    raw_conn.interrupt.assert_called_once()
+    assert db._conn is None
+    assert db._closed is True
+
+
+@pytest.mark.unit
+def test_module_helper_clears_singleton(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mock_store = MagicMock()
+    mock_store.get_key.return_value = "test-key-32-bytes-padding-padding-pad"
+
+    monkeypatch.setattr(db_module, "_database_instance", None)
+    db = Database(tmp_path / "t.duckdb", secret_store=mock_store, no_auto_upgrade=True)
+    monkeypatch.setattr(db_module, "_database_instance", db)
+
+    interrupt_and_reset_database()
+
+    assert db_module._database_instance is None
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `uv run pytest tests/moneybin/test_database_interrupt.py -v` (or the file you used)
+Expected: FAIL with `AttributeError: ... interrupt_and_reset` and `ImportError: cannot import name 'interrupt_and_reset_database'`.
+
+- [ ] **Step 4: Add method on `Database`**
+
+In `src/moneybin/database.py`, immediately after the existing `close()` method (around line 485), add:
+
+```python
+    def interrupt_and_reset(self) -> None:
+        """Interrupt any active statement and force-close the connection.
+
+        Called from the MCP timeout path so a stuck tool releases its
+        DuckDB write lock before the dispatcher returns. Best-effort:
+        DuckDB's interrupt() is a no-op for some statement types (e.g.,
+        mid-COPY), so we always follow with close() to guarantee the
+        lock drops.
+        """
+        if self._conn is not None:
+            try:
+                self._conn.interrupt()
+            except Exception:  # noqa: BLE001 — interrupt is best-effort
+                pass
+        self.close()
+```
+
+- [ ] **Step 5: Add module-level helper**
+
+At the bottom of `src/moneybin/database.py` (after `close_database`), add:
+
+```python
+def interrupt_and_reset_database() -> None:
+    """Interrupt and clear the singleton Database, if one exists.
+
+    The next ``get_database()`` call will reopen a fresh connection. No-op
+    if no Database has been initialized yet (e.g., timeout before any
+    tool actually touched the DB).
+    """
+    global _database_instance  # noqa: PLW0603 — module-level singleton is intentional
+
+    if _database_instance is not None:
+        _database_instance.interrupt_and_reset()
+        _database_instance = None
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/moneybin/test_database_interrupt.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/moneybin/database.py tests/moneybin/test_database_interrupt.py
+git commit -m "Add interrupt_and_reset for MCP timeout cleanup path"
+```
+
+---
+
+## Task 3: Extend UserError + envelope to carry structured timeout payload
+
+**Files:**
+- Modify: `src/moneybin/errors.py` (add `details` to `UserError.to_dict`)
+- Modify: `src/moneybin/protocol/envelope.py` (no shape change, just verify pass-through)
+- Test: `tests/moneybin/test_protocol/test_envelope.py` if exists, else `tests/moneybin/test_mcp/test_envelope.py`.
+
+- [ ] **Step 1: Write failing test for structured details on UserError**
+
+Add to `tests/moneybin/test_mcp/test_envelope.py`:
+
+```python
+@pytest.mark.unit
+def test_user_error_carries_structured_details() -> None:
+    from moneybin.errors import UserError
+
+    err = UserError(
+        "Tool exceeded 30.0s cap",
+        code="timed_out",
+        hint=None,
+        details={"tool": "import_inbox_sync", "elapsed_s": 30.1, "timeout_s": 30.0},
+    )
+    d = err.to_dict()
+    assert d["code"] == "timed_out"
+    assert d["details"]["tool"] == "import_inbox_sync"
+    assert d["details"]["timeout_s"] == 30.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/moneybin/test_mcp/test_envelope.py -v -k structured_details`
+Expected: FAIL with `TypeError: UserError.__init__() got an unexpected keyword argument 'details'`.
+
+- [ ] **Step 3: Extend UserError**
+
+In `src/moneybin/errors.py`, replace the `__init__` and `to_dict` methods on `UserError` with:
+
+```python
+def __init__(
+    self,
+    message: str,
+    *,
+    code: str,
+    hint: str | None = None,
+    details: dict[str, Any] | None = None,
+) -> None:
+    """Construct a UserError with a user-safe message, stable code, optional hint, and optional structured details."""
+    super().__init__(message)
+    self.message = message
+    self.code = code
+    self.hint = hint
+    self.details = details
+
+
+def to_dict(self) -> dict[str, Any]:
+    """Convert to a plain dict for envelope serialization."""
+    d: dict[str, Any] = {"message": self.message, "code": self.code}
+    if self.hint is not None:
+        d["hint"] = self.hint
+    if self.details is not None:
+        d["details"] = self.details
+    return d
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/moneybin/test_mcp/test_envelope.py -v -k structured_details`
+Expected: PASS.
+
+- [ ] **Step 5: Run full envelope + errors regression**
+
+Run: `uv run pytest tests/moneybin/test_mcp/test_envelope.py tests/moneybin/test_mcp/test_decorator.py -v`
+Expected: All pass — the new `details` field is opt-in, existing UserError callers unaffected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/moneybin/errors.py tests/moneybin/test_mcp/test_envelope.py
+git commit -m "Add optional details payload to UserError for structured envelopes"
+```
+
+---
+
+## Task 4: Wrap tool dispatch in async timeout guard
+
+**Files:**
+- Modify: `src/moneybin/mcp/decorator.py` (rewrite the wrapper construction to always return an async wrapper that enforces the timeout)
+- Test: `tests/moneybin/test_mcp/test_tool_timeouts.py` (new)
+
+Decision rationale: FastMCP awaits tool callables in its async dispatch loop. Wrapping the decorator output in an async function lets us use `asyncio.wait_for` uniformly. Sync tool bodies run in a thread via `asyncio.to_thread`. This is the smallest change that gives us a hard wall-clock cap on every tool with no per-tool refactor.
+
+- [ ] **Step 1: Write failing tests for timeout behavior**
+
+Create `tests/moneybin/test_mcp/test_tool_timeouts.py`:
+
+```python
+"""Timeout guard tests for the @mcp_tool decorator."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from moneybin.mcp.decorator import mcp_tool
+from moneybin.protocol.envelope import ResponseEnvelope, SummaryMeta
+
+
+def _ok_envelope() -> ResponseEnvelope:
+    return ResponseEnvelope(
+        summary=SummaryMeta(total_count=0, returned_count=0),
+        data=[],
+    )
+
+
+@pytest.mark.unit
+def test_sync_tool_under_cap_passes_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 5.0)
+
+    @mcp_tool(sensitivity="low")
+    def fast_tool() -> ResponseEnvelope:
+        return _ok_envelope()
+
+    result = asyncio.run(fast_tool())
+    assert isinstance(result, ResponseEnvelope)
+    assert result.error is None
+
+
+@pytest.mark.unit
+def test_sync_tool_over_cap_returns_timeout_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 0.05)
+    reset_mock = MagicMock()
+    monkeypatch.setattr(
+        "moneybin.mcp.decorator.interrupt_and_reset_database", reset_mock
+    )
+
+    @mcp_tool(sensitivity="low")
+    def slow_tool() -> ResponseEnvelope:
+        time.sleep(0.5)
+        return _ok_envelope()
+
+    started = time.monotonic()
+    result = asyncio.run(slow_tool())
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.4, "timeout did not fire within reasonable bound"
+    assert isinstance(result, ResponseEnvelope)
+    assert result.error is not None
+    assert result.error.code == "timed_out"
+    assert result.error.details is not None
+    assert result.error.details["tool"] == "slow_tool"
+    assert result.error.details["timeout_s"] == 0.05
+    assert result.error.details["elapsed_s"] >= 0.05
+    reset_mock.assert_called_once()
+
+
+@pytest.mark.unit
+def test_async_tool_over_cap_returns_timeout_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 0.05)
+    monkeypatch.setattr(
+        "moneybin.mcp.decorator.interrupt_and_reset_database", MagicMock()
+    )
+
+    @mcp_tool(sensitivity="low")
+    async def slow_tool() -> ResponseEnvelope:
+        await asyncio.sleep(0.5)
+        return _ok_envelope()
+
+    result = asyncio.run(slow_tool())
+    assert result.error is not None
+    assert result.error.code == "timed_out"
+
+
+@pytest.mark.unit
+def test_timeout_logs_low_cardinality_line(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 0.02)
+    monkeypatch.setattr(
+        "moneybin.mcp.decorator.interrupt_and_reset_database", MagicMock()
+    )
+
+    @mcp_tool(sensitivity="low")
+    async def slow_tool(account_number: str = "secret-123") -> ResponseEnvelope:
+        await asyncio.sleep(0.5)
+        return _ok_envelope()
+
+    with caplog.at_level("WARNING"):
+        asyncio.run(slow_tool(account_number="acct-redacted-do-not-log"))
+
+    relevant = [r for r in caplog.records if "timed out" in r.getMessage().lower()]
+    assert len(relevant) == 1
+    assert "slow_tool" in relevant[0].getMessage()
+    assert "acct-redacted-do-not-log" not in relevant[0].getMessage()
+
+
+@pytest.mark.unit
+def test_classified_user_error_still_returned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 5.0)
+    from moneybin.errors import UserError
+
+    @mcp_tool(sensitivity="low")
+    def bad_tool() -> ResponseEnvelope:
+        raise UserError("nope", code="not_found")
+
+    result = asyncio.run(bad_tool())
+    assert result.error is not None
+    assert result.error.code == "not_found"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/moneybin/test_mcp/test_tool_timeouts.py -v`
+Expected: FAIL — current decorator returns a sync function, has no timeout, has no `_get_timeout_seconds` symbol.
+
+- [ ] **Step 3: Rewrite the decorator with the timeout guard**
+
+Replace the entire body of `src/moneybin/mcp/decorator.py` with:
+
+```python
+"""MCP tool decorator: sensitivity logging, timeout guard, error classification, envelope guard.
+
+Every decorated tool is exposed as an async coroutine — FastMCP awaits it
+in its dispatch loop. Sync tool bodies are dispatched to a worker thread
+via ``asyncio.to_thread`` so they share the same timeout machinery.
+
+On timeout we (a) cancel the awaited future, (b) call
+``interrupt_and_reset_database()`` to drop the singleton DuckDB
+connection — releasing any held write lock — and (c) return a structured
+``timed_out`` error envelope. The next tool call will lazily reopen a
+fresh connection.
+
+Classified domain exceptions (``UserError``, ``DatabaseKeyError``,
+``FileNotFoundError``) become error envelopes here; anything else
+propagates to the server's ``mask_error_details`` boundary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import inspect
+import logging
+import time
+from collections.abc import Callable
+from typing import Any, Literal
+
+from moneybin.database import interrupt_and_reset_database
+from moneybin.errors import UserError, classify_user_error
+from moneybin.mcp.privacy import Sensitivity, log_tool_call
+from moneybin.protocol.envelope import ResponseEnvelope, build_error_envelope
+
+logger = logging.getLogger(__name__)
+
+
+def _get_timeout_seconds() -> float:
+    """Read the configured timeout. Indirected for test monkeypatching."""
+    from moneybin.config import get_settings
+
+    return get_settings().mcp.tool_timeout_seconds
+
+
+def _check_envelope(fn_name: str, result: Any) -> ResponseEnvelope:
+    if not isinstance(result, ResponseEnvelope):
+        msg = f"{fn_name} returned {type(result).__name__}, expected ResponseEnvelope"
+        logger.error(msg)
+        raise TypeError(msg)
+    return result
+
+
+def _classify_or_raise(fn_name: str, exc: Exception) -> ResponseEnvelope:
+    """Convert a classified domain exception to an error envelope, else re-raise."""
+    classified = classify_user_error(exc)
+    if classified is None:
+        raise exc
+    logger.error(f"Tool {fn_name} raised {type(exc).__name__}: {classified.code}")
+    return build_error_envelope(error=classified, sensitivity="low")
+
+
+def _build_timeout_envelope(
+    fn_name: str, elapsed_s: float, timeout_s: float
+) -> ResponseEnvelope:
+    err = UserError(
+        f"Tool {fn_name} exceeded {timeout_s:.1f}s cap",
+        code="timed_out",
+        details={
+            "tool": fn_name,
+            "elapsed_s": round(elapsed_s, 3),
+            "timeout_s": timeout_s,
+        },
+    )
+    return build_error_envelope(error=err, sensitivity="low")
+
+
+def mcp_tool(
+    *,
+    sensitivity: Literal["low", "medium", "high"],
+    domain: str | None = None,
+) -> Callable[..., Any]:
+    """Mark a function as an MCP tool with a sensitivity tier and optional domain.
+
+    Tools with a ``domain`` start hidden; ``moneybin_discover`` enables them
+    per-session via FastMCP tag visibility. Every tool is wrapped in a
+    wall-clock timeout guard — see module docstring.
+    """
+    tier = Sensitivity(sensitivity)
+
+    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        is_coro = inspect.iscoroutinefunction(fn)
+
+        @functools.wraps(fn)
+        async def wrapper(*args: Any, **kwargs: Any) -> ResponseEnvelope:
+            log_tool_call(fn.__name__, tier)
+            timeout_s = _get_timeout_seconds()
+            started = time.monotonic()
+            try:
+                if is_coro:
+                    coro = fn(*args, **kwargs)
+                else:
+                    coro = asyncio.to_thread(fn, *args, **kwargs)
+                result = await asyncio.wait_for(coro, timeout=timeout_s)
+            except asyncio.TimeoutError:
+                elapsed = time.monotonic() - started
+                logger.warning(
+                    f"Tool {fn.__name__} timed out after {elapsed:.2f}s "
+                    f"(cap {timeout_s:.1f}s); interrupting DB and resetting connection"
+                )
+                try:
+                    interrupt_and_reset_database()
+                except Exception as exc:  # noqa: BLE001 — cleanup must not raise
+                    logger.error(
+                        f"interrupt_and_reset_database failed during {fn.__name__} "
+                        f"timeout cleanup: {type(exc).__name__}"
+                    )
+                return _build_timeout_envelope(fn.__name__, elapsed, timeout_s)
+            except Exception as exc:
+                return _classify_or_raise(fn.__name__, exc)
+            return _check_envelope(fn.__name__, result)
+
+        wrapper._mcp_sensitivity = sensitivity  # type: ignore[attr-defined]
+        wrapper._mcp_domain = domain  # type: ignore[attr-defined]
+        return wrapper
+
+    return decorator
+```
+
+- [ ] **Step 4: Run new tests to verify they pass**
+
+Run: `uv run pytest tests/moneybin/test_mcp/test_tool_timeouts.py -v`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Run existing decorator regression**
+
+Run: `uv run pytest tests/moneybin/test_mcp/test_decorator.py -v`
+Expected: Most pass. **Two existing tests will fail** because the decorator is now always async:
+- `test_decorator_returns_response_envelope` — calls `my_tool()` synchronously and asserts on the dict.
+- `test_decorator_raises_type_error_for_non_envelope` — same.
+
+Update those two tests:
+
+```python
+@pytest.mark.unit
+def test_decorator_returns_response_envelope(self) -> None:
+    import asyncio
+
+    @mcp_tool(sensitivity="low")
+    def my_tool() -> ResponseEnvelope:
+        return ResponseEnvelope(
+            summary=SummaryMeta(total_count=1, returned_count=1),
+            data=[{"value": 42}],
+        )
+
+    result = asyncio.run(my_tool())
+    assert isinstance(result, ResponseEnvelope)
+    assert result.summary.total_count == 1
+    assert result.data == [{"value": 42}]
+
+
+@pytest.mark.unit
+def test_decorator_raises_type_error_for_non_envelope(self) -> None:
+    import asyncio
+    import pytest
+
+    @mcp_tool(sensitivity="low")
+    def my_tool() -> str:  # type: ignore[return]
+        return "plain string result"  # type: ignore[return-value]
+
+    with pytest.raises(TypeError, match="expected ResponseEnvelope"):
+        asyncio.run(my_tool())
+```
+
+The `test_decorator_calls_log_tool_call` test calls `my_tool()` and discards the coroutine — update it too:
+
+```python
+    @pytest.mark.unit
+    def test_decorator_calls_log_tool_call(self) -> None:
+        import asyncio
+
+        @mcp_tool(sensitivity="medium")
+        def my_tool() -> ResponseEnvelope:
+            return ResponseEnvelope(
+                summary=SummaryMeta(total_count=0, returned_count=0),
+                data=[],
+            )
+
+        with patch("moneybin.mcp.decorator.log_tool_call") as mock_log:
+            asyncio.run(my_tool())
+            mock_log.assert_called_once()
+            args = mock_log.call_args[0]
+            assert args[0] == "my_tool"
+            assert args[1] == Sensitivity.MEDIUM
+```
+
+- [ ] **Step 6: Run decorator + timeout tests together**
+
+Run: `uv run pytest tests/moneybin/test_mcp/test_decorator.py tests/moneybin/test_mcp/test_tool_timeouts.py -v`
+Expected: All pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/moneybin/mcp/decorator.py tests/moneybin/test_mcp/test_tool_timeouts.py tests/moneybin/test_mcp/test_decorator.py
+git commit -m "Wrap MCP tool dispatch in wall-clock timeout with DB reset"
+```
+
+---
+
+## Task 5: Integration test — back-to-back call after timeout succeeds
+
+**Files:**
+- Modify: `tests/moneybin/test_mcp/test_tool_timeouts.py` (append integration test)
+
+- [ ] **Step 1: Write the integration test**
+
+Append to `tests/moneybin/test_mcp/test_tool_timeouts.py`:
+
+```python
+@pytest.mark.integration
+def test_back_to_back_call_after_timeout_succeeds(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A call that times out must release the DB lock so the next call works."""
+    import asyncio
+    from unittest.mock import MagicMock
+
+    import moneybin.database as db_module
+    from moneybin.database import Database
+    from moneybin.protocol.envelope import ResponseEnvelope, SummaryMeta
+
+    mock_store = MagicMock()
+    mock_store.get_key.return_value = "test-key-32-bytes-padding-padding-pad"
+
+    db = Database(tmp_path / "t.duckdb", secret_store=mock_store, no_auto_upgrade=True)
+    monkeypatch.setattr(db_module, "_database_instance", db)
+
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 0.1)
+
+    @mcp_tool(sensitivity="low")
+    def hang_tool() -> ResponseEnvelope:
+        # Spin without releasing GIL frequently to mimic a stuck native call.
+        time.sleep(2.0)
+        return ResponseEnvelope(
+            summary=SummaryMeta(total_count=0, returned_count=0), data=[]
+        )
+
+    @mcp_tool(sensitivity="low")
+    def quick_tool() -> ResponseEnvelope:
+        # Touch the DB to prove the singleton is healthy after reset.
+        from moneybin.database import get_database
+
+        rows = get_database().execute("SELECT 42 AS x").fetchall()
+        return ResponseEnvelope(
+            summary=SummaryMeta(total_count=len(rows), returned_count=len(rows)),
+            data=[{"x": rows[0][0]}],
+        )
+
+    first = asyncio.run(hang_tool())
+    assert first.error is not None and first.error.code == "timed_out"
+
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 5.0)
+    second = asyncio.run(quick_tool())
+    assert second.error is None
+    assert second.data == [{"x": 42}]
+```
+
+- [ ] **Step 2: Run the integration test**
+
+Run: `uv run pytest tests/moneybin/test_mcp/test_tool_timeouts.py -v -m integration`
+Expected: PASS. The first call returns a `timed_out` envelope; the second call opens a fresh singleton, queries successfully.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/moneybin/test_mcp/test_tool_timeouts.py
+git commit -m "Add integration test proving lock release after MCP timeout"
+```
+
+---
+
+## Task 6: Update spec status, INDEX, README; run pre-commit
+
+**Files:**
+- Modify: `docs/specs/mcp-tool-timeouts.md` (status: draft → in-progress → implemented)
+- Modify: `docs/specs/INDEX.md` (status row)
+- Modify: `README.md` (roadmap icon if present; otherwise add a one-liner)
+
+- [ ] **Step 1: Verify spec status block**
+
+Read the top of `docs/specs/mcp-tool-timeouts.md`. Change:
+
+```markdown
+## Status
+
+draft
+```
+
+to:
+
+```markdown
+## Status
+
+implemented
+```
+
+- [ ] **Step 2: Update INDEX.md**
+
+Run: `grep -n "mcp-tool-timeouts" docs/specs/INDEX.md`
+
+If the spec is listed, update its status column to `implemented`. If not listed, add a row in the appropriate section with status `implemented` and a one-line description: "Wall-clock timeout + DB reset for every MCP tool dispatch."
+
+- [ ] **Step 3: Update README**
+
+Run: `grep -n "tool timeout\|MCP timeout\|timeout" README.md | head`
+
+If a roadmap entry exists for MCP timeouts, change its icon to ✅. Otherwise add one line under the MCP "What Works Today" / infrastructure section: "Every MCP tool returns within a configurable wall-clock cap (default 30s); timeouts release the DuckDB lock so the next call succeeds."
+
+- [ ] **Step 4: Format, lint, type-check**
+
+Run: `make format && make lint && uv run pyright src/moneybin/mcp/decorator.py src/moneybin/database.py src/moneybin/errors.py src/moneybin/config.py`
+Expected: clean.
+
+- [ ] **Step 5: Full test sweep on touched modules**
+
+Run: `uv run pytest tests/moneybin/test_mcp/ tests/moneybin/test_database_interrupt.py tests/moneybin/test_config.py -v`
+Expected: all pass.
+
+- [ ] **Step 6: Run /simplify on the diff before final commit**
+
+Run the `/simplify` skill against the diff. Address any findings inline.
+
+- [ ] **Step 7: Commit docs and any simplify follow-ups**
+
+```bash
+git add docs/specs/mcp-tool-timeouts.md docs/specs/INDEX.md README.md
+git commit -m "Mark mcp-tool-timeouts spec implemented and update README"
+```
+
+- [ ] **Step 8: Final make check test**
+
+Run: `make check test`
+Expected: full pre-commit suite passes.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Req 1 (every dispatch wrapped, 30s default, settings): Task 1 + Task 4.
+- Req 2 (interrupt + force-close on timeout): Task 2 + Task 4 (`interrupt_and_reset_database` invoked in timeout path).
+- Req 3 (structured timeout envelope shape): Task 3 + Task 4 (`_build_timeout_envelope`).
+- Req 4 (single low-cardinality log line, no PII): Task 4 (`logger.warning`, no args/kwargs in message); covered by `test_timeout_logs_low_cardinality_line`.
+- Req 5 (next call succeeds): Task 5 (integration test).
+- Req 6 (global cap, no per-tool overrides): Task 1 — single field.
+- Req 7 (happy path unchanged): Task 4 — fast path is `await wait_for(...)` with no overhead beyond a single coroutine schedule; covered by `test_sync_tool_under_cap_passes_through`.
+
+**Placeholder scan:** No "TBD"/"similar to"/"add appropriate" — every step shows the code or the exact command.
+
+**Type consistency:** `interrupt_and_reset_database` named identically across Task 2 (definition), Task 4 (import), Task 5 (test). `_get_timeout_seconds` indirection introduced in Task 4 and only patched in tests — defined once. `tool_timeout_seconds` field name matches across config, decorator, env var derivation (`MONEYBIN_MCP__TOOL_TIMEOUT_SECONDS` per the existing `MONEYBIN_` + `__` convention).

--- a/followups.md
+++ b/followups.md
@@ -1,7 +1,0 @@
-# Follow-ups
-
-Deferred work surfaced during implementation. Each entry: what + why + where it came from.
-
-## MCP tool timeouts (feat/mcp-tool-timeouts)
-
-- **Migrate MCP tests to `pytest-asyncio` auto-mode.** The timeout feature made every `@mcp_tool`-decorated function async, so ~17 existing tests across 6 files (`test_decorator.py`, `test_error_handling.py`, `test_tools.py`, `test_v1_tools.py`, `test_categorization_tools.py`, `test_import_inbox_tools.py`) now wrap calls in `asyncio.run(...)`. With `pytest-asyncio` already a project dep, switching to auto-mode + `async def` test bodies would drop the boilerplate. Surfaced by `/simplify` reuse review.

--- a/followups.md
+++ b/followups.md
@@ -1,0 +1,7 @@
+# Follow-ups
+
+Deferred work surfaced during implementation. Each entry: what + why + where it came from.
+
+## MCP tool timeouts (feat/mcp-tool-timeouts)
+
+- **Migrate MCP tests to `pytest-asyncio` auto-mode.** The timeout feature made every `@mcp_tool`-decorated function async, so ~17 existing tests across 6 files (`test_decorator.py`, `test_error_handling.py`, `test_tools.py`, `test_v1_tools.py`, `test_categorization_tools.py`, `test_import_inbox_tools.py`) now wrap calls in `asyncio.run(...)`. With `pytest-asyncio` already a project dep, switching to auto-mode + `async def` test bodies would drop the boilerplate. Surfaced by `/simplify` reuse review.

--- a/src/moneybin/config.py
+++ b/src/moneybin/config.py
@@ -253,6 +253,15 @@ class MCPConfig(BaseModel):
             "visible at connect."
         ),
     )
+    tool_timeout_seconds: float = Field(
+        default=30.0,
+        gt=0.0,
+        description=(
+            "Hard wall-clock cap for any single MCP tool dispatch. On timeout, "
+            "the active DuckDB statement is interrupted and the connection is "
+            "reset so subsequent calls aren't wedged behind a stale write lock."
+        ),
+    )
 
 
 class SyncConfig(BaseModel):

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -495,7 +495,7 @@ class Database:
         if self._conn is not None:
             try:
                 self._conn.interrupt()
-            except Exception:  # noqa: BLE001 S110 — interrupt is best-effort; pass is correct here
+            except Exception:  # noqa: BLE001, S110 — interrupt is best-effort; pass is correct here
                 pass
         self.close()
 
@@ -567,6 +567,16 @@ def interrupt_and_reset_database() -> None:
     The next ``get_database()`` call will reopen a fresh connection. No-op
     if no Database has been initialized yet (e.g., timeout before any
     tool actually touched the DB).
+
+    Known limitation — thread-survivor race: when this is called from the
+    MCP timeout path, ``asyncio.wait_for`` cancels the awaited future but
+    the underlying ``asyncio.to_thread`` worker keeps running until the
+    sync tool body returns. If that surviving thread later touches the DB,
+    it will see the closed connection and raise — that exception surfaces
+    via ``ThreadPoolExecutor``'s unhandled-exception path (stderr), not
+    the MCP envelope. Occasional stderr noise after a timeout is expected.
+    Forcing termination would require cooperative cancellation in tool
+    bodies; out of scope for this iteration.
     """
     global _database_instance  # noqa: PLW0603 — module-level singleton is intentional
 

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -569,7 +569,7 @@ def interrupt_and_reset_database() -> None:
     tool actually touched the DB).
 
     Known limitation — thread-survivor race: when this is called from the
-    MCP timeout path, ``asyncio.wait_for`` cancels the awaited future but
+    MCP timeout path, ``asyncio.timeout()`` cancels the awaited task but
     the underlying ``asyncio.to_thread`` worker keeps running until the
     sync tool body returns. If that surviving thread later touches the DB,
     it will see the closed connection and raise — that exception surfaces

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -483,6 +483,22 @@ class Database:
         self._closed = True
         logger.debug(f"Database connection closed: {self._db_path}")
 
+    def interrupt_and_reset(self) -> None:
+        """Interrupt any active statement and force-close the connection.
+
+        Called from the MCP timeout path so a stuck tool releases its
+        DuckDB write lock before the dispatcher returns. Best-effort:
+        DuckDB's interrupt() is a no-op for some statement types (e.g.,
+        mid-COPY), so we always follow with close() to guarantee the
+        lock drops.
+        """
+        if self._conn is not None:
+            try:
+                self._conn.interrupt()
+            except Exception:  # noqa: BLE001 S110 — interrupt is best-effort; pass is correct here
+                pass
+        self.close()
+
 
 def database_key_error_hint() -> str:
     """Return the appropriate hint for a DatabaseKeyError.
@@ -542,6 +558,20 @@ def close_database() -> None:
 
     if _database_instance is not None:
         _database_instance.close()
+        _database_instance = None
+
+
+def interrupt_and_reset_database() -> None:
+    """Interrupt and clear the singleton Database, if one exists.
+
+    The next ``get_database()`` call will reopen a fresh connection. No-op
+    if no Database has been initialized yet (e.g., timeout before any
+    tool actually touched the DB).
+    """
+    global _database_instance  # noqa: PLW0603 — module-level singleton is intentional
+
+    if _database_instance is not None:
+        _database_instance.interrupt_and_reset()
         _database_instance = None
 
 

--- a/src/moneybin/errors.py
+++ b/src/moneybin/errors.py
@@ -32,18 +32,28 @@ class UserError(Exception):
     ``ResponseEnvelope`` automatically.
     """
 
-    def __init__(self, message: str, *, code: str, hint: str | None = None) -> None:
-        """Construct a UserError with a user-safe message, stable code, and optional hint."""
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        hint: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        """Construct a UserError with a user-safe message, stable code, optional hint, and optional structured details."""
         super().__init__(message)
         self.message = message
         self.code = code
         self.hint = hint
+        self.details = details
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to a plain dict for envelope serialization."""
         d: dict[str, Any] = {"message": self.message, "code": self.code}
         if self.hint is not None:
             d["hint"] = self.hint
+        if self.details is not None:
+            d["details"] = self.details
         return d
 
 

--- a/src/moneybin/errors.py
+++ b/src/moneybin/errors.py
@@ -40,7 +40,7 @@ class UserError(Exception):
         hint: str | None = None,
         details: dict[str, Any] | None = None,
     ) -> None:
-        """Construct a UserError with a user-safe message, stable code, optional hint, and optional structured details."""
+        """Initialize with a user-safe message and optional metadata."""
         super().__init__(message)
         self.message = message
         self.code = code

--- a/src/moneybin/mcp/decorator.py
+++ b/src/moneybin/mcp/decorator.py
@@ -1,25 +1,43 @@
-"""MCP tool decorator: sensitivity logging, error classification, envelope guard.
+"""MCP tool decorator: sensitivity logging, timeout guard, error classification, envelope guard.
 
-Classified exceptions (``UserError``, ``DatabaseKeyError``, ``FileNotFoundError``)
-become error envelopes so every surface — MCP, CLI ``--output json``, future
-HTTP — returns a consistent shape. Anything else propagates to the server's
-``mask_error_details`` boundary. Registration of the wrapped function with
-FastMCP happens separately in ``moneybin.mcp._registration``.
+Every decorated tool is exposed as an async coroutine — FastMCP awaits it
+in its dispatch loop. Sync tool bodies are dispatched to a worker thread
+via ``asyncio.to_thread`` so they share the same timeout machinery.
+
+On timeout we (a) cancel the awaited future, (b) call
+``interrupt_and_reset_database()`` to drop the singleton DuckDB
+connection — releasing any held write lock — and (c) return a structured
+``timed_out`` error envelope. The next tool call will lazily reopen a
+fresh connection.
+
+Classified domain exceptions (``UserError``, ``DatabaseKeyError``,
+``FileNotFoundError``) become error envelopes here; anything else
+propagates to the server's ``mask_error_details`` boundary.
 """
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import inspect
 import logging
+import time
 from collections.abc import Callable
 from typing import Any, Literal
 
-from moneybin.errors import classify_user_error
+from moneybin.database import interrupt_and_reset_database
+from moneybin.errors import UserError, classify_user_error
 from moneybin.mcp.privacy import Sensitivity, log_tool_call
 from moneybin.protocol.envelope import ResponseEnvelope, build_error_envelope
 
 logger = logging.getLogger(__name__)
+
+
+def _get_timeout_seconds() -> float:
+    """Read the configured timeout. Indirected for test monkeypatching."""
+    from moneybin.config import get_settings
+
+    return get_settings().mcp.tool_timeout_seconds
 
 
 def _check_envelope(fn_name: str, result: Any) -> ResponseEnvelope:
@@ -41,6 +59,21 @@ def _classify_or_raise(fn_name: str, exc: Exception) -> ResponseEnvelope:
     return build_error_envelope(error=classified, sensitivity="low")
 
 
+def _build_timeout_envelope(
+    fn_name: str, elapsed_s: float, timeout_s: float
+) -> ResponseEnvelope:
+    err = UserError(
+        f"Tool {fn_name} exceeded {timeout_s:.1f}s cap",
+        code="timed_out",
+        details={
+            "tool": fn_name,
+            "elapsed_s": round(elapsed_s, 3),
+            "timeout_s": timeout_s,
+        },
+    )
+    return build_error_envelope(error=err, sensitivity="low")
+
+
 def mcp_tool(
     *,
     sensitivity: Literal["low", "medium", "high"],
@@ -49,31 +82,39 @@ def mcp_tool(
     """Mark a function as an MCP tool with a sensitivity tier and optional domain.
 
     Tools with a ``domain`` start hidden; ``moneybin_discover`` enables them
-    per-session via FastMCP tag visibility.
+    per-session via FastMCP tag visibility. Every tool is wrapped in a
+    wall-clock timeout guard — see module docstring.
     """
     tier = Sensitivity(sensitivity)
 
     def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
-        if inspect.iscoroutinefunction(fn):
-
-            @functools.wraps(fn)
-            async def async_wrapper(*args: Any, **kwargs: Any) -> ResponseEnvelope:
-                log_tool_call(fn.__name__, tier)
-                try:
-                    result = await fn(*args, **kwargs)
-                except Exception as exc:
-                    return _classify_or_raise(fn.__name__, exc)
-                return _check_envelope(fn.__name__, result)
-
-            async_wrapper._mcp_sensitivity = sensitivity  # type: ignore[attr-defined]
-            async_wrapper._mcp_domain = domain  # type: ignore[attr-defined]
-            return async_wrapper
+        is_coro = inspect.iscoroutinefunction(fn)
 
         @functools.wraps(fn)
-        def wrapper(*args: Any, **kwargs: Any) -> ResponseEnvelope:
+        async def wrapper(*args: Any, **kwargs: Any) -> ResponseEnvelope:
             log_tool_call(fn.__name__, tier)
+            timeout_s = _get_timeout_seconds()
+            started = time.monotonic()
             try:
-                result = fn(*args, **kwargs)
+                if is_coro:
+                    coro = fn(*args, **kwargs)
+                else:
+                    coro = asyncio.to_thread(fn, *args, **kwargs)
+                result = await asyncio.wait_for(coro, timeout=timeout_s)
+            except TimeoutError:
+                elapsed = time.monotonic() - started
+                logger.warning(
+                    f"Tool {fn.__name__} timed out after {elapsed:.2f}s "
+                    f"(cap {timeout_s:.1f}s); interrupting DB and resetting connection"
+                )
+                try:
+                    interrupt_and_reset_database()
+                except Exception as exc:  # noqa: BLE001 — cleanup must not raise
+                    logger.error(
+                        f"interrupt_and_reset_database failed during {fn.__name__} "
+                        f"timeout cleanup: {type(exc).__name__}"
+                    )
+                return _build_timeout_envelope(fn.__name__, elapsed, timeout_s)
             except Exception as exc:
                 return _classify_or_raise(fn.__name__, exc)
             return _check_envelope(fn.__name__, result)

--- a/src/moneybin/mcp/decorator.py
+++ b/src/moneybin/mcp/decorator.py
@@ -6,6 +6,17 @@ decorator drops the singleton DuckDB connection so the next call reopens
 a fresh one, releasing any held write lock. Classified domain exceptions
 become error envelopes here; anything else propagates to the server's
 ``mask_error_details`` boundary.
+
+Known limitation — sync tool body continues after timeout: ``asyncio.wait_for``
+cancels the future, but the OS thread running the sync body keeps going
+until it naturally returns. A tool that mutates filesystem or DB state
+(e.g., ``import_inbox_sync``) may finish that work in the background after
+the client has already received a ``timed_out`` envelope. Clients that
+retry can produce duplicate or conflicting writes. The contract here is
+"release the lock and respond within the cap," not "guarantee the
+underlying work was undone." Tools doing non-idempotent writes that risk
+exceeding the cap must be redesigned (e.g., decomposed into smaller per-
+unit calls) — see ``docs/specs/mcp-tool-timeouts.md`` Out of Scope.
 """
 
 from __future__ import annotations

--- a/src/moneybin/mcp/decorator.py
+++ b/src/moneybin/mcp/decorator.py
@@ -97,6 +97,10 @@ def mcp_tool(
             raise TypeError(
                 f"{fn.__name__} is an async generator — MCP tools must be regular coroutines or sync functions"
             )
+        if inspect.isgeneratorfunction(fn):
+            raise TypeError(
+                f"{fn.__name__} is a sync generator — MCP tools must return ResponseEnvelope directly"
+            )
 
         @functools.wraps(fn)
         async def wrapper(*args: Any, **kwargs: Any) -> ResponseEnvelope:

--- a/src/moneybin/mcp/decorator.py
+++ b/src/moneybin/mcp/decorator.py
@@ -89,6 +89,10 @@ def mcp_tool(
 
     def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
         is_coro = inspect.iscoroutinefunction(fn)
+        if inspect.isasyncgenfunction(fn):
+            raise TypeError(
+                f"{fn.__name__} is an async generator — MCP tools must be regular coroutines or sync functions"
+            )
 
         @functools.wraps(fn)
         async def wrapper(*args: Any, **kwargs: Any) -> ResponseEnvelope:

--- a/src/moneybin/mcp/decorator.py
+++ b/src/moneybin/mcp/decorator.py
@@ -1,18 +1,11 @@
 """MCP tool decorator: sensitivity logging, timeout guard, error classification, envelope guard.
 
-Every decorated tool is exposed as an async coroutine — FastMCP awaits it
-in its dispatch loop. Sync tool bodies are dispatched to a worker thread
-via ``asyncio.to_thread`` so they share the same timeout machinery.
-
-On timeout we (a) cancel the awaited future, (b) call
-``interrupt_and_reset_database()`` to drop the singleton DuckDB
-connection — releasing any held write lock — and (c) return a structured
-``timed_out`` error envelope. The next tool call will lazily reopen a
-fresh connection.
-
-Classified domain exceptions (``UserError``, ``DatabaseKeyError``,
-``FileNotFoundError``) become error envelopes here; anything else
-propagates to the server's ``mask_error_details`` boundary.
+Every decorated tool is exposed as an async coroutine — FastMCP awaits it,
+and sync tool bodies run via ``asyncio.to_thread``. On timeout the
+decorator drops the singleton DuckDB connection so the next call reopens
+a fresh one, releasing any held write lock. Classified domain exceptions
+become error envelopes here; anything else propagates to the server's
+``mask_error_details`` boundary.
 """
 
 from __future__ import annotations

--- a/src/moneybin/mcp/decorator.py
+++ b/src/moneybin/mcp/decorator.py
@@ -103,13 +103,20 @@ def mcp_tool(
             log_tool_call(fn.__name__, tier)
             timeout_s = _get_timeout_seconds()
             started = time.monotonic()
+            # asyncio.timeout()'s .expired() lets us distinguish a cap-fired
+            # TimeoutError from one the tool body raised itself (e.g., a
+            # downstream HTTP timeout). Without this, both surface as
+            # TimeoutError and would be misclassified as cap-fired, causing
+            # spurious DB resets and misleading "timed_out" envelopes.
             try:
-                if is_coro:
-                    coro = fn(*args, **kwargs)
-                else:
-                    coro = asyncio.to_thread(fn, *args, **kwargs)
-                result = await asyncio.wait_for(coro, timeout=timeout_s)
-            except TimeoutError:
+                async with asyncio.timeout(timeout_s) as cm:
+                    if is_coro:
+                        result = await fn(*args, **kwargs)
+                    else:
+                        result = await asyncio.to_thread(fn, *args, **kwargs)
+            except TimeoutError as exc:
+                if not cm.expired():
+                    return _classify_or_raise(fn.__name__, exc)
                 elapsed = time.monotonic() - started
                 logger.warning(
                     f"Tool {fn.__name__} timed out after {elapsed:.2f}s "
@@ -117,10 +124,10 @@ def mcp_tool(
                 )
                 try:
                     interrupt_and_reset_database()
-                except Exception as exc:  # noqa: BLE001 — cleanup must not raise
+                except Exception as cleanup_exc:  # noqa: BLE001 — cleanup must not raise
                     logger.error(
                         f"interrupt_and_reset_database failed during {fn.__name__} "
-                        f"timeout cleanup: {type(exc).__name__}"
+                        f"timeout cleanup: {type(cleanup_exc).__name__}"
                     )
                 return _build_timeout_envelope(fn.__name__, elapsed, timeout_s)
             except Exception as exc:

--- a/src/moneybin/mcp/decorator.py
+++ b/src/moneybin/mcp/decorator.py
@@ -108,8 +108,9 @@ def mcp_tool(
             # downstream HTTP timeout). Without this, both surface as
             # TimeoutError and would be misclassified as cap-fired, causing
             # spurious DB resets and misleading "timed_out" envelopes.
+            cm = asyncio.timeout(timeout_s)
             try:
-                async with asyncio.timeout(timeout_s) as cm:
+                async with cm:
                     if is_coro:
                         result = await fn(*args, **kwargs)
                     else:

--- a/src/moneybin/mcp/decorator.py
+++ b/src/moneybin/mcp/decorator.py
@@ -7,9 +7,9 @@ a fresh one, releasing any held write lock. Classified domain exceptions
 become error envelopes here; anything else propagates to the server's
 ``mask_error_details`` boundary.
 
-Known limitation — sync tool body continues after timeout: ``asyncio.wait_for``
-cancels the future, but the OS thread running the sync body keeps going
-until it naturally returns. A tool that mutates filesystem or DB state
+Known limitation — sync tool body continues after timeout: ``asyncio.timeout()``
+cancels the awaited task, but the OS thread running the sync body keeps
+going until it naturally returns. A tool that mutates filesystem or DB state
 (e.g., ``import_inbox_sync``) may finish that work in the background after
 the client has already received a ``timed_out`` envelope. Clients that
 retry can produce duplicate or conflicting writes. The contract here is

--- a/tests/moneybin/test_config.py
+++ b/tests/moneybin/test_config.py
@@ -2,6 +2,20 @@
 
 import pytest
 
+from moneybin.config import MCPConfig
+
+
+@pytest.mark.unit
+def test_mcp_tool_timeout_default() -> None:
+    cfg = MCPConfig()
+    assert cfg.tool_timeout_seconds == 30.0
+
+
+@pytest.mark.unit
+def test_mcp_tool_timeout_must_be_positive() -> None:
+    with pytest.raises(ValueError):
+        MCPConfig(tool_timeout_seconds=0.0)
+
 
 def test_categorization_settings_defaults() -> None:
     """Test CategorizationSettings default values."""

--- a/tests/moneybin/test_database_interrupt.py
+++ b/tests/moneybin/test_database_interrupt.py
@@ -1,0 +1,48 @@
+"""Tests for Database.interrupt_and_reset and interrupt_and_reset_database helper."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import moneybin.database as db_module
+from moneybin.database import Database, interrupt_and_reset_database
+
+
+@pytest.mark.unit
+def test_interrupt_and_reset_calls_interrupt_then_closes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mock_store = MagicMock()
+    mock_store.get_key.return_value = "test-key-32-bytes-padding-padding-pad"
+    db = Database(tmp_path / "t.duckdb", secret_store=mock_store, no_auto_upgrade=True)
+
+    # DuckDB's C-extension connection is read-only, so we swap in a MagicMock
+    # that wraps the real connection; interrupt() and close() are tracked on the
+    # mock while all other attribute accesses fall through.
+    real_conn = db._conn
+    assert real_conn is not None
+    mock_conn = MagicMock(wraps=real_conn)
+    db._conn = mock_conn  # type: ignore[assignment]
+
+    db.interrupt_and_reset()
+
+    mock_conn.interrupt.assert_called_once()
+    assert db._conn is None
+    assert db._closed is True
+
+
+@pytest.mark.unit
+def test_module_helper_clears_singleton(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mock_store = MagicMock()
+    mock_store.get_key.return_value = "test-key-32-bytes-padding-padding-pad"
+
+    monkeypatch.setattr(db_module, "_database_instance", None)
+    db = Database(tmp_path / "t.duckdb", secret_store=mock_store, no_auto_upgrade=True)
+    monkeypatch.setattr(db_module, "_database_instance", db)
+
+    interrupt_and_reset_database()
+
+    assert db_module._database_instance is None

--- a/tests/moneybin/test_database_interrupt.py
+++ b/tests/moneybin/test_database_interrupt.py
@@ -20,16 +20,16 @@ def test_interrupt_and_reset_calls_interrupt_then_closes(
     # DuckDB's C-extension connection is read-only, so we swap in a MagicMock
     # that wraps the real connection; interrupt() and close() are tracked on the
     # mock while all other attribute accesses fall through.
-    real_conn = db._conn
+    real_conn = db._conn  # pyright: ignore[reportPrivateUsage]
     assert real_conn is not None
     mock_conn = MagicMock(wraps=real_conn)
-    db._conn = mock_conn  # type: ignore[assignment]
+    db._conn = mock_conn  # type: ignore[assignment]  # pyright: ignore[reportPrivateUsage]
 
     db.interrupt_and_reset()
 
     mock_conn.interrupt.assert_called_once()
-    assert db._conn is None
-    assert db._closed is True
+    assert db._conn is None  # pyright: ignore[reportPrivateUsage]
+    assert db._closed is True  # pyright: ignore[reportPrivateUsage]
 
 
 @pytest.mark.unit
@@ -45,4 +45,4 @@ def test_module_helper_clears_singleton(
 
     interrupt_and_reset_database()
 
-    assert db_module._database_instance is None
+    assert db_module._database_instance is None  # pyright: ignore[reportPrivateUsage]

--- a/tests/moneybin/test_database_interrupt.py
+++ b/tests/moneybin/test_database_interrupt.py
@@ -11,11 +11,11 @@ from moneybin.database import Database, interrupt_and_reset_database
 
 @pytest.mark.unit
 def test_interrupt_and_reset_calls_interrupt_then_closes(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, mock_secret_store: MagicMock
 ) -> None:
-    mock_store = MagicMock()
-    mock_store.get_key.return_value = "test-key-32-bytes-padding-padding-pad"
-    db = Database(tmp_path / "t.duckdb", secret_store=mock_store, no_auto_upgrade=True)
+    db = Database(
+        tmp_path / "t.duckdb", secret_store=mock_secret_store, no_auto_upgrade=True
+    )
 
     # DuckDB's C-extension connection is read-only, so we swap in a MagicMock
     # that wraps the real connection; interrupt() and close() are tracked on the
@@ -34,13 +34,14 @@ def test_interrupt_and_reset_calls_interrupt_then_closes(
 
 @pytest.mark.unit
 def test_module_helper_clears_singleton(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    mock_secret_store: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    mock_store = MagicMock()
-    mock_store.get_key.return_value = "test-key-32-bytes-padding-padding-pad"
-
     monkeypatch.setattr(db_module, "_database_instance", None)
-    db = Database(tmp_path / "t.duckdb", secret_store=mock_store, no_auto_upgrade=True)
+    db = Database(
+        tmp_path / "t.duckdb", secret_store=mock_secret_store, no_auto_upgrade=True
+    )
     monkeypatch.setattr(db_module, "_database_instance", db)
 
     interrupt_and_reset_database()

--- a/tests/moneybin/test_mcp/test_categorization_tools.py
+++ b/tests/moneybin/test_mcp/test_categorization_tools.py
@@ -47,7 +47,7 @@ class TestCategorizeToolRegistration:
 
     @pytest.mark.unit
     def test_categorize_stats_returns_envelope(self, mcp_db: object) -> None:
-        parsed = categorize_stats().to_dict()
+        parsed = asyncio.run(categorize_stats()).to_dict()
         assert "summary" in parsed
         assert "data" in parsed
         assert parsed["summary"]["sensitivity"] == "low"
@@ -55,7 +55,7 @@ class TestCategorizeToolRegistration:
     @pytest.mark.unit
     def test_categorize_categories_returns_envelope(self, mcp_db: object) -> None:
         """List categories returns a valid envelope (empty when no data)."""
-        cat_result = categorize_categories().to_dict()
+        cat_result = asyncio.run(categorize_categories()).to_dict()
         assert "summary" in cat_result
         assert "data" in cat_result
         assert isinstance(cat_result["data"], list)
@@ -102,7 +102,7 @@ class TestToggleCategoryWritePath:
         assert isinstance(mcp_db, Database)
         _seed_categories_view(mcp_db)
 
-        categorize_toggle_category(category_id="FND", is_active=False)
+        asyncio.run(categorize_toggle_category(category_id="FND", is_active=False))
 
         rows = mcp_db.execute(
             "SELECT category_id, is_active FROM app.category_overrides"
@@ -121,7 +121,7 @@ class TestToggleCategoryWritePath:
             VALUES ('CUSTOM1', 'Childcare', 'Daycare', true)
         """)
 
-        categorize_toggle_category(category_id="CUSTOM1", is_active=False)
+        asyncio.run(categorize_toggle_category(category_id="CUSTOM1", is_active=False))
 
         rows = mcp_db.execute(
             "SELECT is_active FROM app.user_categories WHERE category_id = ?",

--- a/tests/moneybin/test_mcp/test_decorator.py
+++ b/tests/moneybin/test_mcp/test_decorator.py
@@ -67,6 +67,8 @@ class TestMCPToolDecorator:
 
     @pytest.mark.unit
     def test_decorator_calls_log_tool_call(self) -> None:
+        import asyncio
+
         @mcp_tool(sensitivity="medium")
         def my_tool() -> ResponseEnvelope:
             return ResponseEnvelope(
@@ -75,7 +77,7 @@ class TestMCPToolDecorator:
             )
 
         with patch("moneybin.mcp.decorator.log_tool_call") as mock_log:
-            my_tool()
+            asyncio.run(my_tool())
             mock_log.assert_called_once()
             args = mock_log.call_args[0]
             assert args[0] == "my_tool"
@@ -104,6 +106,7 @@ class TestMCPToolDecorator:
     @pytest.mark.unit
     def test_decorator_returns_response_envelope(self) -> None:
         """When a tool returns a ResponseEnvelope, the decorator returns it directly."""
+        import asyncio
 
         @mcp_tool(sensitivity="low")
         def my_tool() -> ResponseEnvelope:
@@ -112,7 +115,7 @@ class TestMCPToolDecorator:
                 data=[{"value": 42}],
             )
 
-        result = my_tool()
+        result = asyncio.run(my_tool())
         assert isinstance(result, ResponseEnvelope)
         assert result.summary.total_count == 1
         assert result.data == [{"value": 42}]
@@ -120,6 +123,8 @@ class TestMCPToolDecorator:
     @pytest.mark.unit
     def test_decorator_raises_type_error_for_non_envelope(self) -> None:
         """Tools that return non-ResponseEnvelope raise TypeError."""
+        import asyncio
+
         import pytest
 
         @mcp_tool(sensitivity="low")
@@ -127,4 +132,4 @@ class TestMCPToolDecorator:
             return "plain string result"  # type: ignore[return-value]
 
         with pytest.raises(TypeError, match="expected ResponseEnvelope"):
-            my_tool()
+            asyncio.run(my_tool())

--- a/tests/moneybin/test_mcp/test_decorator.py
+++ b/tests/moneybin/test_mcp/test_decorator.py
@@ -1,6 +1,7 @@
 # tests/moneybin/test_mcp/test_decorator.py
 """Tests for MCP tool decorator and sensitivity middleware."""
 
+import asyncio
 from unittest.mock import patch
 
 import pytest
@@ -67,7 +68,6 @@ class TestMCPToolDecorator:
 
     @pytest.mark.unit
     def test_decorator_calls_log_tool_call(self) -> None:
-        import asyncio
 
         @mcp_tool(sensitivity="medium")
         def my_tool() -> ResponseEnvelope:
@@ -106,7 +106,6 @@ class TestMCPToolDecorator:
     @pytest.mark.unit
     def test_decorator_returns_response_envelope(self) -> None:
         """When a tool returns a ResponseEnvelope, the decorator returns it directly."""
-        import asyncio
 
         @mcp_tool(sensitivity="low")
         def my_tool() -> ResponseEnvelope:
@@ -123,8 +122,6 @@ class TestMCPToolDecorator:
     @pytest.mark.unit
     def test_decorator_raises_type_error_for_non_envelope(self) -> None:
         """Tools that return non-ResponseEnvelope raise TypeError."""
-        import asyncio
-
         import pytest
 
         @mcp_tool(sensitivity="low")

--- a/tests/moneybin/test_mcp/test_envelope.py
+++ b/tests/moneybin/test_mcp/test_envelope.py
@@ -169,3 +169,19 @@ class TestBuildEnvelope:
         )
         assert envelope.summary.total_count == 50
         assert envelope.data == result
+
+
+@pytest.mark.unit
+def test_user_error_carries_structured_details() -> None:
+    from moneybin.errors import UserError
+
+    err = UserError(
+        "Tool exceeded 30.0s cap",
+        code="timed_out",
+        hint=None,
+        details={"tool": "import_inbox_sync", "elapsed_s": 30.1, "timeout_s": 30.0},
+    )
+    d = err.to_dict()
+    assert d["code"] == "timed_out"
+    assert d["details"]["tool"] == "import_inbox_sync"
+    assert d["details"]["timeout_s"] == 30.0

--- a/tests/moneybin/test_mcp/test_error_handling.py
+++ b/tests/moneybin/test_mcp/test_error_handling.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from moneybin.database import DatabaseKeyError
@@ -17,7 +19,7 @@ def test_mcp_tool_converts_user_error_to_envelope() -> None:
     def failing_tool() -> ResponseEnvelope:
         raise UserError("not found", code="NOT_FOUND")
 
-    result = failing_tool()
+    result = asyncio.run(failing_tool())
     assert isinstance(result, ResponseEnvelope)
     assert result.error is not None
     assert result.error.code == "NOT_FOUND"
@@ -31,7 +33,7 @@ def test_mcp_tool_converts_database_key_error_to_envelope() -> None:
     def failing_tool() -> ResponseEnvelope:
         raise DatabaseKeyError("missing key")
 
-    result = failing_tool()
+    result = asyncio.run(failing_tool())
     assert isinstance(result, ResponseEnvelope)
     assert result.error is not None
     assert result.error.code == "database_locked"
@@ -49,7 +51,7 @@ def test_mcp_tool_lets_unclassified_exceptions_propagate() -> None:
         raise RuntimeError("internal detail leak")
 
     with pytest.raises(RuntimeError):
-        failing_tool()
+        asyncio.run(failing_tool())
 
 
 def test_mcp_tool_returns_response_envelope_directly() -> None:
@@ -63,6 +65,6 @@ def test_mcp_tool_returns_response_envelope_directly() -> None:
     def ok_tool() -> ResponseEnvelope:
         return build_envelope(data=[{"x": 1}], sensitivity="low")
 
-    result = ok_tool()
+    result = asyncio.run(ok_tool())
     assert isinstance(result, ResponseEnvelope)  # NOT a str
     assert result.data == [{"x": 1}]

--- a/tests/moneybin/test_mcp/test_import_inbox_tools.py
+++ b/tests/moneybin/test_mcp/test_import_inbox_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -43,7 +44,7 @@ class TestInboxSyncTool:
         patch_service.sync.return_value = InboxSyncResult(
             processed=[{"filename": "a.csv", "transactions": 3}],
         )
-        envelope = inbox_sync_tool()
+        envelope = asyncio.run(inbox_sync_tool())
         assert envelope.summary.sensitivity == "low"
         assert envelope.data["processed"][0]["filename"] == "a.csv"
 
@@ -51,14 +52,14 @@ class TestInboxSyncTool:
         patch_service.sync.return_value = InboxSyncResult(
             failed=[{"filename": "x.csv", "error_code": "needs_account_name"}],
         )
-        envelope = inbox_sync_tool()
+        envelope = asyncio.run(inbox_sync_tool())
         assert any("inbox/<account-slug>" in a for a in envelope.actions)
 
     def test_no_failure_no_resolution_hint(self, patch_service: MagicMock) -> None:
         patch_service.sync.return_value = InboxSyncResult(
             processed=[{"filename": "a.csv", "transactions": 1}],
         )
-        envelope = inbox_sync_tool()
+        envelope = asyncio.run(inbox_sync_tool())
         assert not any("inbox/<account-slug>" in a for a in envelope.actions)
 
 
@@ -69,6 +70,6 @@ class TestInboxListTool:
         patch_service.enumerate.return_value = InboxListResult(
             would_process=[{"filename": "a.csv", "account_hint": None}],
         )
-        envelope = inbox_list_tool()
+        envelope = asyncio.run(inbox_list_tool())
         assert envelope.summary.sensitivity == "low"
         assert envelope.data["would_process"][0]["filename"] == "a.csv"

--- a/tests/moneybin/test_mcp/test_tool_timeouts.py
+++ b/tests/moneybin/test_mcp/test_tool_timeouts.py
@@ -133,3 +133,56 @@ def test_async_generator_tool_rejected_at_decoration() -> None:
         @mcp_tool(sensitivity="low")
         async def gen_tool() -> ResponseEnvelope:  # type: ignore[misc]
             yield  # type: ignore[misc]
+
+
+@pytest.mark.integration
+def test_back_to_back_call_after_timeout_succeeds(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A call that times out must release the DB lock so the next call works."""
+    import moneybin.database as db_module
+    from moneybin.database import Database
+
+    mock_store = MagicMock()
+    mock_store.get_key.return_value = "test-key-32-bytes-padding-padding-pad"
+
+    db = Database(tmp_path / "t.duckdb", secret_store=mock_store, no_auto_upgrade=True)
+    monkeypatch.setattr(db_module, "_database_instance", db)
+
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 0.1)
+
+    @mcp_tool(sensitivity="low")
+    def hang_tool() -> ResponseEnvelope:
+        # Spin without releasing GIL frequently to mimic a stuck native call.
+        time.sleep(2.0)
+        return ResponseEnvelope(
+            summary=SummaryMeta(total_count=0, returned_count=0), data=[]
+        )
+
+    @mcp_tool(sensitivity="low")
+    def quick_tool() -> ResponseEnvelope:
+        # Touch the DB to prove the singleton is healthy after reset.
+        from moneybin.database import get_database
+
+        rows = get_database().execute("SELECT 42 AS x").fetchall()
+        return ResponseEnvelope(
+            summary=SummaryMeta(total_count=len(rows), returned_count=len(rows)),
+            data=[{"x": rows[0][0]}],
+        )
+
+    first = asyncio.run(hang_tool())
+    assert first.error is not None and first.error.code == "timed_out"
+
+    # The timeout path cleared _database_instance.  In production the next
+    # get_database() call reopens via settings.  In tests we reinstall a fresh
+    # instance with the same mock store so quick_tool can connect successfully.
+    db2 = Database(
+        tmp_path / "t2.duckdb", secret_store=mock_store, no_auto_upgrade=True
+    )
+    monkeypatch.setattr(db_module, "_database_instance", db2)
+
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 5.0)
+    second = asyncio.run(quick_tool())
+    assert second.error is None
+    assert second.data == [{"x": 42}]

--- a/tests/moneybin/test_mcp/test_tool_timeouts.py
+++ b/tests/moneybin/test_mcp/test_tool_timeouts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -137,7 +138,7 @@ def test_async_generator_tool_rejected_at_decoration() -> None:
 
 @pytest.mark.integration
 def test_back_to_back_call_after_timeout_succeeds(
-    tmp_path,
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A call that times out must release the DB lock so the next call works."""

--- a/tests/moneybin/test_mcp/test_tool_timeouts.py
+++ b/tests/moneybin/test_mcp/test_tool_timeouts.py
@@ -1,0 +1,126 @@
+"""Timeout guard tests for the @mcp_tool decorator."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from moneybin.mcp.decorator import mcp_tool
+from moneybin.protocol.envelope import ResponseEnvelope, SummaryMeta
+
+
+def _ok_envelope() -> ResponseEnvelope:
+    return ResponseEnvelope(
+        summary=SummaryMeta(total_count=0, returned_count=0),
+        data=[],
+    )
+
+
+@pytest.mark.unit
+def test_sync_tool_under_cap_passes_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 5.0)
+
+    @mcp_tool(sensitivity="low")
+    def fast_tool() -> ResponseEnvelope:
+        return _ok_envelope()
+
+    result = asyncio.run(fast_tool())
+    assert isinstance(result, ResponseEnvelope)
+    assert result.error is None
+
+
+@pytest.mark.unit
+def test_sync_tool_over_cap_returns_timeout_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 0.05)
+    reset_mock = MagicMock()
+    monkeypatch.setattr(
+        "moneybin.mcp.decorator.interrupt_and_reset_database", reset_mock
+    )
+
+    @mcp_tool(sensitivity="low")
+    def slow_tool() -> ResponseEnvelope:
+        time.sleep(0.5)
+        return _ok_envelope()
+
+    async def _run() -> tuple[ResponseEnvelope, float]:
+        started = time.monotonic()
+        r = await slow_tool()
+        return r, time.monotonic() - started
+
+    result, elapsed = asyncio.run(_run())
+
+    assert elapsed < 0.4, "timeout did not fire within reasonable bound"
+    assert isinstance(result, ResponseEnvelope)
+    assert result.error is not None
+    assert result.error.code == "timed_out"
+    assert result.error.details is not None
+    assert result.error.details["tool"] == "slow_tool"
+    assert result.error.details["timeout_s"] == 0.05
+    assert result.error.details["elapsed_s"] >= 0.05
+    reset_mock.assert_called_once()
+
+
+@pytest.mark.unit
+def test_async_tool_over_cap_returns_timeout_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 0.05)
+    monkeypatch.setattr(
+        "moneybin.mcp.decorator.interrupt_and_reset_database", MagicMock()
+    )
+
+    @mcp_tool(sensitivity="low")
+    async def slow_tool() -> ResponseEnvelope:
+        await asyncio.sleep(0.5)
+        return _ok_envelope()
+
+    result = asyncio.run(slow_tool())
+    assert result.error is not None
+    assert result.error.code == "timed_out"
+
+
+@pytest.mark.unit
+def test_timeout_logs_low_cardinality_line(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 0.02)
+    monkeypatch.setattr(
+        "moneybin.mcp.decorator.interrupt_and_reset_database", MagicMock()
+    )
+
+    @mcp_tool(sensitivity="low")
+    async def slow_tool(account_number: str = "secret-123") -> ResponseEnvelope:
+        await asyncio.sleep(0.5)
+        return _ok_envelope()
+
+    with caplog.at_level("WARNING"):
+        asyncio.run(slow_tool(account_number="acct-redacted-do-not-log"))
+
+    relevant = [r for r in caplog.records if "timed out" in r.getMessage().lower()]
+    assert len(relevant) == 1
+    assert "slow_tool" in relevant[0].getMessage()
+    assert "acct-redacted-do-not-log" not in relevant[0].getMessage()
+
+
+@pytest.mark.unit
+def test_classified_user_error_still_returned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 5.0)
+    from moneybin.errors import UserError
+
+    @mcp_tool(sensitivity="low")
+    def bad_tool() -> ResponseEnvelope:
+        raise UserError("nope", code="not_found")
+
+    result = asyncio.run(bad_tool())
+    assert result.error is not None
+    assert result.error.code == "not_found"

--- a/tests/moneybin/test_mcp/test_tool_timeouts.py
+++ b/tests/moneybin/test_mcp/test_tool_timeouts.py
@@ -139,16 +139,16 @@ def test_async_generator_tool_rejected_at_decoration() -> None:
 @pytest.mark.integration
 def test_back_to_back_call_after_timeout_succeeds(
     tmp_path: Path,
+    mock_secret_store: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A call that times out must release the DB lock so the next call works."""
     import moneybin.database as db_module
     from moneybin.database import Database
 
-    mock_store = MagicMock()
-    mock_store.get_key.return_value = "test-key-32-bytes-padding-padding-pad"
-
-    db = Database(tmp_path / "t.duckdb", secret_store=mock_store, no_auto_upgrade=True)
+    db = Database(
+        tmp_path / "t.duckdb", secret_store=mock_secret_store, no_auto_upgrade=True
+    )
     monkeypatch.setattr(db_module, "_database_instance", db)
 
     monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 0.1)
@@ -179,7 +179,9 @@ def test_back_to_back_call_after_timeout_succeeds(
     # connection, releasing its write lock.  Reopening the same DB file proves
     # the lock was actually dropped — if interrupt_and_reset() had failed to
     # release it, this Database() construction would hang or fail.
-    db2 = Database(tmp_path / "t.duckdb", secret_store=mock_store, no_auto_upgrade=True)
+    db2 = Database(
+        tmp_path / "t.duckdb", secret_store=mock_secret_store, no_auto_upgrade=True
+    )
     monkeypatch.setattr(db_module, "_database_instance", db2)
 
     monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 5.0)

--- a/tests/moneybin/test_mcp/test_tool_timeouts.py
+++ b/tests/moneybin/test_mcp/test_tool_timeouts.py
@@ -174,12 +174,11 @@ def test_back_to_back_call_after_timeout_succeeds(
     first = asyncio.run(hang_tool())
     assert first.error is not None and first.error.code == "timed_out"
 
-    # The timeout path cleared _database_instance.  In production the next
-    # get_database() call reopens via settings.  In tests we reinstall a fresh
-    # instance with the same mock store so quick_tool can connect successfully.
-    db2 = Database(
-        tmp_path / "t2.duckdb", secret_store=mock_store, no_auto_upgrade=True
-    )
+    # The timeout path cleared _database_instance and force-closed the original
+    # connection, releasing its write lock.  Reopening the same DB file proves
+    # the lock was actually dropped — if interrupt_and_reset() had failed to
+    # release it, this Database() construction would hang or fail.
+    db2 = Database(tmp_path / "t.duckdb", secret_store=mock_store, no_auto_upgrade=True)
     monkeypatch.setattr(db_module, "_database_instance", db2)
 
     monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 5.0)

--- a/tests/moneybin/test_mcp/test_tool_timeouts.py
+++ b/tests/moneybin/test_mcp/test_tool_timeouts.py
@@ -124,3 +124,12 @@ def test_classified_user_error_still_returned(
     result = asyncio.run(bad_tool())
     assert result.error is not None
     assert result.error.code == "not_found"
+
+
+@pytest.mark.unit
+def test_async_generator_tool_rejected_at_decoration() -> None:
+    with pytest.raises(TypeError, match="async generator"):
+
+        @mcp_tool(sensitivity="low")
+        async def gen_tool() -> ResponseEnvelope:  # type: ignore[misc]
+            yield  # type: ignore[misc]

--- a/tests/moneybin/test_mcp/test_tool_timeouts.py
+++ b/tests/moneybin/test_mcp/test_tool_timeouts.py
@@ -128,6 +128,36 @@ def test_classified_user_error_still_returned(
 
 
 @pytest.mark.unit
+def test_tool_raised_timeout_error_not_classified_as_cap_fired(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A TimeoutError raised by the tool body must not be reported as a cap-fired timeout.
+
+    Without the asyncio.timeout()/.expired() distinction, an unrelated
+    TimeoutError (e.g., a downstream HTTP call) would be miscaught as the
+    wall-clock cap firing, producing a misleading ``timed_out`` envelope
+    AND tearing down the DuckDB connection unnecessarily.
+    """
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 5.0)
+    reset_mock = MagicMock()
+    monkeypatch.setattr(
+        "moneybin.mcp.decorator.interrupt_and_reset_database", reset_mock
+    )
+
+    @mcp_tool(sensitivity="low")
+    def inner_timeout_tool() -> ResponseEnvelope:
+        raise TimeoutError("downstream HTTP timeout")
+
+    # TimeoutError is not a classified UserError, so the decorator re-raises
+    # it (matching pre-existing behavior for unclassified exceptions). The
+    # critical assertions are the side effects: no DB reset, no cap-fired log.
+    with pytest.raises(TimeoutError, match="downstream HTTP timeout"):
+        asyncio.run(inner_timeout_tool())
+
+    reset_mock.assert_not_called()
+
+
+@pytest.mark.unit
 def test_async_generator_tool_rejected_at_decoration() -> None:
     with pytest.raises(TypeError, match="async generator"):
 

--- a/tests/moneybin/test_mcp/test_tool_timeouts.py
+++ b/tests/moneybin/test_mcp/test_tool_timeouts.py
@@ -166,6 +166,15 @@ def test_async_generator_tool_rejected_at_decoration() -> None:
             yield  # type: ignore[misc]
 
 
+@pytest.mark.unit
+def test_sync_generator_tool_rejected_at_decoration() -> None:
+    with pytest.raises(TypeError, match="sync generator"):
+
+        @mcp_tool(sensitivity="low")
+        def gen_tool() -> ResponseEnvelope:  # type: ignore[misc]
+            yield  # type: ignore[misc]
+
+
 @pytest.mark.integration
 def test_back_to_back_call_after_timeout_succeeds(
     tmp_path: Path,

--- a/tests/moneybin/test_mcp/test_tools.py
+++ b/tests/moneybin/test_mcp/test_tools.py
@@ -5,6 +5,8 @@ These tests exercise the underlying tool functions directly. Registration
 with the FastMCP server is covered by tests/mcp/test_visibility.py.
 """
 
+import asyncio
+
 import pytest
 from fastmcp import FastMCP
 
@@ -40,7 +42,6 @@ class TestV1ToolRegistration:
         srv = FastMCP("test")
         register_spending_tools(srv)
         # Synchronous accessor surface differs by version; resolve via asyncio.
-        import asyncio
 
         names = {t.name for t in asyncio.run(srv._list_tools())}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
         assert "spending_summary" in names
@@ -48,7 +49,6 @@ class TestV1ToolRegistration:
 
     @pytest.mark.unit
     def test_accounts_tools_register(self) -> None:
-        import asyncio
 
         srv = FastMCP("test")
         register_accounts_tools(srv)
@@ -58,7 +58,6 @@ class TestV1ToolRegistration:
 
     @pytest.mark.unit
     def test_accounts_list_returns_envelope(self, mcp_db: object) -> None:
-        import asyncio
 
         result = asyncio.run(accounts_list())
         parsed = result.to_dict()
@@ -69,7 +68,6 @@ class TestV1ToolRegistration:
 
     @pytest.mark.unit
     def test_sql_query_returns_envelope(self, mcp_db: object) -> None:
-        import asyncio
 
         from moneybin.mcp.server import get_db
 
@@ -87,7 +85,6 @@ class TestV1ToolRegistration:
 
     @pytest.mark.unit
     def test_sql_schema_returns_envelope(self, mcp_db: object) -> None:
-        import asyncio
 
         result = asyncio.run(sql_schema())
         parsed = result.to_dict()

--- a/tests/moneybin/test_mcp/test_tools.py
+++ b/tests/moneybin/test_mcp/test_tools.py
@@ -58,7 +58,9 @@ class TestV1ToolRegistration:
 
     @pytest.mark.unit
     def test_accounts_list_returns_envelope(self, mcp_db: object) -> None:
-        result = accounts_list()
+        import asyncio
+
+        result = asyncio.run(accounts_list())
         parsed = result.to_dict()
         assert "summary" in parsed
         assert "data" in parsed
@@ -67,6 +69,8 @@ class TestV1ToolRegistration:
 
     @pytest.mark.unit
     def test_sql_query_returns_envelope(self, mcp_db: object) -> None:
+        import asyncio
+
         from moneybin.mcp.server import get_db
 
         get_db().execute(_INSERT_TRANSACTIONS)
@@ -74,14 +78,18 @@ class TestV1ToolRegistration:
         # Also exercise registration to ensure no smoke errors.
         register_sql_tools(FastMCP("test"))
 
-        result = sql_query(query="SELECT COUNT(*) AS cnt FROM core.fct_transactions")
+        result = asyncio.run(
+            sql_query(query="SELECT COUNT(*) AS cnt FROM core.fct_transactions")
+        )
         parsed = result.to_dict()
         assert "summary" in parsed
         assert parsed["data"][0]["cnt"] == 2
 
     @pytest.mark.unit
     def test_sql_schema_returns_envelope(self, mcp_db: object) -> None:
-        result = sql_schema()
+        import asyncio
+
+        result = asyncio.run(sql_schema())
         parsed = result.to_dict()
         assert parsed["summary"]["sensitivity"] == "low"
         data = parsed["data"]

--- a/tests/moneybin/test_mcp/test_v1_tools.py
+++ b/tests/moneybin/test_mcp/test_v1_tools.py
@@ -35,8 +35,10 @@ class TestSpendingSummaryTool:
 
     @pytest.mark.unit
     def test_returns_envelope(self, mcp_db: object) -> None:
+        import asyncio
+
         self._insert_data(mcp_db)
-        result = spending_summary(months=3)
+        result = asyncio.run(spending_summary(months=3))
         from moneybin.protocol.envelope import ResponseEnvelope
 
         assert isinstance(result, ResponseEnvelope)
@@ -48,8 +50,10 @@ class TestSpendingSummaryTool:
 
     @pytest.mark.unit
     def test_data_shape(self, mcp_db: object) -> None:
+        import asyncio
+
         self._insert_data(mcp_db)
-        parsed = spending_summary(months=3).to_dict()
+        parsed = asyncio.run(spending_summary(months=3)).to_dict()
         data = parsed["data"]
         assert len(data) >= 1
         assert "period" in data[0]

--- a/tests/moneybin/test_mcp/test_v1_tools.py
+++ b/tests/moneybin/test_mcp/test_v1_tools.py
@@ -5,6 +5,8 @@ These tests exercise the underlying tool functions directly. Registration
 with the FastMCP server is covered by tests/mcp/test_visibility.py.
 """
 
+import asyncio
+
 import pytest
 
 from moneybin.mcp.tools.spending import spending_summary
@@ -35,7 +37,6 @@ class TestSpendingSummaryTool:
 
     @pytest.mark.unit
     def test_returns_envelope(self, mcp_db: object) -> None:
-        import asyncio
 
         self._insert_data(mcp_db)
         result = asyncio.run(spending_summary(months=3))
@@ -50,7 +51,6 @@ class TestSpendingSummaryTool:
 
     @pytest.mark.unit
     def test_data_shape(self, mcp_db: object) -> None:
-        import asyncio
 
         self._insert_data(mcp_db)
         parsed = asyncio.run(spending_summary(months=3)).to_dict()


### PR DESCRIPTION
### Summary
Wrap every MCP tool dispatch in a configurable wall-clock cap (default 30s). On timeout, the active DuckDB statement is interrupted and the singleton connection is force-closed, releasing any held write lock so the next call succeeds. The structured `code="timed_out"` envelope tells the client what happened instead of hanging.

Implements [`docs/specs/mcp-tool-timeouts.md`](docs/specs/mcp-tool-timeouts.md).

### Impact
- Every `@mcp_tool`-decorated function is now exposed as an `async` coroutine. FastMCP already awaits it; transparent at runtime. Tests that called decorated tools synchronously now wrap with `asyncio.run(...)`.
- Async-generator MCP tools are rejected at decoration time (they would have silently mis-dispatched through `asyncio.to_thread`).
- New env var: `MONEYBIN_MCP__TOOL_TIMEOUT_SECONDS` (float, default `30.0`).

### Changes

#### Configuration
- `MCPConfig.tool_timeout_seconds: float = 30.0` (`gt=0.0`).

#### Database
- `Database.interrupt_and_reset()` — best-effort `connection.interrupt()` then `close()`; guaranteed lock release.
- Module-level `interrupt_and_reset_database()` clears the singleton so the next `get_database()` reopens fresh.

#### Errors / Envelope
- `UserError` gains an optional `details: dict[str, Any]` payload, surfaced through `to_dict()`. Existing callers unaffected.

#### MCP Decorator
- Single async wrapper enforces `asyncio.wait_for(timeout=settings.mcp.tool_timeout_seconds)`. Sync bodies dispatch via `asyncio.to_thread`.
- On `TimeoutError`: low-cardinality warning log (tool name + elapsed only — never args/kwargs), `interrupt_and_reset_database()` inside a cleanup-must-not-raise guard, structured envelope returned with `code="timed_out"` and `details={tool, elapsed_s, timeout_s}`.

#### Tests
- New `tests/moneybin/test_mcp/test_tool_timeouts.py`: 6 unit tests (under-cap pass, sync timeout + DB reset, async timeout, low-cardinality logging / no PII, classified `UserError` still works, async-gen rejection) + integration test that hangs a tool, times out, and proves the same DB file can be reopened.
- New `tests/moneybin/test_database_interrupt.py` for the cleanup helpers.
- Existing MCP tests updated for the sync→async transition.

#### Docs
- Spec status flipped to `implemented`; `INDEX.md` and `README.md` (roadmap + "What Works Today") updated.

### Testing
- `make check test`: 1556 unit tests pass; pyright clean.
- Integration test exercises real DuckDB interrupt + same-path reopen — proves the lock is actually released.