### PR TITLE
Honor MONEYBIN_PROFILE in non-CLI SQLMesh entry points

### DIFF
--- a/sqlmesh/config.py
+++ b/sqlmesh/config.py
@@ -29,7 +29,17 @@ if "MONEYBIN_HOME" not in os.environ:
 from moneybin.config import (  # noqa: E402 — must follow sys.path setup above
     get_database_path,
     get_settings,
+    set_current_profile,
 )
+
+# Non-CLI entry points (SQLMesh VSCode extension, direct `sqlmesh` shell
+# invocations, the language server) never run moneybin's CLI callback, so the
+# profile resolver is never registered and get_settings() would raise. Honor
+# MONEYBIN_PROFILE here — the same env var the CLI consults — so config.py is
+# self-sufficient for every entry point. The CLI path is unaffected: it sets
+# the profile before SQLMesh loads config.py, and set_current_profile() is a
+# no-op when the name matches.
+set_current_profile(os.environ.get("MONEYBIN_PROFILE", "default"))
 
 _sqlmesh_dir = os.path.dirname(os.path.abspath(__file__))
 

--- a/sqlmesh/config.py
+++ b/sqlmesh/config.py
@@ -27,19 +27,25 @@ if "MONEYBIN_HOME" not in os.environ:
     os.environ["MONEYBIN_HOME"] = _project_root
 
 from moneybin.config import (  # noqa: E402 — must follow sys.path setup above
+    get_current_profile,
     get_database_path,
     get_settings,
     set_current_profile,
 )
 
-# Non-CLI entry points (SQLMesh VSCode extension, direct `sqlmesh` shell
-# invocations, the language server) never run moneybin's CLI callback, so the
-# profile resolver is never registered and get_settings() would raise. Honor
-# MONEYBIN_PROFILE here — the same env var the CLI consults — so config.py is
-# self-sufficient for every entry point. The CLI path is unaffected: it sets
-# the profile before SQLMesh loads config.py, and set_current_profile() is a
-# no-op when the name matches.
-set_current_profile(os.environ.get("MONEYBIN_PROFILE", "default"))
+# Initialize a profile only when none is set in-process. This keeps config.py
+# self-sufficient for non-CLI entry points (SQLMesh VSCode extension, direct
+# `sqlmesh` shell invocations, the language server) which never run moneybin's
+# CLI callback, while preserving the CLI-selected profile. The CLI sets the
+# profile via --profile before SQLMesh loads config.py; SQLMesh then re-executes
+# this file on every Context creation (see comment below), so the gate must be
+# idempotent — set_current_profile() invalidates caches whenever the name
+# differs, so blindly calling it would clobber the CLI's profile back to
+# "default" mid-process.
+try:
+    get_current_profile(auto_resolve=False)
+except RuntimeError:
+    set_current_profile(os.environ.get("MONEYBIN_PROFILE", "default"))
 
 _sqlmesh_dir = os.path.dirname(os.path.abspath(__file__))
 

--- a/tests/moneybin/test_config_profiles.py
+++ b/tests/moneybin/test_config_profiles.py
@@ -411,3 +411,74 @@ def test_tabular_config_account_match_threshold_override() -> None:
 
     cfg = TabularConfig(account_match_threshold=0.85)
     assert cfg.account_match_threshold == 0.85
