### PR TITLE
Fix CI: DuckDB CLI install, docs-path filter, back-fill test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,39 @@ on:
   pull_request:
 
 jobs:
-  ci:
-    name: Lint, Type Check & Test
+  # Detect whether any non-docs files changed. For pushes to main we always
+  # run the full suite; for PRs we skip lint/type/test when only docs changed.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.check.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for non-docs changes
+        id: check
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            git fetch origin "$BASE_REF" --depth=1
+            CHANGED=$(git diff --name-only "origin/$BASE_REF" HEAD)
+            echo "Changed files:"
+            echo "$CHANGED"
+            if echo "$CHANGED" | grep -qvE '^(docs/|CHANGELOG\.md|README\.md)'; then
+              echo "code=true" >> $GITHUB_OUTPUT
+            else
+              echo "code=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "code=true" >> $GITHUB_OUTPUT
+          fi
+
+  format:
+    name: Format Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -22,6 +53,27 @@ jobs:
 
       - name: Check formatting
         run: uv run ruff format --check .
+
+  ci:
+    name: Lint, Type Check & Test
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Install DuckDB CLI
+        run: |
+          curl -fsSL https://install.duckdb.org | sh
+          echo "$HOME/.duckdb/bin" >> $GITHUB_PATH
 
       - name: Lint
         run: uv run ruff check .

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -125,7 +125,7 @@ Single source of truth for spec status. Update this table when a spec's status c
 
 | Spec | Type | Status | Summary |
 |---|---|---|---|
-| [Reports Recipe Library](reports-recipe-library.md) | Feature | in-progress | Eight `reports.*` SQLMesh views (`net_worth`, `cash_flow`, `spending_trend`, `recurring_subscriptions`, `uncategorized_queue`, `merchant_activity`, `large_transactions`, `balance_drift`) inaugurating the `reports` schema; one-time migration of `core.agg_net_worth → reports.net_worth`; CLI/MCP `reports_*` surfaces extended; `moneybin://schema` discoverability extended. M2C entry. |
+| [Reports Recipe Library](reports-recipe-library.md) | Feature | implemented | Eight `reports.*` SQLMesh views (`net_worth`, `cash_flow`, `spending_trend`, `recurring_subscriptions`, `uncategorized_queue`, `merchant_activity`, `large_transactions`, `balance_drift`) inaugurating the `reports` schema; one-time migration of `core.agg_net_worth → reports.net_worth`; CLI/MCP `reports_*` surfaces extended; `moneybin://schema` discoverability extended. M2C entry. |
 
 ## Standalone
 | [Account Management](account-management.md) | Feature | implemented | Owns the `accounts` entity namespace: list/show/rename/archive/include, reversible account merging via bridge model, per-account settings (`app.account_settings`), display preferences. CLI per `cli-restructure.md` v2 (extends with archive/merge/unmerge): top-level `accounts` (entity ops; balance lives nested under `accounts balance` per `net-worth.md`). Bundles with `net-worth.md`. |

--- a/tests/e2e/test_e2e_workflows.py
+++ b/tests/e2e/test_e2e_workflows.py
@@ -246,27 +246,16 @@ class TestAutoRulePipeline:
         )
         fixture = FIXTURES_DIR / "tabular" / "standard.csv"
 
-        # Import the fixture twice under different account IDs so the same
-        # merchant description appears in two separate transactions. The first
-        # import's COFFEE SHOP row will be categorized via `categorize apply`;
-        # the second import's COFFEE SHOP row will remain uncategorized and be
-        # picked up by the auto-rule back-fill on approval.
+        # Import acct-a only first so that categorize apply's post-commit snowball
+        # (categorize_pending) sees no other uncategorized COFFEE SHOP rows — which
+        # would pre-categorize them via merchant mapping and leave nothing for the
+        # back-fill in approve() to exercise.
         result = run_cli(
             "import",
             "file",
             str(fixture),
             "--account-id",
             "wf-autorule-acct-a",
-            "--skip-transform",
-            env=env,
-        )
-        result.assert_success()
-        result = run_cli(
-            "import",
-            "file",
-            str(fixture),
-            "--account-id",
-            "wf-autorule-acct-b",
             "--skip-transform",
             env=env,
         )
@@ -278,9 +267,7 @@ class TestAutoRulePipeline:
         result = run_cli("transform", "seed", env=env)
         result.assert_success()
 
