### PR TITLE
Trim project-level Claude rules and align AGENTS.md

### DIFF
--- a/.claude/rules/agent-experience.md
+++ b/.claude/rules/agent-experience.md
@@ -34,13 +34,7 @@ state:
 
 The signal we care about is *what it felt like to use the surface as an
 agent.* Mechanical test execution and code editing don't produce that
-signal, so they don't produce a report.
-
-This rule exists because the MCP server is a **first-class agent surface**
-(see `mcp-server.md`), and the only reliable way to keep it that way is to
-treat every interaction as feedback. Agents like Claude, Codex CLI, and
-Gemini CLI will be the dominant consumers; their friction — captured *as
-it happens*, not reconstructed from memory — is the metric.
+signal.
 
 The report does not need to be long. A few honest bullets per section beat
 a polished essay. Quote the exact tool name, parameter, or returned string
@@ -80,23 +74,16 @@ improve the agent experience.
 
 ## Reporting workflow
 
-AX reports are **session-internal** — they go to Brandon in the conversation,
+AX reports are **session-internal** — they go to the developer in the conversation,
 not into public artifacts. Workflow:
 
 1. At the end of any session that touched MoneyBin's MCP server, present the
    report directly in chat using the structure above.
-2. Brandon triages each finding. Approved findings get filed as one-line
+2. The developer triages each finding. Approved findings get filed as one-line
    entries in `private/followups.md`; the rest are dropped.
 3. The PR shipping the underlying change describes the change only — **never
    paste the AX report (or a link to it) into the PR body, commit message,
    CHANGELOG, ADR, or any other checked-in artifact**.
 
 The report is raw feedback for prioritizing future work, not a deliverable.
-Brandon's filtering is what gives it signal value; surfacing every friction
-note publicly would invert that.
-
-This rule is paired with `mcp-server.md` (Architecture and Description
-Requirements) and with the `using-superpowers` skill's emphasis on
-intellectual honesty: report friction even when the change you shipped
-caused it. Honesty is the standard for the in-chat report — public artifacts
-remain scoped to what shipped.
+The developer's filtering is what gives it signal value.

--- a/.claude/rules/branching.md
+++ b/.claude/rules/branching.md
@@ -1,3 +1,7 @@
+---
+description: "Branch prefix → PR label mapping, commit message style"
+---
+
 # Branch Naming & PR Labels
 
 ## Branch Format

--- a/.claude/rules/design-principles.md
+++ b/.claude/rules/design-principles.md
@@ -1,3 +1,7 @@
+---
+description: "Durable path selection: heuristics for one-way-door decisions, public-contract triggers, coherence rule"
+---
+
 # Design Principles: Durable Path Selection
 
 Companion to AGENTS.md's "Guiding Principle." Defines what "durable" means
@@ -121,28 +125,23 @@ coherent and durable.
 
 ## Example: applying the protocol
 
-**Decision:** Adding a merchant attribute to `core.fct_transactions`.
-`merchant TEXT` (raw string on the fact table) vs `merchant_id VARCHAR`
-(FK to a new `core.dim_merchants`, populated with a truncated UUID4 per
-`.claude/rules/identifiers.md`)?
+**Decision:** Add a merchant attribute to `core.fct_transactions` —
+`merchant TEXT` on the fact table, or `merchant_id` FK to a new
+`core.dim_merchants`?
 
 **Classification:** One-way door. `core.fct_transactions` is exposed via
 MCP and CLI; consumers will write queries against this shape.
 
-**Option A (durable):** `merchant_id` + `dim_merchants`. Cost: ~3 extra
-days to build the dim table, dedup logic, and joins in `reports`. Locks
-the right shape — merchants are a real entity with attributes
-(normalized name, aliases, category) that will grow.
+**Option A (durable) — `merchant_id` + `dim_merchants`:** ~3 days. Locks
+the right shape; merchants are a real entity with attributes (aliases,
+category) that will grow.
 
