### PR TITLE
feat: moneybin doctor — pipeline integrity command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 M2 work in flight; M2A `transaction-curation.md` spec published (PR #115). Doc surface tightened for the personas reachable today. MCP surface hardened: protocol-standard annotations, `accounts_resolve` for fuzzy account lookup, list-parameter cap, de-bulking renames.
 
 ### Added
+- `moneybin doctor` command — read-only pipeline integrity check that runs SQLMesh named audits (FK integrity, sign convention, transfer balance), staging coverage, and categorization coverage. Exits 0 on pass/warn, 1 on fail. Supports `--verbose` for affected IDs and `--output json` for agent consumption. Registered as `system_doctor` MCP tool.
 - MCP tool decorator now emits protocol-standard `ToolAnnotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`). Clients can render confirmation UI for destructive operations.
 - Decorator-level cap on list-typed tool parameters via `MCPConfig.max_items` (default 500). Exceeding the cap returns `ResponseEnvelope.error` with `code="too_many_items"`.
 - `accounts_resolve` MCP tool and `moneybin accounts resolve "<query>"` CLI command — fuzzy-matches free-text references to an `account_id`.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -120,7 +120,8 @@ Single source of truth for spec status. Update this table when a spec's status c
 
 | Spec | Type | Status | Summary |
 |---|---|---|---|
-| [Data Pipeline Reconciliation](data-reconciliation.md) | Feature | draft | Automated pipeline integrity checks: raw→prep→core row accounting, import batch validation, temporal coverage gaps, orphan detection. Complements financial balance reconciliation in `net-worth.md`. |
+| [MoneyBin Doctor](moneybin-doctor.md) | Feature | in-progress | Pipeline integrity command: `moneybin doctor` runs SQLMesh named audits (FK integrity, sign convention, balanced transfers) + staging coverage + categorization coverage warning. Produces a "✅ N invariants passing" trust artifact. Top-level CLI + `system_doctor` MCP tool. |
+| [Data Pipeline Reconciliation](data-reconciliation.md) | Feature | draft | Broader ETL integrity checks: raw→prep→core row accounting, import batch validation, temporal coverage gaps, orphan detection. `moneybin-doctor.md` is the user-facing subset; this spec covers the full warehouse-grade reconciliation surface. |
 
 ## Reports & Health
 

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -120,7 +120,7 @@ Single source of truth for spec status. Update this table when a spec's status c
 
 | Spec | Type | Status | Summary |
 |---|---|---|---|
-| [MoneyBin Doctor](moneybin-doctor.md) | Feature | in-progress | Pipeline integrity command: `moneybin doctor` runs SQLMesh named audits (FK integrity, sign convention, balanced transfers) + staging coverage + categorization coverage warning. Produces a "✅ N invariants passing" trust artifact. Top-level CLI + `system_doctor` MCP tool. |
+| [MoneyBin Doctor](moneybin-doctor.md) | Feature | implemented | Pipeline integrity command: `moneybin doctor` runs SQLMesh named audits (FK integrity, sign convention, balanced transfers) + staging coverage + categorization coverage warning. Produces a "✅ N invariants passing" trust artifact. Top-level CLI + `system_doctor` MCP tool. |
 | [Data Pipeline Reconciliation](data-reconciliation.md) | Feature | draft | Broader ETL integrity checks: raw→prep→core row accounting, import batch validation, temporal coverage gaps, orphan detection. `moneybin-doctor.md` is the user-facing subset; this spec covers the full warehouse-grade reconciliation surface. |
 
 ## Reports & Health

--- a/docs/specs/mcp-tool-surface.md
+++ b/docs/specs/mcp-tool-surface.md
@@ -1095,6 +1095,16 @@ Data status dashboard — what data exists, how fresh it is, what's pending acti
 - **Service:** `OverviewService.status() -> SystemStatus`
 - **CLI:** `moneybin system status`
 
+### `system_doctor`
+
+Pipeline integrity check — confirms the data pipeline is self-consistent before analysis.
+
+- **Sensitivity:** `low` — counts and status labels only.
+- **Unique parameters:** None.
+- **Behavior:** Runs all SQLMesh named audits (FK integrity, sign convention, transfer balance) plus two hardcoded checks (staging coverage, categorization coverage). Returns pass/fail/warn per invariant and total transaction count. Always runs with `verbose=False` — agents can query `core.fct_transactions` or `core.bridge_transfers` directly for drill-down. Exit is informational only (no exception on fail).
+- **Service:** `DoctorService.run_all(verbose=False) -> DoctorReport`
+- **CLI:** `moneybin doctor [--verbose] [--output json]`
+
 ### `reports_health`
 
 Financial health snapshot — high-level summary across all domains.

