### PR TITLE
Fix V010/V011 migrations and add populated-fixture pattern

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -89,6 +89,24 @@ uv run sqlmesh -p sqlmesh format
 - **Raw schema** (`src/moneybin/sql/schema/*.sql`): Plain SQL DDL.
 - **SQLMesh models** (`sqlmesh/models/**/*.sql`): Plain SQL with `MODEL()` block header.
 
+## Migrations
+
+### Migration test data realism
+
+Migrations that touch existing data MUST be tested against pre-populated tables. "Touches existing data" means any of:
+
+- `ADD COLUMN` with `DEFAULT` (backfill)
+- `ALTER COLUMN SET NOT NULL`
+- `ADD CONSTRAINT UNIQUE / CHECK / FOREIGN KEY`
+- `UPDATE` / data reshape
+- `DROP` / `RENAME` of a column the app writes to
+
+Pure additive DDL (new tables, `ADD COLUMN ... NULL` with no `DEFAULT`, indexes on non-unique columns) does not require populated fixtures — add them only if the test would gain coverage.
+
+Fixtures must insert **≥3 rows** into each affected table with realistic shapes (real-looking IDs, timestamps, non-trivial values in nullable columns). Minimal one-row stubs miss edge cases — e.g., V010's "Cannot create index with outstanding updates" only reproduces when the `ADD COLUMN ... DEFAULT` backfill has real rows to write.
+
+Tests must also reproduce the runner's enclosing `BEGIN TRANSACTION` wrap when the bug class depends on it. Wrap the `migrate()` call in `BEGIN`/`COMMIT` (or call through `MigrationRunner.apply_one`) so any "outstanding writes" interaction with subsequent DDL surfaces in the test.
+
 ## Table and Column Comments
 
 Every column should have a comment. Use existing schema files as examples for style and content.

--- a/src/moneybin/sql/migrations/V010__add_updated_at_to_user_tables.py
+++ b/src/moneybin/sql/migrations/V010__add_updated_at_to_user_tables.py
@@ -37,11 +37,12 @@ def migrate(conn: object) -> None:
                 f"ALTER TABLE app.{table} "  # noqa: S608  # allowlisted table names, not user input
                 "ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
             )
-            # Commit the backfill before SET NOT NULL. A crash in the window
-            # between this COMMIT and the SET NOT NULL below leaves the column
-            # added-but-nullable with a success=false schema_migrations row;
-            # recovery is: delete that row, re-run, and the `elif` branch
-            # below tightens the constraint.
+            # Commit the backfill before SET NOT NULL. A failure between this
+            # COMMIT and the SET NOT NULL below leaves the column added-but-
+            # nullable; the next migration run hits the `elif` branch below
+            # and finishes the tightening. (Exception path also writes a
+            # success=false schema_migrations row that the operator must
+            # delete first; a hard crash leaves no such row.)
             conn.execute("COMMIT")  # type: ignore[union-attr]
             conn.execute("BEGIN TRANSACTION")  # type: ignore[union-attr]
             conn.execute(  # type: ignore[union-attr]

--- a/src/moneybin/sql/migrations/V010__add_updated_at_to_user_tables.py
+++ b/src/moneybin/sql/migrations/V010__add_updated_at_to_user_tables.py
@@ -37,7 +37,11 @@ def migrate(conn: object) -> None:
                 f"ALTER TABLE app.{table} "  # noqa: S608  # allowlisted table names, not user input
                 "ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
             )
-            # Commit the backfill before SET NOT NULL — see module docstring.
+            # Commit the backfill before SET NOT NULL. A crash in the window
+            # between this COMMIT and the SET NOT NULL below leaves the column
+            # added-but-nullable with a success=false schema_migrations row;
+            # recovery is: delete that row, re-run, and the `elif` branch
+            # below tightens the constraint.
             conn.execute("COMMIT")  # type: ignore[union-attr]
             conn.execute("BEGIN TRANSACTION")  # type: ignore[union-attr]
             conn.execute(  # type: ignore[union-attr]

--- a/src/moneybin/sql/migrations/V010__add_updated_at_to_user_tables.py
+++ b/src/moneybin/sql/migrations/V010__add_updated_at_to_user_tables.py
@@ -1,13 +1,12 @@
 """Add updated_at to app.user_categories/user_merchants; tighten override columns to NOT NULL.
 
-Per docs/specs/core-updated-at-convention.md — every app/core table that
-participates in `updated_at` provenance must carry a non-null TIMESTAMP. This
-migration brings the four affected app tables in line with the convention.
-
-DuckDB does not support `ADD COLUMN ... NOT NULL` in a single statement
-(Parser Error: 'Adding columns with constraints not yet supported'). We add
-the column with a DEFAULT — every existing row receives CURRENT_TIMESTAMP —
-then SET NOT NULL. Idempotent: re-running detects the end-state and skips.
+Per docs/specs/core-updated-at-convention.md. DuckDB rejects
+`ADD COLUMN ... NOT NULL` in one statement, so we ADD with DEFAULT (backfills
+every existing row) then SET NOT NULL. The interim COMMIT is required because
+DuckDB refuses to create the SET NOT NULL index while backfill writes from
+the same transaction are still outstanding. Recovery from a crash between
+those two statements goes through the idempotent re-run branch
+(`elif col_map["updated_at"] is True`).
 """
 
 import logging
@@ -38,18 +37,26 @@ def migrate(conn: object) -> None:
                 f"ALTER TABLE app.{table} "  # noqa: S608  # allowlisted table names, not user input
                 "ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
             )
+            # Commit the backfill before SET NOT NULL — see module docstring.
+            conn.execute("COMMIT")  # type: ignore[union-attr]
+            conn.execute("BEGIN TRANSACTION")  # type: ignore[union-attr]
             conn.execute(  # type: ignore[union-attr]
                 f"ALTER TABLE app.{table} "  # noqa: S608  # allowlisted table names
                 "ALTER COLUMN updated_at SET NOT NULL"
             )
         elif col_map["updated_at"] is True:
-            # Column exists but is nullable (partial prior run).
+            # Column exists but is nullable (partial prior run, or a crash
+            # between the two ALTERs above). No outstanding writes, so
+            # SET NOT NULL is safe inside the runner's enclosing transaction.
             logger.info(f"Tightening app.{table}.updated_at to NOT NULL")
             conn.execute(  # type: ignore[union-attr]
                 f"ALTER TABLE app.{table} "  # noqa: S608  # allowlisted table names
                 "ALTER COLUMN updated_at SET NOT NULL"
             )
 
