### PR TITLE
Fix CI: correct DuckDB CLI PATH, remove skip-if guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install DuckDB CLI
         run: |
           curl -fsSL https://install.duckdb.org | sh
-          echo "$HOME/.duckdb/bin" >> $GITHUB_PATH
+          echo "$HOME/.duckdb/cli/latest" >> $GITHUB_PATH
 
       - name: Lint
         run: uv run ruff check .

--- a/tests/e2e/test_e2e_mutating.py
+++ b/tests/e2e/test_e2e_mutating.py
@@ -8,7 +8,6 @@ other tests. Tests that need a fresh MONEYBIN_HOME use tmp_path
 
 from __future__ import annotations
 
-import shutil
 from pathlib import Path
 
 import pytest
@@ -22,8 +21,6 @@ from tests.e2e.conftest import (
     make_workflow_env_fast,
     run_cli,
 )
-
-_has_duckdb_cli = shutil.which("duckdb") is not None
 
 pytestmark = pytest.mark.e2e
 
@@ -303,7 +300,6 @@ class TestCategorizeMutating:
         result = run_cli("transactions", "categorize", "rules", "apply", env=env)
         result.assert_success()
 
-    @pytest.mark.skipif(not _has_duckdb_cli, reason="DuckDB CLI not installed")
     def test_categorize_auto_review_and_confirm(
         self, _mutating_profile_template: Path, tmp_path: Path
     ) -> None:

--- a/tests/e2e/test_e2e_readonly.py
+++ b/tests/e2e/test_e2e_readonly.py
@@ -9,14 +9,11 @@ Covers three groups:
 
 from __future__ import annotations
 
-import shutil
 from pathlib import Path
 
 import pytest
 
 from tests.e2e.conftest import FIXTURES_DIR, run_cli
-
-_has_duckdb_cli = shutil.which("duckdb") is not None
 
 pytestmark = pytest.mark.e2e
 
@@ -144,7 +141,6 @@ class TestDBReadOnlyCommands:
         result = run_cli("db", "info", env=e2e_profile)
         result.assert_success()
 
-    @pytest.mark.skipif(not _has_duckdb_cli, reason="DuckDB CLI not installed")
     def test_db_query(self, e2e_profile: dict[str, str]) -> None:
         result = run_cli("db", "query", "SELECT 1 AS ok", env=e2e_profile)
         result.assert_success()

--- a/tests/e2e/test_e2e_transaction_curation.py
+++ b/tests/e2e/test_e2e_transaction_curation.py
@@ -11,7 +11,6 @@ and ``app.audit_log`` via ``moneybin db query`` so the entire pipeline (manual w
 from __future__ import annotations
 
 import json
-import shutil
 from pathlib import Path
 from typing import Any
 
@@ -24,11 +23,6 @@ from tests.e2e.conftest import (
 )
 
 pytestmark = pytest.mark.e2e
-
-_has_duckdb_cli = shutil.which("duckdb") is not None
-_skip_no_duckdb = pytest.mark.skipif(
-    not _has_duckdb_cli, reason="duckdb CLI required for SQL verification"
-)
 
 
 def _loads(s: str) -> Any:
@@ -68,7 +62,6 @@ def _bootstrap_account(env: dict[str, str], account_id: str) -> None:
     run_cli("transform", "apply", env=env, timeout=180).assert_success()
 
 
-@_skip_no_duckdb
 class TestManualEntryGoldenPath:
     """Manual entry → transform → query confirms row in core.fct_transactions."""
 
@@ -109,7 +102,6 @@ class TestManualEntryGoldenPath:
         assert "Coffee shop" in str(row["description"])
 
 
-@_skip_no_duckdb
 class TestNotesTagsSplitsGoldenPath:
     """Add notes/tags/splits to a manual transaction → visible via fct LIST columns."""
 
@@ -255,7 +247,6 @@ class TestTagRenameAuditChain:
         )
 
 
-@_skip_no_duckdb
 class TestImportLabelsGoldenPath:
     """CSV import → import labels add → list shows the label."""
 
@@ -302,7 +293,6 @@ class TestImportLabelsGoldenPath:
         assert "needs-review" in labels
 
 
