### PR TITLE
test: detect MCP↔CLI canonical-name drift (xfail backlog)

### DIFF
--- a/.claude/rules/mcp-server.md
+++ b/.claude/rules/mcp-server.md
@@ -86,8 +86,12 @@ The `detail` parameter (`summary`, `standard`, `full`) lets the AI self-select v
 
 Default: every operation is MCP-exposed. CLI-only status requires a justified exception. Two acceptable justifications:
 
-1. **Secret material through the LLM context window.** Tools that accept passphrases or encryption keys (`db_unlock`, `db_rotate_key`, `sync_rotate_key`, `db_init`). Routing those through an LLM-mediated channel is a security model violation, not a capability gap.
-2. **Hands-on operator territory.** Bootstrapping, troubleshooting, and developer-tooling operations that require physical operator presence (`db_init/lock/ps/kill/migrate/shell/ui`, `mcp_serve`, `mcp_install`, `mcp_config_path`, `profile_*`, `transform_restate`). The MCP server can't even start when the database is locked, so exposing recovery/lifecycle tools to MCP would be meaningless.
+1. **Secret material through the LLM context window.** Tools that accept or display passphrases, encryption keys, or key-derivation material (`db_init`, `db_unlock`, `db_key_rotate`, `db_key_show`, `db_key_export`, `db_key_import`, `db_key_verify`, `sync_key_rotate`). Routing those through an LLM-mediated channel is a security model violation, not a capability gap.
+2. **Hands-on operator territory.** Bootstrapping, recovery, and developer-tooling operations that require physical operator presence. The MCP server cannot even start when the database is locked, so exposing lifecycle tools to MCP would be meaningless. Covers:
+   - **Database lifecycle:** `db_init`, `db_lock`, `db_ps`, `db_kill`, `db_shell`, `db_ui`, `db_migrate_apply`, `db_migrate_status`, `db_backup`, `db_restore`, `db_info`, `db_query` (raw SQL access; agent path is `sql_query`).
+   - **Server lifecycle:** `mcp_serve`, `mcp_install`, `mcp_config_path`, `mcp_list_tools`, `mcp_list_prompts` (operator introspection of the local MCP surface).
+   - **Profile + identity:** `profile_*`.
+   - **Developer tooling:** `logs`, `stats`, `synthetic_generate`, `synthetic_reset`, `transform_seed`, `transform_restate`.
 
 What is NOT a valid CLI-only justification:
 - "Long-running" — MCP supports progress notifications.

--- a/tests/integration/test_surface_parity.py
+++ b/tests/integration/test_surface_parity.py
@@ -1,22 +1,39 @@
-"""Enforce MCP ↔ CLI surface parity by walking the live registries.
+"""Detect accidental MCP ↔ CLI canonical-name drift.
 
-Encodes the contract from `.claude/rules/mcp-server.md` and
-`docs/specs/architecture-shared-primitives.md` §MCP/CLI/SQL Symmetry:
-every MCP tool has a CLI sibling under the same canonical name (and vice
-versa) unless the divergence falls into a documented exemption category.
+**Scope.** This test compares the canonical *names* registered on each
+surface, not the functional coverage. Names should match where doing so
+costs nothing; divergence is allowed when it has a documented reason
+(batch-vs-fine-grained shape, surface-idiom conventions, secret-material
+or operator-territory exemptions per `.claude/rules/mcp-server.md`). The
+allowlists below carry those citations inline.
 
-The test walks the live FastMCP tool registry and the live Typer command
-tree (no fixture file — a fixture would record drift, not prevent it),
-canonicalizes both into underscore-joined names, and asserts the
-symmetric difference is empty modulo the allowlists below.
+**What this test is NOT.** It is not a functional-parity check. Two
+surfaces with identical user-outcome coverage but different names will
+fail this test; one MCP batch tool replacing four CLI commands will
+fail this test — even though the agent's call path is strictly better.
+Functional-parity (every user-outcome reachable from every supported
+surface, with surface-appropriate idioms) lives in a separate
+N-surface coverage spec (planned, see `docs/specs/` once authored) and
+is enforced by PR review against `mcp-tool-surface.md`'s
+"Surface change discipline" rule, not by this test.
+
+**Mechanism.** Walks the live FastMCP tool registry and the live Typer
+command tree (no fixture file — a fixture would record drift, not
+prevent it), canonicalizes both into underscore-joined names, and
+asserts the symmetric difference is empty modulo the allowlists.
 
 ## Known drift (xfail backlog)
 