-**Option B (fast):** `merchant TEXT`. Cost: ~half a day. Works for the
-M2B demo. Breaks the moment a second merchant attribute is needed —
-forcing a dim-table introduction later plus migration of every consumer
-query already written.
+**Option B (fast) — `merchant TEXT`:** ~½ day. Breaks the moment a
+second merchant attribute is needed — forces dim-table introduction
+later plus migration of every consumer query.
 
-**Recommend A.** Pays 3 days now to avoid a breaking migration of the
-public schema later. **No new ADR needed** — this applies the existing
-dim-table pattern from ADR-001. Capture in the merchants spec and PR
-description; reference ADR-001 for the dim/fact rationale.
+**Recommend A.** Applies the existing dim-table pattern from ADR-001;
+no new ADR. Capture in the merchants spec and PR description.
 
 ## Recording the outcome
 

--- a/.claude/rules/mcp-server.md
+++ b/.claude/rules/mcp-server.md
@@ -46,7 +46,7 @@ Tools use underscore-joined names: `domain_action_or_view`. The MCP spec / SEP-9
 
 Naming: **noun = query** (`spending_summary`), **verb = action** (`categorize_apply`). No CRUD naming.
 
-**Tool disclosure: full surface, taxonomy-led.** Every registered tool is visible at connect. Orientation lives in the FastMCP `instructions` field (see below) and in prefix-grouped tool names with sharp descriptions — not in a runtime discovery tool. Client-driven progressive disclosure was retired 2026-05-17; see `mcp-architecture.md` §3 for rationale and revisit conditions. Each new tool's description, parameter schema, and namespace placement must justify itself against the full-surface bar.
+**Tool disclosure: full surface, taxonomy-led.** Every registered tool is visible at connect. Orientation lives in the FastMCP `instructions` field (see below) and in prefix-grouped tool names with sharp descriptions — not in a runtime discovery tool. Each new tool's description, parameter schema, and namespace placement must justify itself against the full-surface bar. See `mcp-architecture.md` §3 for rationale.
 
 ## Response Envelope
 
@@ -125,7 +125,7 @@ All tools use `get_database()` from `src/moneybin/database.py`. Each call return
 
 ## Surface change discipline
 
-**Stub gate.** Register an `@mcp_tool` only when its backing feature spec in `docs/specs/INDEX.md` is `in-progress` or `implemented`. No stubs on the public surface — tools whose dependency is `draft`, `ready`, or unwritten stay unregistered (the implementation file may remain in `src/moneybin/mcp/tools/` as a dormant building block; only the `register_*_tools(mcp)` call is gated). Phantom prefixes — those with no registered tools — never appear in the orientation surfaces (FastMCP `instructions` field, `moneybin://tools` resource, `mcp-architecture.md` §3 namespace table). One narrow carve-out applies to *promotion* (not registration): a namespace whose tools register but whose top-level domain is deliberately omitted from the orientation surfaces by design must be documented in `moneybin-mcp.md` §15 with the trigger that would promote it. Today's only such carve-out is `transform_*` — infrastructure verbs the agent reaches via `system_status` action hints, not a user-facing domain. Tracked in `moneybin-mcp.md` §17 "Dependency tracker".
+**Stub gate.** Register an `@mcp_tool` only when its backing feature spec in `docs/specs/INDEX.md` is `in-progress` or `implemented`. No stubs on the public surface — tools whose dependency is `draft`, `ready`, or unwritten stay unregistered (the implementation file may remain in `src/moneybin/mcp/tools/` as a dormant building block; only the `register_*_tools(mcp)` call is gated). Phantom prefixes — those with no registered tools — never appear in the orientation surfaces (FastMCP `instructions` field, `moneybin://tools` resource, `mcp-architecture.md` §3 namespace table). One narrow carve-out applies to *promotion* (not registration): a namespace whose tools register but whose top-level domain is deliberately omitted from the orientation surfaces by design must be documented in `moneybin-mcp.md` §15 with the trigger that would promote it. Active carve-outs are tracked in `moneybin-mcp.md` §17 "Dependency tracker".
 
 Any PR that adds, renames, or removes a tool (MCP) or command (CLI) MUST update **two** specs in the same change:
 
