### PR TITLE
Parallelize CI test suites into separate jobs

### DIFF
--- a/.claude/commands/fix-ci.md
+++ b/.claude/commands/fix-ci.md
@@ -1,5 +1,14 @@
 Find and fix failures in the latest CI run for a branch.
 
+The `CI` workflow (`ci.yml`) runs these parallel jobs on each PR:
+
+- `checks` — `ruff format --check`, `ruff check`, `pyright`
+- `test-unit` — `pytest tests/moneybin/ -m "not integration and not e2e and not slow"`
+- `test-integration` — `pytest tests/integration/`
+- `test-e2e` — `pytest tests/e2e/`
+
+Any of them can fail independently. This command handles all of them. For `Scenarios` workflow failures use `/fix-scenarios`; for `Security` workflow findings use `/fix-security`.
+
 ## Usage
 
 - `/fix-ci` — fix the current branch
@@ -21,35 +30,44 @@ Find and fix failures in the latest CI run for a branch.
 
    If no failed run exists for the target branch, report that CI is passing and stop.
 
-3. **Pull the failure logs**:
+3. **Identify which jobs failed** (a single run can have multiple failed jobs):
+   ```
+   gh run view <id> --json jobs --jq '.jobs[] | select(.conclusion=="failure") | .name'
+   ```
+
+4. **Pull the failure logs** (returns logs for every failed job):
    ```
    gh run view <id> --log-failed
    ```
 
-4. **Identify the failure type** from the logs:
-   - `ruff format --check` → formatting issue
-   - `ruff check` → lint error
-   - `pyright` → type error
-   - `pytest` → test failure
+5. **Classify each failure** by the failing job and the tool/output in the logs:
+   - `checks` job:
+     - `ruff format --check` step → formatting issue
+     - `ruff check` step → lint error
+     - `pyright` step → type error
+   - `test-unit`, `test-integration`, `test-e2e` jobs → pytest failure in that suite
 
-5. **If the target branch is not the current branch**, warn the user and ask whether to check it out before fixing or stop. Do not modify files on a branch you are not currently on.
+   Track failures per job so the fix and the local verification can be scoped.
 
-6. **Read the affected files** before making any changes. Understand the context fully.
+6. **If the target branch is not the current branch**, warn the user and ask whether to check it out before fixing or stop. Do not modify files on a branch you are not currently on.
 
-7. **Fix the issues**:
+7. **Read the affected files** before making any changes. Understand the context fully.
+
+8. **Fix the issues**:
    - Formatting: run `uv run ruff format .` and review what changed
    - Lint: fix each flagged line; prefer code changes over `# noqa` (only use `# noqa` with a justification comment when the rule is a false positive)
    - Type errors: fix the type issue; do not use `# type: ignore` unless the error is a known library stub gap — always add a comment explaining why
    - Test failures: read the test, understand what it's asserting, fix the source code (not the test) unless the test itself is wrong
 
-8. **Verify locally** by running the full pre-commit checklist:
-   ```
-   make check test-all
-   ```
+9. **Verify locally**, scoping to what changed:
+   - If only `checks` failed: `make check`
+   - If a single test suite failed: re-run just that suite — e.g. `uv run pytest tests/integration/ -v` or `uv run pytest tests/e2e/ -v` — then `make check`
+   - If multiple jobs failed or you're not sure: `make check test-all`
+
    If anything still fails, fix it before proceeding.
 
-9. **Show a summary** of every change made — files modified, what was wrong, and how it was fixed. Ask the user to confirm before committing.
+10. **Show a summary** of every change made — files modified, what was wrong, and how it was fixed. Ask the user to confirm before committing.
 
-10. **After confirmation**, stage only the files changed to fix CI (do not stage unrelated unstaged files), commit, and push:
+11. **After confirmation**, stage only the files changed to fix CI (do not stage unrelated unstaged files), commit, and push:
     - Commit message: `Fix CI failures: <brief description>` with a bulleted body listing each fix
     - Push to the current branch's remote tracking branch

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -12,20 +12,26 @@ paths: ["tests/**", "**/conftest.py", "src/moneybin/testing/**"]
 
 ## Markers
 