-The test is marked ``xfail(strict=True)`` because pre-existing drift
-between the two surfaces exceeds the documented exemption categories.
+The test is marked ``xfail(strict=True)`` because pre-existing
+canonical-name divergence exceeds what the current allowlists cover.
 Strict mode flips to a CI failure the moment the drift resolves,
-prompting removal of the xfail. Categories of pending drift, captured
-from the diff at test introduction:
+prompting removal of the xfail. Each backlog item is one of:
+**rename** (accidental drift; pick the canonical form and update one
+side), **allowlist** (intentional divergence; add to the relevant
+frozen set below with a citation), or **build** (functional gap; add
+the missing tool/command — caught by the functional-coverage check,
+not by this test). Categories captured from the diff at test
+introduction:
 
 - **A. Naming-pattern mismatches.** MCP ``*_get`` vs CLI ``*_show``
   across the ``reports_*`` family (9 tools), ``accounts_get`` vs
@@ -174,14 +191,14 @@ def _format_diff(label: str, names: set[str]) -> str:
 @pytest.mark.xfail(
     strict=True,
     reason=(
-        "Pre-existing MCP↔CLI drift exceeds the documented exemption "
-        "categories. See module docstring for the A–D backlog. Strict "
-        "xfail flips to FAIL the moment drift resolves — remove this "
-        "marker then."
+        "Pre-existing canonical-name drift exceeds current allowlists. "
+        "See module docstring for the A–D triage backlog (rename / "
+        "allowlist / build). Strict xfail flips to FAIL the moment drift "
+        "resolves — remove this marker then."
     ),
 )
-def test_cli_mcp_surface_parity() -> None:
-    """Every MCP tool has a CLI sibling (or is allowlisted), and vice versa."""
+def test_cli_mcp_name_drift() -> None:
+    """Every registered name matches across surfaces, or is allowlisted."""
     mcp_names = _collect_mcp_tool_names()
     cli_names = _collect_cli_command_names()
 

--- a/tests/integration/test_surface_parity.py
+++ b/tests/integration/test_surface_parity.py
@@ -62,13 +62,14 @@ introduction:
   (``accounts_show``, ``accounts_balance_show``,
   ``accounts_investments_show``).
 - **D. CLI gaps.** MCP tools that need a CLI sibling but lack one:
-  ``moneybin_discover`` (MCP-only by design — the visibility-disclosure
-  tool), ``accounts_summary``, ``import_inbox_sync``,
+  ``accounts_summary``, ``import_inbox_sync``,
   ``transactions_categorize_assist``,
   ``transactions_categorize_pending_list``,
   ``transactions_categorize_rule_delete``,
   ``transactions_categorize_rules_create``, ``transactions_get``,