+    # category_overrides / merchant_overrides: SET NOT NULL only — no
+    # ADD COLUMN, no backfill, no outstanding writes. Safe inside the
+    # runner's transaction. (V012 drops merchant_overrides outright.)
     for table in ("category_overrides", "merchant_overrides"):
         cols = conn.execute(  # type: ignore[union-attr]
             """

--- a/src/moneybin/sql/migrations/V011__add_updated_at_to_balance_assertions.py
+++ b/src/moneybin/sql/migrations/V011__add_updated_at_to_balance_assertions.py
@@ -36,7 +36,11 @@ def migrate(conn: object) -> None:
             "ALTER TABLE app.balance_assertions "
             "ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
         )
-        # Commit the backfill before SET NOT NULL — see module docstring.
+        # Commit the backfill before SET NOT NULL. A crash in the window
+        # between this COMMIT and the SET NOT NULL below leaves the column
+        # added-but-nullable with a success=false schema_migrations row;
+        # recovery is: delete that row, re-run, and the `elif` branch below
+        # tightens the constraint.
         conn.execute("COMMIT")  # type: ignore[union-attr]
         conn.execute("BEGIN TRANSACTION")  # type: ignore[union-attr]
         conn.execute(  # type: ignore[union-attr]

--- a/src/moneybin/sql/migrations/V011__add_updated_at_to_balance_assertions.py
+++ b/src/moneybin/sql/migrations/V011__add_updated_at_to_balance_assertions.py
@@ -36,11 +36,12 @@ def migrate(conn: object) -> None:
             "ALTER TABLE app.balance_assertions "
             "ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
         )
-        # Commit the backfill before SET NOT NULL. A crash in the window
-        # between this COMMIT and the SET NOT NULL below leaves the column
-        # added-but-nullable with a success=false schema_migrations row;
-        # recovery is: delete that row, re-run, and the `elif` branch below
-        # tightens the constraint.
+        # Commit the backfill before SET NOT NULL. A failure between this
+        # COMMIT and the SET NOT NULL below leaves the column added-but-
+        # nullable; the next migration run hits the `elif` branch below and
+        # finishes the tightening. (Exception path also writes a
+        # success=false schema_migrations row that the operator must delete
+        # first; a hard crash leaves no such row.)
         conn.execute("COMMIT")  # type: ignore[union-attr]
         conn.execute("BEGIN TRANSACTION")  # type: ignore[union-attr]
         conn.execute(  # type: ignore[union-attr]

--- a/src/moneybin/sql/migrations/V011__add_updated_at_to_balance_assertions.py
+++ b/src/moneybin/sql/migrations/V011__add_updated_at_to_balance_assertions.py
@@ -1,16 +1,14 @@
 """Add updated_at to app.balance_assertions so edits advance freshness.
 
 Per docs/specs/core-updated-at-convention.md, `core.fct_balances.updated_at`
-sources its user-assertion timestamps from `app.balance_assertions`. Today
-the assertion table tracks only `created_at`, which is preserved on
-re-assertion (per BalanceService.assert_balance ON CONFLICT semantics), so
-edits to an existing assertion (corrected `balance` / updated `notes`) are
-invisible to any "changed since T" consumer. This migration adds a
-mutable `updated_at` column; the service write path refreshes it on the
-ON CONFLICT DO UPDATE branch.
+sources its user-assertion timestamps from `app.balance_assertions`. The
+existing `created_at` is preserved on re-assertion (BalanceService.assert_balance
+ON CONFLICT semantics), so edits to an existing assertion are invisible to
+"changed since T" consumers without a separate mutable column. The write path
+refreshes `updated_at` on the ON CONFLICT DO UPDATE branch.
 
-Two-step ADD then SET NOT NULL pattern per V010 (DuckDB doesn't support
-combined inline NOT NULL). Idempotent: re-runs detect the end state.
+Two-step ADD then SET NOT NULL with an interim COMMIT — see V010 for the
+DuckDB "outstanding updates" rationale and the idempotent recovery branch.
 """
 
 import logging
@@ -38,6 +36,9 @@ def migrate(conn: object) -> None:
             "ALTER TABLE app.balance_assertions "
             "ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
         )
+        # Commit the backfill before SET NOT NULL — see module docstring.
+        conn.execute("COMMIT")  # type: ignore[union-attr]
+        conn.execute("BEGIN TRANSACTION")  # type: ignore[union-attr]
         conn.execute(  # type: ignore[union-attr]
             "ALTER TABLE app.balance_assertions ALTER COLUMN updated_at SET NOT NULL"
         )

--- a/tests/moneybin/migration_helpers.py
+++ b/tests/moneybin/migration_helpers.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Iterable, Sequence
 from typing import Any
 
 from moneybin.database import Database
+
+logger = logging.getLogger(__name__)
 
 
 def column_info(db: Database, schema: str, table: str, column: str) -> tuple[str, bool]:
@@ -67,6 +70,6 @@ def run_migration(db: Database, migrate_fn: Callable[[object], None]) -> None:
         # original migration error.
         try:
             db.execute("ROLLBACK")
-        except Exception:  # noqa: BLE001 S110 — best-effort cleanup; original error re-raised below
-            pass
+        except Exception as rollback_exc:  # noqa: BLE001 — log and continue; original error re-raised below
+            logger.debug(f"ROLLBACK after migration failure raised: {rollback_exc!r}")
         raise

--- a/tests/moneybin/migration_helpers.py
+++ b/tests/moneybin/migration_helpers.py
@@ -61,5 +61,12 @@ def run_migration(db: Database, migrate_fn: Callable[[object], None]) -> None:
         migrate_fn(db._conn)  # pyright: ignore[reportPrivateUsage]
         db.execute("COMMIT")
     except Exception:
-        db.execute("ROLLBACK")
+        # Rollback is best-effort: V010/V011-style migrations may have already
+        # COMMITted and reopened a transaction, so we may rollback either an
+        # empty tx or none at all. Don't let a rollback failure mask the
+        # original migration error.
+        try:
+            db.execute("ROLLBACK")
+        except Exception:  # noqa: BLE001 S110 — best-effort cleanup; original error re-raised below
+            pass
         raise

--- a/tests/moneybin/migration_helpers.py
+++ b/tests/moneybin/migration_helpers.py
@@ -1,0 +1,65 @@
+"""Shared helpers for V0NN migration tests — see .claude/rules/database.md."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Sequence
+from typing import Any
+
+from moneybin.database import Database
+
+
+def column_info(db: Database, schema: str, table: str, column: str) -> tuple[str, bool]:
+    """Return (data_type, is_nullable_bool) for a column from duckdb_columns()."""
+    row = db.execute(
+        """
+        SELECT data_type, is_nullable
+        FROM duckdb_columns()
+        WHERE schema_name = ? AND table_name = ? AND column_name = ?
+        """,
+        [schema, table, column],
+    ).fetchone()
+    assert row is not None, f"{schema}.{table}.{column} not found"
+    data_type, is_nullable = row
+    return data_type, bool(is_nullable)
+
+
+def column_exists(db: Database, schema: str, table: str, column: str) -> bool:
+    """True if (schema, table, column) is present in duckdb_columns()."""
+    row = db.execute(
+        "SELECT 1 FROM duckdb_columns() "
+        "WHERE schema_name = ? AND table_name = ? AND column_name = ?",
+        [schema, table, column],
+    ).fetchone()
+    return row is not None
+
+
+def insert_rows(
+    db: Database,
+    schema: str,
+    table: str,
+    columns: Sequence[str],
+    rows: Iterable[Sequence[Any]],
+) -> None:
+    """Insert tuple/list rows into `schema.table` under `columns` order."""
+    placeholders = ", ".join("?" * len(columns))
+    column_list = ", ".join(columns)
+    sql = f"INSERT INTO {schema}.{table} ({column_list}) VALUES ({placeholders})"  # noqa: S608  # schema/table/columns are caller-controlled, not user input
+    for row in rows:
+        db.execute(sql, list(row))
+
+
+def run_migration(db: Database, migrate_fn: Callable[[object], None]) -> None:
+    """Invoke a migration's `migrate()` inside the runner's BEGIN/COMMIT wrap.
+
+    Required to reproduce bug classes that depend on the enclosing
+    transaction — bare `migrate(db._conn)` auto-commits each statement and
+    masks regressions like V010/V011's "Cannot create index with outstanding
+    updates."
+    """
+    db.execute("BEGIN TRANSACTION")
+    try:
+        migrate_fn(db._conn)  # pyright: ignore[reportPrivateUsage]
+        db.execute("COMMIT")
+    except Exception:
+        db.execute("ROLLBACK")
+        raise

--- a/tests/moneybin/test_migration_v007.py
+++ b/tests/moneybin/test_migration_v007.py
@@ -223,26 +223,20 @@ class TestV007Migration:
     def test_v007_idempotent_on_second_run(self, db: Database) -> None:
         """Second migrate run must leave state byte-identical to first run."""
         _drop_and_recreate_legacy_notes(db)
-        db.execute(
-            "INSERT INTO app.transaction_notes (transaction_id, note, created_at) "
-            "VALUES (?, ?, ?)",
-            ["txn_idem_1", "first legacy note", "2025-03-01 09:00:00"],
-        )
-        db.execute(
-            "INSERT INTO app.transaction_notes (transaction_id, note, created_at) "
-            "VALUES (?, ?, ?)",
-            ["txn_idem_2", "second legacy note", "2025-03-02 09:00:00"],
-        )
+        idem_notes = [
+            ("txn_idem_1", "first legacy note", "2025-03-01 09:00:00"),
+            ("txn_idem_2", "second legacy note", "2025-03-02 09:00:00"),
+            ("txn_idem_3", "third legacy note", "2025-03-03 09:00:00"),
+        ]
+        for transaction_id, note, created_at in idem_notes:
+            db.execute(
+                "INSERT INTO app.transaction_notes "
+                "(transaction_id, note, created_at) VALUES (?, ?, ?)",
+                [transaction_id, note, created_at],
+            )
         _create_legacy_ai_audit_log(db)
-        db.execute(
-            """
-            INSERT INTO app.ai_audit_log (
-                audit_id, timestamp, flow_tier, feature, backend, model,
-                data_sent_summary, data_sent_hash, response_summary,
-                consent_reference, user_initiated
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            [
+        idem_ai_rows = [
+            (
                 "ai_idem_1",
                 "2025-03-03 09:00:00",
                 1,
@@ -254,8 +248,45 @@ class TestV007Migration:
                 "response",
                 "consent_xyz",
                 True,
-            ],
-        )
+            ),
+            (
+                "ai_idem_2",
+                "2025-03-04 10:30:00",
+                2,
+                "smart_import_parse",
+                "anthropic",
+                "claude-haiku-4-5",
+                "8 rows redacted",
+                "deadbeef" * 8,
+                "category labels",
+                "consent_abc",
+                False,
+            ),
+            (
+                "ai_idem_3",
+                "2025-03-05 14:15:00",
+                3,
+                "merchant_normalize",
+                "openai",
+                "gpt-4o-mini",
+                "20 merchants",
+                "feedface" * 8,
+                "canonical names",
+                "consent_def",
+                True,
+            ),
+        ]
+        for row in idem_ai_rows:
+            db.execute(
+                """
+                INSERT INTO app.ai_audit_log (
+                    audit_id, timestamp, flow_tier, feature, backend, model,
+                    data_sent_summary, data_sent_hash, response_summary,
+                    consent_reference, user_initiated
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                list(row),
+            )
 
         migrate(db._conn)  # pyright: ignore[reportPrivateUsage]
 
@@ -279,7 +310,7 @@ class TestV007Migration:
             "FROM app.audit_log ORDER BY audit_id"
         ).fetchall()
 
-        assert len(notes_after_first) == 2
-        assert len(audit_after_first) == 1
+        assert len(notes_after_first) == len(idem_notes)
+        assert len(audit_after_first) == len(idem_ai_rows)
         assert notes_after_second == notes_after_first
         assert audit_after_second == audit_after_first

--- a/tests/moneybin/test_migration_v007.py
+++ b/tests/moneybin/test_migration_v007.py
@@ -81,40 +81,47 @@ class TestV007Migration:
     ) -> None:
         """Single-note rows get note_id (12 hex), author='legacy', preserved created_at."""
         _drop_and_recreate_legacy_notes(db)
