### PR TITLE
Add surface-design rule and sweep post-rename doc references

### DIFF
--- a/.claude/rules/cli.md
+++ b/.claude/rules/cli.md
@@ -5,6 +5,8 @@ paths: ["src/moneybin/cli/**", "src/moneybin/main.py"]
 
 # CLI Development
 
+**Surface-shape rules:** [`surface-design.md`](surface-design.md) — operation-shape taxonomy, verb vocabulary, audience layering. Cross-surface (governs CLI, MCP, and future REST endpoints). Consult before adding, renaming, or restructuring a command.
+
 ## Core Principle
 
 CLI commands are **thin wrappers** around tested business logic. Delegate complex work to business logic classes.

--- a/.claude/rules/mcp-server.md
+++ b/.claude/rules/mcp-server.md
@@ -7,6 +7,8 @@ paths: ["src/moneybin/mcp/**", "src/moneybin/services/**"]
 
 **Authoritative design:** [`docs/specs/mcp-architecture.md`](../../docs/specs/mcp-architecture.md)
 
+**Surface-shape rules:** [`surface-design.md`](surface-design.md) — operation-shape taxonomy, verb vocabulary, audience layering. Cross-surface (governs MCP, CLI, and future REST endpoints). Consult before adding, renaming, or restructuring a tool.
+
 ## Architecture
 
 MCP tools are thin wrappers around a shared service layer. They contain no business logic, no SQL, and no privacy enforcement — all of that lives below them.

