### PR TITLE
docs: update private/ path references after reorganization

### DIFF
--- a/docs/specs/categorization-overview.md
+++ b/docs/specs/categorization-overview.md
@@ -294,7 +294,7 @@ a powerful bootstrap signal:
    useful from day one.
 
 This is the highest-leverage bootstrap strategy for users switching from another tool.
-See `private/specs/strategic-analysis.md` §6 for the full migration strategy.
+See `private/strategy/strategic-analysis.md` §6 for the full migration strategy.
 
 ### Synthetic training data from seed merchants (v1)
 
@@ -314,7 +314,7 @@ Ship a baseline ML model trained on the developer's own categorized transaction 
 
 The baseline model is a static artifact shipped with MoneyBin. It contains no raw transaction data — only the trained model weights (TF-IDF vocabulary + SVM coefficients). The user's own data gradually replaces the baseline as auto-retraining incorporates their categorizations.
 
-**Bootstrap from competitor data.** The baseline can be further enriched using categorized transaction exports from competing tools (Mint, YNAB, Monarch, Tiller) — see `private/specs/strategic-analysis.md` §6 for available export formats and category schemas. Importing and categorizing representative data from multiple tools expands the baseline model's vocabulary beyond any single user's spending patterns.
+**Bootstrap from competitor data.** The baseline can be further enriched using categorized transaction exports from competing tools (Mint, YNAB, Monarch, Tiller) — see `private/strategy/strategic-analysis.md` §6 for available export formats and category schemas. Importing and categorizing representative data from multiple tools expands the baseline model's vocabulary beyond any single user's spending patterns.
 
 **Upgrade path to community model.** The pre-trained baseline is a single-contributor model. A future community model could aggregate anonymized training data from opted-in users (see below), producing a higher-quality baseline. The architecture is the same — a shipped model artifact that the user's data gradually personalizes.
 
@@ -412,5 +412,5 @@ Decisions made during spec review, preserved for context.
 Cross-cutting decisions deferred to child specs or to resolve during implementation.
 - **Observability strategy.** Multiple sections of this spec stipulate logging (retraining events, threshold-tier shifts, auto-rule proposals, ML predictions dropped). A cross-cutting logging/observability design pass is needed to ensure a coherent approach across import summaries, per-transaction provenance, and system-level statistics. This is a concern shared with other specs (sync, matching) and should be addressed holistically rather than per-feature.
 - **First-import prompt design.** The bootstrap strategies identify LLM bulk categorization as the primary cold-start solver, but no MCP prompt is designed specifically for the first-time experience — detecting low coverage, proactively offering AI categorization + auto-rule generation as a guided session. Needs design work in `mcp-tool-surface.md`.
-- **Category mapping tables for migration.** The migration bootstrap strategy references "a one-time mapping table per source tool" but the mapping table schema is not designed. Needed before migration bootstrap can function. See `private/specs/strategic-analysis.md` §6 for source tool category formats.
+- **Category mapping tables for migration.** The migration bootstrap strategy references "a one-time mapping table per source tool" but the mapping table schema is not designed. Needed before migration bootstrap can function. See `private/strategy/strategic-analysis.md` §6 for source tool category formats.
 - **CLI-only cold start.** Bootstrap strategies assume MCP for LLM bulk categorization. CLI-only users lack an AI assistant to bulk-categorize and face a worse cold-start experience. Needs consideration — possibly a CLI command that invokes the LLM directly, or heavier reliance on the pre-trained baseline model.

--- a/docs/specs/cli-restructure.md
+++ b/docs/specs/cli-restructure.md
@@ -33,8 +33,8 @@ Related specs and docs:
 - [`observability.md`](observability.md) — `logs` and `stats` commands
 - [`database-migration.md`](database-migration.md) — `db migrate` commands
 - [`mcp-architecture.md`](mcp-architecture.md) / [`mcp-tool-surface.md`](mcp-tool-surface.md) — MCP tool/prompt enumeration
-- `private/specs/distribution-roadmap.md` — `get_base_dir()` fix, first-run experience
-- `private/specs/mvp-roadmap.md` — implementation leverage ordering
+- `private/strategy/distribution-roadmap.md` — `get_base_dir()` fix, first-run experience
+- `private/strategy/mvp-roadmap.md` — implementation leverage ordering
 
 ## Design Principles
 

