### PR TITLE
Add docs-maintenance skills for spec/progress/doc reconciliation

### DIFF
--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: update-docs
+description: Update the public-facing documentation surface — README, CHANGELOG, CONTRIBUTING, top-level docs (architecture, audience, comparison, features, licensing, roadmap), docs/guides/, docs/reference/, docs/architecture/, docs/tech/ — to reflect what the in-scope code change means for users. Persona-aware writing per docs/audience.md; assumes the reader is not an expert on internals. Excludes specs and ADRs (those are /update-specs and by-hand respectively). Use this when finishing user-visible work, before opening a PR that adds capability, when a milestone closes, or whenever the user says "update the docs" / "make sure the docs reflect this." Don't wait to be asked — if user-visible work just shipped, suggest running it.
+---
+
+# /update-docs
+
+The public doc surface is a storefront, not a manual. Each file has a
+purpose and an audience. This skill updates that surface for in-scope
+changes, with **persona-aware writing** — never as a dumping ground for
+whatever came out of implementation. The goal is that a reader who isn't an
+expert on MoneyBin's internals gets exactly the answer they came for, in the
+voice and density appropriate to where they landed.
+
+## When this skill is the right tool
+
+- Finishing user-visible work (new CLI command, new MCP tool, new import format, behavior change)
+- Before opening a PR that adds capability — so the PR ships with its docs
+- When a milestone closes and the README status callout / roadmap needs to move
+- When the user asks whether the public docs reflect current state
+
+This skill is **not** for writing brand-new guides from scratch — the
+information architecture matters too much to automate. Use it to update,
+prune, and reconcile.
+
+## Files in scope
+
+**IN scope:**
+
+- `README.md`
+- `CHANGELOG.md`
+- `CONTRIBUTING.md`
+- `docs/*.md` — top-level: `architecture.md`, `audience.md`, `comparison.md`, `features.md`, `licensing.md`, `roadmap.md`
+- `docs/guides/`
+- `docs/reference/`
+- `docs/architecture/`
+- `docs/tech/`
+
+**OUT of scope:**
+
+- `docs/specs/` — that's `/update-specs`
+- `docs/decisions/` — ADRs are durable, edited by hand only
+- `private/` — that's `/update-progress`
+
+## Personas (read docs/audience.md as the canonical source)
+
+Voice and density depend on who's reading. The current personas:
+
+- **Power-user finance migrant** — coming from Tiller / Lunch Money / Beancount / hledger; comfortable with CLIs; wants the AI + database story.
+- **AI-native developer** — lives in Claude Code / Cursor / VS Code; wants MCP for every domain; reads code fluently.
+- **Self-hoster** — runs Vaultwarden / NextCloud / Photoprism; has a personal-finance todo; wants clean install + good defaults.
+- **Tracker** (post-launch) — wants polished visual dashboard for spending and net worth.
+- **FIRE / wealth-builder** (post-launch) — net worth + investments + cost basis.
+
+For "not yet for you" cases, point honestly to alternatives (`docs/audience.md` has the table). Honest framing is part of the brand.
+
+## Per-file voice + length budget
+
+| File | Primary persona | Tone | Length budget |
+|---|---|---|---|
+| `README.md` | Power-user migrant + AI-native dev | Storefront — what is it, why care, how to start | ~220–260 lines (per stored feedback) |
+| `CHANGELOG.md` | All users | Factual, one bullet per user-visible change, cite PR | One section per release / Unreleased |
+| `CONTRIBUTING.md` | Self-hoster, OSS contributor | Concrete steps to land a change | As short as possible |
+| `docs/architecture.md` | AI-native dev, technical migrant | Guarantees → diagram → contract → negative space | One page |
+| `docs/audience.md` | Anyone evaluating | Honest "this is and isn't for you" | Tight |
+| `docs/comparison.md` | Migrant from cloud PFM | 7-wide table with ✅/❌/🟡; no text-heavy cells | Tight |
+| `docs/features.md` | Anyone evaluating | Capability snapshot, link out to guides | Bullets |
+| `docs/roadmap.md` | Anyone evaluating | Milestone tables (📐 designed / 🗓️ planned / ✅ shipped) | One page |
+| `docs/guides/` | Power-user migrant | How-to, one task per guide, CLI examples | One screen per concept |
+| `docs/reference/` | AI-native dev | Complete and dense — table-shaped | As long as needed |
+| `docs/architecture/` | AI-native dev | Deep technical context; **Mermaid over ASCII** for diagrams | As long as needed |
+| `docs/tech/` | AI-native dev | Implementation-specific notes | As long as needed |
+
+## Stored anti-patterns (do not reintroduce)
+
+These come from prior feedback memories and should be passed to every
+subagent verbatim. They keep accidentally regrowing:
+
+- **README anti-patterns**: in-README roadmap matrix; text-heavy comparison cells; feature inventories; License essays; "Wave"/"Level" terminology; 9-node pipeline Mermaid in the README. Comparison stays 7-wide with ✅/❌/🟡 emoji. How-It-Works Mermaid stays 3–4 nodes (sales-pitch, not architecture).
+- **No private/ references in public docs.** Never cite `private/...` paths or phrasing like "the strategic review" / "the strategic audit named X" in README, CHANGELOG, CONTRIBUTING, or any `docs/` file. Restate substance directly. If you find existing violations, fix them in-pass.
+- **No `Co-Authored-By: Claude` trailers in any commit message produced by this skill.**
+- **Tagline preserved**: `Your finances, understood by AI.` — do not change unless Brandon explicitly asks.
+- **Milestone names**: `M0`, `M1`, `M2A`, `M2B`, `M2C`, `M3A` (Plaid), `M3B` (investments), `M3C` (multi-currency + budgets), `M3D` (Web UI + Streamable HTTP), `M3E` (hosted launch). Don't invent new ones.
+
+## Scope detection
+
+Default scope is the in-flight change, not a doc sweep. Auditing all docs at
+once produces sprawling diffs and overwrites things that were intentional.
+
+Resolve scope in this order; first match wins:
+
+1. **Explicit arguments.** If the user passed paths, a doc name, or "everything," use those.
+2. **Branch diff.** If HEAD is ahead of main: `git diff main...HEAD --name-only`.
+3. **PR.** Else if `gh pr view --json files -q '.files[].path'` returns a PR's file list, use that.
+4. **Uncommitted.** Else `git status --porcelain | awk '{print $2}'`.
+5. **Empty.** If still nothing, ask what scope to use — don't default to "all docs."
+
+Print a one-line scope summary before doing anything:
+
+> Scope: 4 source files changed (1 new MCP tool, 1 new CLI command); evaluating 3 docs: README.md, docs/guides/cli.md, CHANGELOG.md.
+
+## Process
+
+### 1. Map code changes to user-visible effect
+
+For each in-scope code change, identify what a *user* (not a developer)
+would notice. Common mappings:
+
+- New CLI command → README "What works today" reference + relevant guide + CHANGELOG `Added`
+- New MCP tool → MCP guide + features.md + CHANGELOG `Added`
+- New import format → import guide + features.md + CHANGELOG `Added`
+- Behavior change in existing command → relevant guide + CHANGELOG `Changed`
+- Bug fix users will notice → CHANGELOG `Fixed`
+- Internal refactor with no user-visible effect → no doc change; do not invent one
+
+If a change has no user-visible effect, say so in the report and move on.
+
+### 2. Dispatch one subagent per affected doc file, in parallel
+
+Cap at **3 in flight** per CLAUDE.md. Larger sets process in waves.
+
+Each subagent receives a self-contained prompt with:
+
+- Path of the **single doc file** it owns.
+- The persona, tone, and length budget for that file (from the table above) — paste the row verbatim, don't summarize.
+- The in-scope diff and a short summary of the user-visible effect.
+- The anti-patterns block above — verbatim.
+- The Mermaid-over-ASCII rule (from `.claude/rules/documentation.md`) if diagrams are involved.
+
+Use `subagent_type: general-purpose`.
+
+### 3. Each subagent does, for its file
+
+- Update only what the in-scope change requires.
+- Write in the persona voice for that file.
+- Cut content that's no longer accurate.
+- Respect the length budget — if you're adding, find something to remove or compact. Don't grow indefinitely.
+- Apply the anti-patterns rules. If the file currently violates one (e.g., a private/ ref), fix it in-pass.
+- For new diagrams, use Mermaid code blocks.
+
+### 4. Run the shipping.md checklist for any newly-shipped feature
+
+Per `.claude/rules/shipping.md`:
+
+- **CHANGELOG entry** under `Unreleased` in the correct category (Added / Changed / Deprecated / Removed / Fixed / Security). Cite the PR. Skip if the change is internal-only (refactors, CI tweaks, style, test-only PRs, ADR additions, private/ changes).
+- **`docs/roadmap.md`** — move the feature row from 📐 designed / 🗓️ planned to ✅ shipped. Update milestone status if a sub-milestone just closed.
+- **`docs/features.md`** — add or update the entry if it's a user-facing capability.
+- **`README.md`** status callout — update only if a milestone closed or a previously-promised feature now exists. Do not re-add an in-README roadmap matrix.
+- **Per-feature guides** — extend existing guides; only add new ones for substantial new capability.
+
+### 5. Report
+
+Per-file summary of edits, plus:
+
+- **Touched** — list of files modified, with one-line summary each.
+- **Considered but skipped** — list of files where the in-scope change didn't warrant an edit, with the reason (e.g., "MCP guide: internal refactor, no user-visible change").
+- **Anti-patterns fixed** — any pre-existing violations cleaned up in-pass.
+
+## What this skill will NOT do
+
+- Touch `docs/specs/` — that's `/update-specs`.
+- Touch `docs/decisions/` — ADRs are by hand.
+- Touch `private/` — that's `/update-progress`.
+- Expand scope beyond what's needed for the in-scope change.
+- Reintroduce stored anti-patterns (in-README roadmap, feature inventories, License essays, Wave/Level terminology, private/ refs).
+- Change the README tagline `Your finances, understood by AI.` without explicit user direction.
+- Add `Co-Authored-By: Claude` trailers to any commit.