-        # Find the COFFEE SHOP transaction ID for account-a only — categorizing
-        # just this one leaves account-b's COFFEE SHOP row uncategorized for
-        # the back-fill step to exercise after approval.
+        # Find the COFFEE SHOP transaction ID for account-a.
         result = run_cli(
             "db",
             "query",
@@ -314,6 +301,8 @@ class TestAutoRulePipeline:
 
         # apply categorize — this records a user categorization and triggers the
         # auto-rule pipeline to create a pending proposal (threshold default = 1).
+        # The post-commit snowball runs categorize_pending here, but acct-b has not
+        # been imported yet so no other COFFEE SHOP rows are in fct_transactions.
         result = run_cli(
             "transactions",
             "categorize",
@@ -322,6 +311,22 @@ class TestAutoRulePipeline:
             str(json_path),
             env=env,
         )
+        result.assert_success()
+
+        # Import acct-b after categorize apply so its COFFEE SHOP row lands in
+        # fct_transactions before approval but after the snowball ran. The back-fill
+        # inside approve() will then find and categorize it as 'auto_rule'.
+        result = run_cli(
+            "import",
+            "file",
+            str(fixture),
+            "--account-id",
+            "wf-autorule-acct-b",
+            "--skip-transform",
+            env=env,
+        )
+        result.assert_success()
+        result = run_cli("transform", "apply", env=env, timeout=180)
         result.assert_success()
 
         # auto-review surfaces the seeded proposal
@@ -363,11 +368,10 @@ class TestAutoRulePipeline:
         result.assert_success()
         assert "Active auto-rules" in result.output
 
-        # Approval back-fills the matching tabular transaction with
-        # categorized_by='auto_rule'. This guards against a regression where
-        # tabular descriptions land NULL in core.fct_transactions and the
-        # back-fill SELECT (`WHERE t.description IS NOT NULL`) silently
-        # returns zero rows.
+        # Approval back-fills the acct-b COFFEE SHOP row (imported after the
+        # snowball ran) with categorized_by='auto_rule'. This guards against a
+        # regression where tabular descriptions land NULL in core.fct_transactions
+        # and the back-fill SELECT silently returns zero rows.
         result = run_cli(
             "db",
             "query",


### PR DESCRIPTION
## Summary
Fixes three related CI gaps exposed while debugging the auto-rule back-fill regression. Installs the DuckDB CLI in Actions so previously-skipped tests now run, adds a path filter so docs-only PRs skip lint/type/test, and repairs the back-fill test that silently broke in #122 because it was never running on CI.

## Impact
- Docs-only PRs (`docs/`, `CHANGELOG.md`, `README.md`) now skip lint/type/test and only run format check — faster feedback loop.
- The DuckDB CLI is now present in CI; any test guarded by `shutil.which("duckdb")` will run rather than be skipped.
- No workflow changes needed for contributors.

## Changes

#### GitHub Actions workflow (`ci.yml`)
- `changes` job: for PRs, diffs against the base branch and sets `code=true/false`; for pushes to `main`, unconditionally `code=true`
- `format` job: always runs, independent of path filter
- `ci` job: gated on `needs.changes.outputs.code == 'true'`; contains the new DuckDB CLI install step, lint, type check, and tests
- `BASE_REF` passed through `env:` to avoid the Actions string-interpolation injection pattern

#### Auto-rule back-fill test (`tests/e2e/test_e2e_workflows.py`)
- Root cause: PR #122 added `categorize_pending()` as a post-commit snowball after every `categorize apply`. When both accounts' fixtures were imported before `categorize apply`, the snowball pre-categorized acct-b's COFFEE SHOP via merchant mapping — leaving nothing for the back-fill in `approve()` to categorize.
- Fix: import acct-a only, run `categorize apply` (snowball sees no other COFFEE SHOPs), *then* import acct-b and re-run transform. The back-fill in `auto accept` finds acct-b's transaction uncategorized and assigns `categorized_by='auto_rule'`.

#### Spec index (`docs/specs/INDEX.md`)
- Reports Recipe Library: `in-progress` → `implemented`

## Test plan
- `test_import_then_promote_proposal` passes locally (17 s)
- Workflow logic reviewed: `grep -qvE '^(docs/|CHANGELOG\.md|README\.md)'` correctly passes for any `src/`, `.github/`, `tests/`, or root Python file change
- This PR itself exercises the new path filter: the `ci` job should run (non-docs files changed)

## Notes
The docs-only regex (`^(docs/|CHANGELOG\.md|README\.md)`) is the current allowlist. If new doc-root files are added (e.g. `CONTRIBUTING.md`, `SECURITY.md`) they should be appended to that pattern.