@@ -159,5 +159,5 @@ must produce an agent-experience report per
 [`agent-experience.md`](agent-experience.md). Running the project test
 suite or editing MCP code/tests does not trigger a report; the signal is
 what it felt like to use the surface. Reports are session-internal: present
-to Brandon in chat, never paste into PRs, commits, CHANGELOG, or ADRs. See
+to the developer in chat, never paste into PRs, commits, CHANGELOG, or ADRs. See
 `agent-experience.md` for the full trigger list and reporting workflow.

--- a/.claude/rules/sandboxing.md
+++ b/.claude/rules/sandboxing.md
@@ -1,3 +1,7 @@
+---
+description: "Bash invocation patterns: single commands, allowlisted pipelines, structured-output filtering, policy denials"
+---
+
 # Sandboxed Bash Patterns
 
 Shape bash invocations to run silently and efficiently in this project's sandbox + permission setup.

--- a/.claude/rules/shipping.md
+++ b/.claude/rules/shipping.md
@@ -1,3 +1,7 @@
+---
+description: "Post-implementation checklist: CHANGELOG, roadmap, features, README updates, pre-push /simplify pass"
+---
+
 # Shipping & Public Documentation
 
 ## When a Feature Ships

--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -79,7 +79,7 @@ subagent verbatim. They keep accidentally regrowing:
 - **README anti-patterns**: in-README roadmap matrix; text-heavy comparison cells; feature inventories; License essays; "Wave"/"Level" terminology; 9-node pipeline Mermaid in the README. Comparison stays 7-wide with ✅/❌/🟡 emoji. How-It-Works Mermaid stays 3–4 nodes (sales-pitch, not architecture).
 - **No private/ references in public docs.** Never cite `private/...` paths or phrasing like "the strategic review" / "the strategic audit named X" in README, CHANGELOG, CONTRIBUTING, or any `docs/` file. Restate substance directly. If you find existing violations, fix them in-pass.
 - **No `Co-Authored-By: Claude` trailers in any commit message produced by this skill.**
-- **Tagline preserved**: `Your finances, understood by AI.` — do not change unless Brandon explicitly asks.
+- **Tagline preserved**: `Your finances, understood by AI.` — do not change unless the developer explicitly asks.
 - **Milestone names**: `M0`, `M1`, `M2A`, `M2B`, `M2C`, `M3A` (Plaid), `M3B` (investments), `M3C` (multi-currency + budgets), `M3D` (Web UI + Streamable HTTP), `M3E` (hosted launch). Don't invent new ones.
 
 ## Scope detection

--- a/.claude/skills/update-specs/SKILL.md
+++ b/.claude/skills/update-specs/SKILL.md
@@ -102,7 +102,7 @@ If any subagent changed a spec's status, update the corresponding row in
 
 ### 5. Report
 
-After all subagents complete, summarize for Brandon:
+After all subagents complete, summarize for the developer:
 
 - **Auto-edited** — one line per spec, e.g. `categorization-overview.md: refreshed module paths, bumped status to implemented (PR #142)`.
 - **Awaiting your call** — proposals inline, one block per spec, showing the proposed diff and the reason it wasn't auto-applied.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, sim
 | Database access | `get_database()` → `Database` | `duckdb.connect()` |
 | Configuration | `get_settings()` → `MoneyBinSettings` | `os.getenv()`, hardcoded values |
 | Secrets/keys | `SecretStore` | `os.getenv()`, plain `str` fields |