--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -117,7 +117,8 @@ If a change has no user-visible effect, say so in the report and move on.
 
 ### 2. Dispatch one subagent per affected doc file, in parallel
 
-Cap at **3 in flight** per CLAUDE.md. Larger sets process in waves.
+Cap at **3 in flight** to avoid overwhelming Claude Code's subagent
+capacity. Larger sets process in waves.
 
 Each subagent receives a self-contained prompt with:
 

--- a/.claude/skills/update-progress/SKILL.md
+++ b/.claude/skills/update-progress/SKILL.md
@@ -34,8 +34,9 @@ These files live at the **main repo root**, not inside any worktree.
 (see CLAUDE.md and AGENTS.md `../../private/` reference).
 
 When invoking from a worktree, paths look like `../../private/followups.md`
-or the absolute `/Users/bsaffel/Workspace/moneybin/private/followups.md`.
-Pass absolute paths to subagents to remove ambiguity.
+or the absolute form derived dynamically (e.g.,
+`$(git rev-parse --show-toplevel)/private/followups.md`). Pass absolute
+paths to subagents to remove ambiguity.
 
 ## Pruning rule (the core discipline)
 
@@ -81,7 +82,8 @@ Print a one-line scope summary before doing anything:
 ### 1. Dispatch one subagent per file, in parallel
 
 Four files → process in two waves of two (or one wave of three + one solo)