--- a/docs/specs/moneybin-doctor.md
+++ b/docs/specs/moneybin-doctor.md
@@ -1,0 +1,188 @@
+# Feature: moneybin doctor
+
+## Status
+
+in-progress
+
+## Goal
+
+Provide a single command — `moneybin doctor` — that asserts MoneyBin's pipeline invariants and produces a trust artifact: "✅ N invariants passing across M transactions." The command checks the pipeline, not the user's data. It replaces the dropped `verified` curator flag as MoneyBin's integrity-by-construction signal.
+
+## Background
+
+The `verified` flag was dropped from `transaction-curation.md` (PR #120) because per-row user assertions conflict with the brand promise that MoneyBin's data is trustworthy by construction. The replacement is a system-asserted check: MoneyBin proves its own pipeline is self-consistent.
+
+`moneybin doctor` is the entry point for that proof. It is read-only, zero-argument (no date ranges, no filters), and produces a clear pass/fail summary. The longer-form ETL reconciliation vision (row accounting, amount sums, temporal coverage) lives in `data-reconciliation.md` and is out of scope here.
+
+Related specs:
+- [`transaction-curation.md`](transaction-curation.md) §"Dropped: verified flag" — original motivation
+- [`data-reconciliation.md`](data-reconciliation.md) — broader ETL integrity checks; doctor is a focused, user-facing subset
+- [`cli-restructure.md`](cli-restructure.md) — CLI v2 taxonomy; doctor is top-level, parallel to `transform`
+- [`mcp-tool-surface.md`](mcp-tool-surface.md) — `system_doctor` tool registration
+
+## Design
+
+### Invariant execution: SQLMesh named audits + DoctorService extras
+
+Row-level invariants are defined as SQLMesh standalone named audits in `sqlmesh/audits/`. Each audit is a `SELECT` query that returns violation rows — SQLMesh's convention. `DoctorService` auto-discovers all named audits via `ctx.standalone_audits`, renders each query with `audit.render_audit_query().sql(dialect="duckdb")`, and executes it against the open database connection.
+
+Two additional checks that don't fit the "return violation rows" model (percentage thresholds, cross-layer counts) live as direct SQL in `DoctorService`.
+
+Adding a new invariant in the future: add a `.sql` file to `sqlmesh/audits/` — `DoctorService` picks it up automatically with no Python changes.
+
+### Connection model
+
+`DoctorService` is read-only. Per ADR-010, it should use `Database(read_only=True)` when that API is implemented. Until then it uses the current `get_database()` singleton. `sqlmesh_context()` (which `DoctorService._run_sqlmesh_audits()` uses) borrows the singleton connection — the database must be open before calling.
+
+## Invariants
+
+### SQLMesh named audits (auto-discovered)
+
+| Audit file | Name | What it checks | Fails when |
+|---|---|---|---|
+| `fct_transactions_fk_integrity.sql` | `fct_transactions_fk_integrity` | Every `fct_transactions.account_id` resolves to `dim_accounts` | Any orphaned account_id |
+| `fct_transactions_sign_convention.sql` | `fct_transactions_sign_convention` | No amount is 0 or NULL | Any zero or NULL amount |
+| `bridge_transfers_balanced.sql` | `bridge_transfers_balanced` | Every transfer pair sums to within $0.01 | Any pair with `ABS(SUM(amount)) > 0.01` |
+
+Each audit returns the offending `transaction_id` (or `debit_transaction_id` for transfers) as the first column. `DoctorService` uses this column for `--verbose` affected-ID output.
+
+### DoctorService extras (hardcoded)
+
+**`staging_coverage`** — Cross-layer count check. `raw_total - core_count - known_dedup_secondaries` must be zero. Fails if any raw rows are unaccounted for. Marked `skipped` if the dedup secondary count is not queryable (schema verification required during implementation; see implementation note below).
+
+**`categorization_coverage`** — What percentage of non-transfer transactions have a category. Status is `warn` (not `fail`) when below 50%; `pass` otherwise. Never blocks exit 0 on its own.
+
+### Dropped invariant
+
+**`reconciliation_deltas`** — deferred. Requires a unified balance-evidence model spanning `app.balance_assertions`, OFX `LEDGERBAL`, and future Plaid sync balances. That model doesn't exist yet. See `data-reconciliation.md` for the longer-term design.
+
+## Data Model
+
+No new tables or migrations. All checks are read-only queries against existing schemas.
+
+```python
+@dataclass(frozen=True)
+class InvariantResult:
+    name: str
+    status: Literal["pass", "fail", "warn", "skipped"]
+    detail: str | None       # human-readable description; None on pass
+    affected_ids: list[str]  # populated only when verbose=True; empty otherwise
+```
+
+`DoctorService.run_all()` also returns the total transaction count (from the FK integrity query) for the summary line.
+
+## CLI Interface
+
+Top-level command, parallel to `moneybin transform`:
+
+```
+moneybin doctor [--verbose] [--output text|json]
+```
+
+**Human output (default):**
+
+```
+✅ fct_transactions_fk_integrity
+✅ fct_transactions_sign_convention
+❌ bridge_transfers_balanced — 2 transfer pairs sum to > $0.01
+   Run with --verbose for affected pair IDs
+⚠️  categorization_coverage — 43% of non-transfer transactions are uncategorized
+✅ staging_coverage
+
+5 invariants checked across 14,203 transactions — 1 failing
+```
+
+With `--verbose`, affected IDs appear under each failing line:
+```
+❌ bridge_transfers_balanced — 2 transfer pairs sum to > $0.01
+   Affected: a1b2c3d4e5f6, b7c8d9e0f1a2
+```
+
+**Exit codes:** `0` = all pass or warn-only, `1` = any invariant fails.
+
+**`--output json`** returns the standard `ResponseEnvelope`:
+
+```json
+{
+  "summary": {"total_count": 5, "returned_count": 5, "sensitivity": "low"},
+  "data": {
+    "passing": 3, "failing": 1, "warning": 1,
+    "transaction_count": 14203,
+    "invariants": [
+      {"name": "bridge_transfers_balanced", "status": "fail",
+       "detail": "2 transfer pairs sum to > $0.01", "affected_ids": []}
+    ]
+  },
+  "actions": ["Run with --verbose to see affected transaction IDs"]
+}
+```
+
+`affected_ids` is always `[]` in JSON mode unless `--verbose` is also passed.
+
+## MCP Interface
+
+**`system_doctor`** — registered alongside `system_status` in `src/moneybin/mcp/tools/system.py`.
+
+```python
+@mcp_tool(sensitivity="low", read_only=True)
+def system_doctor() -> ResponseEnvelope:
+    """Run pipeline integrity checks across all SQLMesh named audits.
+    Returns pass/fail/warn per invariant plus a transaction count.
+    Read-only — never writes. Call before relying on analytical results
+    to confirm the pipeline is self-consistent."""
+```
+
+Always runs with `verbose=False` — affected IDs are omitted (agents can query `core.fct_transactions` or `core.bridge_transfers` directly for drill-down). Registered in `register_system_tools()`.
+
+## Implementation Notes
+
+**`staging_coverage` SQL:** The query assumes `app.match_decisions` tracks dedup secondaries with an `is_primary` column. Verify the actual schema during implementation; if the column doesn't exist or the semantics differ, mark the invariant `skipped` rather than silently wrong.
+
+**Audit SQL column contract:** Each named audit's SELECT must return the violation entity's ID as the first column (e.g., `transaction_id`, `debit_transaction_id`). `DoctorService` uses `row[0]` for `affected_ids` — this is a convention, not schema-enforced. Document it in `sqlmesh/audits/README.md` or a comment in `DoctorService`.
+
+**SQLMesh context in tests:** Unit tests mock `sqlmesh_context()` and inject pre-rendered SQL to avoid loading the full SQLMesh project. E2E tests use a real profile with a test database.
+
+## Files to Create
+
+- `sqlmesh/audits/fct_transactions_fk_integrity.sql`
+- `sqlmesh/audits/fct_transactions_sign_convention.sql`
+- `sqlmesh/audits/bridge_transfers_balanced.sql`
+- `src/moneybin/services/doctor_service.py` — `InvariantResult`, `DoctorService`
+- `src/moneybin/cli/commands/doctor.py` — top-level Typer command
+- `tests/moneybin/test_services/test_doctor_service.py`
+- `tests/moneybin/test_cli/test_doctor.py`
+- `tests/e2e/test_e2e_doctor.py`
+
+## Files to Modify
+
+- `src/moneybin/cli/main.py` — register `doctor` command group
+- `src/moneybin/mcp/tools/system.py` — add `system_doctor`, register in `register_system_tools()`
+- `docs/specs/INDEX.md` — add this spec; update `data-reconciliation.md` entry with cross-reference
+- `docs/specs/mcp-tool-surface.md` — document `system_doctor`
+- `CHANGELOG.md` — `Added` entry under `Unreleased`
+- `docs/roadmap.md` — move to `✅ shipped` when complete
+
+## Testing Strategy
+
+**Unit** (`tests/moneybin/test_services/test_doctor_service.py`):
+- Each invariant: one test with clean fixture data (pass), one with deliberate violation (fail)
+- `run_all()` aggregates all results correctly
+- `verbose=True` populates `affected_ids`; `verbose=False` returns empty list
+- `sqlmesh_context()` mocked; audit SQL injected directly
+
+**CLI** (`tests/moneybin/test_cli/test_doctor.py`):
+- Clean pipeline → exit 0, `--output json` shape valid
+- Failing invariant → exit 1
+- `--verbose` adds affected IDs to human output
+- `--output json --verbose` includes affected IDs in JSON
+
+**E2E** (`tests/e2e/test_e2e_doctor.py`):
+- Clean test profile → all invariants pass, exit 0
+- Unbalanced transfer inserted → `bridge_transfers_balanced` fails, exit 1, `--verbose` shows pair ID
+
+## Out of Scope
+
+- `reconciliation_deltas` — requires unified balance-evidence model; deferred
+- Broader ETL checks (raw→prep row accounting, amount sums, temporal gaps) — `data-reconciliation.md`
+- Writing any state — this command is permanently read-only
+- Scheduled or CI-triggered doctor runs — use `make doctor` or a cron wrapper

--- a/docs/specs/moneybin-doctor.md
+++ b/docs/specs/moneybin-doctor.md
@@ -67,9 +67,14 @@ class InvariantResult:
     status: Literal["pass", "fail", "warn", "skipped"]
     detail: str | None       # human-readable description; None on pass
     affected_ids: list[str]  # populated only when verbose=True; empty otherwise
+
+@dataclass(frozen=True)
+class DoctorReport:
+    invariants: list[InvariantResult]
+    transaction_count: int   # total rows in fct_transactions; used in summary line
 ```
 
-`DoctorService.run_all()` also returns the total transaction count (from the FK integrity query) for the summary line.
+`DoctorService.run_all(verbose=False) -> DoctorReport`. The transaction count comes from the FK integrity query's `COUNT(*)` so no extra query is needed.
 
 ## CLI Interface
 
@@ -100,7 +105,7 @@ With `--verbose`, affected IDs appear under each failing line:
 
 **Exit codes:** `0` = all pass or warn-only, `1` = any invariant fails.
 
-**`--output json`** returns the standard `ResponseEnvelope`:
+**`--output json`** returns the standard `ResponseEnvelope` with all invariants included (agents need the full picture, not just failures):
 
 ```json
 {
@@ -109,15 +114,18 @@ With `--verbose`, affected IDs appear under each failing line:
     "passing": 3, "failing": 1, "warning": 1,
     "transaction_count": 14203,
     "invariants": [
-      {"name": "bridge_transfers_balanced", "status": "fail",
-       "detail": "2 transfer pairs sum to > $0.01", "affected_ids": []}
+      {"name": "fct_transactions_fk_integrity", "status": "pass", "detail": null, "affected_ids": []},
+      {"name": "fct_transactions_sign_convention", "status": "pass", "detail": null, "affected_ids": []},
+      {"name": "bridge_transfers_balanced", "status": "fail", "detail": "2 transfer pairs sum to > $0.01", "affected_ids": []},
+      {"name": "categorization_coverage", "status": "warn", "detail": "43% of non-transfer transactions are uncategorized", "affected_ids": []},
+      {"name": "staging_coverage", "status": "pass", "detail": null, "affected_ids": []}
     ]
   },
   "actions": ["Run with --verbose to see affected transaction IDs"]
 }
 ```
 
-`affected_ids` is always `[]` in JSON mode unless `--verbose` is also passed.
+`affected_ids` is always `[]` unless `--verbose` is also passed.
 
 ## MCP Interface
 

--- a/docs/specs/moneybin-doctor.md
+++ b/docs/specs/moneybin-doctor.md
@@ -65,13 +65,14 @@ No new tables or migrations. All checks are read-only queries against existing s
 class InvariantResult:
     name: str
     status: Literal["pass", "fail", "warn", "skipped"]
-    detail: str | None       # human-readable description; None on pass
+    detail: str | None  # human-readable description; None on pass
     affected_ids: list[str]  # populated only when verbose=True; empty otherwise
+
 
 @dataclass(frozen=True)
 class DoctorReport:
     invariants: list[InvariantResult]
-    transaction_count: int   # total rows in fct_transactions; used in summary line
+    transaction_count: int  # total rows in fct_transactions; used in summary line
 ```
 
 `DoctorService.run_all(verbose=False) -> DoctorReport`. The transaction count comes from the FK integrity query's `COUNT(*)` so no extra query is needed.