+
+
+class TestSqlmeshConfigProfileGating:
+    """Regression tests for the profile gate in ``sqlmesh/config.py``.
+
+    SQLMesh re-executes ``sqlmesh/config.py`` on every ``Context`` creation
+    (it clears the module from ``sys.modules``). The file must therefore
+    initialize a profile only when none is already set — otherwise it
+    would clobber the CLI's ``--profile`` selection back to ``default``
+    mid-process and invalidate the encryption-key cache.
+
+    Tests load ``sqlmesh/config.py`` via ``importlib`` so the actual file
+    is exercised. Side effects (log dir mkdir, SQLMesh ``Config`` build)
+    are bounded by the configured profile.
+    """
+
+    @staticmethod
+    def _load_sqlmesh_config() -> None:
+        """Execute sqlmesh/config.py fresh in this process."""
+        import importlib.util
+        import sys
+
+        repo_root = Path(__file__).resolve().parents[2]
+        config_path = repo_root / "sqlmesh" / "config.py"
+        # Discard any cached prior load so the file's top-level statements re-run.
+        sys.modules.pop("_sqlmesh_config_under_test", None)
+        spec = importlib.util.spec_from_file_location(
+            "_sqlmesh_config_under_test", config_path
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+    def test_preserves_already_set_profile(self) -> None:
+        """Re-execution must preserve an in-process profile.
+
+        When the CLI has set a profile (e.g. ``--profile alice``),
+        SQLMesh re-loading ``sqlmesh/config.py`` must not reset it to
+        ``default`` or to ``MONEYBIN_PROFILE``.
+        """
+        with temp_profile("alice"):
+            set_current_profile("alice")
+            assert get_current_profile() == "alice"
+
+            # Simulate a stale MONEYBIN_PROFILE env var the CLI never wrote.
+            os.environ["MONEYBIN_PROFILE"] = "default"
+            try:
+                self._load_sqlmesh_config()
+                assert get_current_profile() == "alice"
+            finally:
+                os.environ.pop("MONEYBIN_PROFILE", None)
+
+    def test_uses_env_var_when_no_profile_set(self, mocker: MockerFixture) -> None:
+        """Non-CLI entry point with MONEYBIN_PROFILE set → that name is used."""
+        with temp_profile("test"):
+            # Reset profile state so the gate's RuntimeError branch fires.
+            clear_settings_cache()
+            mocker.patch.dict(os.environ, {"MONEYBIN_PROFILE": "test"})
+
+            self._load_sqlmesh_config()
+            assert get_current_profile() == "test"
+
+    def test_defaults_when_no_profile_and_no_env(self, mocker: MockerFixture) -> None:
+        """Non-CLI entry point with no profile state and no env var → "default"."""
+        with temp_profile("default"):
+            clear_settings_cache()
+            mocker.patch.dict(os.environ, {}, clear=False)
+            os.environ.pop("MONEYBIN_PROFILE", None)
+
+            self._load_sqlmesh_config()
+            assert get_current_profile() == "default"


### PR DESCRIPTION
### Summary

SQLMesh's VSCode extension, direct `sqlmesh` shell invocations, and the language server load `sqlmesh/config.py` without going through MoneyBin's CLI callback — the callback is where the profile resolver gets registered. These non-CLI entry points hit `get_settings()` with no resolver and the call raises. This change makes `sqlmesh/config.py` self-sufficient by reading `MONEYBIN_PROFILE` itself.

### Impact

- VSCode SQLMesh extension loads the project without a runtime error.
- `sqlmesh` shell invocations from outside the MoneyBin CLI work against the active profile.
- No change for users invoking SQLMesh through `moneybin` CLI commands — the CLI still sets the profile first, and `set_current_profile()` is a no-op on match.

### Changes

#### `sqlmesh/config.py`

- Import `set_current_profile` from `moneybin.config`.
- Call `set_current_profile(os.environ.get("MONEYBIN_PROFILE", "default"))` immediately after imports, before any `get_settings()` use.
- Inline comment captures the constraint and why the CLI path is unaffected.

### Testing

- `make check` (format + lint + pyright) — passed locally.
- `make test` was **not** run on this branch; reviewer should rely on CI.
- Recommended manual verification: open the project in VSCode with the SQLMesh extension and confirm no load error; run a CLI path (e.g. `uv run moneybin doctor`) to confirm CLI invocation still works.

### Notes

Depends on `set_current_profile()` being idempotent when the target name matches the current profile. If that invariant changes, the CLI path would start re-resolving on every SQLMesh load.