### PR TITLE
Enable pytest-asyncio auto mode and drop asyncio.run boilerplate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,6 +247,7 @@ reportUnusedExpression = true
 # Documentation: https://docs.pytest.org/en/stable/reference/reference.html#configuration-options
 minversion = "7.0"
 addopts = "-ra -q --strict-markers --strict-config -n auto"
+asyncio_mode = "auto"
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]

--- a/tests/moneybin/test_mcp/test_categorization_tools.py
+++ b/tests/moneybin/test_mcp/test_categorization_tools.py
@@ -5,8 +5,6 @@ Individual categorization logic is tested in test_categorization_service.py.
 These tests verify the MCP tool wiring, envelope format, and basic end-to-end.
 """
 
-import asyncio
-
 import pytest
 from fastmcp import FastMCP
 
@@ -25,20 +23,20 @@ from moneybin.seeds import refresh_views
 pytestmark = pytest.mark.usefixtures("mcp_db")
 
 
-def _registered_names() -> set[str]:
+async def _registered_names() -> set[str]:
     srv = FastMCP("test")
     register_categories_tools(srv)
     register_merchants_tools(srv)
     register_transactions_categorize_tools(srv)
-    return {t.name for t in asyncio.run(srv._list_tools())}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    return {t.name for t in await srv._list_tools()}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
 
 
 class TestCategorizeToolRegistration:
     """Verify categorize tools register and return envelopes."""
 
     @pytest.mark.unit
-    def test_all_categorize_tools_register(self) -> None:
-        names = _registered_names()
+    async def test_all_categorize_tools_register(self) -> None:
+        names = await _registered_names()
         assert "categories_list" in names
         assert "transactions_categorize_rules_list" in names
         assert "merchants_list" in names
@@ -52,23 +50,23 @@ class TestCategorizeToolRegistration:
         assert "categories_toggle" in names
 
     @pytest.mark.unit
-    def test_categorize_stats_returns_envelope(self, mcp_db: object) -> None:
-        parsed = asyncio.run(transactions_categorize_stats()).to_dict()
+    async def test_categorize_stats_returns_envelope(self, mcp_db: object) -> None:
+        parsed = (await transactions_categorize_stats()).to_dict()
         assert "summary" in parsed
         assert "data" in parsed
         assert parsed["summary"]["sensitivity"] == "low"
 
     @pytest.mark.unit
-    def test_categorize_categories_returns_envelope(self, mcp_db: object) -> None:
+    async def test_categorize_categories_returns_envelope(self, mcp_db: object) -> None:
         """List categories returns a valid envelope (empty when no data)."""
-        cat_result = asyncio.run(categories_list()).to_dict()
+        cat_result = (await categories_list()).to_dict()
         assert "summary" in cat_result
         assert "data" in cat_result
         assert isinstance(cat_result["data"], list)
 
     @pytest.mark.unit
-    def test_register_includes_auto_rule_tools(self) -> None:
-        names = _registered_names()
+    async def test_register_includes_auto_rule_tools(self) -> None:
+        names = await _registered_names()
         assert {
             "transactions_categorize_auto_review",
             "transactions_categorize_auto_confirm",
@@ -102,13 +100,15 @@ class TestToggleCategoryWritePath:
     """categories_toggle routes writes to the right backing table."""
 
     @pytest.mark.unit
-    def test_toggle_default_category_writes_override(self, mcp_db: object) -> None:
+    async def test_toggle_default_category_writes_override(
+        self, mcp_db: object
+    ) -> None:
         from moneybin.database import Database
 
         assert isinstance(mcp_db, Database)
         _seed_categories_view(mcp_db)
 
-        asyncio.run(categories_toggle(category_id="FND", is_active=False))
+        await categories_toggle(category_id="FND", is_active=False)
 
         rows = mcp_db.execute(
             "SELECT category_id, is_active FROM app.category_overrides"
@@ -116,7 +116,9 @@ class TestToggleCategoryWritePath:
         assert rows == [("FND", False)]
 
     @pytest.mark.unit
-    def test_toggle_user_category_updates_user_categories(self, mcp_db: object) -> None:
+    async def test_toggle_user_category_updates_user_categories(
+        self, mcp_db: object
+    ) -> None:
         from moneybin.database import Database
 
         assert isinstance(mcp_db, Database)
@@ -127,7 +129,7 @@ class TestToggleCategoryWritePath:
             VALUES ('CUSTOM1', 'Childcare', 'Daycare', true)
         """)
 
