### PR TITLE
Fix CVEs: pip CVE-2026-6357 and python-multipart CVE-2026-42561

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -43,7 +43,4 @@ jobs:
         run: uv sync
 
       - name: Audit dependencies for CVEs
-        # CVE-2026-3219 (GHSA-58qw-9mgm-455v): pip archive-type confusion.
-        # No fix version yet; pip is a dev/build tool, not invoked at runtime.
-        # Re-evaluate when upstream releases a fix.
-        run: uv run pip-audit --skip-editable --ignore-vuln CVE-2026-3219
+        run: uv run pip-audit --skip-editable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,25 @@
 
 Personal financial data platform. Python + DuckDB + SQLMesh + Typer CLI + MCP server.
 
+## Think Before Coding
+Don't assume. Don't hide confusion. Surface tradeoffs.
+
+### Before implementing
+State your assumptions explicitly. If uncertain, ask.
+If multiple interpretations exist, present them - don't pick silently.
+If a simpler approach exists, say so. Push back when warranted.
+If something is unclear, stop. Name what's confusing. Ask.
+
+## Simplicity First
+Minimum code that solves the problem. Nothing speculative.
+
+No features beyond what was asked.
+No abstractions for single-use code.
+No "flexibility" or "configurability" that wasn't requested.
+No error handling for impossible scenarios.
+If you write 200 lines and it could be 50, rewrite it.
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
 ## Design Philosophy
 
 - **Sync server is opaque.** The client communicates only with moneybin-server's API surface. External service providers are implementation details hidden behind the server.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ dependencies = [
     # Secret management and key derivation
     "keyring>=25.6.0",
     "argon2-cffi>=23.1.0",
-    "python-multipart>=0.0.26",
+    "python-multipart>=0.0.27",  # CVE-2026-42561 — fixed in 0.0.27
     "lxml>=6.1.0",
     "openpyxl>=3.1.5",
     "fastexcel>=0.19.0",
@@ -137,6 +137,8 @@ dev = [
     "sqlparse>=0.5.3",
     # Security auditing
     "pip-audit>=2.10.0",
+    # Security: CVE-2026-6357 (pip 26.0.1) — fixed in 26.1 (transitive via pip-audit → pip-api)
+    "pip>=26.1",
     # Testing framework and tools
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1593,6 +1593,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pip" },
     { name = "pip-audit" },
     { name = "pre-commit" },
     { name = "pyright" },
@@ -1641,7 +1642,7 @@ requires-dist = [
     { name = "pytesseract", specifier = ">=0.3.13" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
-    { name = "python-multipart", specifier = ">=0.0.26" },
+    { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "requests", specifier = ">=2.33.1" },
     { name = "sqlmesh", extras = ["duckdb"], specifier = ">=0.200.0" },
@@ -1651,6 +1652,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pip", specifier = ">=26.1" },
     { name = "pip-audit", specifier = ">=2.10.0" },
     { name = "pre-commit", specifier = ">=4.4.0" },
     { name = "pyright", specifier = ">=1.1.408" },
@@ -2077,11 +2079,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
 ]
 
 [[package]]
@@ -2691,11 +2693,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Addresses two open CVEs surfaced by the weekly dependency audit. `python-multipart` (direct runtime dependency) and `pip` (transitive dev dependency via pip-audit → pip-api) are both upgraded to non-vulnerable versions. The previously suppressed CVE-2026-3219 is also resolved by pip 26.1.1, so its `--ignore-vuln` flag is removed, leaving the audit fully clean with no suppressions.

## Impact

- No consumer workflow changes required — this only affects development environment installs and the security audit step.
- `uv sync` will pull updated packages on next install.

## Changes

### Security: CVE fixes

Three CVEs are addressed in this PR:

- **CVE-2026-42561** (`python-multipart 0.0.26`): bumped lower bound from `>=0.0.26` to `>=0.0.27`; lockfile resolved to 0.0.28
- **CVE-2026-6357** (`pip 26.0.1`): added `pip>=26.1` to the dev dependency group to force a safe version; lockfile resolved to 26.1.1
- **CVE-2026-3219** (`pip`): previously suppressed with `--ignore-vuln` in security.yml because no fix existed; pip 26.1.1 resolves it — suppression removed

### Documentation

- Added "Think Before Coding" and "Simplicity First" guidelines to AGENTS.md

## Testing

- `uv run pip-audit --skip-editable` returns clean with zero suppressions
- `make format && make lint` passes