-        db.execute(
-            "INSERT INTO app.transaction_notes (transaction_id, note, created_at) "
-            "VALUES (?, ?, ?)",
-            ["txn_legacy_1", "old single note", "2025-01-15 10:00:00"],
-        )
+        legacy_notes = [
+            ("txn_legacy_1", "old single note", "2025-01-15 10:00:00"),
+            ("txn_legacy_2", "grocery run on the road", "2025-01-16 09:30:00"),
+            (
+                "txn_legacy_3",
+                "split rent w/ roommate — paid back via venmo",
+                "2025-01-17 18:45:00",
+            ),
+        ]
+        for transaction_id, note, created_at in legacy_notes:
+            db.execute(
+                "INSERT INTO app.transaction_notes "
+                "(transaction_id, note, created_at) VALUES (?, ?, ?)",
+                [transaction_id, note, created_at],
+            )
 
         migrate(db._conn)  # pyright: ignore[reportPrivateUsage]
 
-        row = db.execute(
+        rows = db.execute(
             "SELECT note_id, transaction_id, text, author, created_at "
-            "FROM app.transaction_notes WHERE transaction_id = 'txn_legacy_1'"
-        ).fetchone()
-        assert row is not None
-        note_id, transaction_id, text, author, created_at = row
-        assert isinstance(note_id, str)
-        assert len(note_id) == 12
-        assert all(c in "0123456789abcdef" for c in note_id)
-        assert transaction_id == "txn_legacy_1"
-        assert text == "old single note"
-        assert author == "legacy"
-        assert str(created_at).startswith("2025-01-15 10:00:00")
+            "FROM app.transaction_notes ORDER BY transaction_id"
+        ).fetchall()
+        assert len(rows) == len(legacy_notes)
+        for (note_id, transaction_id, text, author, created_at), (
+            expected_txn,
+            expected_text,
+            expected_ts,
+        ) in zip(rows, legacy_notes, strict=True):
+            assert isinstance(note_id, str)
+            assert len(note_id) == 12
+            assert all(c in "0123456789abcdef" for c in note_id)
+            assert transaction_id == expected_txn
+            assert text == expected_text
+            assert author == "legacy"
+            assert str(created_at).startswith(expected_ts)
 
     def test_v007_retires_ai_audit_log_table(self, db: Database) -> None:
         """ai_audit_log rows move to audit_log with AI fields in context_json; old table dropped."""
         _create_legacy_ai_audit_log(db)