-        asyncio.run(categories_toggle(category_id="CUSTOM1", is_active=False))
+        await categories_toggle(category_id="CUSTOM1", is_active=False)
 
         rows = mcp_db.execute(
             "SELECT is_active FROM app.user_categories WHERE category_id = ?",

--- a/tests/moneybin/test_mcp/test_decorator.py
+++ b/tests/moneybin/test_mcp/test_decorator.py
@@ -1,7 +1,6 @@
 # tests/moneybin/test_mcp/test_decorator.py
 """Tests for MCP tool decorator and sensitivity middleware."""
 
-import asyncio
 from unittest.mock import patch
 
 import pytest
@@ -67,7 +66,7 @@ class TestMCPToolDecorator:
         assert reports_spending_summary.__name__ == "reports_spending_summary"
 
     @pytest.mark.unit
-    def test_decorator_calls_log_tool_call(self) -> None:
+    async def test_decorator_calls_log_tool_call(self) -> None:
 
         @mcp_tool(sensitivity="medium")
         def my_tool() -> ResponseEnvelope:
@@ -77,7 +76,7 @@ class TestMCPToolDecorator:
             )
 
         with patch("moneybin.mcp.decorator.log_tool_call") as mock_log:
-            asyncio.run(my_tool())
+            await my_tool()
             mock_log.assert_called_once()
             args = mock_log.call_args[0]
             assert args[0] == "my_tool"
@@ -104,7 +103,7 @@ class TestMCPToolDecorator:
         assert example_tool._mcp_domain is None  # type: ignore[attr-defined]
 
     @pytest.mark.unit
-    def test_decorator_returns_response_envelope(self) -> None:
+    async def test_decorator_returns_response_envelope(self) -> None:
         """When a tool returns a ResponseEnvelope, the decorator returns it directly."""
 
         @mcp_tool(sensitivity="low")
@@ -114,13 +113,13 @@ class TestMCPToolDecorator:
                 data=[{"value": 42}],
             )
 
-        result = asyncio.run(my_tool())
+        result = await my_tool()
         assert isinstance(result, ResponseEnvelope)
         assert result.summary.total_count == 1
         assert result.data == [{"value": 42}]
 
     @pytest.mark.unit
-    def test_decorator_raises_type_error_for_non_envelope(self) -> None:
+    async def test_decorator_raises_type_error_for_non_envelope(self) -> None:
         """Tools that return non-ResponseEnvelope raise TypeError."""
         import pytest
 
@@ -129,4 +128,4 @@ class TestMCPToolDecorator:
             return "plain string result"  # type: ignore[return-value]
 
         with pytest.raises(TypeError, match="expected ResponseEnvelope"):
-            asyncio.run(my_tool())
+            await my_tool()

--- a/tests/moneybin/test_mcp/test_error_handling.py
+++ b/tests/moneybin/test_mcp/test_error_handling.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 
 from moneybin.database import DatabaseKeyError
@@ -12,34 +10,34 @@ from moneybin.mcp.decorator import mcp_tool
 from moneybin.protocol.envelope import ResponseEnvelope
 
 
-def test_mcp_tool_converts_user_error_to_envelope() -> None:
+async def test_mcp_tool_converts_user_error_to_envelope() -> None:
     """A UserError raised inside a tool becomes an error envelope."""
 
     @mcp_tool(sensitivity="low")
     def failing_tool() -> ResponseEnvelope:
         raise UserError("not found", code="NOT_FOUND")
 
-    result = asyncio.run(failing_tool())
+    result = await failing_tool()
     assert isinstance(result, ResponseEnvelope)
     assert result.error is not None
     assert result.error.code == "NOT_FOUND"
     assert result.data == []
 
 
-def test_mcp_tool_converts_database_key_error_to_envelope() -> None:
+async def test_mcp_tool_converts_database_key_error_to_envelope() -> None:
     """DatabaseKeyError is a recognised classified exception."""
 
     @mcp_tool(sensitivity="low")
     def failing_tool() -> ResponseEnvelope:
         raise DatabaseKeyError("missing key")
 
-    result = asyncio.run(failing_tool())
+    result = await failing_tool()
     assert isinstance(result, ResponseEnvelope)
     assert result.error is not None
     assert result.error.code == "database_locked"
 
 
-def test_mcp_tool_lets_unclassified_exceptions_propagate() -> None:
+async def test_mcp_tool_lets_unclassified_exceptions_propagate() -> None:
     """Non-domain exceptions propagate; the decorator does NOT swallow them.
 
     fastmcp's mask_error_details wraps them into masked ToolErrors at the
@@ -51,10 +49,10 @@ def test_mcp_tool_lets_unclassified_exceptions_propagate() -> None:
         raise RuntimeError("internal detail leak")
 
     with pytest.raises(RuntimeError):
-        asyncio.run(failing_tool())
+        await failing_tool()
 
 
-def test_mcp_tool_returns_response_envelope_directly() -> None:
+async def test_mcp_tool_returns_response_envelope_directly() -> None:
     """Decorator returns ResponseEnvelope directly, not a JSON string.
 
     fastmcp 3.x serializes the model to both content and structured_content.
@@ -65,6 +63,6 @@ def test_mcp_tool_returns_response_envelope_directly() -> None:
     def ok_tool() -> ResponseEnvelope:
         return build_envelope(data=[{"x": 1}], sensitivity="low")
 