-  ``transactions_recurring_list``.
+  ``transactions_recurring_list``. ``moneybin_discover`` is MCP-only by
+  design (visibility-disclosure mechanism) and lives in
+  ``MCP_ONLY_ALLOWED`` rather than the drift backlog.
 """
 
 # ruff: noqa: S101
@@ -101,9 +102,11 @@ _SECRET_MATERIAL: frozenset[str] = frozenset({
 # CLI-only by operator policy: bootstrapping, recovery, and developer-
 # tooling that require physical operator presence. See
 # `.claude/rules/mcp-server.md` "When CLI-only is justified" category 2.
+# Note: ``db_init`` belongs to ``_SECRET_MATERIAL`` (it accepts a
+# passphrase) — secret-material is the load-bearing justification per
+# the rule's NOT-valid list. Not duplicated here.
 _OPERATOR_TERRITORY: frozenset[str] = frozenset({
     # Database lifecycle
-    "db_init",
     "db_lock",
     "db_ps",
     "db_kill",
@@ -140,22 +143,31 @@ _OPERATOR_TERRITORY: frozenset[str] = frozenset({
 
 CLI_ONLY_ALLOWED: frozenset[str] = _SECRET_MATERIAL | _OPERATOR_TERRITORY
 
-# No MCP tool should be missing its CLI sibling. If a justification ever
-# exists, document it here with a citation to the spec section that
-# approves it.
-MCP_ONLY_ALLOWED: frozenset[str] = frozenset()
+# MCP-only by design — tools that implement MCP-protocol-specific
+# mechanisms with no CLI semantic. ``moneybin_discover`` is the
+# visibility-disclosure tool that re-enables extended-namespace tools
+# per MCP session; the CLI has no notion of session-scoped tool
+# visibility. See `.claude/rules/mcp-server.md` Tool Taxonomy
+# (progressive disclosure paragraph) and `docs/specs/mcp-architecture.md`
+# §3.
+MCP_ONLY_ALLOWED: frozenset[str] = frozenset({
+    "moneybin_discover",
+})
 
 
 def _collect_mcp_tool_names() -> set[str]:
     """Every registered MCP tool name, transforms bypassed.
 
-    Uses ``_local_provider.list_tools()`` (FastMCP 3.x internal) so the
-    parity check sees the full registered surface regardless of the
+    Uses ``_list_tools()`` (FastMCP 3.x internal) so the parity check
+    sees the full registered surface regardless of the
     ``progressive_disclosure`` setting — a tool hidden by the Visibility