--- a/docs/specs/privacy-data-protection.md
+++ b/docs/specs/privacy-data-protection.md
@@ -32,7 +32,7 @@ account numbers, or spending patterns.
 
 ### Competitive context
 No open-source personal finance tool encrypts the local database by default. See
-`private/specs/strategic-analysis.md` §1 for the full competitor comparison. This is a
+`private/strategy/strategic-analysis.md` §1 for the full competitor comparison. This is a
 genuine differentiator: MoneyBin is the only tool in this space where a copied database
 file is a useless encrypted blob without the key.
 

--- a/docs/specs/smart-import-tabular.md
+++ b/docs/specs/smart-import-tabular.md
@@ -43,7 +43,7 @@ format-based system) and absorbs Pillar B (Excel import) from
 - `CLAUDE.md` "Architecture: Data Layers" — raw/prep/core layering this spec conforms to.
 - `.claude/rules/cli.md` — non-interactive parity requirement (every interactive
   prompt has a flag equivalent).
-- `private/specs/strategic-analysis.md` §6 — data portability and migration strategy
+- `private/strategy/strategic-analysis.md` §6 — data portability and migration strategy
   that motivates the built-in formats and category migration flow.
 
 ### Competitive context
@@ -52,7 +52,7 @@ No open-source personal finance tool treats migration as a first-class feature. 
 tools typically means: export transactions, re-import, re-categorize from scratch —
 discarding years of categorization work. MoneyBin's smart tabular importer preserves
 imported categories and uses them to seed the auto-rule engine, giving users a
-fully-categorized MoneyBin on day one. See `private/specs/strategic-analysis.md` §6 for
+fully-categorized MoneyBin on day one. See `private/strategy/strategic-analysis.md` §6 for
 the full migration path matrix.
 
 ---

--- a/docs/specs/sync-overview.md
+++ b/docs/specs/sync-overview.md
@@ -435,7 +435,7 @@ Selected for simplicity, auditability, and mature library support. X25519 is the
 **Known limitations:**
 
 - **Not quantum-resistant.** X25519 is vulnerable to Shor's algorithm on a sufficiently powerful quantum computer. The threat to personal financial data is not imminent, but the design must not preclude an upgrade.
-- **Not FIPS 140-3 compliant.** X25519 is not a NIST-approved curve. FIPS requires P-256, P-384, or P-521 for ECC. Argon2id (used for passphrase-based key protection) is also not FIPS-approved (FIPS requires PBKDF2 or HKDF). If MoneyBin ever pursues SOC 2 certification or serves regulated entities, these algorithms would need to be swapped. See `private/specs/compliance-gap-analysis.md` (planned) for the full gap assessment.
+- **Not FIPS 140-3 compliant.** X25519 is not a NIST-approved curve. FIPS requires P-256, P-384, or P-521 for ECC. Argon2id (used for passphrase-based key protection) is also not FIPS-approved (FIPS requires PBKDF2 or HKDF). If MoneyBin ever pursues SOC 2 certification or serves regulated entities, these algorithms would need to be swapped. See `private/strategy/compliance-gap-analysis.md` (planned) for the full gap assessment.
 
 **Upgrade path: hybrid X25519 + ML-KEM (CRYSTALS-Kyber)**
 
@@ -675,7 +675,7 @@ The [`testing-and-validation-overview.md`](testing-and-validation-overview.md) u
 
 ### Relationship to MVP roadmap
 
-Phase 1 of this spec maps to MVP Level 2 ("Plaid Transactions") in `private/specs/mvp-roadmap.md`. Phases 2–4 are post-MVP enhancements. The build order here refines the internal phasing within the Level 2 deliverable — it does not change the roadmap sequencing.
+Phase 1 of this spec maps to MVP Level 2 ("Plaid Transactions") in `private/strategy/mvp-roadmap.md`. Phases 2–4 are post-MVP enhancements. The build order here refines the internal phasing within the Level 2 deliverable — it does not change the roadmap sequencing.
 
 ---
 