-    result = asyncio.run(ok_tool())
+    result = await ok_tool()
     assert isinstance(result, ResponseEnvelope)  # NOT a str
     assert result.data == [{"x": 1}]

--- a/tests/moneybin/test_mcp/test_import_inbox_tools.py
+++ b/tests/moneybin/test_mcp/test_import_inbox_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -40,36 +39,42 @@ def patch_service(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> MagicMock:
 class TestInboxSyncTool:
     """import_inbox_sync envelope shape and actions."""
 
-    def test_returns_low_sensitivity_envelope(self, patch_service: MagicMock) -> None:
+    async def test_returns_low_sensitivity_envelope(
+        self, patch_service: MagicMock
+    ) -> None:
         patch_service.sync.return_value = InboxSyncResult(
             processed=[{"filename": "a.csv", "transactions": 3}],
         )
-        envelope = asyncio.run(inbox_sync_tool())
+        envelope = await inbox_sync_tool()
         assert envelope.summary.sensitivity == "low"
         assert envelope.data["processed"][0]["filename"] == "a.csv"
 
-    def test_failure_includes_actions_hint(self, patch_service: MagicMock) -> None:
+    async def test_failure_includes_actions_hint(
+        self, patch_service: MagicMock
+    ) -> None:
         patch_service.sync.return_value = InboxSyncResult(
             failed=[{"filename": "x.csv", "error_code": "needs_account_name"}],
         )
-        envelope = asyncio.run(inbox_sync_tool())
+        envelope = await inbox_sync_tool()
         assert any("inbox/<account-slug>" in a for a in envelope.actions)
 
-    def test_no_failure_no_resolution_hint(self, patch_service: MagicMock) -> None:
+    async def test_no_failure_no_resolution_hint(
+        self, patch_service: MagicMock
+    ) -> None:
         patch_service.sync.return_value = InboxSyncResult(
             processed=[{"filename": "a.csv", "transactions": 1}],
         )
-        envelope = asyncio.run(inbox_sync_tool())
+        envelope = await inbox_sync_tool()
         assert not any("inbox/<account-slug>" in a for a in envelope.actions)
 
 
 class TestInboxListTool:
     """import_inbox_list envelope shape."""
 
-    def test_returns_would_process_shape(self, patch_service: MagicMock) -> None:
+    async def test_returns_would_process_shape(self, patch_service: MagicMock) -> None:
         patch_service.enumerate.return_value = InboxListResult(
             would_process=[{"filename": "a.csv", "account_hint": None}],
         )
-        envelope = asyncio.run(inbox_list_tool())
+        envelope = await inbox_list_tool()
         assert envelope.summary.sensitivity == "low"
         assert envelope.data["would_process"][0]["filename"] == "a.csv"

--- a/tests/moneybin/test_mcp/test_resources.py
+++ b/tests/moneybin/test_mcp/test_resources.py
@@ -151,41 +151,39 @@ class TestResourceTools:
 
         register_core_tools()
 
-    def _read(self) -> dict[str, Any]:
-        import asyncio
-
-        return json.loads(asyncio.run(resource_tools()))
+    async def _read(self) -> dict[str, Any]:
+        return json.loads(await resource_tools())
 
     @pytest.mark.unit
-    def test_returns_core_namespaces(self) -> None:
-        data = self._read()
+    async def test_returns_core_namespaces(self) -> None:
+        data = await self._read()
         assert "core" in data
         assert isinstance(data["core"], list)
         core: list[dict[str, Any]] = data["core"]
         assert len(core) > 0
 
     @pytest.mark.unit
-    def test_core_namespaces_have_required_fields(self) -> None:
-        data = self._read()
+    async def test_core_namespaces_have_required_fields(self) -> None:
+        data = await self._read()
         for entry in data["core"]:
             assert "namespace" in entry
             assert "loaded" in entry
             assert "description" in entry
 
     @pytest.mark.unit
-    def test_core_namespaces_loaded_true(self) -> None:
-        data = self._read()
+    async def test_core_namespaces_loaded_true(self) -> None:
+        data = await self._read()
         core_entries: list[dict[str, Any]] = data["core"]
         assert all(entry["loaded"] is True for entry in core_entries)
 
     @pytest.mark.unit
-    def test_discover_tool_present(self) -> None:
-        data = self._read()
+    async def test_discover_tool_present(self) -> None:
+        data = await self._read()
         assert data["discover_tool"] == "moneybin_discover"
 
     @pytest.mark.unit
-    def test_known_namespaces_present(self) -> None:
-        data = self._read()
+    async def test_known_namespaces_present(self) -> None:
+        data = await self._read()
         namespaces = {e["namespace"] for e in data["core"]}
         assert "reports" in namespaces
         assert "accounts" in namespaces

--- a/tests/moneybin/test_mcp/test_sync_tools.py
+++ b/tests/moneybin/test_mcp/test_sync_tools.py
@@ -8,7 +8,6 @@ not_implemented envelope shape — not real sync behavior.
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Callable
 from typing import Any
 
@@ -42,11 +41,11 @@ _EXPECTED_TOOLS = {
 
 
 @pytest.mark.unit
-def test_register_sync_tools_registers_all_nine() -> None:
+async def test_register_sync_tools_registers_all_nine() -> None:
     """All nine sync tools register; key rotate is excluded by design."""
     srv = FastMCP("test")
     register_sync_tools(srv)
-    names = {t.name for t in asyncio.run(srv._list_tools())}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    names = {t.name for t in await srv._list_tools()}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     assert _EXPECTED_TOOLS <= names
     assert "sync_key_rotate" not in names
     assert "sync_rotate_key" not in names
@@ -67,9 +66,11 @@ def test_register_sync_tools_registers_all_nine() -> None:
         sync_schedule_remove,
     ],
 )