--- a/docs/specs/moneybin-doctor.md
+++ b/docs/specs/moneybin-doctor.md
@@ -75,7 +75,7 @@ class DoctorReport:
     transaction_count: int  # total rows in fct_transactions; used in summary line
 ```
 
-`DoctorService.run_all(verbose=False) -> DoctorReport`. The transaction count comes from the FK integrity query's `COUNT(*)` so no extra query is needed.
+`DoctorService.run_all(verbose=False) -> DoctorReport`. The transaction count is fetched by a dedicated `_get_transaction_count()` query against `core.fct_transactions`; returns `0` if the schema doesn't exist yet (pre-first-transform).
 
 ## CLI Interface
 

--- a/docs/specs/moneybin-doctor.md
+++ b/docs/specs/moneybin-doctor.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-in-progress
+implemented
 
 ## Goal
 

--- a/sqlmesh/audits/bridge_transfers_balanced.sql
+++ b/sqlmesh/audits/bridge_transfers_balanced.sql
@@ -1,0 +1,17 @@
+AUDIT (
+  name bridge_transfers_balanced,
+);
+/* Returns the debit_transaction_id of any transfer pair whose debit+credit
+   amounts don't cancel to within $0.01. First column is the violation
+   entity ID (debit side). */
+SELECT
+  bt.debit_transaction_id
+FROM core.bridge_transfers AS bt
+  JOIN core.fct_transactions AS d
+    ON bt.debit_transaction_id = d.transaction_id
+  JOIN core.fct_transactions AS c
+    ON bt.credit_transaction_id = c.transaction_id
+WHERE
+  ABS(d.amount + c.amount) > 0.01
+ORDER BY
+  bt.debit_transaction_id

--- a/sqlmesh/audits/fct_transactions_fk_integrity.sql
+++ b/sqlmesh/audits/fct_transactions_fk_integrity.sql
@@ -1,0 +1,15 @@
+AUDIT (
+  name fct_transactions_fk_integrity,
+);
+/* Returns orphaned transaction_ids — any transaction whose account_id has
+   no matching row in dim_accounts. First column is the violation entity ID
+   (required by DoctorService convention — see doctor_service.py). */
+SELECT
+  t.transaction_id
+FROM core.fct_transactions AS t
+  LEFT JOIN core.dim_accounts AS a
+    ON t.account_id = a.account_id
+WHERE
+  a.account_id IS NULL
+ORDER BY
+  t.transaction_id

--- a/sqlmesh/audits/fct_transactions_sign_convention.sql
+++ b/sqlmesh/audits/fct_transactions_sign_convention.sql
@@ -1,0 +1,13 @@
+AUDIT (
+  name fct_transactions_sign_convention,
+);
+/* Returns transaction_ids where amount is zero or NULL — both violate the
+   sign convention (negative=expense, positive=income; zero is undefined).
+   First column is the violation entity ID. */
+SELECT
+  transaction_id
+FROM core.fct_transactions
+WHERE
+  amount = 0 OR amount IS NULL
+ORDER BY
+  transaction_id

--- a/sqlmesh/config.py
+++ b/sqlmesh/config.py
@@ -29,11 +29,7 @@ if "MONEYBIN_HOME" not in os.environ:
 from moneybin.config import (  # noqa: E402 — must follow sys.path setup above
     get_database_path,
     get_settings,
-    set_current_profile,
 )
-
-# Set default profile if not already set by CLI (e.g. when using sqlmesh format)
-set_current_profile("default")
 
 _sqlmesh_dir = os.path.dirname(os.path.abspath(__file__))
 

--- a/sqlmesh/config.py
+++ b/sqlmesh/config.py
@@ -29,7 +29,11 @@ if "MONEYBIN_HOME" not in os.environ:
 from moneybin.config import (  # noqa: E402 — must follow sys.path setup above
     get_database_path,
     get_settings,
+    set_current_profile,
 )
+
+# Set default profile if not already set by CLI (e.g. when using sqlmesh format)
+set_current_profile("default")
 
 _sqlmesh_dir = os.path.dirname(os.path.abspath(__file__))
 

--- a/src/moneybin/cli/commands/doctor.py
+++ b/src/moneybin/cli/commands/doctor.py
@@ -88,7 +88,9 @@ def doctor_command(
             typer.echo("   Run with --verbose for affected IDs")
 
     n = len(report.invariants)
-    summary = f"\n{n} invariants checked across {report.transaction_count:,} transactions"
+    summary = (
+        f"\n{n} invariants checked across {report.transaction_count:,} transactions"
+    )
     if failing:
         summary += f" — {failing} failing"
     else:

--- a/src/moneybin/cli/commands/doctor.py
+++ b/src/moneybin/cli/commands/doctor.py
@@ -1,0 +1,93 @@
+"""doctor — pipeline integrity checks."""
+
+from __future__ import annotations
+
+import logging
+
+import typer
+
+from moneybin.cli.output import OutputFormat, output_option
+from moneybin.cli.utils import handle_cli_errors
+from moneybin.protocol.envelope import build_envelope
+from moneybin.services.doctor_service import DoctorService
+
+logger = logging.getLogger(__name__)
+
+verbose_option: bool = typer.Option(
+    False,
+    "--verbose",
+    "-V",
+    help="Show affected transaction IDs for each failing invariant.",
+)
+
+
+def doctor_command(
+    verbose: bool = verbose_option,
+    output: OutputFormat = output_option,
+) -> None:
+    """Run pipeline integrity checks across all invariants.
+
+    Checks that all fct_transactions resolve to known accounts, amounts
+    are non-zero, transfer pairs balance, and categorization is healthy.
+    Exits 0 when all invariants pass or warn; exits 1 when any fail.
+    """
+    with handle_cli_errors() as db:
+        report = DoctorService(db).run_all(verbose=verbose)
+
+    _STATUS_ICON = {"pass": "✅", "fail": "❌", "warn": "⚠️ ", "skipped": "⏭️ "}
+
+    failing = sum(1 for r in report.invariants if r.status == "fail")
+    warning = sum(1 for r in report.invariants if r.status == "warn")
+    passing = sum(1 for r in report.invariants if r.status == "pass")
+
+    if output == OutputFormat.JSON:
+        data = {
+            "passing": passing,
+            "failing": failing,
+            "warning": warning,
+            "transaction_count": report.transaction_count,
+            "invariants": [
+                {
+                    "name": r.name,
+                    "status": r.status,
+                    "detail": r.detail,
+                    "affected_ids": r.affected_ids,
+                }
+                for r in report.invariants
+            ],
+        }
+        actions = []
+        if failing > 0:
+            actions.append("Run with --verbose to see affected transaction IDs")
+        envelope = build_envelope(
+            data=data,
+            sensitivity="low",
+            total_count=len(report.invariants),
+            actions=actions,
+        )
+        typer.echo(envelope.to_json())
+        if failing > 0:
+            raise typer.Exit(1)
+        return
+
+    for result in report.invariants:
+        icon = _STATUS_ICON.get(result.status, "?")
+        line = f"{icon} {result.name}"
+        if result.detail:
+            line += f" — {result.detail}"
+        typer.echo(line)
+        if verbose and result.affected_ids:
+            typer.echo(f"   Affected: {', '.join(result.affected_ids)}")
+        elif result.status == "fail" and not verbose:
+            typer.echo("   Run with --verbose for affected IDs")
+
+    n = len(report.invariants)
+    summary = f"\n{n} invariants checked across {report.transaction_count:,} transactions"
+    if failing:
+        summary += f" — {failing} failing"
+    else:
+        summary += " — all passing"
+    typer.echo(summary)
+
+    if failing > 0:
+        raise typer.Exit(1)

--- a/src/moneybin/cli/commands/doctor.py
+++ b/src/moneybin/cli/commands/doctor.py
@@ -6,7 +6,7 @@ import logging
 
 import typer
 
-from moneybin.cli.output import OutputFormat, output_option
+from moneybin.cli.output import OutputFormat, output_option, quiet_option
 from moneybin.cli.utils import handle_cli_errors
 from moneybin.protocol.envelope import build_envelope
 from moneybin.services.doctor_service import DoctorService
@@ -24,6 +24,7 @@ verbose_option: bool = typer.Option(
 def doctor_command(
     verbose: bool = verbose_option,
     output: OutputFormat = output_option,
+    quiet: bool = quiet_option,
 ) -> None:
     """Run pipeline integrity checks across all invariants.
 
@@ -84,18 +85,19 @@ def doctor_command(
         typer.echo(line)
         if verbose and result.affected_ids:
             typer.echo(f"   Affected: {', '.join(result.affected_ids)}")
-        elif result.status == "fail" and not verbose:
-            typer.echo("   Run with --verbose for affected IDs")
 
-    n = len(report.invariants)
-    summary = (
-        f"\n{n} invariants checked across {report.transaction_count:,} transactions"
-    )
-    if failing:
-        summary += f" — {failing} failing"
-    else:
-        summary += " — all passing"
-    typer.echo(summary)
+    if not quiet:
+        n = len(report.invariants)
+        summary = (
+            f"\n{n} invariants checked across {report.transaction_count:,} transactions"
+        )
+        if failing:
+            summary += f" — {failing} failing"
+            if not verbose:
+                summary += " — run --verbose for affected IDs"
+        else:
+            summary += " — all passing"
+        typer.echo(summary)
 
     if failing > 0:
         raise typer.Exit(1)

--- a/src/moneybin/cli/commands/doctor.py
+++ b/src/moneybin/cli/commands/doctor.py
@@ -40,6 +40,10 @@ def doctor_command(
     warning = sum(1 for r in report.invariants if r.status == "warn")
     passing = sum(1 for r in report.invariants if r.status == "pass")
 
+    from moneybin.metrics.registry import DOCTOR_RUNS_TOTAL  # noqa: PLC0415 — defer import
+
+    DOCTOR_RUNS_TOTAL.labels(outcome="fail" if failing > 0 else "pass").inc()
+
     if output == OutputFormat.JSON:
         data = {
             "passing": passing,

--- a/src/moneybin/cli/commands/doctor.py
+++ b/src/moneybin/cli/commands/doctor.py
@@ -37,9 +37,9 @@ def doctor_command(
 
     status_icon = {"pass": "✅", "fail": "❌", "warn": "⚠️ ", "skipped": "⏭️ "}
 
-    failing = sum(1 for r in report.invariants if r.status == "fail")
-    warning = sum(1 for r in report.invariants if r.status == "warn")
-    passing = sum(1 for r in report.invariants if r.status == "pass")
+    failing = report.failing
+    warning = report.warning
+    passing = report.passing
 
     from moneybin.metrics.registry import (
         DOCTOR_RUNS_TOTAL,  # noqa: PLC0415 — defer import

--- a/src/moneybin/cli/commands/doctor.py
+++ b/src/moneybin/cli/commands/doctor.py
@@ -40,7 +40,9 @@ def doctor_command(
     warning = sum(1 for r in report.invariants if r.status == "warn")
     passing = sum(1 for r in report.invariants if r.status == "pass")
 
-    from moneybin.metrics.registry import DOCTOR_RUNS_TOTAL  # noqa: PLC0415 — defer import
+    from moneybin.metrics.registry import (
+        DOCTOR_RUNS_TOTAL,  # noqa: PLC0415 — defer import
+    )
 
     DOCTOR_RUNS_TOTAL.labels(outcome="fail" if failing > 0 else "pass").inc()
 

--- a/src/moneybin/cli/commands/doctor.py
+++ b/src/moneybin/cli/commands/doctor.py
@@ -34,7 +34,7 @@ def doctor_command(
     with handle_cli_errors() as db:
         report = DoctorService(db).run_all(verbose=verbose)
 
-    _STATUS_ICON = {"pass": "✅", "fail": "❌", "warn": "⚠️ ", "skipped": "⏭️ "}
+    status_icon = {"pass": "✅", "fail": "❌", "warn": "⚠️ ", "skipped": "⏭️ "}
 
     failing = sum(1 for r in report.invariants if r.status == "fail")
     warning = sum(1 for r in report.invariants if r.status == "warn")
@@ -56,7 +56,7 @@ def doctor_command(
                 for r in report.invariants
             ],
         }
-        actions = []
+        actions: list[str] = []
         if failing > 0:
             actions.append("Run with --verbose to see affected transaction IDs")
         envelope = build_envelope(
@@ -71,7 +71,7 @@ def doctor_command(
         return
 
     for result in report.invariants:
-        icon = _STATUS_ICON.get(result.status, "?")
+        icon = status_icon.get(result.status, "?")
         line = f"{icon} {result.name}"
         if result.detail:
             line += f" — {result.detail}"

--- a/src/moneybin/cli/commands/doctor.py
+++ b/src/moneybin/cli/commands/doctor.py
@@ -40,6 +40,7 @@ def doctor_command(
     failing = report.failing
     warning = report.warning
     passing = report.passing
+    skipped = report.skipped
 
     from moneybin.metrics.registry import (
         DOCTOR_RUNS_TOTAL,  # noqa: PLC0415 — defer import
@@ -52,6 +53,7 @@ def doctor_command(
             "passing": passing,
             "failing": failing,
             "warning": warning,
+            "skipped": skipped,
             "transaction_count": report.transaction_count,
             "invariants": [
                 {
@@ -69,7 +71,6 @@ def doctor_command(
         envelope = build_envelope(
             data=data,
             sensitivity="low",
-            total_count=len(report.invariants),
             actions=actions,
         )
         typer.echo(envelope.to_json())
@@ -93,8 +94,12 @@ def doctor_command(
         )
         if failing:
             summary += f" — {failing} failing"
+            if warning or skipped:
+                summary += f" ({warning} warn, {skipped} skipped)"
             if not verbose:
                 summary += " — run --verbose for affected IDs"
+        elif warning or skipped:
+            summary += f" — {passing} passing, {warning} warn, {skipped} skipped"
         else:
             summary += " — all passing"
         typer.echo(summary)

--- a/src/moneybin/cli/main.py
+++ b/src/moneybin/cli/main.py
@@ -41,6 +41,9 @@ from .commands import (
 from .commands import (
     budget as budget_cmd,
 )
+from .commands import (
+    doctor as doctor_cmd,
+)
 from .commands.stubs import (
     export_app,
 )
@@ -157,6 +160,10 @@ app.add_typer(
     name="synthetic",
     help="Generate and manage synthetic financial data for testing",
 )
+app.command(
+    name="doctor",
+    help="Run pipeline integrity checks across all invariants",
+)(doctor_cmd.doctor_command)
 app.command(name="stats", help="Show lifetime metric aggregates")(stats.stats_command)
 app.add_typer(export_app, name="export", help="Export data to external formats")
 app.add_typer(

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -59,6 +59,7 @@ def system_doctor() -> ResponseEnvelope:
     to confirm the pipeline is self-consistent.
     """
     from moneybin.database import get_database
+    from moneybin.metrics.registry import DOCTOR_RUNS_TOTAL  # noqa: PLC0415
     from moneybin.services.doctor_service import DoctorService
 
     db = get_database()
@@ -67,6 +68,8 @@ def system_doctor() -> ResponseEnvelope:
     failing = sum(1 for r in report.invariants if r.status == "fail")
     warning = sum(1 for r in report.invariants if r.status == "warn")
     passing = sum(1 for r in report.invariants if r.status == "pass")
+
+    DOCTOR_RUNS_TOTAL.labels(outcome="fail" if failing > 0 else "pass").inc()
 
     actions: list[str] = []
     if failing > 0:

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -80,6 +80,7 @@ def system_doctor() -> ResponseEnvelope:
             "passing": passing,
             "failing": failing,
             "warning": warning,
+            "skipped": report.skipped,
             "transaction_count": report.transaction_count,
             "invariants": [
                 {
@@ -92,7 +93,6 @@ def system_doctor() -> ResponseEnvelope:
             ],
         },
         sensitivity="low",
-        total_count=len(report.invariants),
         actions=actions,
     )
 

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -50,6 +50,50 @@ def system_status() -> ResponseEnvelope:
     )
 
 
+@mcp_tool(sensitivity="low", read_only=True)
+def system_doctor() -> ResponseEnvelope:
+    """Run pipeline integrity checks across all SQLMesh named audits.
+
+    Returns pass/fail/warn per invariant plus a transaction count.
+    Read-only — never writes. Call before relying on analytical results
+    to confirm the pipeline is self-consistent.
+    """
+    from moneybin.database import get_database
+    from moneybin.services.doctor_service import DoctorService
+
+    db = get_database()
+    report = DoctorService(db).run_all(verbose=False)
+
+    failing = sum(1 for r in report.invariants if r.status == "fail")
+    warning = sum(1 for r in report.invariants if r.status == "warn")
+    passing = sum(1 for r in report.invariants if r.status == "pass")
+
+    actions: list[str] = []
+    if failing > 0:
+        actions.append("Run moneybin doctor --verbose for affected transaction IDs")
+
+    return build_envelope(
+        data={
+            "passing": passing,
+            "failing": failing,
+            "warning": warning,
+            "transaction_count": report.transaction_count,
+            "invariants": [
+                {
+                    "name": r.name,
+                    "status": r.status,
+                    "detail": r.detail,
+                    "affected_ids": r.affected_ids,
+                }
+                for r in report.invariants
+            ],
+        },
+        sensitivity="low",
+        total_count=len(report.invariants),
+        actions=actions,
+    )
+
+
 def register_system_tools(mcp: FastMCP) -> None:
     """Register all system namespace tools with the FastMCP server."""
     register(
@@ -58,4 +102,12 @@ def register_system_tools(mcp: FastMCP) -> None:
         "system_status",
         "Return data inventory (accounts, transactions, freshness) and pending review queue counts. "
         "Call this first to orient before suggesting analytical queries.",
+    )
+    register(
+        mcp,
+        system_doctor,
+        "system_doctor",
+        "Run pipeline integrity checks across all SQLMesh named audits. "
+        "Returns pass/fail/warn per invariant plus transaction count. "
+        "Read-only. Call before relying on analytical results to confirm the pipeline is self-consistent.",
     )

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -65,9 +65,9 @@ def system_doctor() -> ResponseEnvelope:
     db = get_database()
     report = DoctorService(db).run_all(verbose=False)
 
-    failing = sum(1 for r in report.invariants if r.status == "fail")
-    warning = sum(1 for r in report.invariants if r.status == "warn")
-    passing = sum(1 for r in report.invariants if r.status == "pass")
+    failing = report.failing
+    warning = report.warning
+    passing = report.passing
 
     DOCTOR_RUNS_TOTAL.labels(outcome="fail" if failing > 0 else "pass").inc()
 

--- a/src/moneybin/metrics/registry.py
+++ b/src/moneybin/metrics/registry.py
@@ -257,3 +257,11 @@ audit_events_emitted_total = Counter(
     "Audit log events written to app.audit_log.",
     ["action", "actor"],
 )
+
+# ── Doctor ───────────────────────────────────────────────────────────────────
+
+DOCTOR_RUNS_TOTAL = Counter(
+    "moneybin_doctor_runs_total",
+    "Doctor command invocations by outcome",
+    ["outcome"],  # "pass", "fail", "error"
+)

--- a/src/moneybin/metrics/registry.py
+++ b/src/moneybin/metrics/registry.py
@@ -263,5 +263,5 @@ audit_events_emitted_total = Counter(
 DOCTOR_RUNS_TOTAL = Counter(
     "moneybin_doctor_runs_total",
     "Doctor command invocations by outcome",
-    ["outcome"],  # "pass", "fail", "error"
+    ["outcome"],  # "pass", "fail"
 )

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -65,19 +65,23 @@ class DoctorService:
                     rows = self._db.execute(sql).fetchall()  # noqa: S608 — rendered from trusted audit files
                     if rows:
                         affected = [str(r[0]) for r in rows] if verbose else []
-                        results.append(InvariantResult(
-                            name=name,
-                            status="fail",
-                            detail=f"{len(rows)} violation(s)",
-                            affected_ids=affected,
-                        ))
+                        results.append(
+                            InvariantResult(
+                                name=name,
+                                status="fail",
+                                detail=f"{len(rows)} violation(s)",
+                                affected_ids=affected,
+                            )
+                        )
                     else:
-                        results.append(InvariantResult(
-                            name=name,
-                            status="pass",
-                            detail=None,
-                            affected_ids=[],
-                        ))
+                        results.append(
+                            InvariantResult(
+                                name=name,
+                                status="pass",
+                                detail=None,
+                                affected_ids=[],
+                            )
+                        )
         except Exception as e:  # noqa: BLE001 — SQLMesh raises broad exceptions
             logger.warning(f"SQLMesh audit discovery failed: {e}")
         return results

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -53,6 +53,9 @@ class DoctorService:
             ).fetchone()
             return int(row[0]) if row else 0
         except Exception:  # noqa: BLE001 — core schema may not exist before first transform
+            logger.debug(
+                "core.fct_transactions not available; transaction count unavailable"
+            )
             return 0
 
     def _run_sqlmesh_audits(self, verbose: bool) -> list[InvariantResult]:
@@ -61,8 +64,20 @@ class DoctorService:
         try:
             with sqlmesh_context() as ctx:
                 for name, audit in ctx.standalone_audits.items():
-                    sql = audit.render_audit_query().sql(dialect="duckdb")
-                    rows = self._db.execute(sql).fetchall()  # noqa: S608 — rendered from trusted audit files
+                    try:
+                        sql = audit.render_audit_query().sql(dialect="duckdb")
+                        # Audit SQL must return the violation entity ID in column 0.
+                        rows = self._db.execute(sql).fetchall()  # noqa: S608 — rendered from trusted audit files
+                    except Exception as e:  # noqa: BLE001 — per-audit isolation
+                        results.append(
+                            InvariantResult(
+                                name=name,
+                                status="skipped",
+                                detail=f"audit failed: {e}",
+                                affected_ids=[],
+                            )
+                        )
+                        continue
                     if rows:
                         affected = [str(r[0]) for r in rows] if verbose else []
                         results.append(
@@ -124,12 +139,15 @@ class DoctorService:
                 affected_ids=[],
             )
         uncategorized, total = int(row[0]), int(row[1])
-        pct_categorized = round((total - uncategorized) / total * 100)
+        # Use unrounded ratio for the threshold so values like 49.6% categorized
+        # correctly trigger the warning instead of rounding up to 50 and passing.
+        pct_categorized = (total - uncategorized) / total * 100
         if pct_categorized < 50:
+            pct_uncategorized = round(uncategorized / total * 100)
             return InvariantResult(
                 name="categorization_coverage",
                 status="warn",
-                detail=f"{100 - pct_categorized}% of non-transfer transactions are uncategorized",
+                detail=f"{pct_uncategorized}% of non-transfer transactions are uncategorized",
                 affected_ids=[],
             )
         return InvariantResult(

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -44,6 +44,11 @@ class DoctorReport:
         """Count of invariants with status 'pass'."""
         return sum(1 for r in self.invariants if r.status == "pass")
 
+    @property
+    def skipped(self) -> int:
+        """Count of invariants with status 'skipped'."""
+        return sum(1 for r in self.invariants if r.status == "skipped")
+
 
 class DoctorService:
     """Run pipeline integrity invariants and aggregate results."""
@@ -114,6 +119,14 @@ class DoctorService:
                         )
         except Exception as e:  # noqa: BLE001 — SQLMesh raises broad exceptions
             logger.warning(f"SQLMesh audit discovery failed: {e}")
+            results.append(
+                InvariantResult(
+                    name="sqlmesh_audits_unavailable",
+                    status="skipped",
+                    detail=f"SQLMesh audit discovery failed: {e}",
+                    affected_ids=[],
+                )
+            )
         return results
 
     def _run_staging_coverage(self) -> InvariantResult:

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -34,6 +34,7 @@ class DoctorService:
     """Run pipeline integrity invariants and aggregate results."""
 
     def __init__(self, db: Database) -> None:
+        """Store the open database connection for invariant queries."""
         self._db = db
 
     def run_all(self, verbose: bool = False) -> DoctorReport:

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -1,0 +1,27 @@
+"""Pipeline integrity checks — DoctorService."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class InvariantResult:
+    """Result of one pipeline invariant check."""
+
+    name: str
+    status: Literal["pass", "fail", "warn", "skipped"]
+    detail: str | None
+    affected_ids: list[str]
+
+
+@dataclass(frozen=True)
+class DoctorReport:
+    """Aggregated result of all pipeline invariant checks."""
+
+    invariants: list[InvariantResult]
+    transaction_count: int

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -29,6 +29,21 @@ class DoctorReport:
     invariants: list[InvariantResult]
     transaction_count: int
 
+    @property
+    def failing(self) -> int:
+        """Count of invariants with status 'fail'."""
+        return sum(1 for r in self.invariants if r.status == "fail")
+
+    @property
+    def warning(self) -> int:
+        """Count of invariants with status 'warn'."""
+        return sum(1 for r in self.invariants if r.status == "warn")
+
+    @property
+    def passing(self) -> int:
+        """Count of invariants with status 'pass'."""
+        return sum(1 for r in self.invariants if r.status == "pass")
+
 
 class DoctorService:
     """Run pipeline integrity invariants and aggregate results."""

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -6,6 +6,9 @@ import logging
 from dataclasses import dataclass
 from typing import Literal
 
+from moneybin.database import Database, sqlmesh_context
+from moneybin.tables import FCT_TRANSACTIONS
+
 logger = logging.getLogger(__name__)
 
 
@@ -25,3 +28,108 @@ class DoctorReport:
 
     invariants: list[InvariantResult]
     transaction_count: int
+
+
+class DoctorService:
+    """Run pipeline integrity invariants and aggregate results."""
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    def run_all(self, verbose: bool = False) -> DoctorReport:
+        """Run all invariants and return a DoctorReport."""
+        transaction_count = self._get_transaction_count()
+        sqlmesh_results = self._run_sqlmesh_audits(verbose)
+        staging = self._run_staging_coverage()
+        categorization = self._run_categorization_coverage()
+        invariants = [*sqlmesh_results, staging, categorization]
+        return DoctorReport(invariants=invariants, transaction_count=transaction_count)
+
+    def _get_transaction_count(self) -> int:
+        try:
+            row = self._db.execute(
+                f"SELECT COUNT(*) FROM {FCT_TRANSACTIONS.full_name}"  # noqa: S608 — TableRef constant
+            ).fetchone()
+            return int(row[0]) if row else 0
+        except Exception:  # noqa: BLE001 — core schema may not exist before first transform
+            return 0
+
+    def _run_sqlmesh_audits(self, verbose: bool) -> list[InvariantResult]:
+        """Discover and run all named SQLMesh standalone audits."""
+        results: list[InvariantResult] = []
+        try:
+            with sqlmesh_context() as ctx:
+                for name, audit in ctx.standalone_audits.items():
+                    sql = audit.render_audit_query().sql(dialect="duckdb")
+                    rows = self._db.execute(sql).fetchall()  # noqa: S608 — rendered from trusted audit files
+                    if rows:
+                        affected = [str(r[0]) for r in rows] if verbose else []
+                        results.append(InvariantResult(
+                            name=name,
+                            status="fail",
+                            detail=f"{len(rows)} violation(s)",
+                            affected_ids=affected,
+                        ))
+                    else:
+                        results.append(InvariantResult(
+                            name=name,
+                            status="pass",
+                            detail=None,
+                            affected_ids=[],
+                        ))
+        except Exception as e:  # noqa: BLE001 — SQLMesh raises broad exceptions
+            logger.warning(f"SQLMesh audit discovery failed: {e}")
+        return results
+
+    def _run_staging_coverage(self) -> InvariantResult:
+        # app.match_decisions has no is_primary column — cannot compute
+        # dedup secondary count. Mark skipped rather than silently wrong.
+        # Revisit when match_decisions gains a primary/secondary designation.
+        return InvariantResult(
+            name="staging_coverage",
+            status="skipped",
+            detail="requires is_primary column in app.match_decisions — schema not yet available",
+            affected_ids=[],
+        )
+
+    def _run_categorization_coverage(self) -> InvariantResult:
+        """Warn (not fail) when <50% of non-transfer transactions are categorized."""
+        try:
+            row = self._db.execute(
+                f"""
+                SELECT
+                    COUNT(*) FILTER (WHERE category IS NULL) AS uncategorized,
+                    COUNT(*) AS total
+                FROM {FCT_TRANSACTIONS.full_name}
+                WHERE NOT COALESCE(is_transfer, FALSE)
+                """  # noqa: S608 — TableRef constant, not user input
+            ).fetchone()
+        except Exception:  # noqa: BLE001 — core schema may not exist before first transform
+            return InvariantResult(
+                name="categorization_coverage",
+                status="skipped",
+                detail="fct_transactions not available",
+                affected_ids=[],
+            )
+        if not row or row[1] == 0:
+            return InvariantResult(
+                name="categorization_coverage",
+                status="pass",
+                detail=None,
+                affected_ids=[],
+            )
+        uncategorized, total = int(row[0]), int(row[1])
+        pct_categorized = round((total - uncategorized) / total * 100)
+        if pct_categorized < 50:
+            return InvariantResult(
+                name="categorization_coverage",
+                status="warn",
+                detail=f"{100 - pct_categorized}% of non-transfer transactions are uncategorized",
+                affected_ids=[],
+            )
+        return InvariantResult(
+            name="categorization_coverage",
+            status="pass",
+            detail=None,
+            affected_ids=[],
+        )

--- a/tests/e2e/test_e2e_doctor.py
+++ b/tests/e2e/test_e2e_doctor.py
@@ -19,6 +19,7 @@ pytestmark = pytest.mark.e2e
 
 class TestDoctorCommand:
     """E2E tests for the `moneybin doctor` command."""
+
     def test_doctor_help(self) -> None:
         result = run_cli("doctor", "--help")
         result.assert_success()
@@ -51,7 +52,9 @@ class TestDoctorCommand:
         result = run_cli("doctor", "--verbose", env=e2e_profile)
         assert "Traceback" not in result.stderr
 
-    def test_doctor_json_verbose_flag_accepted(self, e2e_profile: dict[str, str]) -> None:
+    def test_doctor_json_verbose_flag_accepted(
+        self, e2e_profile: dict[str, str]
+    ) -> None:
         result = run_cli("doctor", "--output", "json", "--verbose", env=e2e_profile)
         assert "Traceback" not in result.stderr
         envelope = json.loads(result.stdout)

--- a/tests/e2e/test_e2e_doctor.py
+++ b/tests/e2e/test_e2e_doctor.py
@@ -18,6 +18,7 @@ pytestmark = pytest.mark.e2e
 
 
 class TestDoctorCommand:
+    """E2E tests for the `moneybin doctor` command."""
     def test_doctor_help(self) -> None:
         result = run_cli("doctor", "--help")
         result.assert_success()

--- a/tests/e2e/test_e2e_doctor.py
+++ b/tests/e2e/test_e2e_doctor.py
@@ -1,0 +1,57 @@
+# ruff: noqa: S101
+"""E2E tests for `moneybin doctor`.
+
+doctor is read-only, so it uses the shared e2e_profile fixture (no mutations).
+The clean profile has no transactions, so all SQLMesh audits and the
+categorization check pass trivially (0 of 0 is not < 50%).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.e2e.conftest import run_cli
+
+pytestmark = pytest.mark.e2e
+
+
+class TestDoctorCommand:
+    def test_doctor_help(self) -> None:
+        result = run_cli("doctor", "--help")
+        result.assert_success()
+        assert "--verbose" in result.output
+        assert "--output" in result.output
+
+    def test_doctor_clean_profile_exits_0(self, e2e_profile: dict[str, str]) -> None:
+        """A freshly initialized profile has no data — all audits pass (no violations)."""
+        result = run_cli("doctor", env=e2e_profile)
+        # SQLMesh may not have audits available if transform was never run;
+        # the command must not crash regardless.
+        assert "Traceback" not in result.stderr
+        # exit 0 (pass) or 1 (fail with real violations) — never crash
+        assert result.exit_code in (0, 1)
+
+    def test_doctor_json_output_shape(self, e2e_profile: dict[str, str]) -> None:
+        result = run_cli("doctor", "--output", "json", env=e2e_profile)
+        assert "Traceback" not in result.stderr
+        # JSON must parse and have the standard envelope shape
+        envelope = json.loads(result.stdout)
+        assert "summary" in envelope
+        assert "data" in envelope
+        data = envelope["data"]
+        assert "invariants" in data
+        assert "transaction_count" in data
+        assert "passing" in data
+        assert "failing" in data
+
+    def test_doctor_verbose_flag_accepted(self, e2e_profile: dict[str, str]) -> None:
+        result = run_cli("doctor", "--verbose", env=e2e_profile)
+        assert "Traceback" not in result.stderr
+
+    def test_doctor_json_verbose_flag_accepted(self, e2e_profile: dict[str, str]) -> None:
+        result = run_cli("doctor", "--output", "json", "--verbose", env=e2e_profile)
+        assert "Traceback" not in result.stderr
+        envelope = json.loads(result.stdout)
+        assert "data" in envelope

--- a/tests/e2e/test_e2e_help.py
+++ b/tests/e2e/test_e2e_help.py
@@ -86,6 +86,7 @@ _HELP_COMMANDS: list[list[str]] = [
     ["db", "key"],
     ["db", "migrate"],
     ["logs"],
+    ["doctor"],
     ["mcp"],
     ["mcp", "config"],
     ["stats"],

--- a/tests/moneybin/test_cli/test_cli_output_quiet.py
+++ b/tests/moneybin/test_cli/test_cli_output_quiet.py
@@ -37,6 +37,7 @@ _READ_ONLY_HELP_PATHS: list[list[str]] = [
     ["db", "migrate", "status", "--help"],
     ["stats", "--help"],
     ["logs", "--help"],
+    ["doctor", "--help"],
 ]
 
 

--- a/tests/moneybin/test_cli/test_doctor.py
+++ b/tests/moneybin/test_cli/test_doctor.py
@@ -27,7 +27,9 @@ _PASSING_REPORT = DoctorReport(
 _FAILING_REPORT = DoctorReport(
     invariants=[
         InvariantResult("fct_transactions_fk_integrity", "pass", None, []),
-        InvariantResult("fct_transactions_sign_convention", "fail", "1 violation(s)", []),
+        InvariantResult(
+            "fct_transactions_sign_convention", "fail", "1 violation(s)", []
+        ),
         InvariantResult("bridge_transfers_balanced", "pass", None, []),
         InvariantResult("categorization_coverage", "warn", "80% uncategorized", []),
         InvariantResult("staging_coverage", "skipped", "no is_primary column", []),
@@ -125,8 +127,7 @@ def test_doctor_json_verbose_includes_affected_ids(
     verbose_report = DoctorReport(
         invariants=[
             InvariantResult(
-                "fct_transactions_fk_integrity", "fail",
-                "1 violation(s)", ["abc123"]
+                "fct_transactions_fk_integrity", "fail", "1 violation(s)", ["abc123"]
             ),
         ],
         transaction_count=5,

--- a/tests/moneybin/test_cli/test_doctor.py
+++ b/tests/moneybin/test_cli/test_doctor.py
@@ -1,0 +1,140 @@
+"""Unit tests for the `doctor` CLI command."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from moneybin.cli.main import app
+from moneybin.services.doctor_service import DoctorReport, InvariantResult
+
+runner = CliRunner()
+
+_PASSING_REPORT = DoctorReport(
+    invariants=[
+        InvariantResult("fct_transactions_fk_integrity", "pass", None, []),
+        InvariantResult("fct_transactions_sign_convention", "pass", None, []),
+        InvariantResult("bridge_transfers_balanced", "pass", None, []),
+        InvariantResult("categorization_coverage", "pass", None, []),
+        InvariantResult("staging_coverage", "skipped", "no is_primary column", []),
+    ],
+    transaction_count=100,
+)
+
+_FAILING_REPORT = DoctorReport(
+    invariants=[
+        InvariantResult("fct_transactions_fk_integrity", "pass", None, []),
+        InvariantResult("fct_transactions_sign_convention", "fail", "1 violation(s)", []),
+        InvariantResult("bridge_transfers_balanced", "pass", None, []),
+        InvariantResult("categorization_coverage", "warn", "80% uncategorized", []),
+        InvariantResult("staging_coverage", "skipped", "no is_primary column", []),
+    ],
+    transaction_count=50,
+)
+
+
+@pytest.mark.unit
+def test_doctor_help_exits_cleanly() -> None:
+    result = runner.invoke(app, ["doctor", "--help"])
+    assert result.exit_code == 0
+    assert "--verbose" in result.output
+    assert "--output" in result.output
+
+
+@patch("moneybin.cli.utils.get_database")
+@patch("moneybin.cli.commands.doctor.DoctorService")
+def test_doctor_exits_0_when_all_pass(
+    mock_svc_cls: MagicMock, mock_get_db: MagicMock
+) -> None:
+    mock_get_db.return_value = MagicMock()
+    mock_svc_cls.return_value.run_all.return_value = _PASSING_REPORT
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0
+    assert "✅" in result.output
+
+
+@patch("moneybin.cli.utils.get_database")
+@patch("moneybin.cli.commands.doctor.DoctorService")
+def test_doctor_exits_1_when_any_fail(
+    mock_svc_cls: MagicMock, mock_get_db: MagicMock
+) -> None:
+    mock_get_db.return_value = MagicMock()
+    mock_svc_cls.return_value.run_all.return_value = _FAILING_REPORT
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 1
+
+
+@patch("moneybin.cli.utils.get_database")
+@patch("moneybin.cli.commands.doctor.DoctorService")
+def test_doctor_json_output_shape(
+    mock_svc_cls: MagicMock, mock_get_db: MagicMock
+) -> None:
+    mock_get_db.return_value = MagicMock()
+    mock_svc_cls.return_value.run_all.return_value = _PASSING_REPORT
+    result = runner.invoke(app, ["doctor", "--output", "json"])
+    assert result.exit_code == 0
+    envelope = json.loads(result.stdout)
+    assert "summary" in envelope
+    assert "data" in envelope
+    data = envelope["data"]
+    assert "passing" in data
+    assert "failing" in data
+    assert "warning" in data
+    assert "transaction_count" in data
+    assert "invariants" in data
+    assert len(data["invariants"]) == 5
+
+
+@patch("moneybin.cli.utils.get_database")
+@patch("moneybin.cli.commands.doctor.DoctorService")
+def test_doctor_verbose_passes_flag_to_service(
+    mock_svc_cls: MagicMock, mock_get_db: MagicMock
+) -> None:
+    mock_get_db.return_value = MagicMock()
+    mock_svc_cls.return_value.run_all.return_value = _PASSING_REPORT
+    runner.invoke(app, ["doctor", "--verbose"])
+    mock_svc_cls.return_value.run_all.assert_called_once_with(verbose=True)
+
+
+@patch("moneybin.cli.utils.get_database")
+@patch("moneybin.cli.commands.doctor.DoctorService")
+def test_doctor_warn_only_exits_0(
+    mock_svc_cls: MagicMock, mock_get_db: MagicMock
+) -> None:
+    """warn-only status → exit 0 (not a hard failure)."""
+    warn_report = DoctorReport(
+        invariants=[
+            InvariantResult("categorization_coverage", "warn", "80% uncategorized", []),
+        ],
+        transaction_count=10,
+    )
+    mock_get_db.return_value = MagicMock()
+    mock_svc_cls.return_value.run_all.return_value = warn_report
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0
+
+
+@patch("moneybin.cli.utils.get_database")
+@patch("moneybin.cli.commands.doctor.DoctorService")
+def test_doctor_json_verbose_includes_affected_ids(
+    mock_svc_cls: MagicMock, mock_get_db: MagicMock
+) -> None:
+    verbose_report = DoctorReport(
+        invariants=[
+            InvariantResult(
+                "fct_transactions_fk_integrity", "fail",
+                "1 violation(s)", ["abc123"]
+            ),
+        ],
+        transaction_count=5,
+    )
+    mock_get_db.return_value = MagicMock()
+    mock_svc_cls.return_value.run_all.return_value = verbose_report
+    result = runner.invoke(app, ["doctor", "--output", "json", "--verbose"])
+    assert result.exit_code == 1
+    envelope = json.loads(result.stdout)
+    inv = envelope["data"]["invariants"][0]
+    assert inv["affected_ids"] == ["abc123"]

--- a/tests/moneybin/test_mcp/test_system_tools.py
+++ b/tests/moneybin/test_mcp/test_system_tools.py
@@ -76,3 +76,46 @@ async def test_register_system_tools() -> None:
     register_system_tools(srv)
     names = {t.name for t in await srv._list_tools()}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     assert "system_status" in names
+
+
+# ── system_doctor ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+async def test_system_doctor_returns_envelope(mcp_db: object) -> None:
+    from moneybin.mcp.tools.system import system_doctor
+
+    result = await system_doctor()
+    parsed = result.to_dict()
+    assert "summary" in parsed
+    assert "data" in parsed
+
+
+@pytest.mark.unit
+async def test_system_doctor_data_has_required_keys(mcp_db: object) -> None:
+    from moneybin.mcp.tools.system import system_doctor
+
+    result = await system_doctor()
+    data = result.to_dict()["data"]
+    assert "passing" in data
+    assert "failing" in data
+    assert "warning" in data
+    assert "transaction_count" in data
+    assert "invariants" in data
+
+
+@pytest.mark.unit
+async def test_system_doctor_transaction_count_is_int(mcp_db: object) -> None:
+    from moneybin.mcp.tools.system import system_doctor
+
+    result = await system_doctor()
+    data = result.to_dict()["data"]
+    assert isinstance(data["transaction_count"], int)
+
+
+@pytest.mark.unit
+async def test_system_doctor_sensitivity_is_low(mcp_db: object) -> None:
+    from moneybin.mcp.tools.system import system_doctor
+
+    result = await system_doctor()
+    assert result.to_dict()["summary"]["sensitivity"] == "low"

--- a/tests/moneybin/test_services/test_doctor_service.py
+++ b/tests/moneybin/test_services/test_doctor_service.py
@@ -352,3 +352,59 @@ def test_categorization_coverage_warns_when_below_50pct(
     cat = next(r for r in report.invariants if r.name == "categorization_coverage")
     assert cat.status == "warn"
     assert "uncategorized" in (cat.detail or "").lower()
+
+
+@pytest.mark.unit
+def test_run_all_returns_5_invariants(
+    doctor_db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mock_ctx = _make_mock_ctx(_CLEAN_AUDITS)
+
+    @contextmanager
+    def _fake_ctx(*args: Any, **kwargs: Any) -> Generator[Any, None, None]:
+        yield mock_ctx
+
+    monkeypatch.setattr("moneybin.services.doctor_service.sqlmesh_context", _fake_ctx)
+    svc = DoctorService(doctor_db)
+    report = svc.run_all()
+    assert len(report.invariants) == 5
+    names = [r.name for r in report.invariants]
+    assert "fct_transactions_fk_integrity" in names
+    assert "fct_transactions_sign_convention" in names
+    assert "bridge_transfers_balanced" in names
+    assert "staging_coverage" in names
+    assert "categorization_coverage" in names
+
+
+@pytest.mark.unit
+def test_fk_detail_message_contains_count(
+    doctor_db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    doctor_db.execute("""
+        INSERT INTO core.fct_transactions (
+            transaction_id, account_id, transaction_date, amount,
+            amount_absolute, transaction_direction, description,
+            transaction_type, is_pending, currency_code, source_type,
+            source_extracted_at, loaded_at,
+            transaction_year, transaction_month, transaction_day,
+            transaction_day_of_week, transaction_year_month, transaction_year_quarter
+        ) VALUES
+        ('BAD1', 'NONE', '2026-05-01', -1.00, 1.00, 'expense', 'Bad',
+         'DEBIT', false, 'USD', 'ofx', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
+         2026, 5, 1, 4, '2026-05', '2026-Q2'),
+        ('BAD2', 'NONE', '2026-05-02', -2.00, 2.00, 'expense', 'Bad2',
+         'DEBIT', false, 'USD', 'ofx', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
+         2026, 5, 2, 5, '2026-05', '2026-Q2')
+    """)  # noqa: S608 — test input, not user data
+    mock_ctx = _make_mock_ctx(_CLEAN_AUDITS)
+
+    @contextmanager
+    def _fake_ctx(*args: Any, **kwargs: Any) -> Generator[Any, None, None]:
+        yield mock_ctx
+
+    monkeypatch.setattr("moneybin.services.doctor_service.sqlmesh_context", _fake_ctx)
+    svc = DoctorService(doctor_db)
+    report = svc.run_all()
+    fk = next(r for r in report.invariants if r.name == "fct_transactions_fk_integrity")
+    assert fk.status == "fail"
+    assert "2" in (fk.detail or "")

--- a/tests/moneybin/test_services/test_doctor_service.py
+++ b/tests/moneybin/test_services/test_doctor_service.py
@@ -257,7 +257,9 @@ def test_sign_convention_fails_zero_amount(
     monkeypatch.setattr("moneybin.services.doctor_service.sqlmesh_context", _fake_ctx)
     svc = DoctorService(doctor_db)
     report = svc.run_all(verbose=True)
-    sign = next(r for r in report.invariants if r.name == "fct_transactions_sign_convention")
+    sign = next(
+        r for r in report.invariants if r.name == "fct_transactions_sign_convention"
+    )
     assert sign.status == "fail"
     assert "ZERO" in sign.affected_ids
 

--- a/tests/moneybin/test_services/test_doctor_service.py
+++ b/tests/moneybin/test_services/test_doctor_service.py
@@ -292,3 +292,63 @@ def test_verbose_false_returns_empty_affected_ids(
     fk = next(r for r in report.invariants if r.name == "fct_transactions_fk_integrity")
     assert fk.status == "fail"
     assert fk.affected_ids == []  # verbose=False → no IDs
+
+
+@pytest.mark.unit
+def test_staging_coverage_is_always_skipped(
+    doctor_db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mock_ctx = _make_mock_ctx(_CLEAN_AUDITS)
+
+    @contextmanager
+    def _fake_ctx(*args: Any, **kwargs: Any) -> Generator[Any, None, None]:
+        yield mock_ctx
+
+    monkeypatch.setattr("moneybin.services.doctor_service.sqlmesh_context", _fake_ctx)
+    svc = DoctorService(doctor_db)
+    report = svc.run_all()
+    staging = next(r for r in report.invariants if r.name == "staging_coverage")
+    assert staging.status == "skipped"
+    assert staging.detail is not None
+
+
+@pytest.mark.unit
+def test_categorization_coverage_passes_when_all_categorized(
+    doctor_db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Set category on all non-transfer transactions
+    doctor_db.execute("""
+        UPDATE core.fct_transactions
+        SET category = 'Food & Drink'
+        WHERE transaction_id IN ('T1', 'T2')
+    """)  # noqa: S608 — test input, not user data
+    mock_ctx = _make_mock_ctx(_CLEAN_AUDITS)
+
+    @contextmanager
+    def _fake_ctx(*args: Any, **kwargs: Any) -> Generator[Any, None, None]:
+        yield mock_ctx
+
+    monkeypatch.setattr("moneybin.services.doctor_service.sqlmesh_context", _fake_ctx)
+    svc = DoctorService(doctor_db)
+    report = svc.run_all()
+    cat = next(r for r in report.invariants if r.name == "categorization_coverage")
+    assert cat.status == "pass"
+
+
+@pytest.mark.unit
+def test_categorization_coverage_warns_when_below_50pct(
+    doctor_db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # T1 and T2 have no category (default NULL) — 0% categorized → warn
+    mock_ctx = _make_mock_ctx(_CLEAN_AUDITS)
+
+    @contextmanager
+    def _fake_ctx(*args: Any, **kwargs: Any) -> Generator[Any, None, None]:
+        yield mock_ctx
+
+    monkeypatch.setattr("moneybin.services.doctor_service.sqlmesh_context", _fake_ctx)
+    svc = DoctorService(doctor_db)
+    report = svc.run_all()
+    cat = next(r for r in report.invariants if r.name == "categorization_coverage")
+    assert cat.status == "warn"
+    assert "uncategorized" in (cat.detail or "").lower()

--- a/tests/moneybin/test_services/test_doctor_service.py
+++ b/tests/moneybin/test_services/test_doctor_service.py
@@ -410,3 +410,68 @@ def test_fk_detail_message_contains_count(
     fk = next(r for r in report.invariants if r.name == "fct_transactions_fk_integrity")
     assert fk.status == "fail"
     assert "2" in (fk.detail or "")
+
+
+@pytest.mark.unit
+def test_bridge_transfers_balanced_fails_unbalanced_pair(
+    doctor_db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Insert a debit+credit pair where |debit.amount + credit.amount| > 0.01.
+    # Debit: -100.00, Credit: +99.00 → net = -1.00 → imbalanced.
+    doctor_db.execute("""
+        INSERT INTO core.fct_transactions (
+            transaction_id, account_id, transaction_date, amount,
+            amount_absolute, transaction_direction, description,
+            transaction_type, is_pending, currency_code, source_type,
+            source_extracted_at, loaded_at,
+            transaction_year, transaction_month, transaction_day,
+            transaction_day_of_week, transaction_year_month, transaction_year_quarter
+        ) VALUES
+        ('DEBIT1', 'ACC1', '2026-04-01', -100.00, 100.00, 'expense', 'Transfer out',
+         'DEBIT', false, 'USD', 'ofx', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
+         2026, 4, 1, 2, '2026-04', '2026-Q2'),
+        ('CREDIT1', 'ACC1', '2026-04-01', 99.00, 99.00, 'income', 'Transfer in',
+         'CREDIT', false, 'USD', 'ofx', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
+         2026, 4, 1, 2, '2026-04', '2026-Q2')
+    """)  # noqa: S608 — test input, not user data
+    doctor_db.execute("""
+        INSERT INTO core.bridge_transfers (
+            transfer_id, debit_transaction_id, credit_transaction_id,
+            date_offset_days, amount
+        ) VALUES ('XFR1', 'DEBIT1', 'CREDIT1', 0, 100.00)
+    """)  # noqa: S608 — test input, not user data
+    mock_ctx = _make_mock_ctx(_CLEAN_AUDITS)
+
+    @contextmanager
+    def _fake_ctx(*args: Any, **kwargs: Any) -> Generator[Any, None, None]:
+        yield mock_ctx
+
+    monkeypatch.setattr("moneybin.services.doctor_service.sqlmesh_context", _fake_ctx)
+    svc = DoctorService(doctor_db)
+    report = svc.run_all(verbose=True)
+    xfr = next(r for r in report.invariants if r.name == "bridge_transfers_balanced")
+    assert xfr.status == "fail"
+    assert "DEBIT1" in xfr.affected_ids
+
+
+@pytest.mark.unit
+def test_sqlmesh_discovery_failure_emits_skipped_invariant(
+    doctor_db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    @contextmanager
+    def _failing_ctx(*args: Any, **kwargs: Any) -> Generator[Any, None, None]:
+        msg = "SQLMesh config not found"
+        raise RuntimeError(msg)
+        yield  # noqa: unreachable — satisfies generator type
+
+    monkeypatch.setattr(
+        "moneybin.services.doctor_service.sqlmesh_context", _failing_ctx
+    )
+    svc = DoctorService(doctor_db)
+    report = svc.run_all()
+    skipped = next(
+        (r for r in report.invariants if r.name == "sqlmesh_audits_unavailable"), None
+    )
+    assert skipped is not None
+    assert skipped.status == "skipped"
+    assert "SQLMesh" in (skipped.detail or "")

--- a/tests/moneybin/test_services/test_doctor_service.py
+++ b/tests/moneybin/test_services/test_doctor_service.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
+import dataclasses
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
 import pytest
 
-from moneybin.services.doctor_service import DoctorReport, InvariantResult
+import moneybin.database as db_module
+from moneybin.database import Database
+from moneybin.services.doctor_service import DoctorReport, DoctorService, InvariantResult
+from tests.moneybin.db_helpers import create_core_tables
 
 
 @pytest.mark.unit
@@ -36,7 +46,7 @@ def test_invariant_result_fail_has_detail() -> None:
 @pytest.mark.unit
 def test_invariant_result_is_frozen() -> None:
     result = InvariantResult(name="x", status="pass", detail=None, affected_ids=[])
-    with pytest.raises(Exception):
+    with pytest.raises(dataclasses.FrozenInstanceError):
         result.name = "y"  # type: ignore[misc]
 
 
@@ -51,5 +61,230 @@ def test_doctor_report_holds_invariants() -> None:
 @pytest.mark.unit
 def test_doctor_report_is_frozen() -> None:
     report = DoctorReport(invariants=[], transaction_count=0)
-    with pytest.raises(Exception):
+    with pytest.raises(dataclasses.FrozenInstanceError):
         report.transaction_count = 1  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# DoctorService tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def doctor_db(tmp_path: Path) -> Generator[Database, None, None]:
+    """Minimal DB with core tables for DoctorService tests."""
+    mock_store = MagicMock()
+    mock_store.get_key.return_value = "test-encryption-key-256bit-placeholder"
+    database = Database(
+        tmp_path / "doctor.duckdb",
+        secret_store=mock_store,
+        no_auto_upgrade=True,
+    )
+    create_core_tables(database)
+    # Seed one valid account and two transactions (both resolve)
+    database.execute("""
+        INSERT INTO core.dim_accounts (
+            account_id, routing_number, account_type, institution_name,
+            institution_fid, source_type, source_file, extracted_at, loaded_at,
+            updated_at, display_name, iso_currency_code,
+            archived, include_in_net_worth
+        ) VALUES ('ACC1', '111', 'CHECKING', 'Bank', 'fid', 'ofx',
+                  'a.qfx', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
+                  CURRENT_TIMESTAMP, 'Bank CHECKING', 'USD', FALSE, TRUE)
+    """)  # noqa: S608 — test input, not user data
+    database.execute("""
+        INSERT INTO core.fct_transactions (
+            transaction_id, account_id, transaction_date, amount,
+            amount_absolute, transaction_direction, description,
+            transaction_type, is_pending, currency_code, source_type,
+            source_extracted_at, loaded_at,
+            transaction_year, transaction_month, transaction_day,
+            transaction_day_of_week, transaction_year_month,
+            transaction_year_quarter
+        ) VALUES
+        ('T1', 'ACC1', '2026-01-01', -50.00, 50.00, 'expense', 'Coffee',
+         'DEBIT', false, 'USD', 'ofx', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
+         2026, 1, 1, 3, '2026-01', '2026-Q1'),
+        ('T2', 'ACC1', '2026-01-02', 1000.00, 1000.00, 'income', 'Paycheck',
+         'CREDIT', false, 'USD', 'ofx', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
+         2026, 1, 2, 4, '2026-01', '2026-Q1')
+    """)  # noqa: S608 — test input, not user data
+    db_module._database_instance = database  # type: ignore[attr-defined]
+    yield database
+    db_module._database_instance = None  # type: ignore[attr-defined]
+    database.close()
+
+
+def _make_mock_ctx(audits: dict[str, tuple[str, str]]) -> Any:
+    """Build a mock SQLMesh Context where each audit renders to given SQL."""
+    mock_ctx = MagicMock()
+    audit_mocks = {}
+    for name, (sql, _dialect) in audits.items():
+        audit = MagicMock()
+        audit.name = name
+        audit.render_audit_query.return_value.sql.return_value = sql
+        audit_mocks[name] = audit
+    mock_ctx.standalone_audits = audit_mocks
+    return mock_ctx
+
+
+_FK_SQL = """
+    SELECT t.transaction_id
+    FROM core.fct_transactions AS t
+    LEFT JOIN core.dim_accounts AS a ON t.account_id = a.account_id
+    WHERE a.account_id IS NULL
+    ORDER BY t.transaction_id
+"""  # noqa: S608 — test SQL
+
+_SIGN_SQL = """
+    SELECT transaction_id
+    FROM core.fct_transactions
+    WHERE amount = 0 OR amount IS NULL
+    ORDER BY transaction_id
+"""  # noqa: S608 — test SQL
+
+_TRANSFER_SQL = """
+    SELECT bt.debit_transaction_id
+    FROM core.bridge_transfers AS bt
+    JOIN core.fct_transactions AS d ON bt.debit_transaction_id = d.transaction_id
+    JOIN core.fct_transactions AS c ON bt.credit_transaction_id = c.transaction_id
+    WHERE ABS(d.amount + c.amount) > 0.01
+    ORDER BY bt.debit_transaction_id
+"""  # noqa: S608 — test SQL
+
+_CLEAN_AUDITS = {
+    "fct_transactions_fk_integrity": (_FK_SQL, "duckdb"),
+    "fct_transactions_sign_convention": (_SIGN_SQL, "duckdb"),
+    "bridge_transfers_balanced": (_TRANSFER_SQL, "duckdb"),
+}
+
+
+@pytest.mark.unit
+def test_transaction_count_returns_correct_count(
+    doctor_db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mock_ctx = _make_mock_ctx(_CLEAN_AUDITS)
+
+    @contextmanager
+    def _fake_ctx(*args: Any, **kwargs: Any) -> Generator[Any, None, None]:
+        yield mock_ctx
+
+    monkeypatch.setattr("moneybin.services.doctor_service.sqlmesh_context", _fake_ctx)
+    svc = DoctorService(doctor_db)
+    report = svc.run_all(verbose=False)
+    assert report.transaction_count == 2
+
+
+@pytest.mark.unit
+def test_fk_integrity_passes_clean_data(
+    doctor_db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mock_ctx = _make_mock_ctx(_CLEAN_AUDITS)
+
+    @contextmanager
+    def _fake_ctx(*args: Any, **kwargs: Any) -> Generator[Any, None, None]:
+        yield mock_ctx
+
+    monkeypatch.setattr("moneybin.services.doctor_service.sqlmesh_context", _fake_ctx)
+    svc = DoctorService(doctor_db)
+    report = svc.run_all()
+    fk = next(r for r in report.invariants if r.name == "fct_transactions_fk_integrity")
+    assert fk.status == "pass"
+    assert fk.detail is None
+    assert fk.affected_ids == []
+
+
+@pytest.mark.unit
+def test_fk_integrity_fails_orphaned_account(
+    doctor_db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Insert a transaction with an account_id not in dim_accounts
+    doctor_db.execute("""
+        INSERT INTO core.fct_transactions (
+            transaction_id, account_id, transaction_date, amount,
+            amount_absolute, transaction_direction, description,
+            transaction_type, is_pending, currency_code, source_type,
+            source_extracted_at, loaded_at,
+            transaction_year, transaction_month, transaction_day,
+            transaction_day_of_week, transaction_year_month, transaction_year_quarter
+        ) VALUES
+        ('ORPHAN', 'GHOST_ACC', '2026-02-01', -10.00, 10.00, 'expense', 'Ghost',
+         'DEBIT', false, 'USD', 'ofx', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
+         2026, 2, 1, 6, '2026-02', '2026-Q1')
+    """)  # noqa: S608 — test input, not user data
+    mock_ctx = _make_mock_ctx(_CLEAN_AUDITS)
+
+    @contextmanager
+    def _fake_ctx(*args: Any, **kwargs: Any) -> Generator[Any, None, None]:
+        yield mock_ctx
+
+    monkeypatch.setattr("moneybin.services.doctor_service.sqlmesh_context", _fake_ctx)
+    svc = DoctorService(doctor_db)
+    report = svc.run_all(verbose=True)
+    fk = next(r for r in report.invariants if r.name == "fct_transactions_fk_integrity")
+    assert fk.status == "fail"
+    assert "1 transaction" in (fk.detail or "") or "violation" in (fk.detail or "")
+    assert "ORPHAN" in fk.affected_ids
+
+
+@pytest.mark.unit
+def test_sign_convention_fails_zero_amount(
+    doctor_db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    doctor_db.execute("""
+        INSERT INTO core.fct_transactions (
+            transaction_id, account_id, transaction_date, amount,
+            amount_absolute, transaction_direction, description,
+            transaction_type, is_pending, currency_code, source_type,
+            source_extracted_at, loaded_at,
+            transaction_year, transaction_month, transaction_day,
+            transaction_day_of_week, transaction_year_month, transaction_year_quarter
+        ) VALUES
+        ('ZERO', 'ACC1', '2026-03-01', 0.00, 0.00, 'expense', 'Zero',
+         'DEBIT', false, 'USD', 'ofx', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
+         2026, 3, 1, 6, '2026-03', '2026-Q1')
+    """)  # noqa: S608 — test input, not user data
+    mock_ctx = _make_mock_ctx(_CLEAN_AUDITS)
+
+    @contextmanager
+    def _fake_ctx(*args: Any, **kwargs: Any) -> Generator[Any, None, None]:
+        yield mock_ctx
+
+    monkeypatch.setattr("moneybin.services.doctor_service.sqlmesh_context", _fake_ctx)
+    svc = DoctorService(doctor_db)
+    report = svc.run_all(verbose=True)
+    sign = next(r for r in report.invariants if r.name == "fct_transactions_sign_convention")
+    assert sign.status == "fail"
+    assert "ZERO" in sign.affected_ids
+
+
+@pytest.mark.unit
+def test_verbose_false_returns_empty_affected_ids(
+    doctor_db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Insert orphaned transaction to cause a failure
+    doctor_db.execute("""
+        INSERT INTO core.fct_transactions (
+            transaction_id, account_id, transaction_date, amount,
+            amount_absolute, transaction_direction, description,
+            transaction_type, is_pending, currency_code, source_type,
+            source_extracted_at, loaded_at,
+            transaction_year, transaction_month, transaction_day,
+            transaction_day_of_week, transaction_year_month, transaction_year_quarter
+        ) VALUES
+        ('ORPHAN2', 'NO_ACC', '2026-04-01', -5.00, 5.00, 'expense', 'Ghost',
+         'DEBIT', false, 'USD', 'ofx', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
+         2026, 4, 1, 2, '2026-04', '2026-Q2')
+    """)  # noqa: S608 — test input, not user data
+    mock_ctx = _make_mock_ctx(_CLEAN_AUDITS)
+
+    @contextmanager
+    def _fake_ctx(*args: Any, **kwargs: Any) -> Generator[Any, None, None]:
+        yield mock_ctx
+
+    monkeypatch.setattr("moneybin.services.doctor_service.sqlmesh_context", _fake_ctx)
+    svc = DoctorService(doctor_db)
+    report = svc.run_all(verbose=False)
+    fk = next(r for r in report.invariants if r.name == "fct_transactions_fk_integrity")
+    assert fk.status == "fail"
+    assert fk.affected_ids == []  # verbose=False → no IDs

--- a/tests/moneybin/test_services/test_doctor_service.py
+++ b/tests/moneybin/test_services/test_doctor_service.py
@@ -13,7 +13,11 @@ import pytest
 
 import moneybin.database as db_module
 from moneybin.database import Database
-from moneybin.services.doctor_service import DoctorReport, DoctorService, InvariantResult
+from moneybin.services.doctor_service import (
+    DoctorReport,
+    DoctorService,
+    InvariantResult,
+)
 from tests.moneybin.db_helpers import create_core_tables
 
 

--- a/tests/moneybin/test_services/test_doctor_service.py
+++ b/tests/moneybin/test_services/test_doctor_service.py
@@ -1,0 +1,55 @@
+"""Unit tests for DoctorService — pipeline invariant checks."""
+
+from __future__ import annotations
+
+import pytest
+
+from moneybin.services.doctor_service import DoctorReport, InvariantResult
+
+
+@pytest.mark.unit
+def test_invariant_result_pass_has_no_detail() -> None:
+    result = InvariantResult(
+        name="test_audit",
+        status="pass",
+        detail=None,
+        affected_ids=[],
+    )
+    assert result.status == "pass"
+    assert result.detail is None
+    assert result.affected_ids == []
+
+
+@pytest.mark.unit
+def test_invariant_result_fail_has_detail() -> None:
+    result = InvariantResult(
+        name="test_audit",
+        status="fail",
+        detail="2 violations found",
+        affected_ids=["abc123"],
+    )
+    assert result.status == "fail"
+    assert result.detail == "2 violations found"
+    assert result.affected_ids == ["abc123"]
+
+
+@pytest.mark.unit
+def test_invariant_result_is_frozen() -> None:
+    result = InvariantResult(name="x", status="pass", detail=None, affected_ids=[])
+    with pytest.raises(Exception):
+        result.name = "y"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_doctor_report_holds_invariants() -> None:
+    r = InvariantResult(name="a", status="pass", detail=None, affected_ids=[])
+    report = DoctorReport(invariants=[r], transaction_count=42)
+    assert len(report.invariants) == 1
+    assert report.transaction_count == 42
+
+
+@pytest.mark.unit
+def test_doctor_report_is_frozen() -> None:
+    report = DoctorReport(invariants=[], transaction_count=0)
+    with pytest.raises(Exception):
+        report.transaction_count = 1  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Implements the `moneybin doctor` command ([spec](docs/specs/moneybin-doctor.md)), a read-only pipeline integrity checker that auto-discovers SQLMesh named audits and runs a fixed set of coverage invariants. Also exposes a `system_doctor` MCP tool so agents can query pipeline health without opening a shell.

## Impact

- New CLI command: `moneybin doctor [--verbose] [--output json]`
- New MCP tool: `system_doctor` (sensitivity: low, read-only)
- No breaking changes; no schema migrations

## Changes

#### SQLMesh named audits
Three standalone SQL audits under `sqlmesh/audits/` that DoctorService auto-discovers at runtime:
- `fct_transactions_fk_integrity` — orphaned account_id references
- `fct_transactions_sign_convention` — zero/null amount violations
- `bridge_transfers_balanced` — transfer pairs where debit + credit don't net to zero within $0.01

#### DoctorService (`src/moneybin/services/doctor_service.py`)
- `InvariantResult` / `DoctorReport` frozen dataclasses
- `run_all(verbose)` — runs SQLMesh audits + staging coverage + categorization coverage
- `staging_coverage` permanently `skipped` (requires `is_primary` column not yet in `app.match_decisions`)
- `categorization_coverage` warns when <50% of non-transfer transactions are categorized

#### CLI (`src/moneybin/cli/commands/doctor.py`, `main.py`)
- Leaf command registered at `moneybin doctor`
- Exit 0 when all pass/warn; exit 1 on any fail
- `--output json` emits standard response envelope
- `DOCTOR_RUNS_TOTAL` Prometheus counter with `outcome` label

#### MCP (`src/moneybin/mcp/tools/system.py`)
- `system_doctor()` async tool wrapping `DoctorService.run_all()`
- `mcp-tool-surface.md` updated with `system_doctor` entry

#### Tests
- 15 unit tests for `DoctorService` (data model, SQLMesh audit runner, coverage invariants, aggregation)
- 7 CLI unit tests (`CliRunner` with mocked service)
- 4 MCP unit tests (envelope shape, data keys, sensitivity)
- 5 E2E subprocess tests (`test_e2e_doctor.py`)
- `test_e2e_help.py` updated with `doctor` help entry

#### Docs
- `docs/specs/moneybin-doctor.md` → `implemented`
- `docs/specs/INDEX.md` updated
- `CHANGELOG.md` entry under `Unreleased`

## Testing

- `uv run pytest tests/moneybin/test_services/test_doctor_service.py tests/moneybin/test_cli/test_doctor.py tests/moneybin/test_mcp/test_system_tools.py -v` — all pass
- `uv run pytest tests/e2e/test_e2e_doctor.py -m e2e -v` — all pass
- Two pre-existing E2E failures in `test_e2e_mcp.py` (fastmcp version cache sandbox block) are unrelated to this PR and fail identically on `main`

## Notes

`staging_coverage` is permanently `skipped` until `app.match_decisions` gains an `is_primary` column. The skip reason is surfaced in `InvariantResult.detail` and tracked as follow-up work.