### PR TITLE
Stop shadowing moneybin.cli.main module with main() function

### DIFF
--- a/src/moneybin/cli/__init__.py
+++ b/src/moneybin/cli/__init__.py
@@ -2,8 +2,13 @@
 
 This package provides a unified command-line interface for all MoneyBin operations,
 including data extraction, credential management, and system utilities.
+
+Note: the `main()` function is intentionally NOT re-exported here. The console
+script entry point (`moneybin.cli.main:main`) imports it directly from the
+submodule, and re-exporting it would shadow the submodule of the same name —
+forcing callers into `sys.modules` workarounds.
 """
 
-from .main import app, main
+from .main import app
 
-__all__ = ["app", "main"]
+__all__ = ["app"]

--- a/tests/moneybin/test_cli/test_help_no_wizard.py
+++ b/tests/moneybin/test_cli/test_help_no_wizard.py
@@ -2,20 +2,14 @@
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 from typer.testing import CliRunner
 
-from moneybin.cli.main import app  # noqa: F401  # ensures module is imported
-
-# `from moneybin.cli import main` resolves to the re-exported function rather
-# than the submodule (the CLI package re-exports `main` in its __init__).
-# Look the module up via sys.modules to monkeypatch its attributes.
-cli_main = sys.modules["moneybin.cli.main"]
-cli_utils = sys.modules["moneybin.cli.utils"]
+from moneybin.cli import utils as cli_utils
+from moneybin.cli.main import app
 
 
 @pytest.fixture()

--- a/tests/moneybin/test_cli/test_module_shape.py
+++ b/tests/moneybin/test_cli/test_module_shape.py
@@ -1,0 +1,31 @@
+"""Locks in the package-level shape of moneybin.cli.
+
+Specifically: `moneybin.cli.main` must resolve to the *module*, not the
+`main()` function. Re-exporting the function at the package level shadows
+the submodule and forces test code into `sys.modules` workarounds.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_cli_main_attribute_is_module() -> None:
+    cli = importlib.import_module("moneybin.cli")
+    assert isinstance(cli.main, ModuleType), (
+        "moneybin.cli.main is shadowed by a non-module attribute "
+        "(likely a function re-export). The submodule must remain accessible."
+    )
+
+
+def test_cli_package_does_not_export_main_function() -> None:
+    cli = importlib.import_module("moneybin.cli")
+    assert "main" not in cli.__all__, (
+        "`main` is in moneybin.cli.__all__; remove it to keep the submodule "
+        "name unshadowed."
+    )


### PR DESCRIPTION
### Summary

The CLI package's `__init__.py` was re-exporting `main` from the submodule of the same name, which shadowed `moneybin.cli.main` (the module) with `moneybin.cli.main` (the function) once the package was imported. That foot-gun forced one test file into a `sys.modules` workaround and would have tripped any future contributor who reached for `from moneybin.cli import main`. This drops the re-export, removes the workaround, and adds a regression test that fails fast if anyone re-shadows the submodule.

### Impact

- No workflow changes. The console script entry point (`moneybin = "moneybin.cli.main:main"` in `pyproject.toml`) addresses the module:function pair directly and is unaffected — `uv run moneybin --help` still renders.
- No public API change. A repo-wide grep confirmed no consumer imports `main` from the package level; every existing call site already uses `from moneybin.cli.main import app` (or the entry point).

### Changes

#### Drop the function re-export

Removed `main` from the imports and from `__all__` in `src/moneybin/cli/__init__.py`. Added a docstring note explaining why the re-export is intentionally absent, so the next contributor tempted to add it back sees the rationale in place.

- `src/moneybin/cli/__init__.py` — `from .main import app` only; `__all__ = ["app"]`.

#### Replace the `sys.modules` workaround in `test_help_no_wizard.py`

The previous test used `cli_utils = sys.modules["moneybin.cli.utils"]` to dodge the shadow. With the shadow gone, normal imports work. Also dropped a dead `cli_main = sys.modules[...]` line that was assigned but never used, and the now-stale `# noqa: F401` annotation on the `app` import (which is genuinely used by `runner.invoke`).

- `tests/moneybin/test_cli/test_help_no_wizard.py` — normal `from moneybin.cli import utils as cli_utils` and `from moneybin.cli.main import app`.

#### Add a regression-net test

New file with two pytest cases that lock in the package-level shape: `moneybin.cli.main` must resolve to a `ModuleType`, and `"main"` must not appear in `moneybin.cli.__all__`. Failure messages teach the next contributor what they did wrong.

- `tests/moneybin/test_cli/test_module_shape.py` — new file, 2 unit tests.

### Testing

- `uv run pytest tests/moneybin/test_cli/test_module_shape.py -q` — 2/2 passing.
- `uv run pytest tests/moneybin/test_cli/ -q` — 338/338 passing.
- `make test` — 1634/1634 passing.
- `make format && make lint` — clean.
- `uv run pyright` on the three touched files — 0 errors.
- `uv run moneybin --help` — renders normally.