-def test_sync_tool_returns_not_implemented_envelope(fn: Callable[..., Any]) -> None:
+async def test_sync_tool_returns_not_implemented_envelope(
+    fn: Callable[..., Any],
+) -> None:
     """Every sync tool returns a stub envelope pointing at the spec."""
-    parsed = asyncio.run(fn()).to_dict()
+    parsed = (await fn()).to_dict()
     assert parsed["summary"]["sensitivity"] == "low"
     assert parsed["data"]["status"] == "not_implemented"
     assert parsed["data"]["spec"] == "docs/specs/sync-overview.md"

--- a/tests/moneybin/test_mcp/test_system_tools.py
+++ b/tests/moneybin/test_mcp/test_system_tools.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 from fastmcp import FastMCP
 
@@ -13,9 +11,9 @@ pytestmark = pytest.mark.usefixtures("mcp_db")
 
 
 @pytest.mark.unit
-def test_system_status_returns_response_envelope(mcp_db: object) -> None:
+async def test_system_status_returns_response_envelope(mcp_db: object) -> None:
     """system_status returns a valid ResponseEnvelope."""
-    result = asyncio.run(system_status())
+    result = await system_status()
     parsed = result.to_dict()
     assert "summary" in parsed
     assert "data" in parsed
@@ -24,9 +22,9 @@ def test_system_status_returns_response_envelope(mcp_db: object) -> None:
 
 
 @pytest.mark.unit
-def test_system_status_data_keys(mcp_db: object) -> None:
+async def test_system_status_data_keys(mcp_db: object) -> None:
     """system_status data dict has all required domain keys."""
-    result = asyncio.run(system_status())
+    result = await system_status()
     parsed = result.to_dict()
     data = parsed["data"]
     assert "accounts" in data
@@ -36,17 +34,17 @@ def test_system_status_data_keys(mcp_db: object) -> None:
 
 
 @pytest.mark.unit
-def test_system_status_accounts_count(mcp_db: object) -> None:
+async def test_system_status_accounts_count(mcp_db: object) -> None:
     """Accounts count reflects the mcp_db fixture's 2 accounts."""
-    result = asyncio.run(system_status())
+    result = await system_status()
     parsed = result.to_dict()
     assert parsed["data"]["accounts"]["count"] == 2
 
 
 @pytest.mark.unit
-def test_system_status_transactions_empty(mcp_db: object) -> None:
+async def test_system_status_transactions_empty(mcp_db: object) -> None:
     """Transactions count is 0 when no transactions are inserted."""
-    result = asyncio.run(system_status())
+    result = await system_status()
     parsed = result.to_dict()
     txn = parsed["data"]["transactions"]
     assert txn["count"] == 0
@@ -55,26 +53,26 @@ def test_system_status_transactions_empty(mcp_db: object) -> None:
 
 
 @pytest.mark.unit
-def test_system_status_queue_counts_are_integers(mcp_db: object) -> None:
+async def test_system_status_queue_counts_are_integers(mcp_db: object) -> None:
     """matches.pending_review and categorization.uncategorized are integers."""
-    result = asyncio.run(system_status())
+    result = await system_status()
     parsed = result.to_dict()
     assert isinstance(parsed["data"]["matches"]["pending_review"], int)
     assert isinstance(parsed["data"]["categorization"]["uncategorized"], int)
 
 
 @pytest.mark.unit
-def test_system_status_actions_non_empty(mcp_db: object) -> None:
+async def test_system_status_actions_non_empty(mcp_db: object) -> None:
     """system_status provides at least one action hint."""
-    result = asyncio.run(system_status())
+    result = await system_status()
     parsed = result.to_dict()
     assert len(parsed["actions"]) >= 1
 
 
 @pytest.mark.unit
-def test_register_system_tools() -> None:
+async def test_register_system_tools() -> None:
     """register_system_tools registers system_status with a FastMCP server."""
     srv = FastMCP("test")
     register_system_tools(srv)
-    names = {t.name for t in asyncio.run(srv._list_tools())}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    names = {t.name for t in await srv._list_tools()}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     assert "system_status" in names