+Every test belongs to exactly one **category**: `unit`, `integration`, `e2e`, or `scenarios`. `tests/conftest.py` auto-applies `unit` to any test that lacks a category marker, so unit tests need no marker; everything else declares its category explicitly. The conftest hook errors at collection if a test ends up with more than one category. `slow` is orthogonal — it can stack on any category to flag long-running tests for local-dev opt-out.
+
 ```python
-@pytest.mark.unit         # Fast unit tests (default)
-@pytest.mark.integration  # Requires external systems
+@pytest.mark.unit         # Fast unit tests (default — auto-applied when no category present)
+@pytest.mark.integration  # Requires external systems / real DB / SQLMesh
 @pytest.mark.e2e          # End-to-end subprocess tests
-@pytest.mark.slow         # Long-running
+@pytest.mark.scenarios    # Whole-pipeline scenario tests (real DB, real SQLMesh, slow)
+@pytest.mark.slow         # Orthogonal: stacks on any category; locally opt out via `-m "not slow"`
 ```
 
 ## Commands
 
 ```bash
 uv run pytest tests/ -v                                       # All tests
-uv run pytest tests/ -v -m "not integration and not e2e"      # Unit only
+uv run pytest tests/ -m unit                                  # Unit only
+uv run pytest tests/ -m integration                           # Integration only
+uv run pytest tests/ -m e2e                                   # E2E only
+uv run pytest tests/ -m scenarios                             # Scenarios only
+uv run pytest tests/ -m "unit and not slow"                   # Fast local dev loop (matches `make test`)
 uv run pytest tests/test_file.py -v                           # Specific file
-uv run pytest tests/e2e/ -m "e2e" -v                          # E2E only
 uv run pytest tests/ --cov=src/moneybin --cov-report=html     # Coverage
 uv run pytest tests/path/to/test.py -n0 -v                    # Disable xdist (for pdb / clean output)
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   # Detect whether any non-docs files changed. For pushes to main we always
-  # run the full suite; for PRs we skip lint/type/test when only docs changed.
+  # run the full suite; for PRs we skip code jobs when only docs changed.
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
@@ -37,8 +37,10 @@ jobs:
             echo "code=true" >> $GITHUB_OUTPUT
           fi
 
-  format:
-    name: Format Check
+  checks:
+    name: Checks
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -51,11 +53,17 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
 
-      - name: Check formatting
+      - name: Format check
         run: uv run ruff format --check .
 
-  ci:
-    name: Lint, Type Check & Test
+      - name: Lint
+        run: uv run ruff check .
+
+      - name: Type check
+        run: uv run pyright
+
+  test-unit:
+    name: Unit tests
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
@@ -75,14 +83,8 @@ jobs:
           curl -fsSL https://install.duckdb.org | sh
           echo "$HOME/.duckdb/cli/latest" >> $GITHUB_PATH
 
-      - name: Lint
-        run: uv run ruff check .
-
-      - name: Type check
-        run: uv run pyright
-
       - name: Test
-        run: uv run pytest tests/ -v --cov=src --cov-report=xml --durations=25
+        run: uv run pytest tests/moneybin/ -m "not integration and not e2e and not slow" -v --cov=src --cov-report=xml --durations=25
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v7
@@ -90,3 +92,51 @@ jobs:
         with:
           name: coverage
           path: coverage.xml
+
+  test-integration:
+    name: Integration tests
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Install DuckDB CLI
+        run: |
+          curl -fsSL https://install.duckdb.org | sh
+          echo "$HOME/.duckdb/cli/latest" >> $GITHUB_PATH
+
+      - name: Test
+        run: uv run pytest tests/integration/ -v --durations=25
+
+  test-e2e:
+    name: E2E tests
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Install DuckDB CLI
+        run: |
+          curl -fsSL https://install.duckdb.org | sh
+          echo "$HOME/.duckdb/cli/latest" >> $GITHUB_PATH
+
+      - name: Test
+        run: uv run pytest tests/e2e/ -v --durations=25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,11 @@ jobs:
       - name: Type check
         run: uv run pyright
 
+  # Test jobs select by marker across the whole tests/ tree, not by
+  # directory. Every test ends up with exactly one of
+  # {unit, integration, e2e, scenarios} — the root conftest auto-applies
+  # `unit` when no category marker is present and errors on conflicts,
+  # so each job can use a plain `-m <category>` selection.
   test-unit:
     name: Unit tests
     needs: [changes]
@@ -84,7 +89,7 @@ jobs:
           echo "$HOME/.duckdb/cli/latest" >> $GITHUB_PATH
 
       - name: Test
-        run: uv run pytest tests/moneybin/ -m "not integration and not e2e and not slow" -v --cov=src --cov-report=xml --durations=25
+        run: uv run pytest tests/ -m unit -v --cov=src --cov-report=xml --durations=25
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v7
@@ -115,7 +120,7 @@ jobs:
           echo "$HOME/.duckdb/cli/latest" >> $GITHUB_PATH
 
       - name: Test
-        run: uv run pytest tests/integration/ -v --durations=25
+        run: uv run pytest tests/ -m integration -v --durations=25
 
   test-e2e:
     name: E2E tests
@@ -139,4 +144,4 @@ jobs:
           echo "$HOME/.duckdb/cli/latest" >> $GITHUB_PATH
 
       - name: Test
-        run: uv run pytest tests/e2e/ -v --durations=25
+        run: uv run pytest tests/ -m e2e -v --durations=25

--- a/.github/workflows/scenarios.yml
+++ b/.github/workflows/scenarios.yml
@@ -44,7 +44,7 @@ jobs:
           MONEYBIN_DATABASE__ENCRYPTION_KEY: ci-ephemeral-key-runner-destroyed-after-job
         run: |
           set -o pipefail
-          uv run pytest tests/scenarios/ -m scenarios -v \
+          uv run pytest tests/ -m scenarios -v \
             --json-report --json-report-file=scenarios.json \
             --durations=25
 

--- a/Makefile
+++ b/Makefile
@@ -130,9 +130,9 @@ pre-commit: venv ## Setup & Installation: Install pre-commit hooks
 	@echo "$(GREEN)✅ Pre-commit hooks installed$(RESET)"
 	@echo "$(BLUE)ℹ️  Pre-commit will use uv run for consistent tool versions$(RESET)"
 
-test-unit: venv ## Development: Run unit tests only (excludes integration, e2e, and slow tests)
+test-unit: venv ## Development: Run unit tests only (skips slow ones; use 'make test-all' for everything)
 	@echo "$(BLUE)🧪 Running unit tests (use 'make test-all' for all tests)...$(RESET)"
-	@uv run pytest tests/ -m "not integration and not e2e and not slow" --durations=25
+	@uv run pytest tests/ -m "unit and not slow" --durations=25
 
 test: test-unit ## Development: Run unit tests (alias for test-unit)
 
@@ -142,7 +142,7 @@ test-all: venv ## Development: Run all tests (unit, integration, e2e) with verbo
 
 test-cov: venv ## Development: Run tests with coverage report
 	@echo "$(BLUE)🧪 Running tests with coverage...$(RESET)"
-	@uv run pytest --cov=src tests/ -m "not integration and not e2e and not slow" --durations=25
+	@uv run pytest --cov=src tests/ -m "unit and not slow" --durations=25
 	@echo "$(BLUE)📊 Coverage report generated$(RESET)"
 
 test-integration: venv ## Development: Run integration tests only
@@ -151,7 +151,7 @@ test-integration: venv ## Development: Run integration tests only
 
 test-e2e: venv ## Development: Run end-to-end subprocess tests
 	@echo "$(BLUE)🧪 Running end-to-end tests...$(RESET)"
-	@uv run pytest tests/e2e/ -m "e2e" -v --durations=25
+	@uv run pytest tests/ -m e2e -v --durations=25
 
 test-scenarios: venv ## Development: Run all whole-pipeline scenarios via pytest
 	@echo "$(BLUE)🧪 Running all scenarios...$(RESET)"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,29 @@ import os
 import tempfile
 from pathlib import Path
 
+import pytest
+
 os.environ["MAX_FORK_WORKERS"] = "1"
+
+# Test categories partition the suite. Every collected test gets exactly
+# one of these; `unit` is auto-applied below if none is present, so test
+# authors only mark when departing from unit. CI selects per-category
+# with a single `-m <category>` (no exclusion gymnastics).
+_CATEGORY_MARKERS = ("unit", "integration", "e2e", "scenarios")
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    categories = set(_CATEGORY_MARKERS)
+    for item in items:
+        present = {m.name for m in item.iter_markers()} & categories
+        if not present:
+            item.add_marker(pytest.mark.unit)
+        elif len(present) > 1:
+            raise pytest.UsageError(
+                f"{item.nodeid}: multiple category markers {sorted(present)}; "
+                f"each test must have exactly one of {sorted(categories)}"
+            )
+
 
 # Force every Typer app to use plain Click help rendering during tests.
 # Rich-mode help wraps option names in bold/dim ANSI escapes

--- a/tests/moneybin/test_stg_plaid.py
+++ b/tests/moneybin/test_stg_plaid.py
@@ -17,6 +17,8 @@ from moneybin.connectors.sync_models import SyncDataResponse
 from moneybin.database import Database, sqlmesh_context
 from moneybin.loaders.plaid_loader import PlaidLoader
 
+pytestmark = pytest.mark.integration
+
 FIXTURE = (
     Path(__file__).parent / "test_loaders" / "fixtures" / "plaid_sync_response.yaml"
 )

--- a/tests/moneybin/test_sync_e2e.py
+++ b/tests/moneybin/test_sync_e2e.py
@@ -14,6 +14,8 @@ from moneybin.database import Database, sqlmesh_context
 from moneybin.loaders.plaid_loader import PlaidLoader
 from moneybin.services.sync_service import SyncService
 
+pytestmark = pytest.mark.integration
+
 FIXTURE = (
     Path(__file__).parent / "test_loaders" / "fixtures" / "plaid_sync_response.yaml"
 )


### PR DESCRIPTION
### Summary
Splits the monolithic `Lint, Type Check & Test` CI job into four parallel jobs so PR feedback returns faster and each failure mode reports independently. Also stops `tests/scenarios/` from running twice — once in CI and again in the `Scenarios` workflow.

### Impact
- **Required status checks need updating.** The old `Lint, Type Check & Test` and `Format Check` jobs are gone. New required checks: `Checks`, `Unit tests`, `Integration tests`, `E2E tests`. Update GitHub branch protection settings before merging this changes the gate.
- No app code or test code changed. Local workflow (`make check test`) is unaffected.

### Changes

#### `.github/workflows/ci.yml`
- New parallel jobs: `checks` (format + lint + pyright), `test-unit`, `test-integration`, `test-e2e`.
- Removed the standalone `format` job (folded into `checks`).
- `test-unit` scoped to `tests/moneybin/` with markers excluding `integration`/`e2e`/`slow` — drops the duplicate run of `tests/scenarios/` already covered by `scenarios.yml`.
- Coverage stays on `test-unit` only (single source for `coverage.xml`).
- `changes` docs-gate retained on every code job.

#### `.claude/commands/fix-ci.md`
- Documents the new parallel job set and defers to `/fix-scenarios` and `/fix-security` for the sibling workflows.
- Adds a step to enumerate failed jobs via `gh run view --json jobs` so multi-job failures aren't missed.
- Scopes local verification to the affected suite instead of unconditionally running `make check test-all`.

### Testing
The workflow YAML parses with the five expected jobs (`changes`, `checks`, `test-unit`, `test-integration`, `test-e2e`). Actual behavior gets exercised when this PR's own CI run kicks off.

### Notes
After merge, update branch-protection required status checks to the new job names so they gate merges.