-        db.execute(
-            """
-            INSERT INTO app.ai_audit_log (
-                audit_id, timestamp, flow_tier, feature, backend, model,
-                data_sent_summary, data_sent_hash, response_summary,
-                consent_reference, user_initiated
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            [
+        legacy_ai_rows = [
+            (
                 "ai_audit_1",
                 "2025-02-01 12:00:00",
                 2,
@@ -126,12 +133,48 @@ class TestV007Migration:
                 "category labels list",
                 "consent_grant_xyz",
                 False,
-            ],
-        )
+            ),
+            (
+                "ai_audit_2",
+                "2025-02-02 14:30:00",
+                1,
+                "categorize",
+                "anthropic",
+                "claude-haiku-4-5",
+                "12 txns, masked merchants",
+                "cafef00d" * 8,
+                "category assignments",
+                "consent_grant_abc",
+                True,
+            ),
+            (
+                "ai_audit_3",
+                "2025-02-03 09:15:00",
+                3,
+                "merchant_normalize",
+                "openai",
+                "gpt-4o-mini",
+                "30 merchant strings",
+                "feedface" * 8,
+                "canonical names",
+                "consent_grant_def",
+                True,
+            ),
+        ]
+        for row in legacy_ai_rows:
+            db.execute(
+                """
+                INSERT INTO app.ai_audit_log (
+                    audit_id, timestamp, flow_tier, feature, backend, model,
+                    data_sent_summary, data_sent_hash, response_summary,
+                    consent_reference, user_initiated
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                list(row),
+            )
 
         migrate(db._conn)  # pyright: ignore[reportPrivateUsage]
 
-        # Old table is gone.
         result = db.execute(
             "SELECT COUNT(*) FROM information_schema.tables "
             "WHERE table_schema = 'app' AND table_name = 'ai_audit_log'"
@@ -139,31 +182,46 @@ class TestV007Migration:
         assert result is not None
         assert result[0] == 0
 
-        # Row re-routed into app.audit_log.
-        row = db.execute(
+        rows = db.execute(
             "SELECT audit_id, action, actor, occurred_at, context_json "
-            "FROM app.audit_log WHERE audit_id = 'ai_audit_1'"
-        ).fetchone()
-        assert row is not None
-        audit_id, action, actor, occurred_at, context_json = row
-        assert audit_id == "ai_audit_1"
-        assert action == "ai.external_call"
-        assert actor == "ai:anthropic:claude-sonnet-4-6"
-        assert str(occurred_at).startswith("2025-02-01 12:00:00")
-        ctx = (
-            json.loads(context_json) if isinstance(context_json, str) else context_json
-        )
-        assert ctx["flow_tier"] == 2
-        assert ctx["feature"] == "smart_import_parse"
-        assert ctx["backend"] == "anthropic"
-        assert ctx["model"] == "claude-sonnet-4-6"
-        assert ctx["data_sent_hash"] == "deadbeef" * 8
-        assert ctx["consent_reference"] == "consent_grant_xyz"
-        assert ctx["user_initiated"] is False
+            "FROM app.audit_log ORDER BY audit_id"
+        ).fetchall()
+        assert len(rows) == len(legacy_ai_rows)
+        for (audit_id, action, actor, occurred_at, context_json), legacy in zip(
+            rows, legacy_ai_rows, strict=True
+        ):
+            (
+                expected_audit_id,
+                expected_ts,
+                expected_flow_tier,
+                expected_feature,
+                expected_backend,
+                expected_model,
+                _summary,
+                expected_hash,
+                _response,
+                expected_consent,
+                expected_user_initiated,
+            ) = legacy
+            assert audit_id == expected_audit_id
+            assert action == "ai.external_call"
+            assert actor == f"ai:{expected_backend}:{expected_model}"
+            assert str(occurred_at).startswith(expected_ts)
+            ctx = (
+                json.loads(context_json)
+                if isinstance(context_json, str)
+                else context_json
+            )
+            assert ctx["flow_tier"] == expected_flow_tier
+            assert ctx["feature"] == expected_feature
+            assert ctx["backend"] == expected_backend
+            assert ctx["model"] == expected_model
+            assert ctx["data_sent_hash"] == expected_hash
+            assert ctx["consent_reference"] == expected_consent
+            assert ctx["user_initiated"] is expected_user_initiated
 
     def test_v007_idempotent_on_second_run(self, db: Database) -> None:
         """Second migrate run must leave state byte-identical to first run."""
-        # Seed both legacy structures so the migration has real work to do.
         _drop_and_recreate_legacy_notes(db)
         db.execute(
             "INSERT INTO app.transaction_notes (transaction_id, note, created_at) "
@@ -221,7 +279,6 @@ class TestV007Migration:
             "FROM app.audit_log ORDER BY audit_id"
         ).fetchall()
 
-        # Same row counts, same identifiers, same content.
         assert len(notes_after_first) == 2
         assert len(audit_after_first) == 1
         assert notes_after_second == notes_after_first

--- a/tests/moneybin/test_migration_v008.py
+++ b/tests/moneybin/test_migration_v008.py
@@ -1,0 +1,161 @@
+"""Tests for V008: add exemplars to app.user_merchants and relax raw_pattern NOT NULL.
+
+V008 adds `exemplars VARCHAR[] DEFAULT []` (backfills every existing row) and
+relaxes `raw_pattern` from NOT NULL to nullable. Tests populate user_merchants
+with >=3 realistic rows so the backfill path is exercised against real data.
+
+See `docs/specs/categorization-matching-mechanics.md` — Schema changes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from moneybin.database import Database
+from moneybin.sql.migrations.V008__user_merchants_exemplars import migrate
+from tests.moneybin.migration_helpers import (
+    column_exists,
+    column_info,
+    insert_rows,
+    run_migration,
+)
+
+
+def _reset_to_pre_v008_state(db: Database) -> None:
+    """Reverse the V008 end-state: drop `exemplars`, restore raw_pattern NOT NULL."""
+    if column_exists(db, "app", "user_merchants", "exemplars"):
+        db.execute("ALTER TABLE app.user_merchants DROP COLUMN exemplars")
+    # raw_pattern was NOT NULL pre-V008. The fresh schema relaxes it; tighten
+    # it back so the migration's DROP NOT NULL branch has work to do.
+    _, raw_pattern_nullable = column_info(db, "app", "user_merchants", "raw_pattern")
+    if raw_pattern_nullable:
+        db.execute(
+            "ALTER TABLE app.user_merchants ALTER COLUMN raw_pattern SET NOT NULL"
+        )
+
+
+_PRE_V008_ROWS: list[tuple[str, str, str, str, str | None, str | None, str]] = [
+    (
+        "m_pre_v008_a",
+        "STARBUCKS",
+        "contains",
+        "Starbucks",
+        "Food & Dining",
+        "Coffee Shops",
+        "user",
+    ),
+    (
+        "m_pre_v008_b",
+        "WHOLE FOODS",
+        "contains",
+        "Whole Foods Market",
+        "Food & Dining",
+        "Groceries",
+        "user",
+    ),
+    (
+        "m_pre_v008_c",
+        "LYFT",
+        "exact",
+        "Lyft",
+        "Transport",
+        "Rideshare",
+        "rule",
+    ),
+    (
+        "m_pre_v008_d",
+        "AMZN",
+        "contains",
+        "Amazon",
+        None,
+        None,
+        "plaid",
+    ),
+]
+
+
+def _populate_user_merchants(db: Database) -> None:
+    insert_rows(
+        db,
+        "app",
+        "user_merchants",
+        (
+            "merchant_id",
+            "raw_pattern",
+            "match_type",
+            "canonical_name",
+            "category",
+            "subcategory",
+            "created_by",
+        ),
+        _PRE_V008_ROWS,
+    )
+
+
+class TestV008Migration:
+    """V008 migration: exemplars added, raw_pattern relaxed to nullable."""
+
+    def test_v008_adds_exemplars_and_backfills_empty_list(self, db: Database) -> None:
+        """Exemplars column exists, every pre-existing row gets the empty-list default."""
+        _reset_to_pre_v008_state(db)
+        _populate_user_merchants(db)
+
+        run_migration(db, migrate)
+
+        data_type, _ = column_info(db, "app", "user_merchants", "exemplars")
+        assert data_type == "VARCHAR[]"
+
+        rows = db.execute(
+            "SELECT merchant_id, exemplars FROM app.user_merchants ORDER BY merchant_id"
+        ).fetchall()
+        assert len(rows) == len(_PRE_V008_ROWS)
+        for _merchant_id, exemplars in rows:
+            assert exemplars == []
+
+    def test_v008_relaxes_raw_pattern_to_nullable(self, db: Database) -> None:
+        """raw_pattern becomes nullable; pre-existing values are preserved."""
+        _reset_to_pre_v008_state(db)
+        _populate_user_merchants(db)
+
+        _, pre_nullable = column_info(db, "app", "user_merchants", "raw_pattern")
+        assert pre_nullable is False
+
+        run_migration(db, migrate)
+
+        _, post_nullable = column_info(db, "app", "user_merchants", "raw_pattern")
+        assert post_nullable is True
+
+        rows = db.execute(
+            "SELECT merchant_id, raw_pattern FROM app.user_merchants ORDER BY merchant_id"
+        ).fetchall()
+        assert [(r[0], r[1]) for r in rows] == [(r[0], r[1]) for r in _PRE_V008_ROWS]
+
+    def test_v008_idempotent_on_second_run(self, db: Database) -> None:
+        """Second migrate() leaves the same end-state."""
+        _reset_to_pre_v008_state(db)
+        _populate_user_merchants(db)
+
+        run_migration(db, migrate)
+        run_migration(db, migrate)
+
+        data_type, _ = column_info(db, "app", "user_merchants", "exemplars")
+        assert data_type == "VARCHAR[]"
+        _, raw_pattern_nullable = column_info(
+            db, "app", "user_merchants", "raw_pattern"
+        )
+        assert raw_pattern_nullable is True
+
+    def test_v008_idempotent_on_fresh_install(self, db: Database) -> None:
+        """On a fresh DB where init_schemas already produced the end-state, migrate() is a no-op."""
+        run_migration(db, migrate)
+
+        data_type, _ = column_info(db, "app", "user_merchants", "exemplars")
+        assert data_type == "VARCHAR[]"
+        _, raw_pattern_nullable = column_info(
+            db, "app", "user_merchants", "raw_pattern"
+        )
+        assert raw_pattern_nullable is True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/moneybin/test_migration_v009.py
+++ b/tests/moneybin/test_migration_v009.py
@@ -1,0 +1,150 @@
+"""Tests for V009: purge V004/V005 schema_migrations rows.
+
+V009 deletes the V004 and V005 rows from `app.schema_migrations` because the
+corresponding files were removed (they were pure CREATE-TABLE-IF-NOT-EXISTS
+duplicates of their schema counterparts). Databases that applied V004/V005
+would otherwise emit "File missing" drift warnings from `check_drift()`.
+
+Test populates schema_migrations with a realistic spread of migration
+history rows so the DELETE's selectivity is verified — only V004/V005 are
+removed, all other rows survive.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from moneybin.database import Database
+from moneybin.sql.migrations.V009__purge_redundant_table_migrations import migrate
+from tests.moneybin.migration_helpers import insert_rows, run_migration
+
+_SCHEMA_MIGRATIONS_COLS = (
+    "version",
+    "filename",
+    "checksum",
+    "success",
+    "execution_ms",
+    "applied_at",
+)
+
+_SEED_ROWS: list[tuple[int, str, str, bool, int, datetime]] = [
+    (
+        1,
+        "V001__rename_ofx_transaction_id.py",
+        "a" * 64,
+        True,
+        12,
+        datetime(2025, 11, 1, 10, 0, 0),
+    ),
+    (
+        3,
+        "V003__ofx_import_batch_columns.py",
+        "b" * 64,
+        True,
+        18,
+        datetime(2025, 11, 2, 10, 0, 0),
+    ),
+    (
+        4,
+        "V004__create_app_account_settings.sql",
+        "c" * 64,
+        True,
+        9,
+        datetime(2025, 11, 3, 10, 0, 0),
+    ),
+    (
+        5,
+        "V005__create_app_balance_assertions.sql",
+        "d" * 64,
+        True,
+        7,
+        datetime(2025, 11, 4, 10, 0, 0),
+    ),
+    (
+        6,
+        "V006__migrate_app_merchants_to_user_merchants.py",
+        "e" * 64,
+        True,
+        24,
+        datetime(2025, 11, 5, 10, 0, 0),
+    ),
+    (
+        7,
+        "V007__transaction_curation.py",
+        "f" * 64,
+        True,
+        31,
+        datetime(2025, 11, 6, 10, 0, 0),
+    ),
+]
+
+
+def _populate_schema_migrations(db: Database) -> None:
+    # schema_migrations is empty after init_schemas; reset defensively in case
+    # a future change pre-seeds it.
+    db.execute("DELETE FROM app.schema_migrations")
+    insert_rows(db, "app", "schema_migrations", _SCHEMA_MIGRATIONS_COLS, _SEED_ROWS)
+
+
+class TestV009Migration:
+    """V009 migration: V004/V005 history rows purged; other rows preserved."""
+
+    def test_v009_deletes_v004_and_v005_rows(self, db: Database) -> None:
+        """V004 and V005 rows are removed; non-target rows untouched."""
+        _populate_schema_migrations(db)
+
+        run_migration(db, migrate)
+
+        remaining = db.execute(
+            "SELECT version FROM app.schema_migrations ORDER BY version"
+        ).fetchall()
+        assert [r[0] for r in remaining] == [1, 3, 6, 7]
+
+    def test_v009_preserves_other_row_contents(self, db: Database) -> None:
+        """Non-target rows keep their filenames, checksums, and timestamps."""
+        _populate_schema_migrations(db)
+
+        run_migration(db, migrate)
+
+        rows = db.execute(
+            "SELECT version, filename, checksum, success, execution_ms, applied_at "
+            "FROM app.schema_migrations ORDER BY version"
+        ).fetchall()
+        expected = [row for row in _SEED_ROWS if row[0] not in {4, 5}]
+        assert rows == expected
+
+    def test_v009_noop_when_v004_v005_absent(self, db: Database) -> None:
+        """Fresh installs that never ran V004/V005 see no error and no row churn."""
+        db.execute("DELETE FROM app.schema_migrations")
+        insert_rows(
+            db,
+            "app",
+            "schema_migrations",
+            _SCHEMA_MIGRATIONS_COLS,
+            [r for r in _SEED_ROWS if r[0] not in {4, 5}],
+        )
+
+        run_migration(db, migrate)
+
+        rows = db.execute(
+            "SELECT version FROM app.schema_migrations ORDER BY version"
+        ).fetchall()
+        assert [r[0] for r in rows] == [1, 3, 6, 7]
+
+    def test_v009_idempotent_on_second_run(self, db: Database) -> None:
+        """Second migrate() is a clean no-op — rows stay as the first run left them."""
+        _populate_schema_migrations(db)
+
+        run_migration(db, migrate)
+        run_migration(db, migrate)
+
+        remaining = db.execute(
+            "SELECT version FROM app.schema_migrations ORDER BY version"
+        ).fetchall()
+        assert [r[0] for r in remaining] == [1, 3, 6, 7]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/moneybin/test_migration_v010.py
+++ b/tests/moneybin/test_migration_v010.py
@@ -4,6 +4,13 @@ V010 adds `updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP` to
 `app.user_categories` and `app.user_merchants`, and tightens the existing
 `updated_at` column on `app.category_overrides` to NOT NULL.
 
+The user_categories / user_merchants path is the load-bearing one: ADD COLUMN
+with DEFAULT backfills every pre-existing row, then SET NOT NULL needs that
+backfill committed before DuckDB will create the implicit index. Tests
+populate both tables with >=3 realistic rows so the backfill+tighten path is
+exercised end-to-end and any "Cannot create index with outstanding updates"
+regression is caught immediately.
+
 (V010 also tightens `app.merchant_overrides.updated_at` for any historical DB
 that still has that table; the table itself is dropped in V012. Tests for
 that branch were removed when the table was retired.)
@@ -17,45 +24,100 @@ import pytest
 
 from moneybin.database import Database
 from moneybin.sql.migrations.V010__add_updated_at_to_user_tables import migrate
-
-
-def _column_info(
-    db: Database, schema: str, table: str, column: str
-) -> tuple[str, bool]:
-    """Return (data_type, is_nullable_bool) for a column from duckdb_columns()."""
-    row = db.execute(
-        """
-        SELECT data_type, is_nullable
-        FROM duckdb_columns()
-        WHERE schema_name = ? AND table_name = ? AND column_name = ?
-        """,
-        [schema, table, column],
-    ).fetchone()
-    assert row is not None, f"{schema}.{table}.{column} not found"
-    data_type, is_nullable = row
-    return data_type, bool(is_nullable)
+from tests.moneybin.migration_helpers import (
+    column_exists,
+    column_info,
+    insert_rows,
+    run_migration,
+)
 
 
 def _reset_to_pre_v010_state(db: Database) -> None:
-    """Reverse the V010 end-state on a freshly-initialised DB.
+    """Reverse the V010 end-state so the migration has work to do.
 
-    `init_schemas` already creates the end-state shape. To exercise the migration
-    we drop the new columns and re-add the override column as nullable.
+    `init_schemas` produces the end-state shape; drop the new columns and
+    relax the override column back to nullable.
     """
-    # user_categories / user_merchants: drop the updated_at column if present.
     for table in ("user_categories", "user_merchants"):
-        cols = db.execute(
-            "SELECT column_name FROM duckdb_columns() "
-            "WHERE schema_name = 'app' AND table_name = ?",
-            [table],
-        ).fetchall()
-        col_names = {c[0] for c in cols}
-        if "updated_at" in col_names:
+        if column_exists(db, "app", table, "updated_at"):
             db.execute(f"ALTER TABLE app.{table} DROP COLUMN updated_at")  # noqa: S608  # table is hardcoded allowlist, not user input
 
-    # category_overrides: relax NOT NULL on updated_at.
     db.execute(
         "ALTER TABLE app.category_overrides ALTER COLUMN updated_at DROP NOT NULL"
+    )
+
+
+_USER_CATEGORIES_ROWS: list[tuple[str, str, str | None, str | None]] = [
+    ("c1a2b3c4d5e6", "Food & Dining", "Coffee Shops", "Cafes and espresso bars"),
+    ("c2b3c4d5e6f7", "Food & Dining", "Restaurants", None),
+    ("c3c4d5e6f7a8", "Transport", "Rideshare", "Lyft, Uber, etc."),
+    ("c4d5e6f7a8b9", "Income", "Side Gigs", None),
+]
+
+_USER_MERCHANTS_ROWS: list[
+    tuple[str, str | None, str, str, str | None, str | None, str]
+] = [
+    (
+        "m1a2b3c4d5e6",
+        "STARBUCKS",
+        "contains",
+        "Starbucks",
+        "Food & Dining",
+        "Coffee Shops",
+        "user",
+    ),
+    (
+        "m2b3c4d5e6f7",
+        None,
+        "oneOf",
+        "Lyft",
+        "Transport",
+        "Rideshare",
+        "ai",
+    ),
+    (
+        "m3c4d5e6f7a8",
+        "WHOLE FOODS",
+        "contains",
+        "Whole Foods Market",
+        "Food & Dining",
+        "Groceries",
+        "user",
+    ),
+    (
+        "m4d5e6f7a8b9",
+        "AMZN",
+        "contains",
+        "Amazon",
+        None,
+        None,
+        "plaid",
+    ),
+]
+
+
+def _populate_user_tables(db: Database) -> None:
+    insert_rows(
+        db,
+        "app",
+        "user_categories",
+        ("category_id", "category", "subcategory", "description"),
+        _USER_CATEGORIES_ROWS,
+    )
+    insert_rows(
+        db,
+        "app",
+        "user_merchants",
+        (
+            "merchant_id",
+            "raw_pattern",
+            "match_type",
+            "canonical_name",
+            "category",
+            "subcategory",
+            "created_by",
+        ),
+        _USER_MERCHANTS_ROWS,
     )
 
 
@@ -65,81 +127,95 @@ class TestV010Migration:
     def test_v010_adds_updated_at_to_user_categories(self, db: Database) -> None:
         """app.user_categories.updated_at must exist as TIMESTAMP NOT NULL after migration."""
         _reset_to_pre_v010_state(db)
+        _populate_user_tables(db)
 
-        # Confirm the column is absent before the migration runs (TDD anchor).
-        pre = db.execute(
-            "SELECT COUNT(*) FROM duckdb_columns() "
-            "WHERE schema_name = 'app' AND table_name = 'user_categories' "
-            "AND column_name = 'updated_at'"
-        ).fetchone()
-        assert pre is not None
-        assert pre[0] == 0
+        assert not column_exists(db, "app", "user_categories", "updated_at")
 
-        migrate(db._conn)  # pyright: ignore[reportPrivateUsage]
+        run_migration(db, migrate)
 
-        data_type, is_nullable = _column_info(
-            db, "app", "user_categories", "updated_at"
-        )
+        data_type, is_nullable = column_info(db, "app", "user_categories", "updated_at")
         assert data_type == "TIMESTAMP"
         assert is_nullable is False
+
+        null_count = db.execute(
+            "SELECT COUNT(*) FROM app.user_categories WHERE updated_at IS NULL"
+        ).fetchone()
+        assert null_count is not None
+        assert null_count[0] == 0
+
+        rows = db.execute(
+            "SELECT category_id, category, subcategory, description "
+            "FROM app.user_categories ORDER BY category_id"
+        ).fetchall()
+        assert rows == _USER_CATEGORIES_ROWS
 
     def test_v010_adds_updated_at_to_user_merchants(self, db: Database) -> None:
         """app.user_merchants.updated_at must exist as TIMESTAMP NOT NULL after migration."""
         _reset_to_pre_v010_state(db)
+        _populate_user_tables(db)
 
-        pre = db.execute(
-            "SELECT COUNT(*) FROM duckdb_columns() "
-            "WHERE schema_name = 'app' AND table_name = 'user_merchants' "
-            "AND column_name = 'updated_at'"
-        ).fetchone()
-        assert pre is not None
-        assert pre[0] == 0
+        assert not column_exists(db, "app", "user_merchants", "updated_at")
 
-        migrate(db._conn)  # pyright: ignore[reportPrivateUsage]
+        run_migration(db, migrate)
 
-        data_type, is_nullable = _column_info(db, "app", "user_merchants", "updated_at")
+        data_type, is_nullable = column_info(db, "app", "user_merchants", "updated_at")
         assert data_type == "TIMESTAMP"
         assert is_nullable is False
+
+        null_count = db.execute(
+            "SELECT COUNT(*) FROM app.user_merchants WHERE updated_at IS NULL"
+        ).fetchone()
+        assert null_count is not None
+        assert null_count[0] == 0
+
+        rows = db.execute(
+            "SELECT merchant_id, raw_pattern, match_type, canonical_name, "
+            "category, subcategory, created_by "
+            "FROM app.user_merchants ORDER BY merchant_id"
+        ).fetchall()
+        assert rows == _USER_MERCHANTS_ROWS
 
     def test_v010_tightens_category_overrides_updated_at(self, db: Database) -> None:
         """app.category_overrides.updated_at must be NOT NULL after migration."""
         _reset_to_pre_v010_state(db)
+        _populate_user_tables(db)
 
-        _, pre_nullable = _column_info(db, "app", "category_overrides", "updated_at")
+        _, pre_nullable = column_info(db, "app", "category_overrides", "updated_at")
         assert pre_nullable is True
 
-        migrate(db._conn)  # pyright: ignore[reportPrivateUsage]
+        run_migration(db, migrate)
 
-        _, post_nullable = _column_info(db, "app", "category_overrides", "updated_at")
+        _, post_nullable = column_info(db, "app", "category_overrides", "updated_at")
         assert post_nullable is False
 
     def test_v010_idempotent_on_second_run(self, db: Database) -> None:
         """Second migrate() must leave the same end-state — all three columns NOT NULL TIMESTAMP."""
         _reset_to_pre_v010_state(db)
+        _populate_user_tables(db)
 
-        migrate(db._conn)  # pyright: ignore[reportPrivateUsage]
-        migrate(db._conn)  # pyright: ignore[reportPrivateUsage]
+        run_migration(db, migrate)
+        run_migration(db, migrate)
 
         for table in (
             "user_categories",
             "user_merchants",
             "category_overrides",
         ):
-            data_type, is_nullable = _column_info(db, "app", table, "updated_at")
+            data_type, is_nullable = column_info(db, "app", table, "updated_at")
             assert data_type == "TIMESTAMP", f"{table}.updated_at type drift"
             assert is_nullable is False, f"{table}.updated_at nullability drift"
 
     def test_v010_idempotent_on_fresh_install(self, db: Database) -> None:
         """On a fresh DB where init_schemas already produced the end-state, migrate() is a no-op."""
         # No _reset call — db comes from init_schemas with the final shape.
-        migrate(db._conn)  # pyright: ignore[reportPrivateUsage]
+        run_migration(db, migrate)
 
         for table in (
             "user_categories",
             "user_merchants",
             "category_overrides",
         ):
-            data_type, is_nullable = _column_info(db, "app", table, "updated_at")
+            data_type, is_nullable = column_info(db, "app", table, "updated_at")
             assert data_type == "TIMESTAMP"
             assert is_nullable is False
 

--- a/tests/moneybin/test_migration_v011.py
+++ b/tests/moneybin/test_migration_v011.py
@@ -1,0 +1,124 @@
+"""Tests for V011: add updated_at to app.balance_assertions.
+
+V011 adds `updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP` to
+`app.balance_assertions`. Same bug class as V010: ADD COLUMN with DEFAULT
+backfills every pre-existing row, then SET NOT NULL needs that backfill
+committed before DuckDB will create the implicit index. The test populates
+the table with >=3 realistic balance assertions so the backfill+tighten
+path is exercised end-to-end and the "Cannot create index with outstanding
+updates" regression cannot slip through.
+
+See `docs/specs/core-updated-at-convention.md` — App-table schema changes.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from moneybin.database import Database
+from moneybin.sql.migrations.V011__add_updated_at_to_balance_assertions import (
+    migrate,
+)
+from tests.moneybin.migration_helpers import (
+    column_exists,
+    column_info,
+    insert_rows,
+    run_migration,
+)
+
+
+def _reset_to_pre_v011_state(db: Database) -> None:
+    """Drop the V011 `updated_at` column so the migration has work to do."""
+    if column_exists(db, "app", "balance_assertions", "updated_at"):
+        db.execute("ALTER TABLE app.balance_assertions DROP COLUMN updated_at")
+
+
+_BALANCE_ROWS: list[tuple[str, date, Decimal, str | None]] = [
+    (
+        "acct_amex_gold_002",
+        date(2026, 1, 31),
+        Decimal("-1284.92"),
+        "billing cycle close",
+    ),
+    (
+        "acct_chase_chk_001",
+        date(2026, 1, 31),
+        Decimal("4823.17"),
+        "from paper statement",
+    ),
+    ("acct_chase_chk_001", date(2026, 2, 28), Decimal("5102.44"), None),
+    ("acct_vanguard_003", date(2026, 2, 28), Decimal("76430.00"), "monthly snapshot"),
+]
+
+
+def _populate_balance_assertions(db: Database) -> None:
+    insert_rows(
+        db,
+        "app",
+        "balance_assertions",
+        ("account_id", "assertion_date", "balance", "notes"),
+        _BALANCE_ROWS,
+    )
+
+
+class TestV011Migration:
+    """V011 migration: updated_at added to app.balance_assertions."""
+
+    def test_v011_adds_updated_at_with_backfill(self, db: Database) -> None:
+        """updated_at exists as TIMESTAMP NOT NULL and every pre-existing row is backfilled."""
+        _reset_to_pre_v011_state(db)
+        _populate_balance_assertions(db)
+
+        assert not column_exists(db, "app", "balance_assertions", "updated_at")
+
+        run_migration(db, migrate)
+
+        data_type, is_nullable = column_info(
+            db, "app", "balance_assertions", "updated_at"
+        )
+        assert data_type == "TIMESTAMP"
+        assert is_nullable is False
+
+        null_count = db.execute(
+            "SELECT COUNT(*) FROM app.balance_assertions WHERE updated_at IS NULL"
+        ).fetchone()
+        assert null_count is not None
+        assert null_count[0] == 0
+
+        rows = db.execute(
+            "SELECT account_id, assertion_date, balance, notes "
+            "FROM app.balance_assertions "
+            "ORDER BY account_id, assertion_date"
+        ).fetchall()
+        assert rows == _BALANCE_ROWS
+
+    def test_v011_idempotent_on_second_run(self, db: Database) -> None:
+        """Second migrate() leaves the same end-state — column stays NOT NULL TIMESTAMP."""
+        _reset_to_pre_v011_state(db)
+        _populate_balance_assertions(db)
+
+        run_migration(db, migrate)
+        run_migration(db, migrate)
+
+        data_type, is_nullable = column_info(
+            db, "app", "balance_assertions", "updated_at"
+        )
+        assert data_type == "TIMESTAMP"
+        assert is_nullable is False
+
+    def test_v011_idempotent_on_fresh_install(self, db: Database) -> None:
+        """On a fresh DB where init_schemas already produced the end-state, migrate() is a no-op."""
+        run_migration(db, migrate)
+
+        data_type, is_nullable = column_info(
+            db, "app", "balance_assertions", "updated_at"
+        )
+        assert data_type == "TIMESTAMP"
+        assert is_nullable is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/moneybin/test_migration_v012.py
+++ b/tests/moneybin/test_migration_v012.py
@@ -111,25 +111,51 @@ class TestV012Migration:
         Without this, the post-migration `_SOURCE_PRIORITY` CASE returns NULL
         for these rows and every subsequent precedence check (including user
         writes) silently fails because `priority <= NULL` is NULL.
+
+        Populates >=3 'seed' rows alongside non-seed rows to verify selectivity:
+        only 'seed' is rewritten, other categorized_by values survive.
         """
         # Bypass the service-layer Literal check; this is the pre-migration shape.
         # No FK enforcement against core.fct_transactions (which is a view), so a
         # bare insert into app.transaction_categories is sufficient.
-        db.execute(
-            "INSERT INTO app.transaction_categories "
-            "(transaction_id, category, subcategory, categorized_at, categorized_by) "
-            "VALUES ('t_legacy_seed', 'Food & Dining', 'Coffee Shops', "
-            "CURRENT_TIMESTAMP, 'seed')"
-        )
+        seed_rows = [
+            ("t_legacy_seed_1", "Food & Dining", "Coffee Shops", "seed"),
+            ("t_legacy_seed_2", "Transport", "Rideshare", "seed"),
+            ("t_legacy_seed_3", "Shopping", "General Merchandise", "seed"),
+        ]
+        non_seed_rows = [
+            ("t_user_1", "Food & Dining", "Restaurants", "user"),
+            ("t_rule_1", "Bills & Utilities", "Internet", "rule"),
+        ]
+        for transaction_id, category, subcategory, categorized_by in (
+            seed_rows + non_seed_rows
+        ):
+            db.execute(
+                "INSERT INTO app.transaction_categories "
+                "(transaction_id, category, subcategory, categorized_at, categorized_by) "
+                "VALUES (?, ?, ?, CURRENT_TIMESTAMP, ?)",
+                [transaction_id, category, subcategory, categorized_by],
+            )
 
         migrate(db._conn)  # pyright: ignore[reportPrivateUsage]
 
-        row = db.execute(
-            "SELECT categorized_by FROM app.transaction_categories "
-            "WHERE transaction_id = 't_legacy_seed'"
-        ).fetchone()
-        assert row is not None
-        assert row[0] == "rule"
+        for transaction_id, _category, _sub, _by in seed_rows:
+            row = db.execute(
+                "SELECT categorized_by FROM app.transaction_categories "
+                "WHERE transaction_id = ?",
+                [transaction_id],
+            ).fetchone()
+            assert row is not None
+            assert row[0] == "rule"
+
+        for transaction_id, _category, _sub, original_by in non_seed_rows:
+            row = db.execute(
+                "SELECT categorized_by FROM app.transaction_categories "
+                "WHERE transaction_id = ?",
+                [transaction_id],
+            ).fetchone()
+            assert row is not None
+            assert row[0] == original_by
 
     def test_v012_seed_rewrite_is_noop_when_absent(self, db: Database) -> None:
         """No legacy 'seed' rows → UPDATE is a clean no-op; migration completes."""


### PR DESCRIPTION
## Summary
V010 (and the same-shape V011) fail on any DB with pre-existing rows in `app.user_merchants` / `app.balance_assertions`: `ADD COLUMN ... DEFAULT` backfills every row, then `SET NOT NULL` tries to create an index under that uncommitted write and DuckDB raises `TransactionContext Error: Cannot create index with outstanding updates`. The fix is an interim `COMMIT`/`BEGIN TRANSACTION` between the two statements inside the migration body. Tests previously passed because the fixture tables were empty.

This PR fixes both migrations, establishes a `.claude/rules/database.md` rule mandating populated fixtures for data-touching migrations, and audits V007–V012 against the new rule.

## Impact
- **Local DBs blocked on V010**: after this lands, `moneybin transform apply` succeeds. If a prior failed V010 attempt left a `success=false` row in `app.schema_migrations`, delete that row (per the existing stuck-migration recovery message), then re-run.
- **Test authors**: new migrations that touch existing data must follow the rule in `.claude/rules/database.md` → "Migration test data realism". Use the new `tests/moneybin/migration_helpers.py` helpers (`column_info`, `column_exists`, `insert_rows`, `run_migration`).
- No CLI, API, or schema changes.

## Changes

### Migration fixes
- `V010__add_updated_at_to_user_tables.py`: COMMIT/BEGIN between `ADD COLUMN ... DEFAULT` and `SET NOT NULL` on the two user tables. The `category_overrides` / `merchant_overrides` loop (SET NOT NULL only — no backfill) stays inside the runner's transaction. Docstring trimmed to the non-obvious why.
- `V011__add_updated_at_to_balance_assertions.py`: same fix shape, cross-references V010 for the rationale.

### Migration test data realism rule
- `.claude/rules/database.md` gains a "Migrations" section with the ≥3-row populated-fixture rule and the requirement to wrap `migrate()` in `BEGIN`/`COMMIT` when reproducing transaction-bound bug classes.

### Test audit (V007 → V012)

| Migration | Touches data? | Test status | Action |
|---|---|---|---|
| V007 — reshape `transaction_notes`, retire `ai_audit_log` | yes | populated (1 row, 1 row) | bumped to 3 rows in both data paths |
| V008 — add `exemplars` backfill, relax `raw_pattern` | yes | no test | wrote `test_migration_v008.py` (≥3 rows) |
| V009 — purge V004/V005 schema_migrations rows | yes | no test | wrote `test_migration_v009.py` (6 rows incl. non-targets) |
| V010 — add `updated_at` to user tables | yes | EMPTY | rewrote with populated fixtures + applied the fix; verified test catches regression |
| V011 — add `updated_at` to `balance_assertions` | yes (same bug class) | no test | wrote `test_migration_v011.py` (≥3 rows) + applied the same fix; verified |
| V012 — drop `merchant_overrides`, rewrite `seed` rows | yes | populated (1 row UPDATE path) | bumped to 3 seed rows + 2 non-seed controls |

### Shared helper
- `tests/moneybin/migration_helpers.py`: `column_info`, `column_exists`, `insert_rows`, `run_migration(db, migrate_fn)`. Replaces helper boilerplate across V008/V009/V010/V011 tests. Keeps the BEGIN-TRANSACTION-wrap discipline in one place so the rule and the test code can't drift.

## Test plan
- [x] `make check test` clean (2297 unit tests passing).
- [x] V010 and V011 rewritten/new tests reproduce `TransactionContext Error: Cannot create index with outstanding updates` against the un-fixed migration (verified via `git stash` of the fix), then pass once the fix is restored.
- [ ] Manual verification on the local brandon-cc DB: run `moneybin transform apply`; if a stuck V010 row exists, delete it from `app.schema_migrations` first. Confirm `/mcp` reconnect + `accounts_list` returns all 5 accounts.

## Notes
- The interim COMMIT inside `migrate()` breaks the runner's "DDL + tracking row commit atomically" invariant for V010/V011. A crash between the COMMIT and the SET NOT NULL leaves the column added-but-nullable with no tracking row; the migration is idempotent and recovers via the existing `elif col_map["updated_at"] is True` branch on re-run. Documented in both migration module docstrings.
- The migration runner's wrap-in-transaction model is unchanged. No AST lint added for the anti-pattern — `.claude/rules/database.md` + reviewer attention is sufficient until we see the bug class a third time.