-| Table references | `TableRef.FCT_TRANSACTIONS`, etc. | Hardcoded table name strings |
+| Table references | `from moneybin.tables import FCT_TRANSACTIONS`, etc. | Hardcoded table name strings |
 | DataFrames | DuckDB > Polars > Pandas | Pandas (unless required for library compat — document why) |
 
 ## Code Standards
@@ -109,7 +109,7 @@ Full schema reference (including `meta`, `seeds`, `synthetic`, prefix convention
 2. **Multi-source union** — Core models `UNION ALL` from every staging source with `source_type` column.
 3. **Dedup in core** — `ROW_NUMBER()` windows for duplicates; mapping tables for cross-source dedup.
 4. **Accounting sign convention** — negative = expense, positive = income. `DECIMAL(18,2)` for amounts, `DATE` for dates.
-5. **Source-agnostic consumers** — MCP server, CLI use `TableRef` constants, never source-specific logic.
+5. **Source-agnostic consumers** — MCP server, CLI use `moneybin.tables` constants, never source-specific logic.
 
 ## Specs & Implementation Tracking
 


### PR DESCRIPTION
### Summary

Tighten the `.claude/rules/` and `.claude/skills/` content that loads into every session. Removes historical narrative, point-in-time wording, and rationale prose that pads rules without changing behavior. Also fixes one stale code idiom in AGENTS.md and harmonizes frontmatter across always-loaded rules.

### Impact

- No behavior change for tooling or CI.
- Agents reading these files at session start get terser, more current guidance.
- The `TableRef.FCT_TRANSACTIONS` fix in AGENTS.md prevents agents from writing code against a pattern that doesn't resolve (real idiom is `from moneybin.tables import FCT_TRANSACTIONS`).

### Changes

#### Rules trim

- `mcp-server.md`: dropped retired-strategy historical note; kept the active disclosure rule + spec pointer. Replaced "today's only such carve-out is `transform_*`" with "active carve-outs are tracked in `moneybin-mcp.md` §17".
- `design-principles.md`: compressed the merchants worked example. The AGENTS.md pointer at `.claude/rules/design-principles.md` "as the output template" still resolves.
- `agent-experience.md`: cut two rationale paragraphs and a closing meta-paragraph that paired the rule with `mcp-server.md` + `using-superpowers`. Operational rule intact.

#### "Brandon" → "the developer"

Renamed all project-level first-person references so the rules and skills read as project-shared, not user-personal. Touches `agent-experience.md`, `mcp-server.md`, `update-docs/SKILL.md`, `update-specs/SKILL.md`. User-global `~/.claude/CLAUDE.md` intentionally left as-is.

#### AGENTS.md drift fix

The Key Abstractions table told agents to use `TableRef.FCT_TRANSACTIONS`, but `TableRef` is a `NamedTuple` *type* in `src/moneybin/tables.py`, not a namespace — the actual idiom is module-level constants. Fixed the table entry and the matching line in the "Source-agnostic consumers" invariant.

#### Frontmatter coherence

Four always-loaded rules (`branching.md`, `design-principles.md`, `sandboxing.md`, `shipping.md`) had no frontmatter at all, while `agent-experience.md` had a `description:` block. Added one-line `description:` to the four, copying from the AGENTS.md Rules Index table. The rules directory now has uniform self-describing frontmatter: path-scoped rules carry `description` + `paths:`, always-loaded rules carry `description:` only.

### Testing

- Spot-grepped to confirm no remaining "Brandon" references in project-level files.
- Verified ADR references (000, 001, 002, 009, 010) still exist at `docs/decisions/`.
- Verified `moneybin.tables` exports `FCT_TRANSACTIONS` (and that no code uses the old `TableRef.X` form).
- No code changes; nothing to run.

### Notes

User-global `~/.claude/CLAUDE.md` was deliberately excluded from the rename pass per the developer's instruction — it's personal global config, not project-shared.