@@ -720,7 +720,7 @@ Not designed here. Architectural constraints noted so the current design does no
 3. **Plaid Liabilities** — sync loan, mortgage, and credit card debt details. Separate child spec.
 4. **Webhook-based sync** — server pushes notifications when new data is available, eliminating polling. Requires a client-side listener or notification mechanism.
 5. **Integration test environment** — coordinated setup for running server-dependent tests. Separate spec covering docker-compose, Auth0 test tenant, sandbox credential management.
-6. **Compliance gap analysis** — assessment of MoneyBin's security posture against SOC 2, FIPS 140-3, and other certifications. Planned as `private/specs/compliance-gap-analysis.md`.
+6. **Compliance gap analysis** — assessment of MoneyBin's security posture against SOC 2, FIPS 140-3, and other certifications. Planned as `private/strategy/compliance-gap-analysis.md`.
 
 ## Success criteria
 

--- a/docs/specs/testing-overview.md
+++ b/docs/specs/testing-overview.md
@@ -2,7 +2,7 @@
 
 > Last updated: 2026-04-26
 > Status: Ready — umbrella doc for the testing & validation initiative. Child specs listed in [Child Specs](#child-specs) are written separately.
-> Companions: `private/specs/core-concerns.md` §10 (original requirements, not checked in), `CLAUDE.md` "Architecture: Data Layers", [`sync-overview.md`](sync-overview.md) (owns Plaid Sandbox testing)
+> Companions: `private/strategy/core-concerns.md` §10 (original requirements, not checked in), `CLAUDE.md` "Architecture: Data Layers", [`sync-overview.md`](sync-overview.md) (owns Plaid Sandbox testing)
 
 ## Purpose
 

--- a/docs/specs/testing-synthetic-data.md
+++ b/docs/specs/testing-synthetic-data.md
@@ -19,7 +19,7 @@ rewrites.
   umbrella spec. Defines verification tiers, scenario format, persona catalog, and
   assertion library. This spec implements the generator; the scenario runner is a peer
   concern.
-- `private/specs/core-concerns.md` §10 — original requirements scaffold for testing &
+- `private/strategy/core-concerns.md` §10 — original requirements scaffold for testing &
   synthetic data.
 - [`smart-import-tabular.md`](smart-import-tabular.md) — defines
   `Database.ingest_dataframe()`, the bulk write primitive the generator uses.
@@ -31,7 +31,7 @@ rewrites.
   enable Tier 3 scored evaluation of transfer detection.
 - `CLAUDE.md` "Architecture: Data Layers" — raw/prep/core layering. Generated data
   enters at raw and flows through the full pipeline.
-- `private/specs/mvp-roadmap.md` — Level 0 deliverable. The generator is an
+- `private/strategy/mvp-roadmap.md` — Level 0 deliverable. The generator is an
   infrastructure multiplier: every feature after it has proper test data.
 
 ### Companion spec


### PR DESCRIPTION
### Summary
The local (gitignored) `private/` directory was reorganized — strategic positioning docs moved from `private/specs/` to `private/strategy/`. This PR updates the 7 public spec docs that referenced the old location. No content was changed beyond the path strings.

### Impact
Documentation-only. No workflow changes. Anyone with their own `private/` checkout should mirror the local rename (`mv private/specs private/strategy`) — this PR can't help with that since `private/` is gitignored.

### Changes
#### docs/specs path-reference sweep
Replaced all `private/specs/...` references with `private/strategy/...`:
- `categorization-overview.md` — 3 refs to `strategic-analysis.md`
- `cli-restructure.md` — refs to `distribution-roadmap.md`, `mvp-roadmap.md`
- `privacy-data-protection.md` — ref to `strategic-analysis.md`
- `smart-import-tabular.md` — 2 refs to `strategic-analysis.md`
- `sync-overview.md` — 2 refs to `compliance-gap-analysis.md`, 1 ref to `mvp-roadmap.md`
- `testing-overview.md` — ref to `core-concerns.md`
- `testing-synthetic-data.md` — refs to `core-concerns.md` and `mvp-roadmap.md`

### Testing
- `grep -rn "private/specs" docs/` returns no matches.
- Visually confirmed each diff is a pure substring replacement.

### Notes
None.