-@_skip_no_duckdb
 @pytest.mark.skip(
     reason=(
         "CategorizationService.set_category emits category.set audit events, "
@@ -383,7 +373,6 @@ class TestCategoryEditAudit:
         assert any(e.get("after_value") for e in cat_sets), cat_sets
 
 
-@_skip_no_duckdb
 @pytest.mark.asyncio
 class TestMCPBulkCreate:
     """MCP transactions_create with 5 entries → all 5 land in core.fct_transactions."""

--- a/tests/e2e/test_e2e_workflows.py
+++ b/tests/e2e/test_e2e_workflows.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import json
-import shutil
 from pathlib import Path
 
 import pytest
@@ -15,8 +14,6 @@ from tests.e2e.conftest import (
     make_workflow_env_fast,
     run_cli,
 )
-
-_has_duckdb_cli = shutil.which("duckdb") is not None
 
 pytestmark = pytest.mark.e2e
 
@@ -47,19 +44,18 @@ class TestSyntheticPipeline:
         result = run_cli("transform", "apply", env=env, timeout=180)
         result.assert_success()
 
-        # Verify core tables have data (requires DuckDB CLI)
-        if _has_duckdb_cli:
-            result = run_cli(
-                "db",
-                "query",
-                "SELECT COUNT(*) AS n FROM core.fct_transactions",
-                "--output",
-                "csv",
-                env=env,
-            )
-            result.assert_success()
-            count = int(result.stdout.strip().split("\n")[-1].strip())
-            assert count > 0, f"Expected rows in core.fct_transactions, got {count}"
+        # Verify core tables have data
+        result = run_cli(
+            "db",
+            "query",
+            "SELECT COUNT(*) AS n FROM core.fct_transactions",
+            "--output",
+            "csv",
+            env=env,
+        )
+        result.assert_success()
+        count = int(result.stdout.strip().split("\n")[-1].strip())
+        assert count > 0, f"Expected rows in core.fct_transactions, got {count}"
 
 
 class TestCSVImportPipeline:
@@ -88,19 +84,18 @@ class TestCSVImportPipeline:
         result = run_cli("transform", "apply", env=env, timeout=180)
         result.assert_success()
 
-        # Verify core tables have data (requires DuckDB CLI)
-        if _has_duckdb_cli:
-            result = run_cli(
-                "db",
-                "query",
-                "SELECT COUNT(*) AS n FROM core.fct_transactions",
-                "--output",
-                "csv",
-                env=env,
-            )
-            result.assert_success()
-            count = int(result.stdout.strip().split("\n")[-1].strip())
-            assert count > 0, f"Expected rows after CSV import, got {count}"
+        # Verify core tables have data
+        result = run_cli(
+            "db",
+            "query",
+            "SELECT COUNT(*) AS n FROM core.fct_transactions",
+            "--output",
+            "csv",
+            env=env,
+        )
+        result.assert_success()
+        count = int(result.stdout.strip().split("\n")[-1].strip())
+        assert count > 0, f"Expected rows after CSV import, got {count}"
 
 
 class TestOFXImportPipeline:
@@ -127,19 +122,18 @@ class TestOFXImportPipeline:
         result = run_cli("transform", "apply", env=env, timeout=180)
         result.assert_success()
 
-        # Verify core tables have data (requires DuckDB CLI)
-        if _has_duckdb_cli:
-            result = run_cli(
-                "db",
-                "query",
-                "SELECT COUNT(*) AS n FROM core.fct_transactions",
-                "--output",
-                "csv",
-                env=env,
-            )
-            result.assert_success()
-            count = int(result.stdout.strip().split("\n")[-1].strip())
-            assert count > 0, f"Expected rows after OFX import, got {count}"
+        # Verify core tables have data
+        result = run_cli(
+            "db",
+            "query",
+            "SELECT COUNT(*) AS n FROM core.fct_transactions",
+            "--output",
+            "csv",
+            env=env,
+        )
+        result.assert_success()
+        count = int(result.stdout.strip().split("\n")[-1].strip())
+        assert count > 0, f"Expected rows after OFX import, got {count}"
 
 
 class TestLockUnlockCycle:
@@ -238,9 +232,6 @@ class TestAutoRulePipeline:
     def test_import_then_promote_proposal(
         self, _mutating_profile_template: Path, e2e_home: Path
     ) -> None:
-        if not _has_duckdb_cli:
-            pytest.skip("DuckDB CLI required to verify rule promotion")
-
         env = make_workflow_env_fast(
             e2e_home, "wf-autorule", _mutating_profile_template
         )


### PR DESCRIPTION
### Summary
PR #126 added the DuckDB CLI install step but pointed `$GITHUB_PATH` at `~/.duckdb/bin`, which the installer never creates. The binary lands at `~/.duckdb/cli/latest/`. Since `duckdb` was never on `PATH`, `shutil.which("duckdb")` returned `None` at module import time and 8 e2e tests silently skipped every run. This PR fixes the path and removes the skip guards so a missing binary fails loudly.

### Impact
No workflow changes for contributors. The 8 previously-silent e2e tests will now run (and fail if `duckdb` is absent instead of skipping).

### Changes
#### CI workflow (`.github/workflows/ci.yml`)
`$HOME/.duckdb/bin` → `$HOME/.duckdb/cli/latest`. The installer itself advertises this path: `export PATH="/home/runner/.duckdb/cli/latest":$PATH`.

#### E2E tests (4 files)
Removed `_has_duckdb_cli`, `_skip_no_duckdb`, all `@pytest.mark.skipif` decorators, inline `if _has_duckdb_cli:` guards, and the `pytest.skip()` early-return. Also removed the now-unused `import shutil` from each file.

### Testing
Diagnosed from CI run logs for PRs #128 and #131: install step succeeded, but `duckdb` was absent from `PATH` in the test step, confirming the path mismatch.

### Notes
Both open PRs (#128 and #131) will need to rebase on `main` to pick up this fix.