--- a/tests/moneybin/test_mcp/test_tool_timeouts.py
+++ b/tests/moneybin/test_mcp/test_tool_timeouts.py
@@ -21,7 +21,7 @@ def _ok_envelope() -> ResponseEnvelope:
 
 
 @pytest.mark.unit
-def test_sync_tool_under_cap_passes_through(
+async def test_sync_tool_under_cap_passes_through(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 5.0)
@@ -30,13 +30,13 @@ def test_sync_tool_under_cap_passes_through(
     def fast_tool() -> ResponseEnvelope:
         return _ok_envelope()
 
-    result = asyncio.run(fast_tool())
+    result = await fast_tool()
     assert isinstance(result, ResponseEnvelope)
     assert result.error is None
 
 
 @pytest.mark.unit
-def test_sync_tool_over_cap_returns_timeout_envelope(
+async def test_sync_tool_over_cap_returns_timeout_envelope(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 0.05)
@@ -55,7 +55,7 @@ def test_sync_tool_over_cap_returns_timeout_envelope(
         r = await slow_tool()
         return r, time.monotonic() - started
 
-    result, elapsed = asyncio.run(_run())
+    result, elapsed = await _run()
 
     # Cap=0.05 + 0.5s grace sleep (decorator awaits cleanup unwind before
     # returning) + scheduling slop. Ceiling stays well under the 0.5s sleep
@@ -72,7 +72,7 @@ def test_sync_tool_over_cap_returns_timeout_envelope(
 
 
 @pytest.mark.unit
-def test_async_tool_over_cap_returns_timeout_envelope(
+async def test_async_tool_over_cap_returns_timeout_envelope(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 0.05)
@@ -85,13 +85,13 @@ def test_async_tool_over_cap_returns_timeout_envelope(
         await asyncio.sleep(0.5)
         return _ok_envelope()
 
-    result = asyncio.run(slow_tool())
+    result = await slow_tool()
     assert result.error is not None
     assert result.error.code == "timed_out"
 
 
 @pytest.mark.unit
-def test_timeout_logs_low_cardinality_line(
+async def test_timeout_logs_low_cardinality_line(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -106,7 +106,7 @@ def test_timeout_logs_low_cardinality_line(
         return _ok_envelope()
 
     with caplog.at_level("WARNING"):
-        asyncio.run(slow_tool(account_number="acct-redacted-do-not-log"))
+        await slow_tool(account_number="acct-redacted-do-not-log")
 
     relevant = [r for r in caplog.records if "timed out" in r.getMessage().lower()]
     assert len(relevant) == 1
@@ -115,7 +115,7 @@ def test_timeout_logs_low_cardinality_line(
 
 
 @pytest.mark.unit
-def test_classified_user_error_still_returned(
+async def test_classified_user_error_still_returned(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 5.0)
@@ -125,13 +125,13 @@ def test_classified_user_error_still_returned(
     def bad_tool() -> ResponseEnvelope:
         raise UserError("nope", code="not_found")
 
-    result = asyncio.run(bad_tool())
+    result = await bad_tool()
     assert result.error is not None
     assert result.error.code == "not_found"
 
 
 @pytest.mark.unit
-def test_tool_raised_timeout_error_not_classified_as_cap_fired(
+async def test_tool_raised_timeout_error_not_classified_as_cap_fired(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A TimeoutError raised by the tool body must not be reported as a cap-fired timeout.
@@ -155,7 +155,7 @@ def test_tool_raised_timeout_error_not_classified_as_cap_fired(
     # it (matching pre-existing behavior for unclassified exceptions). The
     # critical assertions are the side effects: no DB reset, no cap-fired log.
     with pytest.raises(TimeoutError, match="downstream HTTP timeout"):
-        asyncio.run(inner_timeout_tool())
+        await inner_timeout_tool()
 
     reset_mock.assert_not_called()
 
@@ -179,7 +179,7 @@ def test_sync_generator_tool_rejected_at_decoration() -> None:
 
 
 @pytest.mark.integration
-def test_back_to_back_call_after_timeout_succeeds(
+async def test_back_to_back_call_after_timeout_succeeds(
     tmp_path: Path,
     mock_secret_store: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
@@ -214,7 +214,7 @@ def test_back_to_back_call_after_timeout_succeeds(
             data=[{"x": rows[0][0]}],
         )
 
-    first = asyncio.run(hang_tool())
+    first = await hang_tool()
     assert first.error is not None and first.error.code == "timed_out"
 
     # The timeout path cleared _database_instance and force-closed the original
@@ -227,6 +227,6 @@ def test_back_to_back_call_after_timeout_succeeds(
     monkeypatch.setattr(db_module, "_database_instance", db2)
 
     monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 5.0)
-    second = asyncio.run(quick_tool())
+    second = await quick_tool()
     assert second.error is None
     assert second.data == [{"x": 42}]

--- a/tests/moneybin/test_mcp/test_tools.py
+++ b/tests/moneybin/test_mcp/test_tools.py
@@ -5,8 +5,6 @@ These tests exercise the underlying tool functions directly. Registration
 with the FastMCP server is covered by tests/mcp/test_visibility.py.
 """
 
-import asyncio
-
 import pytest
 from fastmcp import FastMCP
 
@@ -38,28 +36,26 @@ class TestV1ToolRegistration:
     """Verify v1 tools register correctly and produce envelope responses."""
 
     @pytest.mark.unit
-    def test_spending_tools_register(self) -> None:
+    async def test_spending_tools_register(self) -> None:
         srv = FastMCP("test")
         register_reports_tools(srv)
-        # Synchronous accessor surface differs by version; resolve via asyncio.
-
-        names = {t.name for t in asyncio.run(srv._list_tools())}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        names = {t.name for t in await srv._list_tools()}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
         assert "reports_spending_summary" in names
         assert "reports_spending_by_category" in names
 
     @pytest.mark.unit
-    def test_accounts_tools_register(self) -> None:
+    async def test_accounts_tools_register(self) -> None:
 
         srv = FastMCP("test")
         register_accounts_tools(srv)
-        names = {t.name for t in asyncio.run(srv._list_tools())}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        names = {t.name for t in await srv._list_tools()}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
         assert "accounts_list" in names
         assert "accounts_balance_list" in names
 
     @pytest.mark.unit
-    def test_accounts_list_returns_envelope(self, mcp_db: object) -> None:
+    async def test_accounts_list_returns_envelope(self, mcp_db: object) -> None:
 
-        result = asyncio.run(accounts_list())
+        result = await accounts_list()
         parsed = result.to_dict()
         assert "summary" in parsed
         assert "data" in parsed
@@ -67,7 +63,7 @@ class TestV1ToolRegistration:
         assert len(parsed["data"]) == 2  # 2 accounts from mcp_db fixture
 
     @pytest.mark.unit
-    def test_sql_query_returns_envelope(self, mcp_db: object) -> None:
+    async def test_sql_query_returns_envelope(self, mcp_db: object) -> None:
 
         from moneybin.mcp.server import get_db
 
@@ -76,17 +72,17 @@ class TestV1ToolRegistration:
         # Also exercise registration to ensure no smoke errors.
         register_sql_tools(FastMCP("test"))
 
-        result = asyncio.run(
-            sql_query(query="SELECT COUNT(*) AS cnt FROM core.fct_transactions")
+        result = await sql_query(
+            query="SELECT COUNT(*) AS cnt FROM core.fct_transactions"
         )
         parsed = result.to_dict()
         assert "summary" in parsed
         assert parsed["data"][0]["cnt"] == 2
 
     @pytest.mark.unit
-    def test_sql_schema_returns_envelope(self, mcp_db: object) -> None:
+    async def test_sql_schema_returns_envelope(self, mcp_db: object) -> None:
 
-        result = asyncio.run(sql_schema())
+        result = await sql_schema()
         parsed = result.to_dict()
         assert parsed["summary"]["sensitivity"] == "low"
         data = parsed["data"]

--- a/tests/moneybin/test_mcp/test_transactions_tools.py
+++ b/tests/moneybin/test_mcp/test_transactions_tools.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 from fastmcp import FastMCP
 
@@ -16,9 +14,9 @@ pytestmark = pytest.mark.usefixtures("mcp_db")
 
 
 @pytest.mark.unit
-def test_review_status_returns_envelope(mcp_db: object) -> None:
+async def test_review_status_returns_envelope(mcp_db: object) -> None:
     """transactions_review_status returns a valid ResponseEnvelope."""
-    parsed = asyncio.run(transactions_review_status()).to_dict()
+    parsed = (await transactions_review_status()).to_dict()
     assert "summary" in parsed
     assert "data" in parsed
     assert "actions" in parsed
@@ -26,9 +24,9 @@ def test_review_status_returns_envelope(mcp_db: object) -> None:
 
 
 @pytest.mark.unit
-def test_review_status_data_shape(mcp_db: object) -> None:
+async def test_review_status_data_shape(mcp_db: object) -> None:
     """Data dict carries matches_pending, categorize_pending, and total."""
-    data = asyncio.run(transactions_review_status()).to_dict()["data"]
+    data = (await transactions_review_status()).to_dict()["data"]
     assert "matches_pending" in data
     assert "categorize_pending" in data
     assert "total" in data
@@ -38,18 +36,18 @@ def test_review_status_data_shape(mcp_db: object) -> None:
 
 
 @pytest.mark.unit
-def test_review_status_actions_non_empty(mcp_db: object) -> None:
+async def test_review_status_actions_non_empty(mcp_db: object) -> None:
     """Tool provides next-step action hints."""
-    parsed = asyncio.run(transactions_review_status()).to_dict()
+    parsed = (await transactions_review_status()).to_dict()
     assert len(parsed["actions"]) >= 1
 
 
 @pytest.mark.unit
-def test_register_includes_review_status() -> None:
+async def test_register_includes_review_status() -> None:
     """register_transactions_tools registers transactions_review_status."""
     srv = FastMCP("test")
     register_transactions_tools(srv)
-    names = {t.name for t in asyncio.run(srv._list_tools())}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    names = {t.name for t in await srv._list_tools()}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     assert "transactions_review_status" in names
     assert "transactions_search" in names
     assert "transactions_recurring_list" in names

--- a/tests/moneybin/test_mcp/test_transform_tools.py
+++ b/tests/moneybin/test_mcp/test_transform_tools.py
@@ -8,7 +8,6 @@ and envelope shape, not real SQLMesh behavior.
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Callable
 from typing import Any
 
@@ -34,11 +33,11 @@ _EXPECTED_TOOLS = {
 
 
 @pytest.mark.unit
-def test_register_transform_tools_registers_all_five() -> None:
+async def test_register_transform_tools_registers_all_five() -> None:
     """All 5 transform tools register; restate is excluded by design."""
     srv = FastMCP("test")
     register_transform_tools(srv)
-    names = {t.name for t in asyncio.run(srv._list_tools())}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    names = {t.name for t in await srv._list_tools()}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     assert _EXPECTED_TOOLS <= names
     assert "transform_restate" not in names
 
@@ -54,11 +53,11 @@ def test_register_transform_tools_registers_all_five() -> None:
         transform_apply,
     ],
 )
-def test_transform_tool_returns_not_implemented_envelope(
+async def test_transform_tool_returns_not_implemented_envelope(
     fn: Callable[..., Any],
 ) -> None:
     """Every transform tool returns a stub envelope referencing the spec."""
-    parsed = asyncio.run(fn()).to_dict()
+    parsed = (await fn()).to_dict()
     assert parsed["summary"]["sensitivity"] == "low"
     assert parsed["data"]["status"] == "not_implemented"
     assert parsed["data"]["spec"] == "docs/specs/mcp-tool-surface.md"

--- a/tests/moneybin/test_mcp/test_v1_tools.py
+++ b/tests/moneybin/test_mcp/test_v1_tools.py
@@ -5,8 +5,6 @@ These tests exercise the underlying tool functions directly. Registration
 with the FastMCP server is covered by tests/mcp/test_visibility.py.
 """
 
-import asyncio
-
 import pytest
 
 from moneybin.mcp.tools.reports import reports_spending_summary
@@ -36,10 +34,10 @@ class TestSpendingSummaryTool:
         get_db().execute(_INSERT_TRANSACTIONS)
 
     @pytest.mark.unit
-    def test_returns_envelope(self, mcp_db: object) -> None:
+    async def test_returns_envelope(self, mcp_db: object) -> None:
 
         self._insert_data(mcp_db)
-        result = asyncio.run(reports_spending_summary(months=3))
+        result = await reports_spending_summary(months=3)
         from moneybin.protocol.envelope import ResponseEnvelope
 
         assert isinstance(result, ResponseEnvelope)
@@ -50,10 +48,10 @@ class TestSpendingSummaryTool:
         assert parsed["summary"]["sensitivity"] == "low"
 
     @pytest.mark.unit
-    def test_data_shape(self, mcp_db: object) -> None:
+    async def test_data_shape(self, mcp_db: object) -> None:
 
         self._insert_data(mcp_db)
-        parsed = asyncio.run(reports_spending_summary(months=3)).to_dict()
+        parsed = (await reports_spending_summary(months=3)).to_dict()
         data = parsed["data"]
         assert len(data) >= 1
         assert "period" in data[0]

--- a/tests/moneybin/test_mcp/test_visibility.py
+++ b/tests/moneybin/test_mcp/test_visibility.py
@@ -39,7 +39,6 @@ def monkeypatch_module() -> Generator[pytest.MonkeyPatch, None, None]:
     mp.undo()
 
 
-@pytest.mark.asyncio
 async def test_core_tools_visible_at_connect() -> None:
     """Tools without a domain are listed by default."""
     from moneybin.mcp.server import mcp
@@ -50,7 +49,6 @@ async def test_core_tools_visible_at_connect() -> None:
         assert "accounts_list" in names
 
 
-@pytest.mark.asyncio
 async def test_extended_tools_hidden_at_connect() -> None:
     """Tools with a domain are not listed by default — Visibility transforms hide them."""
     from moneybin.mcp.server import mcp
@@ -61,7 +59,6 @@ async def test_extended_tools_hidden_at_connect() -> None:
         assert "budget_set" not in names
 
 
-@pytest.mark.asyncio
 async def test_discover_reveals_namespace_tools() -> None:
     """Discover reveals namespace tools for the calling session.
 
@@ -76,7 +73,6 @@ async def test_discover_reveals_namespace_tools() -> None:
         assert "transactions_categorize_bulk_apply" in names
 
 
-@pytest.mark.asyncio
 async def test_unknown_domain_returns_error_envelope() -> None:
     """Calling discover('not-a-real-namespace') returns an error envelope."""
     import json
@@ -91,7 +87,6 @@ async def test_unknown_domain_returns_error_envelope() -> None:
         assert "Unknown domain" in str(envelope["error"])
 
 
-@pytest.mark.asyncio
 async def test_per_session_discover_isolated() -> None:
     """Two clients connected to the same server have independent visibility.
 
@@ -117,7 +112,6 @@ async def test_per_session_discover_isolated() -> None:
         )
 
 
-@pytest.mark.asyncio
 async def test_visibility_or_match_semantics() -> None:
     """A tool tagged with one extended domain stays hidden when only a different domain is enabled.
 
@@ -141,7 +135,6 @@ async def test_visibility_or_match_semantics() -> None:
         )
 
 
-@pytest.mark.asyncio
 async def test_full_discover_reveals_every_extended_tool() -> None:
     """After discovering every extended domain, total visible tool count matches the unfiltered registry.
 
@@ -166,7 +159,6 @@ async def test_full_discover_reveals_every_extended_tool() -> None:
         )
 
 
-@pytest.mark.asyncio
 async def test_every_tool_name_matches_anthropic_openai_pattern() -> None:
     """Every registered tool name must match ``^[a-zA-Z0-9_-]{1,64}$``.
 
@@ -189,7 +181,6 @@ async def test_every_tool_name_matches_anthropic_openai_pattern() -> None:
     )
 
 
-@pytest.mark.asyncio
 async def test_hidden_tool_is_uncallable_via_tools_call() -> None:
     """Hidden tools must be uncallable.
 


### PR DESCRIPTION
### Summary

Switches pytest-asyncio to `auto` mode and rewrites 13 MCP test files so async test bodies are written as `async def` + `await` directly instead of wrapping every awaitable in `asyncio.run(...)`. Net: 47 `asyncio.run` calls removed, 9 redundant `@pytest.mark.asyncio` decorators removed, no behavior change.

### Impact

- Easier to write new MCP tool tests (no boilerplate to copy-paste).
- 14 commits, one per file plus the config flip — fully bisectable if a regression appears.
- No production code touched. The two remaining `asyncio.run` call sites in `src/moneybin/cli/commands/mcp.py` are correct: Typer commands are sync entry points that must bridge into async at the boundary.

### Changes

#### Enable auto mode in pyproject.toml

Adds `asyncio_mode = "auto"` to `[tool.pytest.ini_options]`. Under auto mode, pytest-asyncio runs every `async def test_*` inside an event loop automatically — `@pytest.mark.asyncio` becomes redundant, and tests stop wrapping awaitables with `asyncio.run()`. Sync tests are untouched. Composes cleanly with `pytest-xdist` (verified: 165/165 MCP tests pass under both `-n auto` and `-n0`).

- `pyproject.toml` — single-line config addition.

#### Convert 13 MCP test files

One commit per file, named `test: drop asyncio.run from <basename>` (or `test: drop asyncio marker from test_visibility` for the file that only had decorators). Conversions follow a fixed recipe:

- `def test_x(): asyncio.run(coro)` → `async def test_x(): await coro`
- `with pytest.raises(...): asyncio.run(coro)` → `with pytest.raises(...): await coro`
- `asyncio.run(fn()).to_dict()` → `(await fn()).to_dict()`
- `{t.name for t in asyncio.run(srv._list_tools())}` → `{t.name for t in await srv._list_tools()}`
- Inner-coroutine pattern in `test_tool_timeouts.py`: outer test becomes `async def`, inner `_run` stays `async def`, `result = await _run()` (no nested `asyncio.run`).
- Sync helpers wrapping `asyncio.run` and used 3+ times converted to `async def`: `_registered_names` in `test_categorization_tools.py`, `_read` in `test_resources.py`. Callers `await` them.
- `import asyncio` dropped from each file unless `asyncio.<other>` is genuinely still used. Retained only in `test_tool_timeouts.py`, which calls `asyncio.sleep(...)` inside coroutine bodies.
- `@pytest.mark.asyncio` decorators removed (9 from `test_visibility.py`, 0 elsewhere — `test_decorator.py`'s plan-anticipated decorators turned out not to exist).

### Testing

- `uv run pytest tests/moneybin/test_mcp/ -q` — 165/165 passing under both `-n auto` and `-n0`.
- `make test` — 1635/1635 passing.
- `make format && make lint` — clean.
- `uv run pyright tests/moneybin/test_mcp/` — 0 errors, 0 warnings.
- `grep -rn "asyncio.run" tests/moneybin/test_mcp/` — empty.
- `grep -rn "@pytest.mark.asyncio" tests/moneybin/test_mcp/` — empty.

### Notes

The per-file commit structure is intentional. Plaid-sync work is about to add a second wave of MCP tool tests; if any conversion subtly broke something, `git bisect` against per-file commits gives a one-file blast radius. Squash-merging the PR would erase that property — prefer rebase or merge.