--- a/.claude/rules/surface-design.md
+++ b/.claude/rules/surface-design.md
@@ -1,0 +1,226 @@
+# Surface Design: Tools, Commands, and APIs
+
+Cross-surface pattern for MoneyBin's three agent/user surfaces — MCP tools, CLI commands, and (future) REST endpoints. Invoke whenever adding, renaming, or restructuring an entry on any of those surfaces.
+
+Companion to `.claude/rules/design-principles.md` (durable-path selection) and the surface-specific specs in `docs/specs/moneybin-mcp.md` and `docs/specs/moneybin-cli.md`. Per-item application of this rule lives in `private/plans/2026-05-16-mcp-surface-consolidation-decisions.md`.
+
+## Primary principle: match the operation's natural shape
+
+Tool count is an outcome, not a target. Every operation has a natural shape — a way it maps to user/agent intent. The taxonomy below names the five shapes MoneyBin uses; identify the shape and the surface form follows.
+
+When two shapes seem to fit equally, prefer the one with the smaller surface footprint AND the better agent-ergonomics. One tool the agent picks confidently beats two tools the agent disambiguates between.
+
+## The five operation shapes
+
+### Shape 1 — Idempotent set
+
+Two sub-forms determined by the cardinality of the call's input.
+
+**1a. Collection state-set.**
+
+- **Test:** the input fully expresses a closed collection's state.
+- **Form:** `<entity>_set(scope, full_state)` — typically a list or map.
+- **Delete handling:** by omission. NO paired `_delete` tool.
+- **Examples:**
+  - `transactions_tags_set(transaction_id, tags=[...])` — all tags on one transaction.
+  - `transactions_splits_set(transaction_id, splits=[...])`.
+  - `import_labels_set(import_id, labels=[...])`.
+
+**1b. Entity upsert / partial update.**
+
+- **Test:** the input names one entity (by id or natural key) and creates-or-updates it.
+- **Form:** `<entity>_set(id, fields)` or `<entity>_set(natural_key, fields)`.
+- **Delete handling:** REQUIRES paired `_delete` — there's nothing to omit from.
+- **Examples:**
+  - `budget_set(category, monthly_amount, start_month)` — upsert one (category, period) entry.
+  - `accounts_set(account_id, ...)` — partial update of one account's settings.
+
+**Distinguishing 1a vs 1b at design time:**
+
+> "If a second call with different inputs leaves the first call's effect intact, you have 1b. If a second call replaces it, you have 1a."
+
+### Shape 2 — Lifecycle-with-id
+
+- **Test:** the entity has its own identity referenced after creation; create, update, and delete are distinct operations the caller composes.
+- **Form:** `<entity>_create` / `<entity>_set(id, fields)` (partial update) / `<entity>_delete(id)`.
+- **Examples:**
+  - `transactions_notes_add` / `_edit` / `_delete` — each note has `note_id`.
+  - `categories_create` / `categories_set` / `categories_delete`.
+
+Shape 2 uses `_set(id, fields)` for partial update — the same verb as 1b. The operational difference: shape 2 has a strict `_create` that errors on existing entity; shape 1b's `_set` upserts directly.
+
+### Shape 3 — Discrete-verb
+
+- **Test:** the operation is an event, not a state change. Has timing and side effects. Reversibility lives in an audit log, not in a paired "undo" tool.
+- **Form:** `<entity>_<verb>(...)`. The verb names what happens, not the entity's resulting state.
+- **Examples:**
+  - `import_files(paths, refresh, force)` — batch import event.
+  - `sync_pull(institution, force, refresh)` — pull from a connector.
+  - `transactions_tags_rename(old_tag, new_tag)` — global rename event (mutates N rows).
+  - `refresh_run()` — execute the refresh pipeline.
+
+Batch tools with per-item error handling (`transactions_create`, `merchants_create`, `transactions_categorize_run`) are shape 3 — each call is one batch event; per-item failures don't abort the batch.
+
+### Shape 4 — Agent-reasoning-choice
+
+- **Test:** alternative strategies have STRUCTURALLY DIFFERENT inputs OR structurally different outputs. The agent picks because their data and need require a specific one.
+- **Form:** separate tools per strategy.
+- **NOT shape 4** when strategies share inputs and outputs and differ only in quality-of-service (latency, determinism, cost, privacy contract enforced by middleware). Those collapse into one tool with a methods parameter.
+
+**Sharpening note (verify against actual code).** "Different strategies for the same goal" is suspicious framing — check whether the strategies *really* have the same I/O. If one takes `(filter_params)` and returns `[redacted_rows]` while another takes `[explicit_categorizations]` and returns `applied_count`, those are not strategies of one operation — they are different operations that happen to live in the same domain. Categorize was initially framed as a methods-collapse case in the 2026-05-16 brainstorm; verifying against `transactions_categorize_apply` / `_assist` showed they fail this test (different inputs, different outputs, different read/write semantics). When in doubt, read the function signatures before classifying.
+
+Shape 4 is narrower than it first appears. Many "different strategies" cases are really one operation with a parameter — but many others are entirely different operations that just share a domain prefix.
+
+### Shape 5 — Read-projection
+
+- **Test:** returns data in a specific shape — one entity, collection, summary/aggregate, cross-entity, time-series.
+- **Form:** one tool per projection shape. Collapse only when two projections have genuinely identical shape AND consumers; most reads stay distinct.
+- **Verb conventions:**
+  - **Collection / summary / aggregate / time-series:** noun-only. `reports_networth`, `accounts_summary`, `transactions_review`, `accounts_balance_history`.
+  - **Single entity by id:** `_get` suffix. `transactions_get`, `accounts_get`.
+  - **Status snapshot of a recent operation:** `_status` suffix. `transform_status`, `transactions_categorize_status`.
+
+## Decision flowchart
+
+```mermaid
+flowchart TD
+    A[New operation] --> B{Read or write?}
+    B -->|Read| C{Single entity by id?}
+    B -->|Write| D{Discrete event or state assertion?}
+    C -->|Yes| C1["Shape 5: _get suffix"]
+    C -->|No| C2["Shape 5: noun-only<br/>(or _status / _summary / _history)"]
+    D -->|Event| E{Multiple strategies?}
+    D -->|State| F{Caller expresses full collection state?}
+    E -->|No| E1["Shape 3: <entity>_<verb>"]
+    E -->|"Yes, same I/O"| E2["Shape 3 with methods param"]
+    E -->|"Yes, different I/O"| E3["Shape 4: separate tools"]
+    F -->|Yes| G["Shape 1a: _set, no _delete"]
+    F -->|No| H{Entity has own id with independent lifecycle?}
+    H -->|Yes| I["Shape 2: _create / _set / _delete"]
+    H -->|No| J["Shape 1b: _set + paired _delete"]
+```
+
+## Verb vocabulary
+
+Coherence requires that when a verb appears, it means the same thing everywhere. The verbs in active use:
+
+| Verb | Meaning | Example |
+|---|---|---|
+| `_set` | Idempotent state assertion (1a collection-set OR 1b entity upsert / partial update) | `budget_set`, `tags_set`, `accounts_set` |
+| `_create` | Strict create — errors if entity exists | `categories_create`, `transactions_create` |
+| `_delete` | Remove one entity by id or natural key | `budget_delete`, `categories_delete` |
+| `_run` | Execute a discrete batch/pipeline operation | `categorize_run`, `refresh_run` |
+| `_refresh` | Rebuild derived state from raw inputs (refresh domain) | `refresh_run` (umbrella) |
+| `_get` | Fetch one entity by id | `transactions_get`, `accounts_get` |
+| `_status` | Status snapshot of a recent operation | `transform_status`, `transactions_categorize_status` |
+| `_history` | Time-series projection | `accounts_balance_history` |
+| `_summary` | Cross-entity aggregate snapshot | `accounts_summary` |
+
+Plus domain-specific discrete verbs (`_rename`, `_archive`, `_revert`, `_pull`, `_connect`) — use these when the verb carries domain meaning the generic verbs would erase.
+
+**Verbs to avoid:**
+
+- `_apply` — was overloaded between refresh-domain ("apply transforms") and strategy-execution ("apply rules"). Both senses now route to `_run`. Currently zero callers after consolidation; OK to leave unused.
+- `_toggle` — too narrow (binary flip). Use `_set` with a typed field: `categories_set(category_id, is_active=...)` instead of `categories_toggle`.
+- `_update` — synonym of `_set` in this codebase. The rename pass picked `_set` (`accounts_settings_update` → `accounts_set`); follow that precedent.
+- `_list` suffix on read tools — drop it (noun-only). `transactions_recurring_list` is the canonical example to remove.
+- `manage_*` with action-polymorphism — rejected absolutely (see Polymorphism below).
+
+**Pluralization:** match the noun. Collection writes use plural even when operating on one element (`_rules_create`, `_rules_delete`). Singular `_rule_delete` is wrong even when deleting one rule.
+
+## Polymorphism
+
+Method-parameter polymorphism (`tool(method=...)`) is **acceptable** when all four hold:
+
+1. Methods share inputs (same parameter shape).
+2. Methods share outputs (same response envelope).
+3. Differences are quality-of-service: latency, determinism, cost, privacy contract enforced by middleware (not by the agent).
+4. The cascade has a natural default behavior.
+
+**Acceptable example:** `transactions_categorize_run(methods=["rules","ml","assist"], transactions=None)`. Methods differ in QoS only; the cascade has a meaningful default.
+
+Polymorphism is **rejected** when:
+
+- Strategies differ in input shape (then they're shape 4).
+- Strategies differ in output shape (then they're shape 4).
+- The choice is a routing decision the agent makes based on input data (then it's not really a choice — collapse around the routing logic, not the surface).
+
+**`manage_X(action="...")` polymorphism is rejected absolutely.** It dispatches structurally different operations through a polymorphic argument — moving complexity from the tool list (visible at selection time) to the input schema (visible only after the tool is selected). Pure relocation, no reduction.
+
+## Audience layering
+
+MoneyBin's surface mixes three audiences:
+
+| Audience | Examples | Default treatment |
+|---|---|---|
+| **User-intent** | `reports_spending`, `accounts_summary`, `transactions_search` | Always-visible |
+| **Mid-CRUD** | `transactions_tags_set`, `budget_set`, `categories_set` | Always-visible |
+| **Infrastructure** | `transform_apply`, `sql_query`, `system_doctor`, `system_audit_list` | Discover-gated via `moneybin_discover('admin')` |
+
+The agent attention budget is set by always-visible surface size (see `mcp-server.md` "Progressive disclosure"). Discover-gating infrastructure doesn't remove capability — it removes attention cost from the default working set.
+
+**Test:** if a tool's primary caller is a human operator (or a power-user agent explicitly inspecting internals), it belongs behind discover. If the primary caller is an agent helping a user with their finances, it stays always-visible.
+
+**Umbrella pattern:** when re-layering removes a tool from the default surface, a higher-level tool often fills the slot. `transform_apply` moves behind discover; `refresh_run` becomes the always-visible umbrella over the refresh pipeline (match + transform + categorize) that the discover-gated tools compose.
+
+## Surface implications
+
+### MCP
+
+The five shapes and verb vocabulary above are MCP-native. Audience layering uses `moneybin_discover('admin')` for infrastructure; user-intent and mid-CRUD stay always-visible. Progressive disclosure (`mcp-server.md` §"Progressive disclosure") is the long-term mechanism once client support stabilizes.
+
+### CLI
+
+The CLI has subgroup nesting MCP doesn't (`moneybin transactions tags set` vs flat `transactions_tags_set`). That changes one thing: **discoverability is cheaper in CLI** because subgroups give `--help` navigation without context-window cost. Audience layering is less load-bearing — operator-only commands already live in operator-territory subgroups (`moneybin db init`, `moneybin profile *`).
+
+Everything else transfers directly:
+
+- Operation shapes — same five.
+- Verb vocabulary — same table, expressed as subcommands (`<group> set`, `<group> create`, `<group> delete`, `<group> run`).
+- CLI symmetry — every MCP tool has a CLI command via the same service layer (`mcp-server.md` line 28). The same shape choice surfaces in both.
+
+### REST API (future, M3D+)
+
+The taxonomy maps cleanly to HTTP verbs:
+
+| Shape | REST form |
+|---|---|
+| 1a Collection state-set | `PUT /<resource>` with collection body |
+| 1b Entity upsert | `PUT /<resource>/<id>` with fields |
+| 2 Lifecycle-with-id | `POST /<resource>` (create) / `PATCH /<resource>/<id>` (update) / `DELETE /<resource>/<id>` |
+| 3 Discrete-verb | `POST /<resource>/<verb>` action endpoint |
+| 4 Agent-reasoning-choice | Separate sub-paths per strategy |
+| 5 Read-projection | `GET /<resource>` (collection) / `GET /<resource>/<id>` (single) / `GET /<resource>/<projection>` (summary, history) |
+
+Audience layering uses separate base paths: `/api/v1/...` for user-intent + mid-CRUD; `/api/v1/admin/...` for infrastructure.
+
+## Coherence and pre-launch posture
+
+Pre-launch (per `design-principles.md`), iterate the surface aggressively to find the right shape. The coherence rule applies: if a tool's name or form contradicts the taxonomy, refactor rather than introduce a parallel pattern.
+
+Defended exceptions are legitimate but must be **documented in the tool's MCP description** with a one-line "why" — the agent never reads this file. Example: `accounts_balance_assert` is shape 1b but keeps the name because "assertion" carries domain meaning beyond a generic upsert; the description should say so.
+
+## Anti-patterns
+
+- `manage_X(action="...")` polymorphism — rejected absolutely.
+- `_set` semantics where the tool actually performs a discrete event.
+- `_apply` for refresh-domain operations — use `_refresh` / `_run`.
+- Method-parameter polymorphism when methods have structurally different I/O.
+- `_get` / `_list` suffix on collection or summary reads — drop them (noun-only).
+- Pluralization drift (`_rule_delete` vs `_rules_create`).
+- Duplicate tools where one is strictly richer (`transactions_recurring_list` vs `reports_recurring`).
+- Infrastructure tools always-visible alongside user-intent tools.
+- New entity-mutation tools when `<entity>_set` already covers the field.
+
+## Applying this rule
+
+When adding or modifying a tool / command / endpoint:
+
+1. Identify the operation shape using the flowchart.
+2. Apply the verb vocabulary for that shape.
+3. Place it in the correct audience layer; discover-gate if infrastructure.
+4. Verify CLI and (future) REST symmetry inherits the shape.
+5. If proposing a defended exception, document the "why" inline in the tool description.
+
+Per-tool triage of the existing surface against this rule:
+`private/plans/2026-05-16-mcp-surface-consolidation-decisions.md`.

--- a/.claude/rules/surface-design.md
+++ b/.claude/rules/surface-design.md
@@ -109,7 +109,7 @@ Coherence requires that when a verb appears, it means the same thing everywhere.
 | `_set` | Idempotent state assertion (1a collection-set OR 1b entity upsert / partial update) | `budget_set`, `tags_set`, `accounts_set` |
 | `_create` | Strict create — errors if entity exists | `categories_create`, `transactions_create` |
 | `_delete` | Remove one entity by id or natural key | `budget_delete`, `categories_delete` |
-| `_run` | Execute a discrete batch/pipeline operation | `categorize_run`, `refresh_run` |
+| `_run` | Execute a discrete batch/pipeline operation | `refresh_run` |
 | `_refresh` | Rebuild derived state from raw inputs (refresh domain) | `refresh_run` (umbrella) |
 | `_get` | Fetch one entity by id | `transactions_get`, `accounts_get` |
 | `_status` | Status snapshot of a recent operation | `transform_status`, `transactions_categorize_status` |
@@ -137,7 +137,7 @@ Method-parameter polymorphism (`tool(method=...)`) is **acceptable** when all fo
 3. Differences are quality-of-service: latency, determinism, cost, privacy contract enforced by middleware (not by the agent).
 4. The cascade has a natural default behavior.
 
-**Acceptable example:** `transactions_categorize_run(methods=["rules","ml","assist"], transactions=None)`. Methods differ in QoS only; the cascade has a meaningful default.
+**Acceptable example (hypothetical):** `tool(methods=["rules","ml"], transactions=None)` where both methods take the same input shape (a transaction set) and produce the same output shape (applied categorizations) — differing only in QoS (rules deterministic and fast; ML probabilistic and bulk). A method that returns a structurally different output (e.g. redacted rows for human review) fails criterion 2 and belongs in a separate tool, not in this `methods=` list — see the Shape 4 sharpening note above.
 
 Polymorphism is **rejected** when:
 
@@ -151,23 +151,23 @@ Polymorphism is **rejected** when:
 
 MoneyBin's surface mixes three audiences:
 
-| Audience | Examples | Default treatment |
+| Audience | Examples | Positioning |
 |---|---|---|
-| **User-intent** | `reports_spending`, `accounts_summary`, `transactions_search` | Always-visible |
-| **Mid-CRUD** | `transactions_tags_set`, `budget_set`, `categories_set` | Always-visible |
-| **Infrastructure** | `transform_apply`, `sql_query`, `system_doctor`, `system_audit_list` | Discover-gated via `moneybin_discover('admin')` |
+| **User-intent** | `reports_spending`, `accounts_summary`, `transactions_search` | Surfaced prominently in the `instructions` field, in user-facing tools' `actions[]` hints, and in docs |
+| **Mid-CRUD** | `transactions_tags_set`, `budget_set`, `categories_set` | Surfaced as the agent's hands — referenced by user-intent tools' `actions[]` and in workflow examples |
+| **Operator territory** | `transform_apply`, `sql_query`, `system_doctor`, `system_audit_list` | Visible but deprioritized: description prose calls out the operator audience; not promoted in `instructions` enumeration; reached via specific `actions[]` hints when relevant |
 
-The agent attention budget is set by always-visible surface size (see `mcp-server.md` "Progressive disclosure"). Discover-gating infrastructure doesn't remove capability — it removes attention cost from the default working set.
+**Per `docs/specs/mcp-architecture.md` §3 ("Tool disclosure: full surface, taxonomy-led"):** the full registered tool surface is visible at connect — client-driven progressive disclosure was retired 2026-05-17. Audience positioning happens through three levers MoneyBin controls end-to-end: the FastMCP `instructions` field, prefix-grouped tool names with sharp descriptions, and surface discipline (tools register only when their backing spec reaches `in-progress`/`implemented`, per `mcp-server.md` "Surface change discipline"). The `@mcp_tool(domain=...)` markers stay as dormant metadata for a future first-party client that can implement schema injection in the style of Claude Code's `tool_search`.
 
-**Test:** if a tool's primary caller is a human operator (or a power-user agent explicitly inspecting internals), it belongs behind discover. If the primary caller is an agent helping a user with their finances, it stays always-visible.
+**Test:** if a tool's primary caller is a human operator (or a power-user agent explicitly inspecting internals), the tool's description should say so, it should NOT be cited in user-facing tools' `actions[]` hints, and it should NOT appear in the `instructions` field's top-level enumeration. If the primary caller is an agent helping a user with their finances, the opposite — surface it prominently across those three levers.
 
-**Umbrella pattern:** when re-layering removes a tool from the default surface, a higher-level tool often fills the slot. `transform_apply` moves behind discover; `refresh_run` becomes the always-visible umbrella over the refresh pipeline (match + transform + categorize) that the discover-gated tools compose.
+**Umbrella pattern:** when an operator-territory tool also serves a user-relevant capability, an umbrella tool exposes the capability at the user-intent layer. Example: `refresh_run` is the always-visible umbrella over the refresh pipeline (match + transform + categorize); `transform_apply` and friends remain registered for operators but are not promoted in user-facing `actions[]` or in `instructions`. Both layers stay visible — the difference is positioning, not gating.
 
 ## Surface implications
 
 ### MCP
 
-The five shapes and verb vocabulary above are MCP-native. Audience layering uses `moneybin_discover('admin')` for infrastructure; user-intent and mid-CRUD stay always-visible. Progressive disclosure (`mcp-server.md` §"Progressive disclosure") is the long-term mechanism once client support stabilizes.
+The five shapes and verb vocabulary above are MCP-native. The full registered tool surface is always visible per `mcp-architecture.md` §3; audience positioning happens via the `instructions` field, description prose, `actions[]` hint placement, and the surface-discipline rule that gates registration on backing-spec maturity (see "Audience layering" above).
 
 ### CLI
 
@@ -209,7 +209,7 @@ Defended exceptions are legitimate but must be **documented in the tool's MCP de
 - `_get` / `_list` suffix on collection or summary reads — drop them (noun-only).
 - Pluralization drift (`_rule_delete` vs `_rules_create`).
 - Duplicate tools where one is strictly richer (`transactions_recurring_list` vs `reports_recurring`).
-- Infrastructure tools always-visible alongside user-intent tools.
+- Operator-territory tools promoted in `instructions` or in user-intent tools' `actions[]` hints alongside user-intent tools (full surface stays visible, but positioning matters — see Audience layering).
 - New entity-mutation tools when `<entity>_set` already covers the field.
 
 ## Applying this rule
@@ -218,7 +218,7 @@ When adding or modifying a tool / command / endpoint:
 
 1. Identify the operation shape using the flowchart.
 2. Apply the verb vocabulary for that shape.
-3. Place it in the correct audience layer; discover-gate if infrastructure.
+3. Place it in the correct audience layer; if operator territory, position via description prose and keep it out of user-facing `actions[]` hints and the `instructions` enumeration (full surface stays visible per `mcp-architecture.md` §3).
 4. Verify CLI and (future) REST symmetry inherits the shape.
 5. If proposing a defended exception, document the "why" inline in the tool description.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,7 @@ Files in `.claude/rules/` auto-load via Claude Code's `paths:` frontmatter — p
 | Rule | Covers |
 |------|--------|
 | `design-principles.md` | Durable path selection: heuristics for "inevitable choice" decisions and the trigger list for the agent protocol |
+| `surface-design.md` | Cross-surface (MCP / CLI / REST) operation-shape taxonomy, verb vocabulary, audience layering. Consult before adding, renaming, or restructuring a tool/command/endpoint |
 | `shipping.md` | Post-implementation checklist: README updates, roadmap icons, `/simplify` pre-push pass |
 | `branching.md` | Branch prefix → PR label mapping, commit message style |
 | `sandboxing.md` | Bash invocation patterns: single commands, allowlisted pipelines, structured-output filtering, policy denials |

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -130,7 +130,7 @@ Single source of truth for spec status. Update this table when a spec's status c
 
 | Spec | Type | Status | Summary |
 |---|---|---|---|
-| [MoneyBin Doctor](moneybin-doctor.md) | Feature | implemented | Pipeline integrity command: `moneybin doctor` runs SQLMesh named audits (FK integrity, sign convention, balanced transfers) + staging coverage + categorization coverage warning. Produces a "✅ N invariants passing" trust artifact. Top-level CLI + `system_doctor` MCP tool. |
+| [MoneyBin Doctor](moneybin-doctor.md) | Feature | implemented | Pipeline integrity command: `moneybin system doctor` runs SQLMesh named audits (FK integrity, sign convention, balanced transfers) + staging coverage + categorization coverage warning. Produces a "✅ N invariants passing" trust artifact. CLI lives under the `system` group; MCP exposes `system_doctor`. |
 | [Data Pipeline Reconciliation](data-reconciliation.md) | Feature | draft | Broader ETL integrity checks: raw→prep→core row accounting, import batch validation, temporal coverage gaps, orphan detection. `moneybin-doctor.md` is the user-facing subset; this spec covers the full warehouse-grade reconciliation surface. |
 
 ## Reports & Health

--- a/docs/specs/moneybin-cli.md
+++ b/docs/specs/moneybin-cli.md
@@ -576,12 +576,12 @@ Restructure-only. Move and rename existing commands to the new tree; rename MCP 
 
 | Change | Scope |
 |---|---|
-| Create `accounts` group with `list`, `get`, `rename`, `include` (thin entity ops) | New CLI module |
+| Create `accounts` group with `list`, `get`, `set`, `resolve` (thin entity ops); `rename`/`include`/`archive`/`unarchive` fold into `accounts set` flags per #164 | New CLI module |
 | Move `track balance` → `accounts balance` (preserve subcommands as stubs where they were) | Rename + reparent |
 | Move `track networth` → `reports networth` (preserve subcommands as stubs) | Rename + reparent into reports group |
 | Add top-level `assets` group (placeholder; workflows owned by `asset-tracking.md`) | New CLI module, all stubs |
 | Keep `tax` top-level (not nested in `reports`) | Stub initially; tools added by `tax-*.md` specs |
-| Create `transactions` group with `list`, `show`, `search` (thin entity ops) | New CLI module |
+| Create `transactions` group with `list`, `get`, `search` (thin entity ops) | New CLI module |
 | Move `matches` → `transactions matches` (existing functionality preserved) | Reparent + update tests |
 | Move `categorize` → `transactions categorize` (workflow tools + rules + auto + ml) | Reparent + update tests |
 | Pull `categorize categories *` and `categorize create-category` / `categorize toggle-category` → top-level `categories` group | Promote to entity group |

--- a/docs/specs/moneybin-cli.md
+++ b/docs/specs/moneybin-cli.md
@@ -511,8 +511,8 @@ This is a hard cut. No aliases, no deprecation period. v1 paths break in the sam
 | `categorize *` (workflow + rules + auto + ml) | `transactions categorize *` | Workflow on transactions |
 | `categorize categories / create-category / toggle-category` | `categories list / create / set / delete` | Reference-data taxonomy → top-level entity group |
 | `categorize merchants / create-merchants` | `merchants list / create` | Reference-data taxonomy → top-level entity group |
-| (none) | `accounts list / show / rename / include` | New entity ops |
-| (none) | `transactions list / show / search` | New entity ops |
+| (none) | `accounts list / get / set / resolve` | New entity ops; rename/include/archive/unarchive fold into `accounts set` flags per #164 |
+| (none) | `transactions list / get / search` | New entity ops |
 | (none) | `reports {spending, cashflow, tax, budget}` | New analytical group (subcommands future) |
 
 The `track` group is dissolved entirely.
@@ -576,7 +576,7 @@ Restructure-only. Move and rename existing commands to the new tree; rename MCP 
 
 | Change | Scope |
 |---|---|
-| Create `accounts` group with `list`, `show`, `rename`, `include` (thin entity ops) | New CLI module |
+| Create `accounts` group with `list`, `get`, `rename`, `include` (thin entity ops) | New CLI module |
 | Move `track balance` → `accounts balance` (preserve subcommands as stubs where they were) | Rename + reparent |
 | Move `track networth` → `reports networth` (preserve subcommands as stubs) | Rename + reparent into reports group |
 | Add top-level `assets` group (placeholder; workflows owned by `asset-tracking.md`) | New CLI module, all stubs |

--- a/docs/specs/moneybin-doctor.md
+++ b/docs/specs/moneybin-doctor.md
@@ -157,14 +157,14 @@ Always runs with `verbose=False` — affected IDs are omitted (agents can query 
 - `sqlmesh/audits/fct_transactions_sign_convention.sql`
 - `sqlmesh/audits/bridge_transfers_balanced.sql`
 - `src/moneybin/services/doctor_service.py` — `InvariantResult`, `DoctorService`
-- `src/moneybin/cli/commands/doctor.py` — top-level Typer command
+- `src/moneybin/cli/commands/system/doctor.py` — Typer command under the `system` group
 - `tests/moneybin/test_services/test_doctor_service.py`
 - `tests/moneybin/test_cli/test_doctor.py`
 - `tests/e2e/test_e2e_doctor.py`
 
 ## Files to Modify
 
-- `src/moneybin/cli/main.py` — register `doctor` command group
+- `src/moneybin/cli/commands/system/__init__.py` — register the `doctor` command on the existing `system` Typer group via `app.command(name="doctor")(_doctor.doctor_command)`
 - `src/moneybin/mcp/tools/system.py` — add `system_doctor`, register in `register_system_tools()`
 - `docs/specs/INDEX.md` — add this spec; update `data-reconciliation.md` entry with cross-reference
 - `docs/specs/moneybin-mcp.md` — document `system_doctor`

--- a/docs/specs/reports-recipe-library.md
+++ b/docs/specs/reports-recipe-library.md
@@ -61,7 +61,7 @@ The `reports.*` schema is a **read-only presentation layer** (`architecture-shar
 
 The pattern is small and uniform:
 
-1. **Naming.** `reports.<entity>` mirrors the CLI subcommand `moneybin reports <entity>` and the MCP tool `reports_<entity>_get`. One model, one CLI subcommand, one MCP tool — three names, three surfaces, identical concept.
+1. **Naming.** `reports.<entity>` mirrors the CLI subcommand `moneybin reports <entity>` and the MCP tool `reports_<entity>`. One model, one CLI subcommand, one MCP tool — three names, three surfaces, identical concept.
 2. **Grain.** Each model picks the widest grain its consumers can collapse from. CLI defaults aggregate or rank for the human eye; SQL/MCP consumers re-rank, pivot, or filter as needed.
 3. **Comments.** Every column carries an inline `/* */` comment per `.claude/rules/database.md` — these comments are surfaced verbatim by the `moneybin://schema` MCP resource. The model-level comment (top of the SQL file) explains the view's purpose, grain, and any heuristic it uses.
 4. **Confidence over false certainty.** Where a model is heuristic (`reports.recurring_subscriptions` is the only one in v1), it exposes a `confidence` column instead of a binary classification. Users and AI consumers can apply their own thresholds.
@@ -417,21 +417,20 @@ Extends `moneybin-cli.md` v2's `reports` namespace. Five new subcommands added; 
 
 ```
 moneybin reports
-+-- networth
-|   +-- show [--as-of DATE]                          (existing — now backed by reports.net_worth)
-|   +-- history [--from DATE] [--to DATE] [--interval daily|weekly|monthly]
-+-- cashflow show [--from MONTH] [--to MONTH] [--by account|category|account-and-category]
-+-- spending show [--from MONTH] [--to MONTH] [--category SLUG] [--compare yoy|mom|trailing]
-+-- recurring show [--min-confidence FLOAT] [--status active|inactive|all] [--cadence ...]
-+-- merchants show [--top N] [--sort spend|count|recent]
-+-- uncategorized show [--min-amount DECIMAL] [--account NAME] [--limit N]
-+-- large-transactions show [--top N] [--anomaly account|category|none]
-+-- balance-drift show [--account NAME] [--status drift|warning|clean|no-data] [--since DATE]
++-- networth [--as-of DATE]                          (existing — now backed by reports.net_worth)
++-- networth-history [--from DATE] [--to DATE] [--interval daily|weekly|monthly]
++-- cashflow [--from MONTH] [--to MONTH] [--by account|category|account-and-category]
++-- spending [--from MONTH] [--to MONTH] [--category SLUG] [--compare yoy|mom|trailing]
++-- recurring [--min-confidence FLOAT] [--status active|inactive|all] [--cadence ...]
++-- merchants [--top N] [--sort spend|count|recent]
++-- uncategorized [--min-amount DECIMAL] [--account NAME] [--limit N]
++-- large-transactions [--top N] [--anomaly account|category|none]
++-- balance-drift [--account NAME] [--status drift|warning|clean|no-data] [--since DATE]
 ```
 
 All commands support `--output json` per `moneybin-cli.md`. JSON output uses `ResponseEnvelope` shape per `architecture-shared-primitives.md` §MCP/CLI/SQL Symmetry.
 
-CLI function naming follows `<group>_<verb>` convention (`reports_recurring_show`, etc.) per `.claude/rules/cli.md`.
+CLI function naming follows the noun-only convention for read projections (`reports_recurring`, etc.) per `.claude/rules/surface-design.md` shape 5.
 
 ## MCP Interface
 
@@ -610,7 +609,7 @@ If gaps are discovered during implementation, file a follow-up to `testing-synth
 This spec ships before [`moneybin-doctor.md`](moneybin-doctor.md) (next M2C spec):
 
 1. **PR 1 (this spec):** All eight `reports.*` views; the four migrations from §Migrations (gate-spec amendment, `core.agg_net_worth` → `reports.net_worth`, `app.categories` → `core.dim_categories`, `app.merchants` → `core.dim_merchants`); `schema.py`/`tables.py`/`seeds.py`/`schema_catalog.py` updates; the categorization-service merchant write-path fix; CLI subcommands; MCP tools; tests at all three layers.
-2. **PR 2 (doctor spec):** `moneybin doctor` command + `system_doctor` MCP tool, reading from the existing services and from `reports.balance_drift`.
+2. **PR 2 (doctor spec):** `moneybin system doctor` command + `system_doctor` MCP tool, reading from the existing services and from `reports.balance_drift`.
 
 The two PRs can be reviewed in parallel once both specs are written, but PR 1 must merge first because PR 2's reconciliation traffic-light depends on `reports.balance_drift`. The bundled dim migrations land atomically with the rest of PR 1 — splitting them into a separate "architectural cleanup" PR was considered and rejected because it would re-open the same `tables.py` / `schema_catalog.py` / `seeds.py` surface twice.
 

--- a/tests/e2e/test_e2e_doctor.py
+++ b/tests/e2e/test_e2e_doctor.py
@@ -1,5 +1,5 @@
 # ruff: noqa: S101
-"""E2E tests for `moneybin doctor`.
+"""E2E tests for `moneybin system doctor`.
 
 doctor is read-only, so it uses the shared e2e_profile fixture (no mutations).
 The clean profile has no transactions, so all SQLMesh audits and the
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.e2e
 
 
 class TestDoctorCommand:
-    """E2E tests for the `moneybin doctor` command."""
+    """E2E tests for the `moneybin system doctor` command."""
 
     def test_doctor_help(self) -> None:
         result = run_cli("system", "doctor", "--help")

--- a/tests/integration/test_surface_parity.py
+++ b/tests/integration/test_surface_parity.py
@@ -35,14 +35,14 @@ the missing tool/command — caught by the functional-coverage check,
 not by this test). Categories captured from the diff at test
 introduction:
 
-- **A. Naming-pattern mismatches.** MCP ``*_get`` vs CLI ``*_show``
-  across the ``reports_*`` family (9 tools), ``accounts_get`` vs
-  ``accounts_show``, ``accounts_set`` vs ``accounts_set``,
-  ``transactions_review`` vs ``transactions_review``,
-  ``import_formats_list`` vs ``import_formats_list``, ``system_doctor``
-  vs top-level ``doctor``, ``reports_budget`` vs
-  ``reports_budget``, ``accounts_balance_assertion_delete`` vs
-  ``accounts_balance_delete``.
+- **A. Naming-pattern mismatches.** **RESOLVED 2026-05-17 (PR #159).** The
+  rename pass collapsed all entries in this category by adopting the
+  noun-only convention for read projections (``reports_*``,
+  ``accounts_get``), the ``_set`` verb for partial updates
+  (``accounts_set`` from ``accounts_settings_update``), and the ``system
+  doctor`` CLI placement under the existing ``system`` group. No active
+  Category A entries remain; the xfail marker stays until B, C, and D
+  also land per the PR description.
 - **B. Set-semantic vs verb-list split.** MCP collapses to ``*_set``
   while CLI splits into add/remove/list/clear:
   ``import_labels_set`` / ``import_labels_{add,remove,list}``,


### PR DESCRIPTION
### Summary

Ships two coupled things: the new cross-surface design rule `surface-design.md` (the load-bearing output of the 2026-05-16 MCP-consolidation brainstorm), and a sweep of stale doc references left behind by the rename pass and the accounts collapse. No code, no behavior changes.

### Impact

- New always-loaded rule: contributors and agents will see `surface-design.md` in their working set when adding or restructuring MCP tools, CLI commands, or future REST endpoints. It documents the operation-shape taxonomy (1a/1b/2/3/4/5), verb vocabulary, and audience-layering rules the recent consolidation PRs (#162, #163, #164, #165, #166) all applied.
- No workflow changes for existing tools or commands.

### Changes

#### New rule: `surface-design.md`

Operation-shape taxonomy + verb vocabulary + cross-surface implications. Lands in the always-loaded rules set alongside `design-principles.md`, `shipping.md`, `branching.md`, `sandboxing.md`.

- Five shapes: 1a collection state-set, 1b entity upsert, 2 lifecycle-with-id, 3 discrete-verb, 4 agent-reasoning-choice, 5 read-projection
- Verb table fixes `_set`, `_create`, `_delete`, `_run`, `_refresh`, `_get`, `_status`, `_history`, `_summary` semantics
- Audience-layering rule (operator territory vs user-intent)
- Surface implications for MCP, CLI, and future REST endpoints
- Anti-patterns: `manage_*` polymorphism, `_apply` for refresh-domain, `_get` on collection reads, duplicate tools
- `AGENTS.md` rules-index table gains the new entry
- Two-line pointers added to `mcp-server.md` and `cli.md`

#### Post-rename doc cleanup

Reconciles spec text with what the rename pass (#159) and accounts collapse (#164) actually shipped:

- `docs/specs/INDEX.md` doctor row: `moneybin doctor` → `moneybin system doctor`; phrasing reflects CLI placement under the `system` group
- `docs/specs/moneybin-doctor.md`: `commands/doctor.py` → `commands/system/doctor.py`; registration approach reflects the existing `system` Typer group
- `docs/specs/moneybin-cli.md`: v2 migration row reflects accounts collapse (`rename`/`include` → `set` flags per #164); reports references use noun-only convention; account-management row uses `accounts list / get / set / resolve`
- `docs/specs/reports-recipe-library.md`: `reports_<entity>_get` → `reports_<entity>`; ASCII subcommand tree flattened; rationale links to `surface-design.md` shape 5; `moneybin doctor` → `moneybin system doctor`
- `tests/e2e/test_e2e_doctor.py`: module + class docstrings reference `moneybin system doctor`
- `tests/integration/test_surface_parity.py`: Category A backlog marked **RESOLVED 2026-05-17 (#159)**; xfail marker stays per the test's design (waiting on B/C/D)

### Testing

`make check test` clean before push. The only assertion change is the surface-parity test's Category A docstring; the xfail marker stays. No new tests; this PR is documentation + a rule file.

### Notes

- `surface-design.md` is a rule, not an ADR. Per `.claude/rules/design-principles.md`, the ADR bar is "establishes a pattern others will inherit from." This rule re-states a pattern the recent consolidation PRs collectively established; it doesn't originate one.