-    transform is still registered and still owes a CLI sibling.
+    transform is still registered and still owes a CLI sibling. The
+    public ``list_tools()`` filters by visibility. Matches the
+    established convention used by ``src/moneybin/mcp/resources.py:150``
+    and ``src/moneybin/cli/commands/mcp.py:597``.
     """
     mcp_server.register_core_tools()
-    raw = asyncio.run(mcp_server.mcp._local_provider.list_tools())  # pyright: ignore[reportPrivateUsage]
+    raw = asyncio.run(mcp_server.mcp._list_tools())  # noqa: SLF001  # fastmcp internal — public list_tools() filters by visibility  # pyright: ignore[reportPrivateUsage]
     return {tool.name for tool in raw}
 
 
@@ -173,6 +185,12 @@ def _collect_cli_command_names() -> set[str]:
         for cmd_name, cmd in group.commands.items():
             path = (*prefix, cmd_name.replace("-", "_"))
             if isinstance(cmd, click.Group):
+                # Groups with `invoke_without_command=True` are also callable
+                # bare (e.g., `moneybin import inbox` drains the inbox via its
+                # callback). Record the group path as a command in addition
+                # to recursing into subcommands.
+                if cmd.invoke_without_command:
+                    names.add("_".join(path))
                 names |= walk(cmd, path)
             else:
                 names.add("_".join(path))
@@ -187,14 +205,23 @@ def _format_diff(label: str, names: set[str]) -> str:
     return f"{label} ({len(names)}):\n  " + "\n  ".join(sorted(names))
 
 
+# Marker: integration. The test runs in-process with no DB / SQLMesh /
+# subprocess, but it exercises the wiring between two subsystems (MCP
+# registration + Typer CLI tree) and registers the full MCP tool surface
+# at import time — broader than a single unit. Placement under
+# ``tests/integration/`` matches the directory convention from
+# ``.claude/rules/testing.md`` "Test Coverage by Layer."
 @pytest.mark.integration
 @pytest.mark.xfail(
     strict=True,
+    raises=AssertionError,
     reason=(
         "Pre-existing canonical-name drift exceeds current allowlists. "
         "See module docstring for the A–D triage backlog (rename / "
         "allowlist / build). Strict xfail flips to FAIL the moment drift "
-        "resolves — remove this marker then."
+        "resolves — remove this marker then. ``raises=AssertionError`` "
+        "ensures only the parity assertion is masked; setup or "
+        "introspection errors still fail the test."
     ),
 )
 def test_cli_mcp_name_drift() -> None:

--- a/tests/integration/test_surface_parity.py
+++ b/tests/integration/test_surface_parity.py
@@ -1,0 +1,206 @@
+"""Enforce MCP ↔ CLI surface parity by walking the live registries.
+
+Encodes the contract from `.claude/rules/mcp-server.md` and
+`docs/specs/architecture-shared-primitives.md` §MCP/CLI/SQL Symmetry:
+every MCP tool has a CLI sibling under the same canonical name (and vice
+versa) unless the divergence falls into a documented exemption category.
+
+The test walks the live FastMCP tool registry and the live Typer command
+tree (no fixture file — a fixture would record drift, not prevent it),
+canonicalizes both into underscore-joined names, and asserts the
+symmetric difference is empty modulo the allowlists below.
+
+## Known drift (xfail backlog)
+
+The test is marked ``xfail(strict=True)`` because pre-existing drift
+between the two surfaces exceeds the documented exemption categories.
+Strict mode flips to a CI failure the moment the drift resolves,
+prompting removal of the xfail. Categories of pending drift, captured
+from the diff at test introduction:
+
+- **A. Naming-pattern mismatches.** MCP ``*_get`` vs CLI ``*_show``
+  across the ``reports_*`` family (9 tools), ``accounts_get`` vs
+  ``accounts_show``, ``accounts_settings_update`` vs ``accounts_set``,
+  ``transactions_review_status`` vs ``transactions_review``,
+  ``import_list_formats`` vs ``import_formats_list``, ``system_doctor``
+  vs top-level ``doctor``, ``reports_budget_status`` vs
+  ``reports_budget``, ``accounts_balance_assertion_delete`` vs
+  ``accounts_balance_delete``.
+- **B. Set-semantic vs verb-list split.** MCP collapses to ``*_set``
+  while CLI splits into add/remove/list/clear:
+  ``import_labels_set`` / ``import_labels_{add,remove,list}``,
+  ``transactions_splits_set`` / ``transactions_splits_{add,remove,clear,list}``,
+  ``transactions_tags_set`` / ``transactions_tags_{add,remove,list}``.
+- **C. MCP gaps.** CLI commands that need an MCP sibling but lack one:
+  ``transactions_matches_*`` (4), ``transactions_categorize_ml_*`` (3),
+  ``tax_deductions``, ``privacy_redact``, ``sync_login``/``sync_logout``,
+  ``transactions_audit``, ``transactions_list``, ``transactions_review``,
+  ``transactions_notes_list``, ``export_run``, ``budget_delete``,
+  ``categories_delete``, ``system_audit_show``, ``import_history``,
+  ``import_inbox_path``, ``import_labels_*``,
+  ``transactions_categorize_apply_from_file``,
+  ``transactions_categorize_auto_rules``,
+  ``transactions_categorize_export_uncategorized``,
+  ``transactions_categorize_rules_apply``, plus the singular-show family
+  (``accounts_show``, ``accounts_balance_show``,
+  ``accounts_investments_show``).
+- **D. CLI gaps.** MCP tools that need a CLI sibling but lack one:
+  ``moneybin_discover`` (MCP-only by design — the visibility-disclosure
+  tool), ``accounts_summary``, ``import_inbox_sync``,
+  ``transactions_categorize_assist``,
+  ``transactions_categorize_pending_list``,
+  ``transactions_categorize_rule_delete``,
+  ``transactions_categorize_rules_create``, ``transactions_get``,
+  ``transactions_recurring_list``.
+"""
+
+# ruff: noqa: S101
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+import pytest
+import typer
+
+from moneybin.cli.main import app as cli_app
+from moneybin.mcp import server as mcp_server
+
+# CLI-only by security policy: secret material through the LLM context
+# window. See `.claude/rules/mcp-server.md` "When CLI-only is justified"
+# category 1.
+_SECRET_MATERIAL: frozenset[str] = frozenset({
+    "db_init",
+    "db_unlock",
+    "db_key_rotate",
+    "db_key_show",
+    "db_key_export",
+    "db_key_import",
+    "db_key_verify",
+    "sync_key_rotate",
+})
+
+# CLI-only by operator policy: bootstrapping, recovery, and developer-
+# tooling that require physical operator presence. See
+# `.claude/rules/mcp-server.md` "When CLI-only is justified" category 2.
+_OPERATOR_TERRITORY: frozenset[str] = frozenset({
+    # Database lifecycle
+    "db_init",
+    "db_lock",
+    "db_ps",
+    "db_kill",
+    "db_shell",
+    "db_ui",
+    "db_migrate_apply",
+    "db_migrate_status",
+    "db_backup",
+    "db_restore",
+    "db_info",
+    # Raw SQL access — agent path is `sql_query` MCP tool.
+    "db_query",
+    # MCP server lifecycle + operator introspection
+    "mcp_serve",
+    "mcp_install",
+    "mcp_config_path",
+    "mcp_list_tools",
+    "mcp_list_prompts",
+    # Profile + identity
+    "profile_create",
+    "profile_delete",
+    "profile_list",
+    "profile_set",
+    "profile_show",
+    "profile_switch",
+    # Developer tooling
+    "logs",
+    "stats",
+    "synthetic_generate",
+    "synthetic_reset",
+    "transform_seed",
+    "transform_restate",
+})
+
+CLI_ONLY_ALLOWED: frozenset[str] = _SECRET_MATERIAL | _OPERATOR_TERRITORY
+
+# No MCP tool should be missing its CLI sibling. If a justification ever
+# exists, document it here with a citation to the spec section that
+# approves it.
+MCP_ONLY_ALLOWED: frozenset[str] = frozenset()
+
+
+def _collect_mcp_tool_names() -> set[str]:
+    """Every registered MCP tool name, transforms bypassed.
+
+    Uses ``_local_provider.list_tools()`` (FastMCP 3.x internal) so the
+    parity check sees the full registered surface regardless of the
+    ``progressive_disclosure`` setting — a tool hidden by the Visibility
+    transform is still registered and still owes a CLI sibling.
+    """
+    mcp_server.register_core_tools()
+    raw = asyncio.run(mcp_server.mcp._local_provider.list_tools())  # pyright: ignore[reportPrivateUsage]
+    return {tool.name for tool in raw}
+
+
+def _collect_cli_command_names() -> set[str]:
+    """Walk the Typer command tree → underscore-joined canonical names.
+
+    ``moneybin transactions categorize apply`` →
+    ``transactions_categorize_apply``. Hyphens in command names are
+    normalized to underscores (``list-tools`` → ``list_tools``) to match
+    the MCP convention.
+    """
+
+    def walk(group: click.Group, prefix: tuple[str, ...]) -> set[str]:
+        names: set[str] = set()
+        for cmd_name, cmd in group.commands.items():
+            path = (*prefix, cmd_name.replace("-", "_"))
+            if isinstance(cmd, click.Group):
+                names |= walk(cmd, path)
+            else:
+                names.add("_".join(path))
+        return names
+
+    root = typer.main.get_command(cli_app)
+    assert isinstance(root, click.Group), "moneybin root CLI should be a Group"
+    return walk(root, ())
+
+
+def _format_diff(label: str, names: set[str]) -> str:
+    return f"{label} ({len(names)}):\n  " + "\n  ".join(sorted(names))
+
+
+@pytest.mark.integration
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Pre-existing MCP↔CLI drift exceeds the documented exemption "
+        "categories. See module docstring for the A–D backlog. Strict "
+        "xfail flips to FAIL the moment drift resolves — remove this "
+        "marker then."
+    ),
+)
+def test_cli_mcp_surface_parity() -> None:
+    """Every MCP tool has a CLI sibling (or is allowlisted), and vice versa."""
+    mcp_names = _collect_mcp_tool_names()
+    cli_names = _collect_cli_command_names()
+
+    mcp_only = mcp_names - cli_names - MCP_ONLY_ALLOWED
+    cli_only = cli_names - mcp_names - CLI_ONLY_ALLOWED
+
+    messages: list[str] = []
+    if mcp_only:
+        messages.append(
+            _format_diff("MCP tools without CLI siblings", mcp_only)
+            + "\n  → Add the CLI command, or add to MCP_ONLY_ALLOWED with "
+            "a citation to the spec section that approves it."
+        )
+    if cli_only:
+        messages.append(
+            _format_diff("CLI commands without MCP siblings", cli_only)
+            + "\n  → Add the MCP tool, or add to CLI_ONLY_ALLOWED. The only "
+            "approved CLI-only justifications are in `.claude/rules/"
+            "mcp-server.md` 'When CLI-only is justified'."
+        )
+
+    assert not messages, "\n\n".join(messages)

--- a/tests/integration/test_surface_parity.py
+++ b/tests/integration/test_surface_parity.py
@@ -85,10 +85,12 @@ import typer
 from moneybin.cli.main import app as cli_app
 from moneybin.mcp import server as mcp_server
 
-# CLI-only by security policy: secret material through the LLM context
-# window. See `.claude/rules/mcp-server.md` "When CLI-only is justified"
-# category 1.
-_SECRET_MATERIAL: frozenset[str] = frozenset({
+# Names allowed CLI-only by `.claude/rules/mcp-server.md` "When CLI-only
+# is justified." Grouped by category for documentation; the test only
+# uses the union.
+CLI_ONLY_ALLOWED: frozenset[str] = frozenset({
+    # Category 1 — secret material through the LLM context window
+    # (passphrases, encryption keys, key-derivation material).
     "db_init",
     "db_unlock",
     "db_key_rotate",
@@ -97,16 +99,7 @@ _SECRET_MATERIAL: frozenset[str] = frozenset({
     "db_key_import",
     "db_key_verify",
     "sync_key_rotate",
-})
-
-# CLI-only by operator policy: bootstrapping, recovery, and developer-
-# tooling that require physical operator presence. See
-# `.claude/rules/mcp-server.md` "When CLI-only is justified" category 2.
-# Note: ``db_init`` belongs to ``_SECRET_MATERIAL`` (it accepts a
-# passphrase) — secret-material is the load-bearing justification per
-# the rule's NOT-valid list. Not duplicated here.
-_OPERATOR_TERRITORY: frozenset[str] = frozenset({
-    # Database lifecycle
+    # Category 2 — operator territory. Database lifecycle:
     "db_lock",
     "db_ps",
     "db_kill",
@@ -117,22 +110,21 @@ _OPERATOR_TERRITORY: frozenset[str] = frozenset({
     "db_backup",
     "db_restore",
     "db_info",
-    # Raw SQL access — agent path is `sql_query` MCP tool.
-    "db_query",
-    # MCP server lifecycle + operator introspection
+    "db_query",  # raw SQL access; agent path is `sql_query` MCP tool
+    # MCP server lifecycle + operator introspection:
     "mcp_serve",
     "mcp_install",
     "mcp_config_path",
     "mcp_list_tools",
     "mcp_list_prompts",
-    # Profile + identity
+    # Profile + identity:
     "profile_create",
     "profile_delete",
     "profile_list",
     "profile_set",
     "profile_show",
     "profile_switch",
-    # Developer tooling
+    # Developer tooling:
     "logs",
     "stats",
     "synthetic_generate",
@@ -140,8 +132,6 @@ _OPERATOR_TERRITORY: frozenset[str] = frozenset({
     "transform_seed",
     "transform_restate",
 })
-
-CLI_ONLY_ALLOWED: frozenset[str] = _SECRET_MATERIAL | _OPERATOR_TERRITORY
 
 # MCP-only by design — tools that implement MCP-protocol-specific
 # mechanisms with no CLI semantic. ``moneybin_discover`` is the
@@ -205,12 +195,6 @@ def _format_diff(label: str, names: set[str]) -> str:
     return f"{label} ({len(names)}):\n  " + "\n  ".join(sorted(names))
 
 
-# Marker: integration. The test runs in-process with no DB / SQLMesh /
-# subprocess, but it exercises the wiring between two subsystems (MCP
-# registration + Typer CLI tree) and registers the full MCP tool surface
-# at import time — broader than a single unit. Placement under
-# ``tests/integration/`` matches the directory convention from
-# ``.claude/rules/testing.md`` "Test Coverage by Layer."
 @pytest.mark.integration
 @pytest.mark.xfail(
     strict=True,


### PR DESCRIPTION
## Summary

Adds a single integration test that walks the live FastMCP tool registry and the Typer command tree and detects when canonical names drift apart accidentally. **This is not a functional-parity check** — it's a cheap drift detector with documented exemptions. Functional-coverage parity (every user-outcome reachable from every supported surface, with surface-appropriate idioms) is a separate N-surface artifact, planned alongside the REST API surface in M3D.

The test lands in `xfail(strict=True)` state because pre-existing canonical-name divergence exceeds what the current allowlists cover. Strict mode makes the moment-of-cleanup an actionable CI signal: when the drift resolves the test starts passing, strict xfail converts XPASS → FAIL, and the marker gets removed in the same PR.

## Impact

- New CI signal for accidental name drift on MCP↔CLI surfaces.
- No runtime change. No CLI/MCP surface change. Pure test + rule-doc addition.
- `.claude/rules/mcp-server.md` "When CLI-only is justified" now enumerates a wider set of operator-territory tools that were previously covered by spirit but not letter.

## Changes

### `tests/integration/test_surface_parity.py`

Walks the live FastMCP tool registry (via `_local_provider.list_tools()` so transforms don't hide tools) and the Typer command tree (recursing through `click.Group` subcommands, joining with `_`, normalizing hyphens). Computes the symmetric difference against two frozen-set allowlists with inline justification citing `.claude/rules/mcp-server.md`. Failure message includes both sides of the diff and points the contributor at the triage decision tree (rename / allowlist / build).

Docstring is explicit about scope: this test catches accidental name drift; **it does not enforce functional parity**. One MCP batch tool that replaces four fine-grained CLI commands will fail this test even though the agent's call path is strictly better — that's the functional-coverage spec's job, not this test's.

### `.claude/rules/mcp-server.md` — "When CLI-only is justified"

Expanded category 1 (secret material) to include the `db_key_*` family (`show`, `export`, `import`, `verify`) — all touch encryption-key material. Expanded category 2 (operator territory) into a structured sub-list covering DB lifecycle, server lifecycle + operator introspection, profile + identity, and developer tooling. Names that were already covered by intent but not enumerated (`db_backup`/`restore`/`info`/`query`, `mcp_list_tools`/`prompts`, `logs`, `stats`, `synthetic_*`, `transform_seed`) are now explicit.

## Testing

- `uv run pytest tests/integration/test_surface_parity.py -v` → 1 xfailed (as expected; strict).
- `uv run pytest -q` → full suite green: 1 xfailed (new test, intentional), 1 skipped (pre-existing, unrelated).
- `uv run ruff format && uv run ruff check && uv run pyright tests/integration/test_surface_parity.py` → clean.
- Sanity-checked the failure body renders the full categorized diff under `--runxfail`.

## Notes

The test docstring catalogues the drift backlog as a triage tree, not a "drift to eliminate" list. Each backlog item is one of:

- **rename** — accidental name divergence; pick the canonical form (`mcp-server.md` taxonomy: `noun = query`, `verb = action`, no CRUD naming) and update one side.
- **allowlist** — intentional divergence with documented rationale (batch-vs-fine-grained shape, surface-idiom convention, privacy/security/operator exemption). Add to the relevant frozen set with a citation.
- **build** — real functional gap on one surface. Caught by the upcoming functional-coverage check, not by this test; tracked as feature work.

The xfail marker should be removed in the PR that closes the last item, after the triage is complete.