### PR TITLE
Extend MCP schema drift coverage to app.* interface tables

### DIFF
--- a/tests/moneybin/conftest.py
+++ b/tests/moneybin/conftest.py
@@ -118,7 +118,15 @@ def mock_secret_store() -> MagicMock:
 def schema_catalog_db(
     tmp_path: Path, mock_secret_store: MagicMock
 ) -> Generator[Database, None, None]:
-    """Database with core tables + comments applied; for schema-catalog tests."""
+    """Database with core tables + the app.categories view stub.
+
+    `Database.__init__` runs `init_schemas()` which creates every base
+    `app.*` interface table (budgets, merchants, categorization_rules,
+    transaction_categories, transaction_notes, etc.). It does NOT create
+    `app.categories`, which is a view normally materialized by SQLMesh
+    seeds. We stub it here so drift tests cover the full interface
+    surface, not just core.*.
+    """
     database = Database(
         tmp_path / "schema_catalog.duckdb",
         secret_store=mock_secret_store,
@@ -126,6 +134,18 @@ def schema_catalog_db(
     )
     create_core_tables_raw(database.conn)
     apply_core_table_comments(database)
+    database.execute(
+        "CREATE OR REPLACE VIEW app.categories AS "
+        "SELECT CAST(NULL AS VARCHAR) AS category_id, "
+        "CAST(NULL AS VARCHAR) AS category, "
+        "CAST(NULL AS VARCHAR) AS subcategory, "
+        "CAST(NULL AS VARCHAR) AS description, "
+        "CAST(NULL AS VARCHAR) AS plaid_detailed, "
+        "CAST(NULL AS BOOLEAN) AS is_default, "
+        "CAST(NULL AS BOOLEAN) AS is_active, "
+        "CAST(NULL AS TIMESTAMP) AS created_at "
+        "WHERE FALSE"
+    )
     db_module._database_instance = database  # type: ignore[attr-defined]
     try:
         yield database

--- a/tests/moneybin/test_services/test_schema_catalog.py
+++ b/tests/moneybin/test_services/test_schema_catalog.py
@@ -50,9 +50,12 @@ def test_every_interface_table_has_at_least_one_example() -> None:
 
 
 def _present_tables(db: Database) -> set[str]:
-    """Return fully-qualified names of all tables in the test DB."""
+    """Return fully-qualified names of all tables and views in the test DB."""
     rows = db.execute(
-        "SELECT schema_name || '.' || table_name FROM duckdb_tables()"
+        "SELECT schema_name || '.' || table_name FROM duckdb_tables() "
+        "UNION ALL "
+        "SELECT schema_name || '.' || view_name FROM duckdb_views() "
+        "WHERE NOT internal"
     ).fetchall()
     return {r[0] for r in rows}
 
@@ -88,15 +91,9 @@ def test_build_schema_doc_includes_interface_views(
 
     Regression test: `duckdb_tables()` excludes views, so the catalog
     query must union it with `duckdb_views()` to surface objects like
-    `app.categories` (created via CREATE OR REPLACE VIEW in seeds.py).
+    `app.categories` (a view normally created via SQLMesh seeds; stubbed
+    in the fixture for tests).
     """
-    schema_catalog_db.execute("CREATE SCHEMA IF NOT EXISTS app")
-    schema_catalog_db.execute(
-        "CREATE OR REPLACE VIEW app.categories AS "
-        "SELECT 'X' AS category_id, 'X' AS category, "
-        "NULL::VARCHAR AS subcategory, NULL::VARCHAR AS description, "
-        "true AS is_active"
-    )
     doc = build_schema_doc()
     names = {t["name"] for t in doc["tables"]}
     assert "app.categories" in names
@@ -141,35 +138,25 @@ def test_build_schema_doc_includes_examples_for_present_tables(
 
 
 def test_interface_tables_present_in_catalog(schema_catalog_db: Database) -> None:
-    """Stale-entry drift: an interface-tagged table is missing from the DB.
+    """Stale-entry drift: every interface-tagged table must exist in the DB.
 
-    Coverage gap: filters to core.* because the fixture only seeds core
-    tables — the six app.* interface tables (categories, budgets, notes,
-    merchants, categorization_rules, transaction_categories) are not
-    presence-checked or example-executed here. See docs/followups.md
-    "MCP schema discoverability — app.* drift coverage".
+    Catches removals or renames of any INTERFACE_TABLES entry — including the
+    six app.* interface tables (categories, budgets, merchants,
+    categorization_rules, transaction_categories, transaction_notes), which
+    were previously skipped because the fixture did not seed them.
     """
     present = _present_tables(schema_catalog_db)
-    missing_core = [
-        t.full_name
-        for t in INTERFACE_TABLES
-        if t.schema == "core" and t.full_name not in present
-    ]
-    assert not missing_core, (
-        f"INTERFACE_TABLES core entries missing from catalog: {missing_core}"
-    )
+    missing = [t.full_name for t in INTERFACE_TABLES if t.full_name not in present]
+    assert not missing, f"INTERFACE_TABLES entries missing from test DB: {missing}"
 
 
 def test_examples_parse_and_execute(schema_catalog_db: Database) -> None:
     """Examples must parse and execute against the live schema.
 
-    Catches column-renamed-but-example-not-updated drift. Skips examples
-    for tables not present in the test DB (app.* tables — see the
-    coverage-gap note on test_interface_tables_present_in_catalog).
+    Catches column-renamed-but-example-not-updated drift. Now exercises
+    examples for app.* interface tables (previously skipped when the
+    fixture did not seed them).
     """
-    present = _present_tables(schema_catalog_db)
-    for table_name, examples in EXAMPLES.items():
-        if table_name not in present:
-            continue
+    for examples in EXAMPLES.values():
         for ex in examples:
             schema_catalog_db.execute(ex.sql).fetchall()


### PR DESCRIPTION
### Summary

Two existing drift tests in `tests/moneybin/test_services/test_schema_catalog.py` filtered to `core.*` because the `schema_catalog_db` fixture only seeded core tables — silently skipping the six `app.*` interface tables. `Database.__init__` already runs `init_schemas()`, so five base `app.*` tables were always present in the fixture; only `app.categories` (a SQLMesh-managed view) needed stubbing. This change stubs the view, drops the filter and the presence-skip, and removes a now-redundant inline view stub from a third test.

### Impact

- Drift coverage expands from 3 core tables to all 9 interface tables (`core.dim_accounts`, `core.fct_transactions`, `core.bridge_transfers` + `app.budgets`, `app.merchants`, `app.categories`, `app.categorization_rules`, `app.transaction_categories`, `app.transaction_notes`).
- No production code changes. Test-only.
- `app.categories` view stub mirrors the production view's 8-column shape (defined in `src/moneybin/seeds.py:refresh_views`) so a future contributor adding a new `EXAMPLES["app.categories"]` query that touches `plaid_detailed`, `is_default`, or `created_at` won't get a false positive from a stub-vs-production divergence.

### Changes

#### Stub `app.categories` in the fixture

`Database.__init__` runs `init_schemas()`, which creates every base `app.*` interface table. It does not create `app.categories` — that's a SQLMesh seeds artifact. The fixture now adds an empty (`WHERE FALSE`) view stub matching the 8-column shape of the production view: `category_id`, `category`, `subcategory`, `description`, `plaid_detailed`, `is_default`, `is_active`, `created_at`.

- `tests/moneybin/conftest.py` — extended `schema_catalog_db` fixture body and docstring.

#### Drop the schema filter and presence-skip in two drift tests

- `test_interface_tables_present_in_catalog` — removed `if t.schema == "core"` so it asserts presence for every entry in `INTERFACE_TABLES`.
- `test_examples_parse_and_execute` — removed `if table_name not in present` so every example in `EXAMPLES` is executed against the live schema. Switched the loop to `EXAMPLES.values()` to satisfy ruff `B007` (the table-name key was no longer used).

#### Mirror production catalog query in test helper

`build_schema_doc()` in `src/moneybin/services/schema_catalog.py` queries `duckdb_tables() UNION ALL duckdb_views() WHERE NOT internal`. The `_present_tables` helper now uses the same shape, so test view-of-the-DB and production view-of-the-DB stay aligned.

#### Remove redundant inline view stub

`test_build_schema_doc_includes_interface_views` previously created the `app.categories` view inline; the fixture now provides it. Inline `CREATE SCHEMA` and `CREATE OR REPLACE VIEW` block dropped; the test still asserts `"app.categories" in names`.

### Testing

- `uv run pytest tests/moneybin/test_services/test_schema_catalog.py -q` — 12/12 passing (was 12/12 before the change but with 5 of 9 interface tables silently skipped).
- `uv run pytest tests/moneybin/test_services/test_schema_catalog.py::test_examples_parse_and_execute` — passes (canary that the column-shape change didn't break example queries).
- `make test` — 1635/1635 passing.
- `make format && make lint` — clean.
- `uv run pyright tests/moneybin/conftest.py tests/moneybin/test_services/test_schema_catalog.py` — 0 errors.

### Notes

The view stub's column list must stay in sync with `src/moneybin/seeds.py:refresh_views` (and indirectly with `sqlmesh/models/seeds/categories.sql`'s column declarations). If a future change reshapes the production view, this stub must be updated in the same change — otherwise the drift tests defending against schema drift will themselves drift.