-to respect the **3-in-flight cap** from CLAUDE.md.
+to stay within a **3-in-flight cap** (a safe default to avoid overwhelming
+Claude Code's subagent capacity).
 
 Each subagent receives a self-contained prompt with:
 

--- a/.claude/skills/update-progress/SKILL.md
+++ b/.claude/skills/update-progress/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: update-progress
+description: Reconcile the private/ tracking docs — design.md, implementation.md, followups.md, findings.md — with the team's current state of work. Removes items that shipped or are no longer relevant (PR + CHANGELOG carry the durable record), promotes in-flight items to their new status, and adds new items discovered in the in-scope work. Aggressively prunes — these are working memory, not history. Use this after shipping a PR, before opening a new one, alongside /update-specs and /update-docs, or whenever the user says "update progress" / "sweep the tracking docs" / "what's the state of the private docs."
+---
+
+# /update-progress
+
+Keep `private/` tracking docs lean and reflective of where the team actually
+is. These docs are working memory — they answer "what's next?" and "what's
+still open?" The PR list, git log, and CHANGELOG are the durable record.
+Anything that bloats these files makes them slower to scan and erodes their
+value as a planning surface.
+
+## Files in scope
+
+Exactly these four:
+
+- `private/design.md` — Spec quality/readiness tracker (formerly `spec_implementation.md`)
+- `private/implementation.md` — Next actions, sequencing
+- `private/followups.md` — Deferred PR-review followups by tier
+- `private/findings.md` — UX questions / product ideas surfaced live
+
+**Out of scope** for this skill:
+
+- `private/strategy/` — durable strategic positioning; edit by hand.
+- `private/plans/` — ephemeral per-task scaffolding; let plans live and die with their tasks.
+- `private/reviews/` — per-PR deep-dive artifacts.
+- `private/simplify.md`, `private/testing.md`, `private/sandboxing.md` — reference notes, not active tracking.
+
+## Important path note
+
+These files live at the **main repo root**, not inside any worktree.
+`private/` is gitignored and shared across worktrees by project convention
+(see CLAUDE.md and AGENTS.md `../../private/` reference).
+
+When invoking from a worktree, paths look like `../../private/followups.md`
+or the absolute `/Users/bsaffel/Workspace/moneybin/private/followups.md`.
+Pass absolute paths to subagents to remove ambiguity.
+
+## Pruning rule (the core discipline)
+
+**Remove resolved items entirely.** When something has shipped or is no
+longer relevant:
+
+- Delete the bullet. Do not move it to a "Resolved" appendix.
+- Do not preserve the rationale in-line. The PR and CHANGELOG carry the why.
+- **Single exception:** if an item resolved with a *decision not to do it*,
+  move it to `findings.md`'s "Won't Do" section with the reopen trigger.
+  That's a different kind of durable: it stops the same idea from
+  re-surfacing in a future planning pass.
+
+The goal is that each tier / section fits in one screen. If a section is
+bloating, prune harder — don't add subheadings. The current state of
+`followups.md` (79K) is the anti-pattern this skill exists to reverse.
+
+## Scope detection
+
+Default scope is the current branch/PR/changes, not a sweep of all work
+ever. Trying to reconcile everything at once produces noise; reconciling
+against the in-flight change finds what genuinely moved.
+
+Resolve scope in this order; first match wins:
+
+1. **Explicit arguments.** If the user passed paths, a file name, or "everything," use those.
+2. **Branch diff.** If HEAD is ahead of main: `git diff main...HEAD --name-only`.
+3. **PR.** Else if `gh pr view --json files -q '.files[].path'` returns a PR's file list, use that.
+4. **Uncommitted.** Else `git status --porcelain | awk '{print $2}'`.
+5. **Empty.** If still nothing, ask what scope to use — don't default to "everything."
+
+Also gather:
+
+- Recent commit subjects on the branch: `git log main..HEAD --oneline`
+- Recently merged PRs (for resolution detection): `gh pr list --state merged --limit 20 --json number,title,mergedAt`
+
+Print a one-line scope summary before doing anything:
+
+> Scope: 7 files changed on this branch, 4 commits, 3 recently-merged PRs (#152, #154, #156)
+
+## Process
+
+### 1. Dispatch one subagent per file, in parallel
+
+Four files → process in two waves of two (or one wave of three + one solo)
+to respect the **3-in-flight cap** from CLAUDE.md.
+
+Each subagent receives a self-contained prompt with:
+
+- The **absolute path** of the single tracking file it owns.
+- The in-scope diff summary.
+- Recent commit subjects.
+- Recently merged PR numbers (with titles).
+- The pruning rule above, verbatim.
+- The expected report format.
+
+Use `subagent_type: general-purpose`. These edits are not read-only.
+
+### 2. Each subagent does, for its file
+
+- **Identify resolved entries.** An entry is resolved if its work shipped in
+  an in-scope or recently-merged PR, or if it referenced an issue / file /
+  follow-up that is now gone. Delete the entry. Do not move it.
+- **Promote in-flight entries.** If something moved from `ready` →
+  `in-progress` or `in-progress` → `implemented`, reflect the new state.
+- **Add new entries.** If the in-scope work surfaced a new followup, design
+  question, or product idea, add it to the appropriate file in the
+  appropriate tier. Be brief — entries should be a sentence or two with a
+  pointer, not a mini-spec.
+- **Update the "Last updated" header.** Each tracking file opens with a
+  date-stamped header summarizing the most recent pass. Replace it with
+  today's date + a one-line description of what changed in this pass.
+
+### 3. Report
+
+Per-file summary:
+
+- **Removed** — count + a one-line sample
+- **Promoted/updated** — count + one-line sample
+- **Added** — count + one-line sample
+- **Won't-Do moved** (findings.md only) — if any
+
+Plus a top-level note: total bytes removed across the four files. The
+metric the user cares about is whether these files got *leaner*.
+
+## What this skill will NOT do
+
+- Touch any public-facing docs (that's `/update-docs`).
+- Touch specs in `docs/specs/` (that's `/update-specs`).
+- Touch `private/strategy/`, `private/plans/`, or other private/ subdirs.
+- Bloat tracking docs with "Resolved" appendices, status histories, or per-PR sections.
+- Expand scope beyond what was detected without explicit user approval.
+- Reference `private/` paths in any public artifact — these stay in private/.

--- a/.claude/skills/update-specs/SKILL.md
+++ b/.claude/skills/update-specs/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: update-specs
+description: Reconcile docs/specs/ with the implementation that actually shipped in the current scope. Reviews recent code changes, identifies which specs the changes touch via docs/specs/INDEX.md, and updates each spec to reflect design evolutions, refactors, or follow-up work that didn't get its own spec. Auto-edits small drift; surfaces design-intent changes for review. Use this whenever finishing a feature branch, after a follow-up PR adds behavior the original spec didn't describe, after a refactor renames or moves primitives referenced in specs, or whenever the user asks "are the specs still accurate?" / "update the specs" / "sync the specs to the code." If you've just finished implementation work that drifted from the spec it was based on, suggest running it without waiting to be asked.
+---
+
+# /update-specs
+
+Keep `docs/specs/` honest. Specs are durable design contracts; implementation
+inevitably drifts as constraints surface during the build. This skill detects
+that drift in the **current scope** (not the whole spec set) and patches it
+back in.
+
+## When this skill is the right tool
+
+- After implementation of a spec is largely done and the result differs from what the spec described
+- After a follow-up PR added behavior that didn't get its own spec
+- After a refactor renamed/moved primitives or modules that specs reference
+- When the user asks whether the specs are still accurate
+
+This skill is **not** for writing new specs. Use `docs/specs/_template.md` by
+hand for that — the design discipline matters too much to automate.
+
+## Scope detection
+
+Default scope is whatever's in flight, not the whole codebase. Trying to
+audit everything at once produces sprawling diffs that are hard to review.
+
+Resolve scope in this order; first match wins:
+
+1. **Explicit arguments.** If the user passed paths, a spec name, or
+   "everything," use those.
+2. **Branch diff.** If HEAD is ahead of main, use `git diff main...HEAD --name-only`.
+3. **PR.** Else if `gh pr view --json files -q '.files[].path'` returns a
+   PR's file list, use that.
+4. **Uncommitted.** Else `git status --porcelain | awk '{print $2}'`.
+5. **Empty.** If still nothing, ask the user what scope they want — don't
+   default to the whole repo.
+
+Before doing any updates, print a one-line scope summary:
+
+> Scope: 7 files changed on this branch (3 in src/moneybin/extractors/, 2 in tests/, 2 in docs/specs/)
+
+This gives the user a chance to interrupt if the inferred scope is wrong.
+
+## Process
+
+### 1. Map files to specs
+
+Read `docs/specs/INDEX.md` — it lists every spec with status and topic. For
+each in-scope source file, infer which specs it touches:
+
+- First pass: match on INDEX descriptions and topic groupings.
+- If INDEX is ambiguous, `grep -l '<module-path>' docs/specs/*.md` to find
+  specs that reference the file directly.
+- A file that maps to **zero specs** is fine — many changes (CI, internal
+  refactors, fixtures) don't warrant a spec touch. Note it in the report,
+  don't force a mapping.
+- A file that maps to **multiple specs** spawns multiple subagents — one
+  per matched spec.
+
+### 2. Dispatch one subagent per spec, in parallel
+
+Cap at **3 in flight** per Brandon's CLAUDE.md guidance on parallel agents.
+If more than 3 specs are touched, process in waves.
+
+Each subagent receives a self-contained prompt with:
+
+- The path of the **single spec** it owns.
+- The list of in-scope files relevant to that spec.
+- A short summary of what changed (commit subjects from `git log main..HEAD --oneline` are usually enough).
+- The auto-edit policy below — verbatim, not summarized.
+- Instructions to report what it changed (or proposed) in a structured way.
+
+Use `subagent_type: general-purpose` unless the analysis is read-only, in
+which case `Explore` is cheaper.
+
+### 3. Auto-edit policy (give this to every subagent verbatim)
+
+**Auto-edit** (no review needed):
+
+- Refresh stale file paths, function names, class names, line counts.
+- Update "shipped via PR #N" footnotes when an in-scope PR closes the work.
+- Promote status (`ready` → `in-progress`, `in-progress` → `implemented`).
+- Add a short bullet to a Notes column reflecting a follow-up that landed.
+- Mermaid diagrams: refresh box labels / arrow targets when names changed.
+
+**Propose for review** (do not auto-edit — surface a diff):
+
+- Adding or removing sections.
+- Changing the design intent or the promised behavior.
+- Renaming concepts that consumers of the spec rely on.
+- Marking previously-spec'd behavior as removed.
+- Anything that changes what the spec **promises** vs. what it **describes**.
+
+If unsure: propose. Specs are public contracts; silent rewrites of intent
+are the kind of thing that hurts later.
+
+### 4. Update INDEX.md
+
+If any subagent changed a spec's status, update the corresponding row in
+`docs/specs/INDEX.md` in the same pass. Don't leave INDEX stale.
+
+### 5. Report
+
+After all subagents complete, summarize for Brandon:
+
+- **Auto-edited** — one line per spec, e.g. `categorization-overview.md: refreshed module paths, bumped status to implemented (PR #142)`.
+- **Awaiting your call** — proposals inline, one block per spec, showing the proposed diff and the reason it wasn't auto-applied.
+- **Unmapped scope** — in-scope files that didn't match any spec. Flag, don't write. The user decides whether they warrant a new spec.
+
+## What this skill will NOT do
+
+- Write new specs (manual; use `_template.md`).
+- Touch ADRs in `docs/decisions/` — durable design records, edit by hand.
+- Touch `private/` tracking docs — that's `/update-progress`.
+- Touch public guides, README, CHANGELOG, roadmap — that's `/update-docs`.
+- Expand scope beyond what was detected without explicit user approval.
+- Reintroduce private/ path references in specs (memory: "no private/ refs in public docs").

--- a/.claude/skills/update-specs/SKILL.md
+++ b/.claude/skills/update-specs/SKILL.md
@@ -60,8 +60,8 @@ each in-scope source file, infer which specs it touches:
 
 ### 2. Dispatch one subagent per spec, in parallel
 
-Cap at **3 in flight** per Brandon's CLAUDE.md guidance on parallel agents.
-If more than 3 specs are touched, process in waves.
+Cap at **3 in flight** to avoid overwhelming Claude Code's subagent
+capacity. If more than 3 specs are touched, process in waves.
 
 Each subagent receives a self-contained prompt with:
 
@@ -115,4 +115,4 @@ After all subagents complete, summarize for Brandon:
 - Touch `private/` tracking docs — that's `/update-progress`.
 - Touch public guides, README, CHANGELOG, roadmap — that's `/update-docs`.
 - Expand scope beyond what was detected without explicit user approval.
-- Reintroduce private/ path references in specs (memory: "no private/ refs in public docs").
+- Add new `private/` path references in specs. Existing references should be **removed when encountered** in the pass, matching the stored "no private/ refs in public docs" guidance — do not preserve them just because they were there before.

--- a/docs/specs/architecture-shared-primitives.md
+++ b/docs/specs/architecture-shared-primitives.md
@@ -434,7 +434,6 @@ Two narrow naming changes ride along with this spec landing. Both are mechanical
 ### Strategic context
 
 - `private/strategy/2026-05-04-strategic-review-engineering.md` §(b) — Architectural review that catalogued the 12 primitives and recommended this spec.
-- `private/design.md` — Spec milestones and sequencing (this spec is M2B entry, sibling to `transaction-curation.md`).
 
 ### Source files (primitives)
 

--- a/docs/specs/architecture-shared-primitives.md
+++ b/docs/specs/architecture-shared-primitives.md
@@ -434,7 +434,7 @@ Two narrow naming changes ride along with this spec landing. Both are mechanical
 ### Strategic context
 
 - `private/strategy/2026-05-04-strategic-review-engineering.md` §(b) — Architectural review that catalogued the 12 primitives and recommended this spec.
-- `private/spec_implementation.md` — Spec milestones and sequencing (this spec is M2B entry, sibling to `transaction-curation.md`).
+- `private/design.md` — Spec milestones and sequencing (this spec is M2B entry, sibling to `transaction-curation.md`).
 
 ### Source files (primitives)
 

--- a/docs/specs/testing-synthetic-data.md
+++ b/docs/specs/testing-synthetic-data.md
@@ -817,7 +817,7 @@ Requirements" section describing what the generator should produce to exercise t
 feature. This becomes the contract between feature authors and generator maintainers.
 
 The spec template (`_template.md`) includes this as an optional section. See
-`spec_implementation.md` for an audit of which specs need and have this section.
+`design.md` for an audit of which specs need and have this section.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds three project-local skills (`/update-specs`, `/update-progress`, `/update-docs`) for keeping documentation aligned with the in-scope code change, rather than auditing everything every time. Also renames a local design tracking doc to match what it actually contains, and updates the two public specs that referenced the old filename.

## Impact

- New skills appear under `.claude/skills/` and are invokable as `/update-specs`, `/update-progress`, `/update-docs`. Each scopes to the current branch / PR / uncommitted changes by default; explicit paths override.
- An internal tracking doc was renamed; local copies need a `mv` on disk (gitignored, so the rename does not propagate via pull). Two public specs that referenced the old filename are updated in this PR.
- `/update-progress` removes resolved items entirely rather than archiving them — the working-memory pruning policy is intentional. PR list and CHANGELOG remain the durable record.
- Skills auto-trigger: Claude may suggest running them when you describe equivalent work in natural language, in addition to explicit `/` invocation.

## Changes

### Update spec references after local tracker rename

A local design tracking doc was renamed; this PR updates the two public specs that referenced the old filename.

- `docs/specs/architecture-shared-primitives.md` — filename reference updated
- `docs/specs/testing-synthetic-data.md` — filename reference updated

### Add /update-specs skill

Reconciles `docs/specs/` with what shipped. Maps in-scope code changes to affected specs via `docs/specs/INDEX.md`, fans out one subagent per spec (3-in-flight cap), auto-edits stale facts (paths, status, PR refs), and surfaces design-intent changes for review rather than silently rewriting contracts.

### Add /update-progress skill

Sweeps four internal tracking docs (`design.md`, `implementation.md`, `followups.md`, `findings.md`). Removes resolved items entirely — single exception is a "Won't Do" section where the reopen trigger needs to persist. Promotes status changes; adds new items surfaced in-scope.

### Add /update-docs skill

Owns the public surface: README, CHANGELOG, CONTRIBUTING, top-level `docs/*.md`, `docs/guides/`, `docs/reference/`, `docs/architecture/`, `docs/tech/`, plus the `docs/roadmap.md` / `docs/features.md` / `README` updates from the shipping.md checklist. Per-file persona + length budget table; anti-patterns from prior feedback baked in verbatim. Explicitly excludes `docs/specs/` and `docs/decisions/`.

## Testing

Skills will be exercised on real PRs going forward — no formal eval loop. Verify by:

- Invoking each skill on this PR's scope and confirming it does not try to update everything in the repo
- Confirming `/update-progress` does not touch files outside its four listed tracking docs
- Confirming `/update-docs` does not touch `docs/specs/` or `docs/decisions/`