### PR TITLE
Add transactions_get MCP tool and transactions list CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ M2 work in flight; M2A `transaction-curation.md` spec published (PR #115). Doc s
 
 ### Added
 - `moneybin doctor` command — read-only pipeline integrity check that runs SQLMesh named audits (FK integrity, sign convention, transfer balance), staging coverage, and categorization coverage. Exits 0 on pass/warn, 1 on fail. Supports `--verbose` for affected IDs and `--output json` for agent consumption. Registered as `system_doctor` MCP tool.
+- `transactions_get` MCP tool: primary transaction read with account/date/category/amount/description filters, curation fields (notes, tags, splits), and opaque cursor pagination.
+- `moneybin transactions list` CLI command with the same filter surface as `transactions_get`; supports `--output text|json`.
 - MCP tool decorator now emits protocol-standard `ToolAnnotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`). Clients can render confirmation UI for destructive operations.
 - Decorator-level cap on list-typed tool parameters via `MCPConfig.max_items` (default 500). Exceeding the cap returns `ResponseEnvelope.error` with `code="too_many_items"`.
 - `accounts_resolve` MCP tool and `moneybin accounts resolve "<query>"` CLI command — fuzzy-matches free-text references to an `account_id`.
@@ -43,6 +45,9 @@ M2 work in flight; M2A `transaction-curation.md` spec published (PR #115). Doc s
 - **README significantly tightened** — from ~196 lines to ~115 lines. Storefront pattern: tagline preserved, status callout + Why-bullets + How-It-Works diagram + Quick Start + 5×5 ✓/✗ comparison + Documentation/Community/Contributing/License pointers. In-README roadmap matrix removed (lives in `docs/roadmap.md`); detailed feature inventory removed (lives in `docs/features.md`); 8-column comparison table replaced with tight 5×5 (full version in `docs/comparison.md`); License essay condensed (full rationale in `docs/licensing.md`). Modeled on Bitwarden, Plausible, DuckDB, SQLMesh peer-set conventions.
 - `.claude/rules/shipping.md` extended with the post-implementation checklist for `CHANGELOG.md`, `docs/roadmap.md`, `docs/features.md`. Documents what does and doesn't earn a CHANGELOG entry.
 - `CONTRIBUTING.md` "Where the strategy lives" expanded to include the new docs and a one-line CHANGELOG rule.
+
+### Removed
+- `transactions_search` MCP tool (superseded by `transactions_get`, which covers all its filters plus multi-account, multi-category, curation fields, and cursor-based pagination).
 
 ### Fixed
 - Five categorization correctness bugs surfaced by live OFX checking-account testing: `memo` was dropped from the matcher and LLM input; `_match_description` only operated on `description`; system-generated merchants used over-generalizing `contains` patterns; `categorize_pending` was never called after `transactions_categorize_apply` so the snowball couldn't roll; OFX `<NAME>` truncation hid merchant identity in `<MEMO>` that the matcher never saw. See [`docs/specs/categorization-matching-mechanics.md`](docs/specs/categorization-matching-mechanics.md) for the full diagnosis. (PR #122)

--- a/docs/specs/mcp-tool-surface.md
+++ b/docs/specs/mcp-tool-surface.md
@@ -296,7 +296,11 @@ Default output is a table with period, income, expenses, net, and count columns.
 
 ---
 
-### 2.2 `transactions_search` — medium sensitivity, pagination, degraded response
+### 2.2 `transactions_get` — medium sensitivity, cursor pagination, curation fields
+
+> **Note:** `transactions_search` was removed and superseded by `transactions_get` in M3E. The exemplar below reflects the current implementation.
+
+
 
 **Service layer**
 
@@ -584,9 +588,17 @@ Net worth across all accounts over time.
 
 **Service class:** `TransactionService` (search, correct, annotate, recurring), `MatchService` (matches sub-domain)
 
-### `transactions_search`
+### `transactions_get`
 
-*Exemplar — see section 2.2.*
+Primary transaction read tool. Returns full transaction records with curation metadata.
+
+- **Sensitivity:** `medium`
+- **Parameters:** `accounts: list[str]?`, `date_from: str?`, `date_to: str?`, `categories: list[str]?`, `amount_min: float?`, `amount_max: float?`, `description: str?`, `uncategorized_only: bool = false`, `limit: int = 50`, `cursor: str?`
+- **Behavior:** Reads from `core.fct_transactions`. `accounts` accepts exact account IDs or display names (resolved internally). `cursor` is an opaque pagination token from `next_cursor` in a previous response. Returns `list[Transaction]` with optional `notes`, `tags`, `splits` fields.
+- **Sign convention:** negative = expense, positive = income.
+- **Service:** `TransactionService.get() -> TransactionGetResult`
+- **CLI:** `moneybin transactions list`
+- **read_only:** true
 
 ### `transactions_correct`
 
@@ -1205,7 +1217,7 @@ Four goal-oriented workflow templates. Each defines the goal, relevant tools, gu
 
 **Parameters:** `tax_year: str` (defaults to prior year).
 
-**Relevant tools:** `tax_w2`, `tax_deductions`, `reports_spending_by_category`, `reports_cashflow_income`, `transactions_search`
+**Relevant tools:** `tax_w2`, `tax_deductions`, `reports_spending_by_category`, `reports_cashflow_income`, `transactions_get`
 
 **Guardrails:**
 
@@ -1315,7 +1327,7 @@ Clean break — old tool names stop working when v1 ships. MoneyBin is pre-1.0; 
 | `describe_table` | `moneybin://schema` resource | Tool → resource |
 | `list_accounts` | `accounts_list` | |
 | `get_account_balances` | `accounts_balances` | |
-| `query_transactions` | `transactions_search` | Richer filters, pagination |
+| `query_transactions` | `transactions_get` | Richer filters, curation fields, cursor pagination |
 | `get_w2_summary` | `tax_w2` | |
 | `list_categories` | `categorize_categories` | |
 | `list_categorization_rules` | `categorize_rules` | |
@@ -1355,7 +1367,7 @@ All prototype prompts are replaced by the four v1 prompts. The prototype's step-
 | `moneybin://schema/tables` | `moneybin://schema` | Consolidated |
 | `moneybin://schema/{table_name}` | `moneybin://schema` | Consolidated |
 | `moneybin://accounts/summary` | `moneybin://accounts` | Simplified |
-| `moneybin://transactions/recent` | Removed | Too dynamic for ambient context; use `transactions_search` |
+| `moneybin://transactions/recent` | Removed | Too dynamic for ambient context; use `transactions_get` |
 | `moneybin://w2/{tax_year}` | Removed | Parameterized data belongs as a tool (`tax_w2`) |
 
 ---
@@ -1389,7 +1401,7 @@ Per [`cli-restructure.md`](cli-restructure.md) v2. Hard cut: rename in place, no
 
 | v1 | v2 | Notes |
 |---|---|---|
-| `transactions_search` | `transactions_search` | Verb already trailing |
+| `transactions_get` | `transactions_get` | Verb already trailing |
 | `transactions_correct` | `transactions_correct` | Verb already trailing |
 | `transactions_annotate` | `transactions_annotate` | Verb already trailing |
 | `transactions_recurring` | `transactions_recurring_list` | Add explicit `_list` |

--- a/docs/specs/mcp-tool-surface.md
+++ b/docs/specs/mcp-tool-surface.md
@@ -298,105 +298,81 @@ Default output is a table with period, income, expenses, net, and count columns.
 
 ### 2.2 `transactions_get` — medium sensitivity, cursor pagination, curation fields
 
-> **Note:** `transactions_search` was removed and superseded by `transactions_get` in M3E. The exemplar below reflects the current implementation.
-
-
-
 **Service layer**
 
 ```python
 class TransactionService:
-    def search(
+    def get(
         self,
-        start_date: str | None = None,
-        end_date: str | None = None,
-        months: int | None = None,
-        min_amount: float | None = None,
-        max_amount: float | None = None,
+        *,
+        accounts: list[str] | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        categories: list[str] | None = None,
+        amount_min: Decimal | None = None,
+        amount_max: Decimal | None = None,
         description: str | None = None,
-        category: str | None = None,
-        account_id: list[str] | None = None,
         uncategorized_only: bool = False,
-        limit: int = 100,
-        offset: int = 0,
-        detail: str = "standard",
-    ) -> TransactionSearchResult: ...
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> TransactionGetResult: ...
 ```
 
-`TransactionSearchResult` contains a list of `Transaction` records and pagination metadata. At `detail=summary`, the service returns category/period aggregates instead of rows (the degraded path reuses this).
+`TransactionGetResult` contains a list of `Transaction` records and an optional `next_cursor` string. `Transaction` includes curation fields (`notes`, `tags`, `splits`) joined from the app schema in `core.fct_transactions`. `accounts` entries are resolved: exact `account_id` matches are used directly; anything else is fuzzy-matched by display name via `AccountService`. Unresolvable entries are silently skipped.
 
 **MCP tool**
 
-- **Name:** `transactions_search`
-- **Description:** "Search transactions with filters. Returns row-level transaction data. For aggregate summaries without consent requirements, use `detail=summary` or the `spending.*` tools instead."
-- **Sensitivity:** `medium` — row-level data (descriptions, amounts, dates) at `standard`/`full` detail. `detail=summary` returns aggregates and does not trigger consent.
+- **Name:** `transactions_get`
+- **Description:** "Fetch transactions with optional filters and cursor pagination. Returns row-level data including curation fields (notes, tags, splits). Amounts use the accounting convention: negative = expense, positive = income. Amount filter parameters accept decimal strings (e.g., `\"-50.00\"`) to preserve precision."
+- **Sensitivity:** `medium` — row-level data (descriptions, amounts, dates).
 - **Parameters:**
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `start_date` | `str?` | — | ISO 8601 start date |
-| `end_date` | `str?` | — | ISO 8601 end date |
-| `months` | `int?` | — | Recent months lookback (overridden by explicit dates) |
-| `min_amount` | `float?` | — | Minimum amount (negative for expenses) |
-| `max_amount` | `float?` | — | Maximum amount |
-| `description` | `str?` | — | ILIKE pattern for description/memo (e.g., `%AMAZON%`) |
-| `category` | `str?` | — | Filter by category name |
-| `account_id` | `list[str]?` | — | Filter to specific accounts |
-| `uncategorized_only` | `bool` | `false` | Only return uncategorized transactions |
-| `limit` | `int` | `100` | Max results (capped at `MAX_ROWS`) |
-| `offset` | `int` | `0` | Pagination offset |
-| `detail` | `str` | `"standard"` | `summary` (aggregates), `standard` (core fields), `full` (all fields including memo, source_type, merchant_name) |
+| `accounts` | `list[str]?` | — | Account IDs or display names (fuzzy-matched) |
+| `date_from` | `str?` | — | ISO 8601 start date, inclusive |
+| `date_to` | `str?` | — | ISO 8601 end date, inclusive |
+| `categories` | `list[str]?` | — | Filter to specific category names |
+| `amount_min` | `str?` | — | Minimum amount as decimal string (e.g., `"-50.00"`) |
+| `amount_max` | `str?` | — | Maximum amount as decimal string |
+| `description` | `str?` | — | ILIKE pattern matched against description and memo |
+| `uncategorized_only` | `bool` | `false` | Only rows with no user/AI/rule categorization (`categorized_by IS NULL`) |
+| `limit` | `int` | `50` | Max results per page |
+| `cursor` | `str?` | — | Opaque pagination token from `next_cursor` in a prior response |
 
-- **Response `data` shape (`standard`):**
+- **Response `data` shape:**
 
 ```json
 [
   {
-    "transaction_id": "tx_abc123",
-    "date": "2026-04-15",
+    "transaction_id": "abc123def456",
+    "account_id": "chase-checking-1234",
+    "transaction_date": "2026-04-15",
     "amount": -42.50,
     "description": "WHOLEFDS MKT #10234",
+    "source_type": "ofx",
     "category": "Food & Drink",
     "subcategory": "Groceries",
-    "account_id": "chase-checking-1234"
+    "tags": ["grocery", "weekly"],
+    "notes": null,
+    "splits": null
   }
 ]
 ```
 
-- **Degraded response** (no consent): Same envelope with `summary.degraded: true`. `data` contains category/period aggregates instead of transaction rows:
-
-```json
-{
-  "summary": {
-    "total_count": 247,
-    "returned_count": 5,
-    "has_more": false,
-    "sensitivity": "low",
-    "degraded": true,
-    "degraded_reason": "Transaction-level data requires data-sharing consent"
-  },
-  "data": [
-    {"category": "Food & Drink", "total": 1245.67, "transaction_count": 42},
-    {"category": "Shopping", "total": 892.30, "transaction_count": 23}
-  ],
-  "actions": [
-    "Run 'moneybin privacy grant mcp-data-sharing' to enable full transaction details"
-  ]
-}
-```
-
-- **Actions (consented):** `["Use transactions_categorize_apply to categorize selected transactions", "Use transactions_correct to fix a transaction's amount or description"]`
+- **Pagination:** `next_cursor` appears at the top level of the envelope when more pages exist. Pass it back as `cursor` to fetch the next page. Absent when all results fit in one page.
+- **Actions:** `["Use transactions_get with the next_cursor value to fetch the next page", "Use reports_spending_get for category breakdowns", "Use transactions_categorize_apply to categorize uncategorized transactions"]`
 
 **CLI command**
 
 ```
-moneybin transactions search [--start-date DATE] [--end-date DATE] [--months N]
-                             [--min-amount N] [--max-amount N] [--description PATTERN]
-                             [--category NAME] [--account-id ID ...] [--uncategorized-only]
-                             [--limit 100] [--offset 0] [--detail standard] [--output json]
+moneybin transactions list [--account ID_OR_NAME] [--from DATE] [--to DATE]
+                           [--category NAME] [--amount-min N] [--amount-max N]
+                           [--description PATTERN] [--uncategorized]
+                           [--limit 50] [--cursor TOKEN] [--output text|json]
 ```
 
-Default output is a table with date, amount, description, category, and account columns. `--output json` returns the response envelope.
+Default output is a table with date, description, amount, category, and account columns. `--output json` returns the response envelope. `--account` is repeatable and resolves by account ID or fuzzy display-name match.
 
 ---
 

--- a/docs/specs/mcp-tool-surface.md
+++ b/docs/specs/mcp-tool-surface.md
@@ -593,7 +593,7 @@ Net worth across all accounts over time.
 Primary transaction read tool. Returns full transaction records with curation metadata.
 
 - **Sensitivity:** `medium`
-- **Parameters:** `accounts: list[str]?`, `date_from: str?`, `date_to: str?`, `categories: list[str]?`, `amount_min: float?`, `amount_max: float?`, `description: str?`, `uncategorized_only: bool = false`, `limit: int = 50`, `cursor: str?`
+- **Parameters:** `accounts: list[str]?`, `date_from: str?`, `date_to: str?`, `categories: list[str]?`, `amount_min: str?` (decimal string e.g. `"-50.00"`), `amount_max: str?` (decimal string), `description: str?`, `uncategorized_only: bool = false`, `limit: int = 50`, `cursor: str?`
 - **Behavior:** Reads from `core.fct_transactions`. `accounts` accepts exact account IDs or display names (resolved internally). `cursor` is an opaque pagination token from `next_cursor` in a previous response. Returns `list[Transaction]` with optional `notes`, `tags`, `splits` fields.
 - **Sign convention:** negative = expense, positive = income.
 - **Service:** `TransactionService.get() -> TransactionGetResult`

--- a/src/moneybin/cli/commands/transactions/__init__.py
+++ b/src/moneybin/cli/commands/transactions/__init__.py
@@ -11,6 +11,7 @@ import typer
 from . import categorize, matches, notes, splits, tags
 from .audit import transactions_audit
 from .create import transactions_create
+from .list_ import transactions_list
 from .review import transactions_review
 
 app = typer.Typer(
@@ -29,3 +30,4 @@ app.add_typer(splits.app, name="splits")
 app.command("review")(transactions_review)
 app.command("create")(transactions_create)
 app.command("audit")(transactions_audit)
+app.command("list")(transactions_list)

--- a/src/moneybin/cli/commands/transactions/list_.py
+++ b/src/moneybin/cli/commands/transactions/list_.py
@@ -8,7 +8,12 @@ from decimal import Decimal
 
 import typer
 
-from moneybin.cli.output import OutputFormat, output_option, quiet_option
+from moneybin.cli.output import (
+    OutputFormat,
+    output_option,
+    quiet_option,
+    render_or_json,
+)
 from moneybin.cli.utils import render_rich_table
 
 logger = logging.getLogger(__name__)
@@ -69,29 +74,32 @@ def transactions_list(
 
     envelope = result.to_envelope()
 
-    if output == OutputFormat.JSON:
-        typer.echo(envelope.to_json())
-        return
+    def _render_text(_: object) -> None:
+        if not result.transactions:
+            if not quiet:
+                typer.echo("No transactions found.")
+            return
 
-    if not result.transactions:
-        if not quiet:
-            typer.echo("No transactions found.")
-        return
+        rows: list[tuple[object, ...]] = []
+        for t in result.transactions:
+            amt = t.amount
+            amount_str = f"{amt:,.2f}"
+            desc = (
+                t.description[:49] + "…" if len(t.description) > 50 else t.description
+            )
+            rows.append((
+                t.transaction_date,
+                desc,
+                amount_str,
+                t.category or "",
+                t.account_id,
+            ))
 
-    rows: list[tuple[object, ...]] = []
-    for t in result.transactions:
-        amt = t.amount
-        amount_str = f"{amt:,.2f}"
-        desc = t.description[:49] + "…" if len(t.description) > 50 else t.description
-        rows.append((
-            t.transaction_date,
-            desc,
-            amount_str,
-            t.category or "",
-            t.account_id,
-        ))
+        render_rich_table(
+            ["date", "description", "amount", "category", "account"], rows
+        )
 
-    render_rich_table(["date", "description", "amount", "category", "account"], rows)
+        if result.next_cursor and not quiet:
+            typer.echo(f"Next page: --cursor {result.next_cursor}", err=True)
 
-    if result.next_cursor and not quiet:
-        typer.echo(f"Next page: --cursor {result.next_cursor}", err=True)
+    render_or_json(envelope, output, render_fn=_render_text)

--- a/src/moneybin/cli/commands/transactions/list_.py
+++ b/src/moneybin/cli/commands/transactions/list_.py
@@ -31,7 +31,9 @@ def transactions_list(
         None, "--description", help="ILIKE pattern against description and memo."
     ),
     uncategorized: bool = typer.Option(
-        False, "--uncategorized", help="Only uncategorized transactions."
+        False,
+        "--uncategorized",
+        help="Only transactions with no user/AI/rule categorization assigned.",
     ),
     limit: int = typer.Option(50, "--limit", help="Maximum rows to return."),
     cursor: str | None = typer.Option(
@@ -72,9 +74,10 @@ def transactions_list(
     for t in result.transactions:
         amt = t.amount
         amount_str = f"-${abs(amt):,.2f}" if amt < Decimal("0") else f"${amt:,.2f}"
+        desc = t.description[:49] + "…" if len(t.description) > 50 else t.description
         rows.append((
             t.transaction_date,
-            t.description[:50],
+            desc,
             amount_str,
             t.category or "",
             t.account_id,

--- a/src/moneybin/cli/commands/transactions/list_.py
+++ b/src/moneybin/cli/commands/transactions/list_.py
@@ -27,6 +27,12 @@ def transactions_list(
     categories: list[str] = typer.Option(
         [], "--category", help="Category filter (repeatable)."
     ),
+    amount_min: str | None = typer.Option(
+        None, "--amount-min", help="Minimum amount as decimal string (e.g. '-50.00')."
+    ),
+    amount_max: str | None = typer.Option(
+        None, "--amount-max", help="Maximum amount as decimal string."
+    ),
     description: str | None = typer.Option(
         None, "--description", help="ILIKE pattern against description and memo."
     ),
@@ -53,6 +59,8 @@ def transactions_list(
             date_from=date_from,
             date_to=date_to,
             categories=categories or None,
+            amount_min=Decimal(amount_min) if amount_min is not None else None,
+            amount_max=Decimal(amount_max) if amount_max is not None else None,
             description=description,
             uncategorized_only=uncategorized,
             limit=limit,
@@ -73,7 +81,7 @@ def transactions_list(
     rows: list[tuple[object, ...]] = []
     for t in result.transactions:
         amt = t.amount
-        amount_str = f"-${abs(amt):,.2f}" if amt < Decimal("0") else f"${amt:,.2f}"
+        amount_str = f"{amt:,.2f}"
         desc = t.description[:49] + "…" if len(t.description) > 50 else t.description
         rows.append((
             t.transaction_date,

--- a/src/moneybin/cli/commands/transactions/list_.py
+++ b/src/moneybin/cli/commands/transactions/list_.py
@@ -17,8 +17,12 @@ def transactions_list(
     accounts: list[str] = typer.Option(
         [], "--account", help="Account ID or display name (repeatable)."
     ),
-    date_from: str | None = typer.Option(None, "--from", help="Start date ISO 8601, inclusive."),
-    date_to: str | None = typer.Option(None, "--to", help="End date ISO 8601, inclusive."),
+    date_from: str | None = typer.Option(
+        None, "--from", help="Start date ISO 8601, inclusive."
+    ),
+    date_to: str | None = typer.Option(
+        None, "--to", help="End date ISO 8601, inclusive."
+    ),
     categories: list[str] = typer.Option(
         [], "--category", help="Category filter (repeatable)."
     ),
@@ -29,7 +33,9 @@ def transactions_list(
         False, "--uncategorized", help="Only uncategorized transactions."
     ),
     limit: int = typer.Option(50, "--limit", help="Maximum rows to return."),
-    cursor: str | None = typer.Option(None, "--cursor", help="Pagination token from previous call."),
+    cursor: str | None = typer.Option(
+        None, "--cursor", help="Pagination token from previous call."
+    ),
     output: OutputFormat = output_option,
     quiet: bool = quiet_option,
 ) -> None:
@@ -61,7 +67,7 @@ def transactions_list(
             typer.echo("No transactions found.")
         return
 
-    rows = []
+    rows: list[tuple[object, ...]] = []
     for t in result.transactions:
         from decimal import Decimal
 

--- a/src/moneybin/cli/commands/transactions/list_.py
+++ b/src/moneybin/cli/commands/transactions/list_.py
@@ -1,0 +1,81 @@
+# src/moneybin/cli/commands/transactions/list_.py
+"""transactions list — fetch and display transactions with optional filters."""
+
+from __future__ import annotations
+
+import logging
+
+import typer
+
+from moneybin.cli.output import OutputFormat, output_option, quiet_option
+from moneybin.cli.utils import render_rich_table
+
+logger = logging.getLogger(__name__)
+
+
+def transactions_list(
+    accounts: list[str] = typer.Option(
+        [], "--account", help="Account ID or display name (repeatable)."
+    ),
+    date_from: str | None = typer.Option(None, "--from", help="Start date ISO 8601, inclusive."),
+    date_to: str | None = typer.Option(None, "--to", help="End date ISO 8601, inclusive."),
+    categories: list[str] = typer.Option(
+        [], "--category", help="Category filter (repeatable)."
+    ),
+    description: str | None = typer.Option(
+        None, "--description", help="ILIKE pattern against description and memo."
+    ),
+    uncategorized: bool = typer.Option(
+        False, "--uncategorized", help="Only uncategorized transactions."
+    ),
+    limit: int = typer.Option(50, "--limit", help="Maximum rows to return."),
+    cursor: str | None = typer.Option(None, "--cursor", help="Pagination token from previous call."),
+    output: OutputFormat = output_option,
+    quiet: bool = quiet_option,
+) -> None:
+    """List transactions with optional filters."""
+    from moneybin.cli.utils import handle_cli_errors
+    from moneybin.services.transaction_service import TransactionService
+
+    with handle_cli_errors() as db:
+        service = TransactionService(db)
+        result = service.get(
+            accounts=accounts or None,
+            date_from=date_from,
+            date_to=date_to,
+            categories=categories or None,
+            description=description,
+            uncategorized_only=uncategorized,
+            limit=limit,
+            cursor=cursor,
+        )
+
+    envelope = result.to_envelope()
+
+    if output == OutputFormat.JSON:
+        typer.echo(envelope.to_json())
+        return
+
+    if not result.transactions:
+        if not quiet:
+            typer.echo("No transactions found.")
+        return
+
+    rows = []
+    for t in result.transactions:
+        from decimal import Decimal
+
+        amt = t.amount
+        amount_str = f"-${abs(amt):,.2f}" if amt < Decimal("0") else f"${amt:,.2f}"
+        rows.append((
+            t.transaction_date,
+            t.description[:50],
+            amount_str,
+            t.category or "",
+            t.account_id,
+        ))
+
+    render_rich_table(["date", "description", "amount", "category", "account"], rows)
+
+    if result.next_cursor and not quiet:
+        typer.echo(f"Next page: --cursor {result.next_cursor}", err=True)

--- a/src/moneybin/cli/commands/transactions/list_.py
+++ b/src/moneybin/cli/commands/transactions/list_.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+from decimal import Decimal
 
 import typer
 
@@ -69,8 +70,6 @@ def transactions_list(
 
     rows: list[tuple[object, ...]] = []
     for t in result.transactions:
-        from decimal import Decimal
-
         amt = t.amount
         amount_str = f"-${abs(amt):,.2f}" if amt < Decimal("0") else f"${amt:,.2f}"
         rows.append((

--- a/src/moneybin/mcp/prompts.py
+++ b/src/moneybin/mcp/prompts.py
@@ -162,14 +162,14 @@ def curate_recent_transactions() -> str:
         next analysis pass has consistent metadata.
 
         **Relevant tools:**
-        - transactions_search — fetch recent rows; pair with system_audit_list to
+        - transactions_get — fetch recent rows; pair with system_audit_list to
           spot gaps (no note.add / tag.add events on a transaction_id).
         - transactions_tags_set — declarative tag replacement (idempotent).
         - transactions_notes_add — append a curator note.
         - system_audit_list — sanity check what already happened.
 
         **Workflow:**
-        1. Call transactions_search with a recent date window (e.g., last 30 days,
+        1. Call transactions_get with a recent date window (e.g., last 30 days,
            limit 50). Preserve transaction_id, description, amount, account_id.
         2. For each row, propose a small set of slug-pattern tags
            (^[a-z0-9_-]+(:[a-z0-9_-]+)?$) and an optional note. Keep tags short
@@ -232,7 +232,7 @@ def tax_prep() -> str:
         **Relevant tools:**
         - tax_w2 — retrieve W-2 wage and tax data
         - reports_spending_get — find deduction-eligible categories
-        - transactions_search — search for specific deductible expenses
+        - transactions_get — search for specific deductible expenses
         - categories_list — review tax-relevant categories
 
         **Workflow:**
@@ -240,7 +240,7 @@ def tax_prep() -> str:
         2. Pull W-2 data with tax_w2 for that year
         3. Review reports_spending_get for deduction-eligible categories
            (charitable, medical, business expenses, etc.)
-        4. If needed, search for specific transactions with transactions_search
+        4. If needed, search for specific transactions with transactions_get
         5. Summarize totals by deduction category
 
         **Guardrails:**

--- a/src/moneybin/mcp/server.py
+++ b/src/moneybin/mcp/server.py
@@ -58,6 +58,9 @@ mcp = FastMCP(
 
         Tool names mirror the hierarchy with underscores, verb at end: accounts_balance_assert, transactions_matches_confirm, reports_networth_get, reports_spending_get.
 
+        Read surface:
+        - transactions_get — primary transaction read tool; filter by account, date, category, amount, description; returns notes/tags/splits; cursor pagination
+
         Curation surface (visible at connect):
         - transactions_create — bulk manual entry (1..100 atomic)
         - transactions_notes_{add,edit,delete} — note threads on a transaction

--- a/src/moneybin/mcp/tools/curation.py
+++ b/src/moneybin/mcp/tools/curation.py
@@ -173,7 +173,7 @@ def transactions_create(
         },
         sensitivity="medium",
         actions=[
-            "Use transactions_search to confirm the rows landed",
+            "Use transactions_get to confirm the rows landed",
             "Use transform_apply to materialize them into core.fct_transactions",
         ],
     )

--- a/src/moneybin/mcp/tools/import_tools.py
+++ b/src/moneybin/mcp/tools/import_tools.py
@@ -107,7 +107,7 @@ def import_file(
             f"Use import_revert with import_id={import_id} to undo this import"
             if import_id
             else "Use import_status to view recent imports",
-            "Use transactions_search to view imported transactions",
+            "Use transactions_get to view imported transactions",
             "Use transactions_categorize_pending_list to categorize new transactions",
         ],
     )

--- a/src/moneybin/mcp/tools/transactions.py
+++ b/src/moneybin/mcp/tools/transactions.py
@@ -26,8 +26,8 @@ def transactions_get(
     date_from: str | None = None,
     date_to: str | None = None,
     categories: list[str] | None = None,
-    amount_min: float | None = None,
-    amount_max: float | None = None,
+    amount_min: str | None = None,
+    amount_max: str | None = None,
     description: str | None = None,
     uncategorized_only: bool = False,
     limit: int = 50,
@@ -45,10 +45,12 @@ def transactions_get(
         date_from: ISO 8601 start date, inclusive (e.g. '2026-01-01').
         date_to: ISO 8601 end date, inclusive.
         categories: Category names to filter by. Multiple values are OR-combined.
-        amount_min: Minimum amount filter. Negative = expense, positive = income.
-        amount_max: Maximum amount filter.
+        amount_min: Minimum amount as a decimal string (e.g. '-50.00'). Negative
+            = expense, positive = income.
+        amount_max: Maximum amount as a decimal string.
         description: Case-insensitive pattern matched against description and memo.
-        uncategorized_only: Only return transactions with no category assigned.
+        uncategorized_only: Only return transactions with no user/AI/rule
+            categorization assigned (includes source-provided categories).
         limit: Maximum rows to return (default 50).
         cursor: Opaque pagination token from a previous response's next_cursor.
     """
@@ -58,8 +60,8 @@ def transactions_get(
         date_from=date_from,
         date_to=date_to,
         categories=categories,
-        amount_min=Decimal(str(amount_min)) if amount_min is not None else None,
-        amount_max=Decimal(str(amount_max)) if amount_max is not None else None,
+        amount_min=Decimal(amount_min) if amount_min is not None else None,
+        amount_max=Decimal(amount_max) if amount_max is not None else None,
         description=description,
         uncategorized_only=uncategorized_only,
         limit=limit,

--- a/src/moneybin/mcp/tools/transactions.py
+++ b/src/moneybin/mcp/tools/transactions.py
@@ -1,10 +1,10 @@
 # src/moneybin/mcp/tools/transactions.py
-"""Transactions namespace tools — search, recurring patterns, review orientation.
+"""Transactions namespace tools.
 
 Tools:
-    - transactions_search — Search transactions with filters (medium sensitivity)
-    - transactions_recurring_list — Detect recurring transaction patterns (medium sensitivity)
-    - transactions_review_status — Pending counts across matches and categorize queues (low)
+    - transactions_get — Fetch transactions with filters (medium sensitivity)
+    - transactions_recurring_list — Detect recurring patterns (medium sensitivity)
+    - transactions_review_status — Pending counts across queues (low)
 """
 
 from __future__ import annotations
@@ -20,51 +20,51 @@ from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
 from moneybin.services.transaction_service import TransactionService
 
 
-@mcp_tool(sensitivity="medium")
-def transactions_search(
-    start_date: str | None = None,
-    end_date: str | None = None,
-    min_amount: str | None = None,
-    max_amount: str | None = None,
+@mcp_tool(sensitivity="medium", read_only=True)
+def transactions_get(
+    accounts: list[str] | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    categories: list[str] | None = None,
+    amount_min: float | None = None,
+    amount_max: float | None = None,
     description: str | None = None,
-    account_id: str | None = None,
-    category: str | None = None,
     uncategorized_only: bool = False,
-    limit: int = 100,
-    offset: int = 0,
+    limit: int = 50,
+    cursor: str | None = None,
 ) -> ResponseEnvelope:
-    """Search transactions with flexible filtering.
+    """Fetch transactions with optional filtering and cursor-based pagination.
 
-    Supports filtering by date range, amount range, description pattern,
-    account, category, and categorization status. Results are ordered by
-    date descending.
+    Returns full transaction records including curation metadata (notes, tags,
+    splits) from core.fct_transactions. All filters are combinable.
 
     Args:
-        start_date: ISO 8601 start date (inclusive).
-        end_date: ISO 8601 end date (inclusive).
-        min_amount: Minimum amount as string (use negative for expenses).
-        max_amount: Maximum amount as string (use negative for expenses).
-        description: Pattern matched against description and memo (case-insensitive).
-        account_id: Filter to a specific account.
-        category: Filter by assigned category.
-        uncategorized_only: Only return uncategorized transactions.
-        limit: Maximum rows to return (default 100).
-        offset: Number of rows to skip for pagination.
+        accounts: Account IDs or display names to filter by. Accepts exact
+            account_id values or fuzzy display names — use accounts_list to
+            discover IDs. Multiple values are OR-combined.
+        date_from: ISO 8601 start date, inclusive (e.g. '2026-01-01').
+        date_to: ISO 8601 end date, inclusive.
+        categories: Category names to filter by. Multiple values are OR-combined.
+        amount_min: Minimum amount filter. Negative = expense, positive = income.
+        amount_max: Maximum amount filter.
+        description: Case-insensitive pattern matched against description and memo.
+        uncategorized_only: Only return transactions with no category assigned.
+        limit: Maximum rows to return (default 50).
+        cursor: Opaque pagination token from a previous response's next_cursor.
     """
     service = TransactionService(get_database())
-    result = service.search(
-        start_date=start_date,
-        end_date=end_date,
-        min_amount=Decimal(min_amount) if min_amount is not None else None,
-        max_amount=Decimal(max_amount) if max_amount is not None else None,
+    return service.get(
+        accounts=accounts,
+        date_from=date_from,
+        date_to=date_to,
+        categories=categories,
+        amount_min=Decimal(str(amount_min)) if amount_min is not None else None,
+        amount_max=Decimal(str(amount_max)) if amount_max is not None else None,
         description=description,
-        account_id=account_id,
-        category=category,
         uncategorized_only=uncategorized_only,
         limit=limit,
-        offset=offset,
-    )
-    return result.to_envelope()
+        cursor=cursor,
+    ).to_envelope()
 
 
 @mcp_tool(sensitivity="medium")
@@ -123,12 +123,15 @@ def register_transactions_tools(mcp: FastMCP) -> None:
     """Register all transactions namespace tools with the FastMCP server."""
     register(
         mcp,
-        transactions_search,
-        "transactions_search",
-        "Search transactions with flexible filtering by date, "
-        "amount, description, account, and category. "
-        "Amounts use the accounting convention: negative = expense, positive = income; transfers exempt. "
-        "Amounts are in the currency named by `summary.display_currency`.",
+        transactions_get,
+        "transactions_get",
+        "Fetch transactions with optional filtering by account, date range, category, "
+        "amount, and description pattern. Returns full transaction records including "
+        "curation fields (notes, tags, splits). "
+        "Amounts use the accounting convention: negative = expense, positive = income; "
+        "transfers exempt. Amounts are in the currency named by `summary.display_currency`. "
+        "`accounts` accepts display names or exact account IDs — use `accounts_list` to "
+        "discover IDs. Pass `next_cursor` from a previous response to fetch the next page.",
     )
     register(
         mcp,

--- a/src/moneybin/protocol/envelope.py
+++ b/src/moneybin/protocol/envelope.py
@@ -119,6 +119,7 @@ def build_envelope(
     data: list[dict[str, Any]] | dict[str, Any],
     sensitivity: Literal["low", "medium", "high"],
     total_count: int | None = None,
+    next_cursor: str | None = None,
     period: str | None = None,
     display_currency: str = "USD",
     actions: list[str] | None = None,
@@ -132,6 +133,8 @@ def build_envelope(
         sensitivity: Sensitivity tier of the response.
         total_count: Total matching records (if known and different from
             returned count). When None, inferred from data length.
+        next_cursor: Opaque pagination token. When provided, ``summary.has_more``
+            is forced to ``True`` regardless of count comparison.
         period: Human-readable period string (e.g., ``"2026-01 to 2026-04"``).
         display_currency: Currency for all amounts in the response.
         actions: Contextual next-step hints.
@@ -147,7 +150,7 @@ def build_envelope(
         returned = 1
 
     actual_total = total_count if total_count is not None else returned
-    has_more = actual_total > returned
+    has_more = next_cursor is not None or actual_total > returned
 
     summary = SummaryMeta(
         total_count=actual_total,
@@ -164,6 +167,7 @@ def build_envelope(
         summary=summary,
         data=data,
         actions=actions or [],
+        next_cursor=next_cursor,
     )
 
 

--- a/src/moneybin/protocol/envelope.py
+++ b/src/moneybin/protocol/envelope.py
@@ -87,12 +87,14 @@ class ResponseEnvelope:
     - ``actions``: contextual next-step hints
     - ``error``: populated when the tool failed with a classified user error;
       ``data`` is empty in this case
+    - ``next_cursor``: opaque pagination token when more results are available
     """
 
     summary: SummaryMeta
     data: list[dict[str, Any]] | dict[str, Any]
     actions: list[str] = field(default_factory=list)
     error: UserError | None = None
+    next_cursor: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to a plain dict suitable for JSON serialization."""
@@ -103,6 +105,8 @@ class ResponseEnvelope:
         }
         if self.error is not None:
             d["error"] = self.error.to_dict()
+        if self.next_cursor is not None:
+            d["next_cursor"] = self.next_cursor
         return d
 
     def to_json(self) -> str:

--- a/src/moneybin/services/spending_service.py
+++ b/src/moneybin/services/spending_service.py
@@ -99,7 +99,7 @@ class CategoryBreakdown:
             period=self.period_label,
             actions=[
                 "Use reports_spending_merchants for merchant-level breakdown",
-                "Use transactions_search to see individual transactions in a category",
+                "Use transactions_get to see individual transactions in a category",
             ],
         )
 

--- a/src/moneybin/services/transaction_service.py
+++ b/src/moneybin/services/transaction_service.py
@@ -37,6 +37,7 @@ _AUDIT_TARGET_MANUAL = ("raw", "manual_transactions")
 _MANUAL_BATCH_MAX = 100
 _MANUAL_FORMAT_NAME = "manual_entry"
 _MANUAL_SOURCE_TYPE = "manual"
+_MIN_ACCOUNT_FUZZY_CONFIDENCE = 0.4
 
 
 def _predict_manual_gold_key(source_transaction_id: str, account_id: str) -> str:
@@ -80,11 +81,11 @@ class Transaction:
             "description": self.description,
             "source_type": self.source_type,
         }
-        if self.memo:
+        if self.memo is not None:
             d["memo"] = self.memo
-        if self.category:
+        if self.category is not None:
             d["category"] = self.category
-        if self.subcategory:
+        if self.subcategory is not None:
             d["subcategory"] = self.subcategory
         if self.notes is not None:
             d["notes"] = self.notes
@@ -241,11 +242,6 @@ class TransactionService:
         """
         from moneybin.services.account_service import AccountService
 
-        # Minimum confidence to accept a fuzzy name match. SequenceMatcher
-        # returns a non-zero score for any two non-empty strings that share
-        # characters, so without a threshold every query resolves to something.
-        _min_confidence = 0.4
-
         placeholders = ", ".join("?" * len(accounts))
         exact_rows = self._db.execute(
             f"SELECT account_id FROM {DIM_ACCOUNTS.full_name} WHERE account_id IN ({placeholders})",  # noqa: S608  # TableRef constant
@@ -253,13 +249,16 @@ class TransactionService:
         ).fetchall()
         exact_ids = {str(r[0]) for r in exact_rows}
 
-        resolved = [a for a in accounts if a in exact_ids]
-        unmatched = [a for a in accounts if a not in exact_ids]
+        resolved: list[str] = []
+        unmatched: list[str] = []
+        for a in accounts:
+            (resolved if a in exact_ids else unmatched).append(a)
+
         if unmatched:
             service = AccountService(self._db)
             for entry in unmatched:
                 matches = service.resolve(entry, limit=1)
-                if matches and matches[0].confidence >= _min_confidence:
+                if matches and matches[0].confidence >= _MIN_ACCOUNT_FUZZY_CONFIDENCE:
                     resolved.append(matches[0].account_id)
         return resolved
 

--- a/src/moneybin/services/transaction_service.py
+++ b/src/moneybin/services/transaction_service.py
@@ -244,7 +244,7 @@ class TransactionService:
         # Minimum confidence to accept a fuzzy name match. SequenceMatcher
         # returns a non-zero score for any two non-empty strings that share
         # characters, so without a threshold every query resolves to something.
-        _MIN_CONFIDENCE = 0.4
+        _min_confidence = 0.4
 
         resolved: list[str] = []
         for entry in accounts:
@@ -256,7 +256,7 @@ class TransactionService:
                 resolved.append(str(row[0]))
             else:
                 matches = AccountService(self._db).resolve(entry, limit=1)
-                if matches and matches[0].confidence >= _MIN_CONFIDENCE:
+                if matches and matches[0].confidence >= _min_confidence:
                     resolved.append(matches[0].account_id)
         return resolved
 
@@ -361,7 +361,9 @@ class TransactionService:
         ]
 
         next_cursor = (
-            base64.b64encode(str(offset + limit).encode()).decode() if has_more else None
+            base64.b64encode(str(offset + limit).encode()).decode()
+            if has_more
+            else None
         )
 
         logger.info(

--- a/src/moneybin/services/transaction_service.py
+++ b/src/moneybin/services/transaction_service.py
@@ -253,7 +253,7 @@ class TransactionService:
         ).fetchall()
         exact_ids = {str(r[0]) for r in exact_rows}
 
-        resolved: list[str] = list(exact_ids)
+        resolved = [a for a in accounts if a in exact_ids]
         unmatched = [a for a in accounts if a not in exact_ids]
         if unmatched:
             service = AccountService(self._db)
@@ -288,6 +288,8 @@ class TransactionService:
         Pagination is offset-based internally; the cursor is base64(str(offset))
         so callers treat it as opaque.
         """
+        if limit < 1:
+            raise ValueError(f"limit must be >= 1, got {limit}")
         offset = int(base64.b64decode(cursor.encode()).decode()) if cursor else 0
 
         conditions: list[str] = []
@@ -326,7 +328,7 @@ class TransactionService:
             params.extend([like, like])
 
         if uncategorized_only:
-            conditions.append("category IS NULL")
+            conditions.append("categorized_by IS NULL")
 
         where = "WHERE " + " AND ".join(conditions) if conditions else ""
 

--- a/src/moneybin/services/transaction_service.py
+++ b/src/moneybin/services/transaction_service.py
@@ -8,6 +8,7 @@ detection. Consumed by both MCP tools and CLI commands.
 from __future__ import annotations
 
 import base64
+import binascii
 import hashlib
 import logging
 import uuid
@@ -289,7 +290,15 @@ class TransactionService:
         """
         if limit < 1:
             raise ValueError(f"limit must be >= 1, got {limit}")
-        offset = int(base64.b64decode(cursor.encode()).decode()) if cursor else 0
+        if cursor is not None:
+            try:
+                offset = int(base64.b64decode(cursor.encode()).decode())
+            except (binascii.Error, UnicodeDecodeError, ValueError) as e:
+                raise ValueError(f"invalid cursor: {cursor!r}") from e
+            if offset < 0:
+                raise ValueError(f"invalid cursor (negative offset): {cursor!r}")
+        else:
+            offset = 0
 
         conditions: list[str] = []
         params: list[object] = []

--- a/src/moneybin/services/transaction_service.py
+++ b/src/moneybin/services/transaction_service.py
@@ -66,6 +66,9 @@ class Transaction:
     source_type: str
     category: str | None
     subcategory: str | None
+    notes: list[dict[str, Any]] | None = None
+    tags: list[str] | None = None
+    splits: list[dict[str, Any]] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to a plain dict for JSON serialization."""
@@ -83,6 +86,12 @@ class Transaction:
             d["category"] = self.category
         if self.subcategory:
             d["subcategory"] = self.subcategory
+        if self.notes is not None:
+            d["notes"] = self.notes
+        if self.tags is not None:
+            d["tags"] = self.tags
+        if self.splits is not None:
+            d["splits"] = self.splits
         return d
 
 

--- a/src/moneybin/services/transaction_service.py
+++ b/src/moneybin/services/transaction_service.py
@@ -104,17 +104,16 @@ class TransactionGetResult:
 
     def to_envelope(self) -> ResponseEnvelope:
         """Build a ResponseEnvelope for MCP/CLI output."""
-        envelope = build_envelope(
+        return build_envelope(
             data=[t.to_dict() for t in self.transactions],
             sensitivity="medium",
+            next_cursor=self.next_cursor,
             actions=[
                 "Use transactions_get with the next_cursor value to fetch the next page",
                 "Use spending_summary for category breakdowns",
                 "Use transactions_categorize_apply to categorize uncategorized transactions",
             ],
         )
-        envelope.next_cursor = self.next_cursor
-        return envelope
 
 
 @dataclass(frozen=True, slots=True)
@@ -236,8 +235,9 @@ class TransactionService:
     def _resolve_account_ids(self, accounts: list[str]) -> list[str]:
         """Resolve display names or IDs to account_id strings.
 
-        Tries exact account_id match first; falls back to fuzzy name match.
-        Unresolvable entries are silently skipped.
+        Batches exact account_id lookups in one query, then fuzzy-matches any
+        remaining entries via AccountService. Unresolvable entries are silently
+        skipped.
         """
         from moneybin.services.account_service import AccountService
 
@@ -246,16 +246,19 @@ class TransactionService:
         # characters, so without a threshold every query resolves to something.
         _min_confidence = 0.4
 
-        resolved: list[str] = []
-        for entry in accounts:
-            row = self._db.execute(
-                f"SELECT account_id FROM {DIM_ACCOUNTS.full_name} WHERE account_id = ?",
-                [entry],
-            ).fetchone()
-            if row:
-                resolved.append(str(row[0]))
-            else:
-                matches = AccountService(self._db).resolve(entry, limit=1)
+        placeholders = ", ".join("?" * len(accounts))
+        exact_rows = self._db.execute(
+            f"SELECT account_id FROM {DIM_ACCOUNTS.full_name} WHERE account_id IN ({placeholders})",  # noqa: S608  # TableRef constant
+            accounts,
+        ).fetchall()
+        exact_ids = {str(r[0]) for r in exact_rows}
+
+        resolved: list[str] = list(exact_ids)
+        unmatched = [a for a in accounts if a not in exact_ids]
+        if unmatched:
+            service = AccountService(self._db)
+            for entry in unmatched:
+                matches = service.resolve(entry, limit=1)
                 if matches and matches[0].confidence >= _min_confidence:
                     resolved.append(matches[0].account_id)
         return resolved

--- a/src/moneybin/services/transaction_service.py
+++ b/src/moneybin/services/transaction_service.py
@@ -110,7 +110,7 @@ class TransactionGetResult:
             next_cursor=self.next_cursor,
             actions=[
                 "Use transactions_get with the next_cursor value to fetch the next page",
-                "Use spending_summary for category breakdowns",
+                "Use reports_spending_get for category breakdowns",
                 "Use transactions_categorize_apply to categorize uncategorized transactions",
             ],
         )

--- a/src/moneybin/services/transaction_service.py
+++ b/src/moneybin/services/transaction_service.py
@@ -7,6 +7,7 @@ detection. Consumed by both MCP tools and CLI commands.
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import logging
 import uuid
@@ -23,7 +24,6 @@ from moneybin.tables import (
     DIM_ACCOUNTS,
     FCT_TRANSACTIONS,
     MANUAL_TRANSACTIONS,
-    TRANSACTION_CATEGORIES,
 )
 
 logger = logging.getLogger(__name__)
@@ -96,23 +96,25 @@ class Transaction:
 
 
 @dataclass(slots=True)
-class TransactionSearchResult:
-    """Result of transaction search query."""
+class TransactionGetResult:
+    """Result of TransactionService.get()."""
 
     transactions: list[Transaction]
-    total_count: int
+    next_cursor: str | None
 
     def to_envelope(self) -> ResponseEnvelope:
         """Build a ResponseEnvelope for MCP/CLI output."""
-        return build_envelope(
+        envelope = build_envelope(
             data=[t.to_dict() for t in self.transactions],
             sensitivity="medium",
-            total_count=self.total_count,
             actions=[
-                "Use transactions_recurring_list to find subscription patterns",
+                "Use transactions_get with the next_cursor value to fetch the next page",
+                "Use spending_summary for category breakdowns",
                 "Use transactions_categorize_apply to categorize uncategorized transactions",
             ],
         )
+        envelope.next_cursor = self.next_cursor
+        return envelope
 
 
 @dataclass(frozen=True, slots=True)
@@ -148,7 +150,7 @@ class RecurringResult:
             data=[t.to_dict() for t in self.transactions],
             sensitivity="medium",
             actions=[
-                "Use transactions_search to see individual occurrences",
+                "Use transactions_get to see individual occurrences",
                 "Use budget_set to create a budget for a recurring expense",
             ],
         )
@@ -231,100 +233,114 @@ class TransactionService:
         self._db = db
         self._audit = audit if audit is not None else AuditService(db)
 
-    def search(
+    def _resolve_account_ids(self, accounts: list[str]) -> list[str]:
+        """Resolve display names or IDs to account_id strings.
+
+        Tries exact account_id match first; falls back to fuzzy name match.
+        Unresolvable entries are silently skipped.
+        """
+        from moneybin.services.account_service import AccountService
+
+        # Minimum confidence to accept a fuzzy name match. SequenceMatcher
+        # returns a non-zero score for any two non-empty strings that share
+        # characters, so without a threshold every query resolves to something.
+        _MIN_CONFIDENCE = 0.4
+
+        resolved: list[str] = []
+        for entry in accounts:
+            row = self._db.execute(
+                f"SELECT account_id FROM {DIM_ACCOUNTS.full_name} WHERE account_id = ?",
+                [entry],
+            ).fetchone()
+            if row:
+                resolved.append(str(row[0]))
+            else:
+                matches = AccountService(self._db).resolve(entry, limit=1)
+                if matches and matches[0].confidence >= _MIN_CONFIDENCE:
+                    resolved.append(matches[0].account_id)
+        return resolved
+
+    def get(
         self,
         *,
-        start_date: str | None = None,
-        end_date: str | None = None,
-        min_amount: Decimal | None = None,
-        max_amount: Decimal | None = None,
+        accounts: list[str] | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        categories: list[str] | None = None,
+        amount_min: Decimal | None = None,
+        amount_max: Decimal | None = None,
         description: str | None = None,
-        account_id: str | None = None,
-        category: str | None = None,
         uncategorized_only: bool = False,
-        limit: int = 100,
-        offset: int = 0,
-    ) -> TransactionSearchResult:
-        """Search transactions with flexible filtering.
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> TransactionGetResult:
+        """Fetch transactions with optional filtering and cursor-based pagination.
 
-        Args:
-            start_date: ISO 8601 start date (inclusive).
-            end_date: ISO 8601 end date (inclusive).
-            min_amount: Minimum amount filter.
-            max_amount: Maximum amount filter.
-            description: ILIKE pattern matched against description and memo.
-            account_id: Filter to a specific account.
-            category: Filter by category (from transaction_categories).
-            uncategorized_only: Only return uncategorized transactions.
-            limit: Maximum rows to return.
-            offset: Number of rows to skip.
+        Reads from core.fct_transactions, which already joins curation columns
+        (notes, tags, splits) from the app schema. Account entries in `accounts`
+        are resolved: exact account_id matches are used directly; everything else
+        is fuzzy-matched against display names via AccountService. Unresolvable
+        entries are silently skipped.
 
-        Returns:
-            TransactionSearchResult with matching transactions and total count.
+        Pagination is offset-based internally; the cursor is base64(str(offset))
+        so callers treat it as opaque.
         """
+        offset = int(base64.b64decode(cursor.encode()).decode()) if cursor else 0
+
         conditions: list[str] = []
         params: list[object] = []
 
-        if start_date:
-            conditions.append("t.transaction_date >= ?")
-            params.append(start_date)
-        if end_date:
-            conditions.append("t.transaction_date <= ?")
-            params.append(end_date)
-        if min_amount is not None:
-            conditions.append("t.amount >= ?")
-            params.append(min_amount)
-        if max_amount is not None:
-            conditions.append("t.amount <= ?")
-            params.append(max_amount)
+        if accounts:
+            account_ids = self._resolve_account_ids(accounts)
+            if not account_ids:
+                return TransactionGetResult(transactions=[], next_cursor=None)
+            placeholders = ", ".join("?" * len(account_ids))
+            conditions.append(f"account_id IN ({placeholders})")
+            params.extend(account_ids)
+
+        if date_from:
+            conditions.append("transaction_date >= ?")
+            params.append(date_from)
+        if date_to:
+            conditions.append("transaction_date <= ?")
+            params.append(date_to)
+
+        if categories:
+            placeholders = ", ".join("?" * len(categories))
+            conditions.append(f"category IN ({placeholders})")
+            params.extend(categories)
+
+        if amount_min is not None:
+            conditions.append("amount >= ?")
+            params.append(amount_min)
+        if amount_max is not None:
+            conditions.append("amount <= ?")
+            params.append(amount_max)
+
         if description:
-            conditions.append("(t.description ILIKE ? OR t.memo ILIKE ?)")
-            like_pattern = f"%{description}%"
-            params.extend([like_pattern, like_pattern])
-        if account_id:
-            conditions.append("t.account_id = ?")
-            params.append(account_id)
-        if category:
-            conditions.append("c.category = ?")
-            params.append(category)
+            conditions.append("(description ILIKE ? OR memo ILIKE ?)")
+            like = f"%{description}%"
+            params.extend([like, like])
+
         if uncategorized_only:
-            conditions.append("c.transaction_id IS NULL")
+            conditions.append("category IS NULL")
 
         where = "WHERE " + " AND ".join(conditions) if conditions else ""
 
-        # Count query (same conditions, no limit/offset)
-        count_sql = f"""
-            SELECT COUNT(*)
-            FROM {FCT_TRANSACTIONS.full_name} t
-            LEFT JOIN {TRANSACTION_CATEGORIES.full_name} c
-                ON t.transaction_id = c.transaction_id
-            {where}
-        """
-        count_result = self._db.execute(count_sql, params)
-        total_count = int(count_result.fetchone()[0])  # type: ignore[index]
-
-        # Data query
         sql = f"""
             SELECT
-                t.transaction_id,
-                t.account_id,
-                t.transaction_date,
-                t.amount,
-                t.description,
-                t.memo,
-                t.source_type,
-                c.category,
-                c.subcategory
-            FROM {FCT_TRANSACTIONS.full_name} t
-            LEFT JOIN {TRANSACTION_CATEGORIES.full_name} c
-                ON t.transaction_id = c.transaction_id
+                transaction_id, account_id, transaction_date, amount,
+                description, memo, source_type, category, subcategory,
+                notes, tags, splits
+            FROM {FCT_TRANSACTIONS.full_name}
             {where}
-            ORDER BY t.transaction_date DESC, t.transaction_id
+            ORDER BY transaction_date DESC, transaction_id
             LIMIT ? OFFSET ?
-        """
+        """  # noqa: S608  # TableRef constant, not user input
 
-        result = self._db.execute(sql, [*params, limit, offset])
-        rows = result.fetchall()
+        rows = self._db.execute(sql, [*params, limit + 1, offset]).fetchall()
+        has_more = len(rows) > limit
+        rows = rows[:limit]
 
         transactions = [
             Transaction(
@@ -337,16 +353,21 @@ class TransactionService:
                 source_type=str(row[6]),
                 category=str(row[7]) if row[7] else None,
                 subcategory=str(row[8]) if row[8] else None,
+                notes=[dict(n) for n in row[9]] if row[9] else None,
+                tags=list(row[10]) if row[10] else None,
+                splits=[dict(s) for s in row[11]] if row[11] else None,
             )
             for row in rows
         ]
 
+        next_cursor = (
+            base64.b64encode(str(offset + limit).encode()).decode() if has_more else None
+        )
+
         logger.info(
-            f"Search returned {len(transactions)} of {total_count} transactions"
+            f"transactions_get returned {len(transactions)} rows (offset={offset}, has_more={has_more})"
         )
-        return TransactionSearchResult(
-            transactions=transactions, total_count=total_count
-        )
+        return TransactionGetResult(transactions=transactions, next_cursor=next_cursor)
 
     def recurring(self, min_occurrences: int = 3) -> RecurringResult:
         """Detect recurring expense transaction patterns (amount < 0).

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -75,6 +75,10 @@ FAST_ARGON2_ENV = {
     # (e.g., "--output" appears verbatim, not split across colour escape codes).
     "NO_COLOR": "1",
     "TERM": "dumb",
+    # Suppress fastmcp's PyPI version check. It calls stat() on a path under
+    # ~/Library/Application Support/ which is blocked by the sandbox; with the
+    # check off, no filesystem access happens at all.
+    "FASTMCP_CHECK_FOR_UPDATES": "off",
 }
 
 TEST_ENCRYPTION_KEY = (

--- a/tests/e2e/test_e2e_help.py
+++ b/tests/e2e/test_e2e_help.py
@@ -41,6 +41,7 @@ _HELP_COMMANDS: list[list[str]] = [
     ["transactions", "review"],
     ["transactions", "create"],
     ["transactions", "audit"],
+    ["transactions", "list"],
     ["transactions", "notes"],
     ["transactions", "notes", "add"],
     ["transactions", "notes", "list"],

--- a/tests/moneybin/test_cli/test_transactions_list.py
+++ b/tests/moneybin/test_cli/test_transactions_list.py
@@ -10,32 +10,38 @@ import pytest
 from typer.testing import CliRunner
 
 from moneybin.cli.main import app
-from moneybin.services.transaction_service import Transaction, TransactionGetResult, TransactionService
+from moneybin.services.transaction_service import (
+    Transaction,
+    TransactionGetResult,
+    TransactionService,
+)
 
 runner = CliRunner()
 
 
 def _make_txn(**overrides: object) -> Transaction:
     """Build a Transaction with sensible defaults."""
-    defaults: dict[str, object] = dict(
-        transaction_id="T1",
-        account_id="A1",
-        transaction_date="2026-04-10",
-        amount=Decimal("-50.00"),
-        description="Coffee Shop",
-        memo=None,
-        source_type="ofx",
-        category="Food & Drink",
-        subcategory=None,
-        notes=None,
-        tags=None,
-        splits=None,
-    )
+    defaults: dict[str, object] = {
+        "transaction_id": "T1",
+        "account_id": "A1",
+        "transaction_date": "2026-04-10",
+        "amount": Decimal("-50.00"),
+        "description": "Coffee Shop",
+        "memo": None,
+        "source_type": "ofx",
+        "category": "Food & Drink",
+        "subcategory": None,
+        "notes": None,
+        "tags": None,
+        "splits": None,
+    }
     defaults.update(overrides)
     return Transaction(**defaults)  # type: ignore[arg-type]
 
 
-def _mock_result(transactions: list[Transaction], next_cursor: str | None = None) -> TransactionGetResult:
+def _mock_result(
+    transactions: list[Transaction], next_cursor: str | None = None
+) -> TransactionGetResult:
     return TransactionGetResult(transactions=transactions, next_cursor=next_cursor)
 
 
@@ -88,7 +94,9 @@ def test_list_empty_text_output() -> None:
 def test_list_passes_account_to_service() -> None:
     """--account is forwarded to TransactionService.get()."""
     with patch("moneybin.cli.utils.handle_cli_errors", _mock_db_ctx):
-        with patch.object(TransactionService, "get", return_value=_mock_result([])) as mock_get:
+        with patch.object(
+            TransactionService, "get", return_value=_mock_result([])
+        ) as mock_get:
             runner.invoke(app, ["transactions", "list", "--account", "Test Bank"])
     mock_get.assert_called_once()
     assert mock_get.call_args.kwargs["accounts"] == ["Test Bank"]
@@ -98,8 +106,12 @@ def test_list_passes_account_to_service() -> None:
 def test_list_repeatable_account_flag() -> None:
     """Multiple --account flags accumulate into a list."""
     with patch("moneybin.cli.utils.handle_cli_errors", _mock_db_ctx):
-        with patch.object(TransactionService, "get", return_value=_mock_result([])) as mock_get:
-            runner.invoke(app, ["transactions", "list", "--account", "A1", "--account", "A2"])
+        with patch.object(
+            TransactionService, "get", return_value=_mock_result([])
+        ) as mock_get:
+            runner.invoke(
+                app, ["transactions", "list", "--account", "A1", "--account", "A2"]
+            )
     assert mock_get.call_args.kwargs["accounts"] == ["A1", "A2"]
 
 
@@ -107,10 +119,19 @@ def test_list_repeatable_account_flag() -> None:
 def test_list_repeatable_category_flag() -> None:
     """Multiple --category flags accumulate into a list."""
     with patch("moneybin.cli.utils.handle_cli_errors", _mock_db_ctx):
-        with patch.object(TransactionService, "get", return_value=_mock_result([])) as mock_get:
+        with patch.object(
+            TransactionService, "get", return_value=_mock_result([])
+        ) as mock_get:
             runner.invoke(
                 app,
-                ["transactions", "list", "--category", "Food & Drink", "--category", "Travel"],
+                [
+                    "transactions",
+                    "list",
+                    "--category",
+                    "Food & Drink",
+                    "--category",
+                    "Travel",
+                ],
             )
     assert mock_get.call_args.kwargs["categories"] == ["Food & Drink", "Travel"]
 
@@ -119,7 +140,9 @@ def test_list_repeatable_category_flag() -> None:
 def test_list_uncategorized_flag() -> None:
     """--uncategorized sets uncategorized_only=True."""
     with patch("moneybin.cli.utils.handle_cli_errors", _mock_db_ctx):
-        with patch.object(TransactionService, "get", return_value=_mock_result([])) as mock_get:
+        with patch.object(
+            TransactionService, "get", return_value=_mock_result([])
+        ) as mock_get:
             runner.invoke(app, ["transactions", "list", "--uncategorized"])
     assert mock_get.call_args.kwargs["uncategorized_only"] is True
 
@@ -128,6 +151,8 @@ def test_list_uncategorized_flag() -> None:
 def test_list_cursor_forwarded() -> None:
     """--cursor is forwarded to TransactionService.get()."""
     with patch("moneybin.cli.utils.handle_cli_errors", _mock_db_ctx):
-        with patch.object(TransactionService, "get", return_value=_mock_result([])) as mock_get:
+        with patch.object(
+            TransactionService, "get", return_value=_mock_result([])
+        ) as mock_get:
             runner.invoke(app, ["transactions", "list", "--cursor", "dGVzdA=="])
     assert mock_get.call_args.kwargs["cursor"] == "dGVzdA=="

--- a/tests/moneybin/test_cli/test_transactions_list.py
+++ b/tests/moneybin/test_cli/test_transactions_list.py
@@ -1,0 +1,133 @@
+"""Tests for 'moneybin transactions list' CLI command."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from moneybin.cli.main import app
+from moneybin.services.transaction_service import Transaction, TransactionGetResult, TransactionService
+
+runner = CliRunner()
+
+
+def _make_txn(**overrides: object) -> Transaction:
+    """Build a Transaction with sensible defaults."""
+    defaults: dict[str, object] = dict(
+        transaction_id="T1",
+        account_id="A1",
+        transaction_date="2026-04-10",
+        amount=Decimal("-50.00"),
+        description="Coffee Shop",
+        memo=None,
+        source_type="ofx",
+        category="Food & Drink",
+        subcategory=None,
+        notes=None,
+        tags=None,
+        splits=None,
+    )
+    defaults.update(overrides)
+    return Transaction(**defaults)  # type: ignore[arg-type]
+
+
+def _mock_result(transactions: list[Transaction], next_cursor: str | None = None) -> TransactionGetResult:
+    return TransactionGetResult(transactions=transactions, next_cursor=next_cursor)
+
+
+@contextmanager
+def _mock_db_ctx():
+    """Context manager that yields a mock database — replaces handle_cli_errors."""
+    yield MagicMock()
+
+
+@pytest.mark.unit
+def test_list_text_output_shows_columns() -> None:
+    """Text output renders date, description, amount, category, account columns."""
+    txns = [_make_txn()]
+    with patch("moneybin.cli.utils.handle_cli_errors", _mock_db_ctx):
+        with patch.object(TransactionService, "get", return_value=_mock_result(txns)):
+            result = runner.invoke(app, ["transactions", "list"])
+    assert result.exit_code == 0
+    assert "2026-04-10" in result.output
+    assert "Coffee Shop" in result.output
+    assert "Food & Drink" in result.output
+
+
+@pytest.mark.unit
+def test_list_json_output_returns_envelope() -> None:
+    """--output json returns a ResponseEnvelope JSON object."""
+    import json
+
+    txns = [_make_txn()]
+    with patch("moneybin.cli.utils.handle_cli_errors", _mock_db_ctx):
+        with patch.object(TransactionService, "get", return_value=_mock_result(txns)):
+            result = runner.invoke(app, ["transactions", "list", "--output", "json"])
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert "summary" in parsed
+    assert "data" in parsed
+    assert parsed["summary"]["sensitivity"] == "medium"
+
+
+@pytest.mark.unit
+def test_list_empty_text_output() -> None:
+    """Empty result set prints a 'no transactions' message."""
+    with patch("moneybin.cli.utils.handle_cli_errors", _mock_db_ctx):
+        with patch.object(TransactionService, "get", return_value=_mock_result([])):
+            result = runner.invoke(app, ["transactions", "list"])
+    assert result.exit_code == 0
+    assert "No transactions" in result.output
+
+
+@pytest.mark.unit
+def test_list_passes_account_to_service() -> None:
+    """--account is forwarded to TransactionService.get()."""
+    with patch("moneybin.cli.utils.handle_cli_errors", _mock_db_ctx):
+        with patch.object(TransactionService, "get", return_value=_mock_result([])) as mock_get:
+            runner.invoke(app, ["transactions", "list", "--account", "Test Bank"])
+    mock_get.assert_called_once()
+    assert mock_get.call_args.kwargs["accounts"] == ["Test Bank"]
+
+
+@pytest.mark.unit
+def test_list_repeatable_account_flag() -> None:
+    """Multiple --account flags accumulate into a list."""
+    with patch("moneybin.cli.utils.handle_cli_errors", _mock_db_ctx):
+        with patch.object(TransactionService, "get", return_value=_mock_result([])) as mock_get:
+            runner.invoke(app, ["transactions", "list", "--account", "A1", "--account", "A2"])
+    assert mock_get.call_args.kwargs["accounts"] == ["A1", "A2"]
+
+
+@pytest.mark.unit
+def test_list_repeatable_category_flag() -> None:
+    """Multiple --category flags accumulate into a list."""
+    with patch("moneybin.cli.utils.handle_cli_errors", _mock_db_ctx):
+        with patch.object(TransactionService, "get", return_value=_mock_result([])) as mock_get:
+            runner.invoke(
+                app,
+                ["transactions", "list", "--category", "Food & Drink", "--category", "Travel"],
+            )
+    assert mock_get.call_args.kwargs["categories"] == ["Food & Drink", "Travel"]
+
+
+@pytest.mark.unit
+def test_list_uncategorized_flag() -> None:
+    """--uncategorized sets uncategorized_only=True."""
+    with patch("moneybin.cli.utils.handle_cli_errors", _mock_db_ctx):
+        with patch.object(TransactionService, "get", return_value=_mock_result([])) as mock_get:
+            runner.invoke(app, ["transactions", "list", "--uncategorized"])
+    assert mock_get.call_args.kwargs["uncategorized_only"] is True
+
+
+@pytest.mark.unit
+def test_list_cursor_forwarded() -> None:
+    """--cursor is forwarded to TransactionService.get()."""
+    with patch("moneybin.cli.utils.handle_cli_errors", _mock_db_ctx):
+        with patch.object(TransactionService, "get", return_value=_mock_result([])) as mock_get:
+            runner.invoke(app, ["transactions", "list", "--cursor", "dGVzdA=="])
+    assert mock_get.call_args.kwargs["cursor"] == "dGVzdA=="

--- a/tests/moneybin/test_mcp/test_envelope.py
+++ b/tests/moneybin/test_mcp/test_envelope.py
@@ -185,3 +185,71 @@ def test_user_error_carries_structured_details() -> None:
     assert d["code"] == "timed_out"
     assert d["details"]["tool"] == "import_inbox_sync"
     assert d["details"]["timeout_s"] == 30.0
+
+
+@pytest.mark.unit
+def test_transaction_curation_fields_in_to_dict() -> None:
+    """Transaction.to_dict() includes curation fields when set."""
+    from moneybin.services.transaction_service import Transaction
+
+    t = Transaction(
+        transaction_id="T1",
+        account_id="A1",
+        transaction_date="2026-04-10",
+        amount=Decimal("-50.00"),
+        description="Coffee Shop",
+        memo=None,
+        source_type="ofx",
+        category="Food & Drink",
+        subcategory=None,
+        notes=[{"note_id": "N1", "text": "my note", "author": "user", "created_at": "2026-04-10T00:00:00"}],
+        tags=["personal", "recurring"],
+        splits=None,
+    )
+    d = t.to_dict()
+    assert d["notes"] == [{"note_id": "N1", "text": "my note", "author": "user", "created_at": "2026-04-10T00:00:00"}]
+    assert d["tags"] == ["personal", "recurring"]
+    assert "splits" not in d
+
+
+@pytest.mark.unit
+def test_transaction_curation_fields_absent_when_none() -> None:
+    """Transaction.to_dict() omits curation fields when None."""
+    from moneybin.services.transaction_service import Transaction
+
+    t = Transaction(
+        transaction_id="T1",
+        account_id="A1",
+        transaction_date="2026-04-10",
+        amount=Decimal("-50.00"),
+        description="Coffee Shop",
+        memo=None,
+        source_type="ofx",
+        category=None,
+        subcategory=None,
+    )
+    d = t.to_dict()
+    assert "notes" not in d
+    assert "tags" not in d
+    assert "splits" not in d
+
+
+@pytest.mark.unit
+def test_response_envelope_next_cursor_in_to_dict() -> None:
+    """ResponseEnvelope.to_dict() includes next_cursor when set."""
+    from moneybin.protocol.envelope import build_envelope
+
+    envelope = build_envelope(data=[], sensitivity="low")
+    envelope.next_cursor = "dGVzdA=="
+    d = envelope.to_dict()
+    assert d["next_cursor"] == "dGVzdA=="
+
+
+@pytest.mark.unit
+def test_response_envelope_next_cursor_absent_when_none() -> None:
+    """ResponseEnvelope.to_dict() omits next_cursor when None."""
+    from moneybin.protocol.envelope import build_envelope
+
+    envelope = build_envelope(data=[], sensitivity="low")
+    d = envelope.to_dict()
+    assert "next_cursor" not in d

--- a/tests/moneybin/test_mcp/test_envelope.py
+++ b/tests/moneybin/test_mcp/test_envelope.py
@@ -202,12 +202,26 @@ def test_transaction_curation_fields_in_to_dict() -> None:
         source_type="ofx",
         category="Food & Drink",
         subcategory=None,
-        notes=[{"note_id": "N1", "text": "my note", "author": "user", "created_at": "2026-04-10T00:00:00"}],
+        notes=[
+            {
+                "note_id": "N1",
+                "text": "my note",
+                "author": "user",
+                "created_at": "2026-04-10T00:00:00",
+            }
+        ],
         tags=["personal", "recurring"],
         splits=None,
     )
     d = t.to_dict()
-    assert d["notes"] == [{"note_id": "N1", "text": "my note", "author": "user", "created_at": "2026-04-10T00:00:00"}]
+    assert d["notes"] == [
+        {
+            "note_id": "N1",
+            "text": "my note",
+            "author": "user",
+            "created_at": "2026-04-10T00:00:00",
+        }
+    ]
     assert d["tags"] == ["personal", "recurring"]
     assert "splits" not in d
 
@@ -236,13 +250,15 @@ def test_transaction_curation_fields_absent_when_none() -> None:
 
 @pytest.mark.unit
 def test_response_envelope_next_cursor_in_to_dict() -> None:
-    """ResponseEnvelope.to_dict() includes next_cursor when set."""
+    """build_envelope sets next_cursor and has_more when next_cursor is provided."""
     from moneybin.protocol.envelope import build_envelope
 
-    envelope = build_envelope(data=[], sensitivity="low")
-    envelope.next_cursor = "dGVzdA=="
+    envelope = build_envelope(data=[], sensitivity="low", next_cursor="dGVzdA==")
+    assert envelope.next_cursor == "dGVzdA=="
+    assert envelope.summary.has_more is True
     d = envelope.to_dict()
     assert d["next_cursor"] == "dGVzdA=="
+    assert d["summary"]["has_more"] is True
 
 
 @pytest.mark.unit

--- a/tests/moneybin/test_mcp/test_transactions_get.py
+++ b/tests/moneybin/test_mcp/test_transactions_get.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import pytest
 from fastmcp import FastMCP
 
-from moneybin.mcp.tools.transactions import register_transactions_tools, transactions_get
+from moneybin.mcp.tools.transactions import (
+    register_transactions_tools,
+    transactions_get,
+)
 
 pytestmark = pytest.mark.usefixtures("mcp_db")
 
@@ -23,7 +26,7 @@ async def test_transactions_get_returns_envelope(mcp_db: object) -> None:
 
 @pytest.mark.unit
 async def test_transactions_get_data_is_list(mcp_db: object) -> None:
-    """data field is a list (may be empty on fresh DB)."""
+    """Data field is a list (may be empty on fresh DB)."""
     result = await transactions_get()
     d = result.to_dict()
     assert isinstance(d["data"], list)

--- a/tests/moneybin/test_mcp/test_transactions_get.py
+++ b/tests/moneybin/test_mcp/test_transactions_get.py
@@ -1,0 +1,50 @@
+"""Tests for the transactions_get MCP tool."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import FastMCP
+
+from moneybin.mcp.tools.transactions import register_transactions_tools, transactions_get
+
+pytestmark = pytest.mark.usefixtures("mcp_db")
+
+
+@pytest.mark.unit
+async def test_transactions_get_returns_envelope(mcp_db: object) -> None:
+    """transactions_get returns a valid ResponseEnvelope."""
+    result = await transactions_get()
+    d = result.to_dict()
+    assert "summary" in d
+    assert "data" in d
+    assert "actions" in d
+    assert d["summary"]["sensitivity"] == "medium"
+
+
+@pytest.mark.unit
+async def test_transactions_get_data_is_list(mcp_db: object) -> None:
+    """data field is a list (may be empty on fresh DB)."""
+    result = await transactions_get()
+    d = result.to_dict()
+    assert isinstance(d["data"], list)
+
+
+@pytest.mark.unit
+async def test_transactions_get_no_cursor_when_empty(mcp_db: object) -> None:
+    """next_cursor absent when all results fit in one page."""
+    result = await transactions_get(limit=50)
+    d = result.to_dict()
+    # Fresh MCP DB has no transactions — no cursor expected
+    assert "next_cursor" not in d or d.get("next_cursor") is None
+
+
+@pytest.mark.unit
+async def test_register_includes_transactions_get() -> None:
+    """register_transactions_tools registers transactions_get."""
+    srv = FastMCP("test")
+    register_transactions_tools(srv)
+    names = {t.name for t in await srv._list_tools()}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    assert "transactions_get" in names
+    assert "transactions_search" not in names
+    assert "transactions_review_status" in names
+    assert "transactions_recurring_list" in names

--- a/tests/moneybin/test_mcp/test_transactions_tools.py
+++ b/tests/moneybin/test_mcp/test_transactions_tools.py
@@ -49,5 +49,4 @@ async def test_register_includes_review_status() -> None:
     register_transactions_tools(srv)
     names = {t.name for t in await srv._list_tools()}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     assert "transactions_review_status" in names
-    assert "transactions_search" in names
     assert "transactions_recurring_list" in names

--- a/tests/moneybin/test_services/test_transaction_get.py
+++ b/tests/moneybin/test_services/test_transaction_get.py
@@ -233,6 +233,19 @@ class TestTransactionGet:
             TransactionService(txn_db).get(limit=0)
 
     @pytest.mark.unit
+    def test_malformed_cursor_raises(self, txn_db: Database) -> None:
+        with pytest.raises(ValueError, match="invalid cursor"):
+            TransactionService(txn_db).get(cursor="not-valid-base64!!!")
+
+    @pytest.mark.unit
+    def test_negative_cursor_raises(self, txn_db: Database) -> None:
+        import base64
+
+        bad = base64.b64encode(b"-10").decode()
+        with pytest.raises(ValueError, match="invalid cursor"):
+            TransactionService(txn_db).get(cursor=bad)
+
+    @pytest.mark.unit
     def test_uncategorized_only_includes_source_categorized(
         self, tmp_path: Path
     ) -> None:

--- a/tests/moneybin/test_services/test_transaction_get.py
+++ b/tests/moneybin/test_services/test_transaction_get.py
@@ -50,28 +50,28 @@ def txn_db(tmp_path: Path) -> Generator[Database, None, None]:
             transaction_year, transaction_month, transaction_day,
             transaction_day_of_week, transaction_year_month,
             transaction_year_quarter,
-            category, notes, tags, splits
+            category, categorized_by, notes, tags, splits
         ) VALUES
         ('T1', 'A1', '2026-04-10', -50.00, 50.00, 'expense',
          'Coffee Shop', 'DEBIT', false, 'USD', 'ofx',
          '2026-04-10', CURRENT_TIMESTAMP,
          2026, 4, 10, 3, '2026-04', '2026-Q2',
-         'Food & Drink', NULL, ['work', 'lunch'], NULL),
+         'Food & Drink', 'user', NULL, ['work', 'lunch'], NULL),
         ('T2', 'A1', '2026-04-15', 5000.00, 5000.00, 'income',
          'Employer Inc', 'CREDIT', false, 'USD', 'ofx',
          '2026-04-15', CURRENT_TIMESTAMP,
          2026, 4, 15, 1, '2026-04', '2026-Q2',
-         NULL, NULL, NULL, NULL),
+         NULL, NULL, NULL, NULL, NULL),
         ('T3', 'A2', '2026-03-10', -50.00, 50.00, 'expense',
          'Coffee Shop', 'DEBIT', false, 'USD', 'ofx',
          '2026-03-10', CURRENT_TIMESTAMP,
          2026, 3, 10, 1, '2026-03', '2026-Q1',
-         'Food & Drink', NULL, NULL, NULL),
+         'Food & Drink', 'user', NULL, NULL, NULL),
         ('T4', 'A1', '2026-02-10', -200.00, 200.00, 'expense',
          'Rent Payment', 'DEBIT', false, 'USD', 'ofx',
          '2026-02-10', CURRENT_TIMESTAMP,
          2026, 2, 10, 1, '2026-02', '2026-Q1',
-         NULL, NULL, NULL, NULL)
+         NULL, NULL, NULL, NULL, NULL)
     """)  # noqa: S608  # test input, not executing SQL
 
     db_module._database_instance = database  # type: ignore[attr-defined]
@@ -219,3 +219,75 @@ class TestTransactionGet:
         d = result.to_envelope().to_dict()
         assert "next_cursor" in d
         assert d["next_cursor"] == result.next_cursor
+
+    @pytest.mark.unit
+    def test_limit_zero_raises(self, txn_db: Database) -> None:
+        with pytest.raises(ValueError, match="limit"):
+            TransactionService(txn_db).get(limit=0)
+
+    @pytest.mark.unit
+    def test_uncategorized_only_includes_source_categorized(
+        self, tmp_path: Path
+    ) -> None:
+        """uncategorized_only returns rows with source-provided category but no user categorization."""
+        mock_store = MagicMock()
+        mock_store.get_key.return_value = "test-encryption-key-256bit-placeholder"
+        db = Database(
+            tmp_path / "src_cat.duckdb", secret_store=mock_store, no_auto_upgrade=True
+        )
+        create_core_tables_raw(db.conn)
+        # T_src: source-provided category ('Groceries'), categorized_by=NULL (no user/AI/rule)
+        db.conn.execute("""
+            INSERT INTO core.fct_transactions (
+                transaction_id, account_id, transaction_date, amount,
+                amount_absolute, transaction_direction, description,
+                transaction_type, is_pending, currency_code, source_type,
+                source_extracted_at, loaded_at,
+                transaction_year, transaction_month, transaction_day,
+                transaction_day_of_week, transaction_year_month,
+                transaction_year_quarter,
+                category, categorized_by, notes, tags, splits
+            ) VALUES
+            ('T_src', 'A1', '2026-04-01', -25.00, 25.00, 'expense',
+             'Grocery Run', 'DEBIT', false, 'USD', 'plaid',
+             '2026-04-01', CURRENT_TIMESTAMP,
+             2026, 4, 1, 2, '2026-04', '2026-Q2',
+             'Groceries', NULL, NULL, NULL, NULL)
+        """)  # noqa: S608  # test input, not executing SQL
+        result = TransactionService(db).get(uncategorized_only=True)
+        assert len(result.transactions) == 1
+        assert result.transactions[0].transaction_id == "T_src"
+        assert result.transactions[0].category == "Groceries"
+        db.close()
+
+    @pytest.mark.unit
+    def test_filter_by_memo(self, tmp_path: Path) -> None:
+        """Description filter matches via the memo OR branch."""
+        mock_store = MagicMock()
+        mock_store.get_key.return_value = "test-encryption-key-256bit-placeholder"
+        db = Database(
+            tmp_path / "memo.duckdb", secret_store=mock_store, no_auto_upgrade=True
+        )
+        create_core_tables_raw(db.conn)
+        db.conn.execute("""
+            INSERT INTO core.fct_transactions (
+                transaction_id, account_id, transaction_date, amount,
+                amount_absolute, transaction_direction, description,
+                transaction_type, is_pending, currency_code, source_type,
+                source_extracted_at, loaded_at,
+                transaction_year, transaction_month, transaction_day,
+                transaction_day_of_week, transaction_year_month,
+                transaction_year_quarter,
+                memo, notes, tags, splits
+            ) VALUES
+            ('M1', 'A1', '2026-04-10', -10.00, 10.00, 'expense',
+             'Acme Corp', 'DEBIT', false, 'USD', 'ofx',
+             '2026-04-10', CURRENT_TIMESTAMP,
+             2026, 4, 10, 3, '2026-04', '2026-Q2',
+             'coffee shop', NULL, NULL, NULL)
+        """)  # noqa: S608  # test input, not executing SQL
+        result = TransactionService(db).get(description="coffee")
+        assert len(result.transactions) == 1
+        assert result.transactions[0].transaction_id == "M1"
+        assert result.transactions[0].memo == "coffee shop"
+        db.close()

--- a/tests/moneybin/test_services/test_transaction_get.py
+++ b/tests/moneybin/test_services/test_transaction_get.py
@@ -137,6 +137,13 @@ class TestTransactionGet:
         assert result.transactions[0].transaction_id == "T2"
 
     @pytest.mark.unit
+    def test_filter_by_amount_max(self, txn_db: Database) -> None:
+        # expenses only (negative) — excludes T2 (income, 5000.00)
+        result = TransactionService(txn_db).get(amount_max=Decimal("0"))
+        assert len(result.transactions) == 3
+        assert all(t.transaction_id != "T2" for t in result.transactions)
+
+    @pytest.mark.unit
     def test_filter_by_categories(self, txn_db: Database) -> None:
         result = TransactionService(txn_db).get(categories=["Food & Drink"])
         assert len(result.transactions) == 2

--- a/tests/moneybin/test_services/test_transaction_get.py
+++ b/tests/moneybin/test_services/test_transaction_get.py
@@ -11,7 +11,11 @@ import pytest
 
 import moneybin.database as db_module
 from moneybin.database import Database
-from moneybin.services.transaction_service import Transaction, TransactionGetResult, TransactionService
+from moneybin.services.transaction_service import (
+    Transaction,
+    TransactionGetResult,
+    TransactionService,
+)
 from tests.moneybin.db_helpers import create_core_tables_raw
 
 
@@ -20,7 +24,9 @@ def txn_db(tmp_path: Path) -> Generator[Database, None, None]:
     """Database with core+app tables and 4 test transactions."""
     mock_store = MagicMock()
     mock_store.get_key.return_value = "test-encryption-key-256bit-placeholder"
-    database = Database(tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True)
+    database = Database(
+        tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True
+    )
     conn = database.conn
     create_core_tables_raw(conn)
 
@@ -184,7 +190,9 @@ class TestTransactionGet:
         assert len(second.transactions) == 2
         assert second.next_cursor is None
 
-        all_ids = {t.transaction_id for t in first.transactions} | {t.transaction_id for t in second.transactions}
+        all_ids = {t.transaction_id for t in first.transactions} | {
+            t.transaction_id for t in second.transactions
+        }
         assert all_ids == {"T1", "T2", "T3", "T4"}
 
     @pytest.mark.unit

--- a/tests/moneybin/test_services/test_transaction_get.py
+++ b/tests/moneybin/test_services/test_transaction_get.py
@@ -1,0 +1,213 @@
+"""Tests for TransactionService.get()."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import moneybin.database as db_module
+from moneybin.database import Database
+from moneybin.services.transaction_service import Transaction, TransactionGetResult, TransactionService
+from tests.moneybin.db_helpers import create_core_tables_raw
+
+
+@pytest.fixture()
+def txn_db(tmp_path: Path) -> Generator[Database, None, None]:
+    """Database with core+app tables and 4 test transactions."""
+    mock_store = MagicMock()
+    mock_store.get_key.return_value = "test-encryption-key-256bit-placeholder"
+    database = Database(tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True)
+    conn = database.conn
+    create_core_tables_raw(conn)
+
+    conn.execute("""
+        INSERT INTO core.dim_accounts
+            (account_id, routing_number, account_type, institution_name, institution_fid,
+             source_type, source_file, extracted_at, loaded_at, updated_at)
+        VALUES
+        ('A1', '111000025', 'CHECKING', 'Test Bank', '1234', 'ofx',
+         'test.qfx', '2026-01-01', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        ('A2', '222000050', 'SAVINGS', 'Other Bank', '5678', 'ofx',
+         'other.qfx', '2026-01-01', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    """)  # noqa: S608  # test input, not executing SQL
+
+    conn.execute("""
+        INSERT INTO core.fct_transactions (
+            transaction_id, account_id, transaction_date, amount,
+            amount_absolute, transaction_direction, description,
+            transaction_type, is_pending, currency_code, source_type,
+            source_extracted_at, loaded_at,
+            transaction_year, transaction_month, transaction_day,
+            transaction_day_of_week, transaction_year_month,
+            transaction_year_quarter,
+            category, notes, tags, splits
+        ) VALUES
+        ('T1', 'A1', '2026-04-10', -50.00, 50.00, 'expense',
+         'Coffee Shop', 'DEBIT', false, 'USD', 'ofx',
+         '2026-04-10', CURRENT_TIMESTAMP,
+         2026, 4, 10, 3, '2026-04', '2026-Q2',
+         'Food & Drink', NULL, ['work', 'lunch'], NULL),
+        ('T2', 'A1', '2026-04-15', 5000.00, 5000.00, 'income',
+         'Employer Inc', 'CREDIT', false, 'USD', 'ofx',
+         '2026-04-15', CURRENT_TIMESTAMP,
+         2026, 4, 15, 1, '2026-04', '2026-Q2',
+         NULL, NULL, NULL, NULL),
+        ('T3', 'A2', '2026-03-10', -50.00, 50.00, 'expense',
+         'Coffee Shop', 'DEBIT', false, 'USD', 'ofx',
+         '2026-03-10', CURRENT_TIMESTAMP,
+         2026, 3, 10, 1, '2026-03', '2026-Q1',
+         'Food & Drink', NULL, NULL, NULL),
+        ('T4', 'A1', '2026-02-10', -200.00, 200.00, 'expense',
+         'Rent Payment', 'DEBIT', false, 'USD', 'ofx',
+         '2026-02-10', CURRENT_TIMESTAMP,
+         2026, 2, 10, 1, '2026-02', '2026-Q1',
+         NULL, NULL, NULL, NULL)
+    """)  # noqa: S608  # test input, not executing SQL
+
+    db_module._database_instance = database  # type: ignore[attr-defined]
+    yield database
+    db_module._database_instance = None  # type: ignore[attr-defined]
+    database.close()
+
+
+class TestTransactionGet:
+    """Tests for TransactionService.get()."""
+
+    @pytest.mark.unit
+    def test_returns_get_result(self, txn_db: Database) -> None:
+        result = TransactionService(txn_db).get()
+        assert isinstance(result, TransactionGetResult)
+        assert len(result.transactions) == 4
+
+    @pytest.mark.unit
+    def test_transaction_fields(self, txn_db: Database) -> None:
+        result = TransactionService(txn_db).get()
+        t = next(x for x in result.transactions if x.transaction_id == "T1")
+        assert isinstance(t, Transaction)
+        assert t.account_id == "A1"
+        assert t.amount == Decimal("-50.00")
+        assert t.description == "Coffee Shop"
+        assert t.category == "Food & Drink"
+
+    @pytest.mark.unit
+    def test_curation_fields_populated(self, txn_db: Database) -> None:
+        result = TransactionService(txn_db).get()
+        t = next(x for x in result.transactions if x.transaction_id == "T1")
+        assert t.tags == ["work", "lunch"]
+        assert t.notes is None
+        assert t.splits is None
+
+    @pytest.mark.unit
+    def test_curation_fields_null_when_absent(self, txn_db: Database) -> None:
+        result = TransactionService(txn_db).get()
+        t = next(x for x in result.transactions if x.transaction_id == "T2")
+        assert t.tags is None
+        assert t.notes is None
+        assert t.splits is None
+
+    @pytest.mark.unit
+    def test_filter_by_date_from(self, txn_db: Database) -> None:
+        result = TransactionService(txn_db).get(date_from="2026-04-01")
+        assert len(result.transactions) == 2
+        for t in result.transactions:
+            assert t.transaction_date >= "2026-04-01"
+
+    @pytest.mark.unit
+    def test_filter_by_date_to(self, txn_db: Database) -> None:
+        result = TransactionService(txn_db).get(date_to="2026-03-31")
+        assert len(result.transactions) == 2
+        for t in result.transactions:
+            assert t.transaction_date <= "2026-03-31"
+
+    @pytest.mark.unit
+    def test_filter_by_amount_min(self, txn_db: Database) -> None:
+        # income only (positive)
+        result = TransactionService(txn_db).get(amount_min=Decimal("0"))
+        assert len(result.transactions) == 1
+        assert result.transactions[0].transaction_id == "T2"
+
+    @pytest.mark.unit
+    def test_filter_by_categories(self, txn_db: Database) -> None:
+        result = TransactionService(txn_db).get(categories=["Food & Drink"])
+        assert len(result.transactions) == 2
+        for t in result.transactions:
+            assert t.category == "Food & Drink"
+
+    @pytest.mark.unit
+    def test_filter_uncategorized_only(self, txn_db: Database) -> None:
+        result = TransactionService(txn_db).get(uncategorized_only=True)
+        assert len(result.transactions) == 2
+        for t in result.transactions:
+            assert t.category is None
+
+    @pytest.mark.unit
+    def test_filter_by_description(self, txn_db: Database) -> None:
+        result = TransactionService(txn_db).get(description="coffee")
+        assert len(result.transactions) == 2
+        for t in result.transactions:
+            assert "Coffee" in t.description
+
+    @pytest.mark.unit
+    def test_filter_by_exact_account_id(self, txn_db: Database) -> None:
+        result = TransactionService(txn_db).get(accounts=["A2"])
+        assert len(result.transactions) == 1
+        assert result.transactions[0].transaction_id == "T3"
+
+    @pytest.mark.unit
+    def test_filter_by_display_name(self, txn_db: Database) -> None:
+        result = TransactionService(txn_db).get(accounts=["Test Bank"])
+        assert len(result.transactions) == 3
+        for t in result.transactions:
+            assert t.account_id == "A1"
+
+    @pytest.mark.unit
+    def test_multi_account_filter(self, txn_db: Database) -> None:
+        result = TransactionService(txn_db).get(accounts=["A1", "A2"])
+        assert len(result.transactions) == 4
+
+    @pytest.mark.unit
+    def test_unresolvable_account_silently_skipped(self, txn_db: Database) -> None:
+        result = TransactionService(txn_db).get(accounts=["DOES_NOT_EXIST_XYZ"])
+        assert len(result.transactions) == 0
+
+    @pytest.mark.unit
+    def test_cursor_pagination(self, txn_db: Database) -> None:
+        first = TransactionService(txn_db).get(limit=2)
+        assert len(first.transactions) == 2
+        assert first.next_cursor is not None
+
+        second = TransactionService(txn_db).get(limit=2, cursor=first.next_cursor)
+        assert len(second.transactions) == 2
+        assert second.next_cursor is None
+
+        all_ids = {t.transaction_id for t in first.transactions} | {t.transaction_id for t in second.transactions}
+        assert all_ids == {"T1", "T2", "T3", "T4"}
+
+    @pytest.mark.unit
+    def test_no_next_cursor_when_fits_in_one_page(self, txn_db: Database) -> None:
+        result = TransactionService(txn_db).get(limit=10)
+        assert result.next_cursor is None
+
+    @pytest.mark.unit
+    def test_empty_result(self, txn_db: Database) -> None:
+        result = TransactionService(txn_db).get(date_from="2030-01-01")
+        assert result.transactions == []
+        assert result.next_cursor is None
+
+    @pytest.mark.unit
+    def test_to_envelope_sensitivity_medium(self, txn_db: Database) -> None:
+        result = TransactionService(txn_db).get()
+        d = result.to_envelope().to_dict()
+        assert d["summary"]["sensitivity"] == "medium"
+        assert isinstance(d["data"], list)
+
+    @pytest.mark.unit
+    def test_to_envelope_next_cursor_propagated(self, txn_db: Database) -> None:
+        result = TransactionService(txn_db).get(limit=2)
+        d = result.to_envelope().to_dict()
+        assert "next_cursor" in d
+        assert d["next_cursor"] == result.next_cursor

--- a/tests/moneybin/test_services/test_transaction_service.py
+++ b/tests/moneybin/test_services/test_transaction_service.py
@@ -23,7 +23,6 @@ from moneybin.services.transaction_service import (
     Split,
     TagRenameResult,
     Transaction,
-    TransactionSearchResult,
     TransactionService,
 )
 from tests.moneybin.db_helpers import create_core_tables_raw
@@ -86,69 +85,6 @@ def transaction_db(tmp_path: Path) -> Generator[Database, None, None]:
     database.close()
 
 
-class TestTransactionSearch:
-    """Tests for TransactionService.search()."""
-
-    @pytest.mark.unit
-    def test_returns_search_result(self, transaction_db: Database) -> None:
-        service = TransactionService(transaction_db)
-        result = service.search()
-        assert isinstance(result, TransactionSearchResult)
-        assert result.total_count == 4
-        assert len(result.transactions) == 4
-
-    @pytest.mark.unit
-    def test_transaction_fields(self, transaction_db: Database) -> None:
-        service = TransactionService(transaction_db)
-        result = service.search()
-        txn = next(t for t in result.transactions if t.transaction_id == "T1")
-        assert isinstance(txn, Transaction)
-        assert txn.account_id == "A1"
-        assert txn.amount == Decimal("-50.00")
-        assert txn.description == "Coffee Shop"
-        assert txn.category == "Food & Drink"
-
-    @pytest.mark.unit
-    def test_filter_by_description(self, transaction_db: Database) -> None:
-        service = TransactionService(transaction_db)
-        result = service.search(description="coffee")
-        assert result.total_count == 3
-        for txn in result.transactions:
-            assert "Coffee" in txn.description
-
-    @pytest.mark.unit
-    def test_filter_by_date_range(self, transaction_db: Database) -> None:
-        service = TransactionService(transaction_db)
-        result = service.search(start_date="2026-04-01", end_date="2026-04-30")
-        assert result.total_count == 2
-
-    @pytest.mark.unit
-    def test_filter_uncategorized_only(self, transaction_db: Database) -> None:
-        service = TransactionService(transaction_db)
-        result = service.search(uncategorized_only=True)
-        # T1 is categorized, T2/T3/T4 are not
-        assert result.total_count == 3
-        for txn in result.transactions:
-            assert txn.category is None
-
-    @pytest.mark.unit
-    def test_limit_and_offset(self, transaction_db: Database) -> None:
-        service = TransactionService(transaction_db)
-        result = service.search(limit=2, offset=0)
-        assert len(result.transactions) == 2
-        assert result.total_count == 4
-
-    @pytest.mark.unit
-    def test_to_envelope_sensitivity_medium(self, transaction_db: Database) -> None:
-        service = TransactionService(transaction_db)
-        result = service.search()
-        envelope = result.to_envelope()
-        d = envelope.to_dict()
-        assert d["summary"]["sensitivity"] == "medium"
-        assert d["summary"]["total_count"] == 4
-        assert isinstance(d["data"], list)
-
-
 class TestRecurring:
     """Tests for TransactionService.recurring()."""
 
@@ -204,12 +140,14 @@ class TestEmptyResults:
         database.close()
 
     @pytest.mark.unit
-    def test_search_empty_db(self, empty_db: Database) -> None:
+    def test_get_empty_db(self, empty_db: Database) -> None:
+        from moneybin.services.transaction_service import TransactionGetResult
+
         service = TransactionService(empty_db)
-        result = service.search()
-        assert isinstance(result, TransactionSearchResult)
-        assert result.total_count == 0
+        result = service.get()
+        assert isinstance(result, TransactionGetResult)
         assert result.transactions == []
+        assert result.next_cursor is None
 
     @pytest.mark.unit
     def test_recurring_empty_db(self, empty_db: Database) -> None:

--- a/tests/moneybin/test_services/test_transaction_service.py
+++ b/tests/moneybin/test_services/test_transaction_service.py
@@ -22,7 +22,6 @@ from moneybin.services.transaction_service import (
     RecurringTransaction,
     Split,
     TagRenameResult,
-    Transaction,
     TransactionService,
 )
 from tests.moneybin.db_helpers import create_core_tables_raw


### PR DESCRIPTION
## Summary

Introduces `transactions_get` as the primary MCP tool for reading transactions and `moneybin transactions list` as its CLI equivalent. Both read from `core.fct_transactions`, support multi-account/category filters, return curation fields (notes, tags, splits), and paginate via an opaque cursor. `transactions_search` is removed — it was a single-account, no-pagination, no-curation predecessor.

Also fixes a latent bug where `summary.has_more` stayed `False` even when a next page existed, and unblocks all E2E MCP tests (which were failing due to fastmcp's startup version check hitting a sandbox-blocked path).

## Impact

- Agents or integrations calling `transactions_search` must migrate to `transactions_get`. All previous filters are supported — renamed for consistency (`start_date` → `date_from`, `account_id` → `accounts` list, `category` → `categories` list).
- `summary.has_more` is now correctly `true` when a next page exists. This was a bug in `build_envelope()` — the fix is backward-compatible, existing callers unaffected.
- `build_envelope()` gains an optional `next_cursor` parameter for paginated callers.

## Changes

### MCP Tool: `transactions_get`

Replaces `transactions_search`. Improvements:

- `accounts` accepts a list of IDs or display names; resolved via a batched exact-ID lookup then fuzzy fallback through `AccountService`
- `categories` accepts a list (OR-combined)
- Curation fields `notes`, `tags`, `splits` returned directly from the view (already on `core.fct_transactions` since PR #120)
- Cursor pagination: pass `cursor` from `next_cursor` to fetch the next page
- Annotated `read_only=True`

### CLI Command: `moneybin transactions list`

New command matching the MCP filter surface: `--account` (repeatable), `--from`, `--to`, `--category` (repeatable), `--description`, `--uncategorized`, `--limit`, `--cursor`. `--output text|json` renders a table or full `ResponseEnvelope`.

### Service Layer

- `TransactionService.get()` replaces `search()`. Reads curation columns from the view directly (no JOIN). Account resolution is batched (one `IN` query for exact IDs, fuzzy match only for the remainder). Pagination uses fetch-N+1 with no `COUNT(*)`.
- `TransactionService.search()` and `TransactionSearchResult` removed.

### Protocol

- `next_cursor: str | None` added to `ResponseEnvelope`
- `build_envelope()` accepts `next_cursor`; forces `summary.has_more = True` when provided

### E2E Test Fix

`FASTMCP_CHECK_FOR_UPDATES=off` added to `FAST_ARGON2_ENV` in `tests/e2e/conftest.py`. fastmcp's version check calls `stat()` on `~/Library/Application Support/fastmcp/version_cache.json` at startup, which was blocked by the sandbox. This flag skips the check entirely. Unblocks 11 previously-failing E2E MCP tests.

## Testing

- **2346 passed, 1 skipped, 0 failed** across the full suite (unit, integration, E2E, scenarios)
- 19 unit tests for `TransactionService.get()`: all filters, account resolution, cursor pagination, curation fields
- 4 async MCP tests: envelope shape, data type, empty DB, tool registration
- 8 CLI unit tests: all flags, text/JSON output, quiet mode, empty result
- 4 envelope tests: `next_cursor` behavior, `has_more` correctness, curation field presence

## Notes

- The 1 skipped test (`TestCategoryEditAudit`) is a pre-existing skip from an earlier PR — unrelated to this change.
- `transactions_search` removal is documented in `CHANGELOG.md` under `Removed`.