### PR TITLE
Switch AI review action to subscription OAuth token

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -24,7 +24,7 @@ jobs:
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--allowedTools Bash,Read,Grep,Glob"
           prompt: |
             Review this pull request for code quality, correctness, security, and adherence to
@@ -57,7 +57,7 @@ jobs:
         if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--allowedTools Bash,Read,Grep,Glob"
           prompt: |
             Respond to the @claude mention in the PR comment. If the request is


### PR DESCRIPTION
### Summary
Reconfigure the `AI Code Review` workflow to authenticate via a Claude subscription OAuth token instead of an Anthropic API key, so review runs are billed against the personal subscription quota rather than pay-as-you-go API credits.

### Impact
- Requires the `CLAUDE_CODE_OAUTH_TOKEN` repo secret to be set (already configured).
- The `ANTHROPIC_API_KEY` secret is no longer referenced by any workflow and can be removed if nothing else depends on it.
- OAuth tokens expire after ~1 year — rotation via `claude setup-token` will be needed eventually.

### Changes
#### `.github/workflows/ai-review.yml`
Both `anthropics/claude-code-action@v1` invocations (the automated PR-review step and the interactive `@claude` comment step) now pass `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` instead of `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`.

### Testing
- `grep -rn "ANTHROPIC_API_KEY\|anthropic_api_key" .github/` returns no matches.
- Functional verification happens on the next PR event: the `AI Code Review` workflow run should succeed and the run should draw from subscription quota rather than API credits.

### Notes
If `ANTHROPIC_API_KEY` is later re-added to the workflow alongside the OAuth token, the API key takes precedence and silently reverts billing to pay-as-you-go — don't reintroduce it.