### PR TITLE
Transfer detection: drop roundness and pair-frequency signals

### DIFF
--- a/docs/specs/matching-transfer-detection.md
+++ b/docs/specs/matching-transfer-detection.md
@@ -330,7 +330,7 @@ class MatchingSettings(BaseModel):
 
 Env var overrides:
 
-- `MONEYBIN_MATCHING__TRANSFER_REVIEW_THRESHOLD=0.65`
+- `MONEYBIN_MATCHING__TRANSFER_REVIEW_THRESHOLD=0.65`  — raise above the 0.55 default to tighten (fewer false positives, more missed transfers); lower toward 0.50 to relax (more reviewed candidates, more false positives)
 - `MONEYBIN_MATCHING__DATE_WINDOW_DAYS=5`
 - `MONEYBIN_MATCHING__TRANSFER_SIGNAL_WEIGHTS='{"date_distance": 0.7, "keyword": 0.3}'`
 

--- a/docs/specs/matching-transfer-detection.md
+++ b/docs/specs/matching-transfer-detection.md
@@ -34,7 +34,7 @@ This spec covers pillar B from the [transaction-matching umbrella](matching-over
 ### Detection
 
 1. Transactions from different accounts with opposite signs and the same absolute amount, within a configurable date window, are candidates for transfer pairing.
-2. Candidates are scored using four signals: date distance, description keyword presence, amount roundness, and account pair frequency within the batch.
+2. Candidates are scored using two signals: date distance and description keyword presence.
 3. All scored pairs above `transfer_review_threshold` go to the review queue. No auto-confirmation in v1.
 4. Pairs below `transfer_review_threshold` are not surfaced (logged at DEBUG level only).
 5. Each transaction participates in at most one transfer pair (1:1 assignment).
@@ -92,7 +92,7 @@ Transfer-specific values in existing columns:
 
 - `match_type = 'transfer'`
 - `match_tier = NULL` (tiers are dedup-specific)
-- `match_signals` JSON carries transfer-specific signal scores: `{"date_distance": 0.8, "keyword_score": 0.6, "amount_roundness": 1.0, "pair_frequency": 0.7}`
+- `match_signals` JSON carries transfer-specific signal scores: `{"date_distance": 0.8, "keyword": 0.6}`
 
 ## Matching Algorithm
 
@@ -136,16 +136,16 @@ This produces a narrow candidate set. No fuzzy logic at this stage.
 
 ### Scoring
 
-For each candidate pair, four signals combined into a confidence score:
+For each candidate pair, two signals combined into a confidence score:
 
 | Signal | Range | Logic |
 |---|---|---|
 | **Date distance** | 0.0-1.0 | `1.0 - (days_apart / date_window_days)`. Same-day = 1.0, 3 days apart = 0.0. Primary discriminator for recurring transfers. |
-| **Keyword presence** | 0.0-1.0 | Scan both descriptions for transfer-indicating terms: TRANSFER, XFER, ACH, DIRECT DEP, WIRE, account number fragments. Score based on how many indicators found in either description. |
-| **Amount roundness** | 0.0-1.0 | Round numbers score higher. 1.0 if divisible by 100, 0.7 if divisible by 10, 0.5 if whole dollar, 0.3 otherwise. |
-| **Account pair frequency** | 0.0-1.0 | How often this (account_a, account_b) pair appears among all candidates in this batch. Accounts that frequently transfer between each other score higher within the current run. |
+| **Keyword presence** | 0.0-1.0 | Scan both descriptions for transfer-indicating terms: TRANSFER, XFER, ACH, DIRECT DEP, WIRE, plus ~40 compound phrases (ONLINE TRANSFER TO SAV, AUTO PAY, CC PAYMENT, etc.). Matched longest-first (non-overlapping) so compound phrases consume their span before sub-keywords can double-count. Score: 0.0 (no match), 0.5 (1 match), 0.8 (2 matches), 1.0 (3+ matches). |
 
-Exact signal weights are an implementation detail, tuned against real data. Default starting point: `{date_distance: 0.4, keyword: 0.3, roundness: 0.15, pair_frequency: 0.15}`. All four signal scores are persisted in `match_signals` JSON for auditability and tuning diagnosis.
+Amount roundness and account pair frequency were dropped: roundness is a weak signal ($437.82 is as real a transfer as $500), and pair frequency is within-batch-only — backfills see different scores than incremental syncs, making the signal unstable. Both remaining signals and their per-pair scores are persisted in `match_signals` JSON for auditability and tuning diagnosis.
+
+Default weights: `{date_distance: 0.6, keyword: 0.4}`. Both signals max at 1.0 and weights sum to 1.0, so confidence score range is [0.0, 1.0].
 
 ### 1:1 assignment
 
@@ -186,8 +186,8 @@ These surface naturally during `moneybin transactions review --type matches`.
 
 ```
 Transfer: Checking -> Savings  $500.00  (2026-03-15 / 2026-03-15)
-  Confidence: 0.88
-  Signals: date_distance=1.0, keyword=0.6, roundness=1.0, pair_freq=0.8
+  Confidence: 0.84
+  Signals: date_distance=1.0, keyword=0.6
   Status: rejected (user, 2026-03-16)
 ```
 
@@ -199,7 +199,7 @@ The signal breakdown shows what's driving false positives or misses.
 |---|---|---|---|
 | **Review threshold** | `matching.transfer_review_threshold` | Raise to see fewer, higher-quality proposals; lower to catch more | Too much noise -> raise. Missing pairs -> lower. |
 | **Date window** | `matching.date_window_days` | Narrow to reduce cross-month false matches; widen for slow ACH | Recurring transfers matching wrong months -> narrow to 2. International wires -> widen. |
-| **Signal weights** | `matching.transfer_signal_weights` | Dict of per-signal weights | When a specific signal consistently drives false positives |
+| **Signal weights** | `matching.transfer_signal_weights` | Dict with `date_distance` and `keyword` weights (must sum to 1.0) | When one signal consistently drives false positives vs the other |
 
 All three are Pydantic settings with env var overrides. Changes take effect on the next `moneybin transactions matches run`.
 
@@ -273,10 +273,10 @@ Transfer detection extends the commands defined in `matching-same-record-dedup.m
 Transfer review shows both sides for full context:
 
 ```
-Transfer pair (confidence: 0.88)
+Transfer pair (confidence: 0.84)
   DEBIT:  Chase Checking  -$500.00  2026-03-15  "ONLINE TRANSFER TO SAV"
   CREDIT: Chase Savings   +$500.00  2026-03-15  "TRANSFER FROM CHK"
-  Signals: date=1.0  keyword=0.6  roundness=1.0  pair_freq=0.8
+  Signals: date=1.0  keyword=0.6
 
   [a]ccept / [r]eject / [s]kip / [q]uit
 ```
@@ -320,21 +320,19 @@ class MatchingSettings(BaseModel):
     # ... existing dedup settings from matching-same-record-dedup.md ...
 
     # Transfer-specific settings
-    transfer_review_threshold: float = 0.70
+    transfer_review_threshold: float = 0.55
     date_window_days: int = 3  # shared with dedup
     transfer_signal_weights: dict[str, float] = {
-        "date_distance": 0.4,
-        "keyword": 0.3,
-        "roundness": 0.15,
-        "pair_frequency": 0.15,
+        "date_distance": 0.6,
+        "keyword": 0.4,
     }
 ```
 
 Env var overrides:
 
-- `MONEYBIN_MATCHING__TRANSFER_REVIEW_THRESHOLD=0.80`
+- `MONEYBIN_MATCHING__TRANSFER_REVIEW_THRESHOLD=0.65`
 - `MONEYBIN_MATCHING__DATE_WINDOW_DAYS=5`
-- `MONEYBIN_MATCHING__TRANSFER_SIGNAL_WEIGHTS='{"date_distance": 0.5, "keyword": 0.25, "roundness": 0.15, "pair_frequency": 0.1}'`
+- `MONEYBIN_MATCHING__TRANSFER_SIGNAL_WEIGHTS='{"date_distance": 0.7, "keyword": 0.3}'`
 
 ### What is not configurable
 
@@ -351,7 +349,7 @@ Env var overrides:
 ### Unit tests
 
 - **Blocking query**: given transactions with known amounts/dates/accounts/signs, verify candidate pairs are correctly identified (opposite signs, same amount, different accounts, within window)
-- **Scoring function**: given a candidate pair, verify each signal component (date distance, keyword, roundness, pair frequency) and the combined score
+- **Scoring function**: given a candidate pair, verify each signal component (date distance, keyword) and the combined score
 - **1:1 assignment with recurring transfers**: 3 months of $500 checking->savings, verify greedy assignment pairs same-day matches correctly without cross-month contamination
 - **Bridge table derivation**: given accepted match decisions, verify `bridge_transfers` output (debit/credit sides, date offset, amount)
 
@@ -434,8 +432,5 @@ Transfers that always occur at the same amount or within a narrow range (e.g., $
 ### Resolved
 
 - **Backfill ordering.** Dedup completes fully first, then transfer detection runs. Transfers are cross-account by definition, so all accounts must be deduplicated before transfer pairing can produce correct results. Same order as import-time matching (Tiers 2b → 3 → 4).
-
-### Deferred to implementation tuning milestone
-
-1. **Confidence score formula.** Exact combination of the four signals. Starting weights provided (`date_distance: 0.4, keyword: 0.3, roundness: 0.15, pair_frequency: 0.15`) but should be tuned against real data. See MVP roadmap M1 tuning milestone.
-2. **Keyword list.** The initial set of transfer-indicating terms (TRANSFER, XFER, ACH, DIRECT DEP, WIRE, etc.) and how to handle institution-specific variations. Start with a reasonable default set; tune alongside confidence scores with real data.
+- **Confidence score formula.** Two-signal model: `date_distance × 0.6 + keyword × 0.4`. Amount roundness dropped ($437.82 is as real a transfer as $500). Account pair frequency dropped — within-batch-only, unstable for backfills. Threshold re-tuned to 0.55 to preserve approximate review-queue size against the prior four-signal baseline.
+- **Keyword list.** Retained as-is (~50 terms including compound phrases like ONLINE TRANSFER TO SAV, AUTO PAY, CC PAYMENT). Matched longest-first via a single compiled regex to prevent sub-phrase double-counting. The compound phrases are doing real recall work and are not candidates for pruning without empirical validation against real data.

--- a/src/moneybin/config.py
+++ b/src/moneybin/config.py
@@ -394,6 +394,9 @@ class MatchingSettings(BaseModel):
         missing = required - v.keys()
         if missing:
             raise ValueError(f"transfer_signal_weights missing keys: {missing}")
+        extra = v.keys() - required
+        if extra:
+            raise ValueError(f"transfer_signal_weights has unrecognised keys: {extra}")
         negative = {k: w for k, w in v.items() if w < 0}
         if negative:
             raise ValueError(f"transfer_signal_weights has negative values: {negative}")

--- a/src/moneybin/config.py
+++ b/src/moneybin/config.py
@@ -365,17 +365,15 @@ class MatchingSettings(BaseModel):
         description="Source types in priority order (first = highest priority)",
     )
     transfer_review_threshold: float = Field(
-        default=0.70,
+        default=0.55,
         ge=0.0,
         le=1.0,
         description="Review queue threshold for transfer pairs",
     )
     transfer_signal_weights: dict[str, float] = Field(
-        default={
-            "date_distance": 0.4,
-            "keyword": 0.3,
-            "roundness": 0.15,
-            "pair_frequency": 0.15,
+        default_factory=lambda: {
+            "date_distance": 0.6,
+            "keyword": 0.4,
         },
         description="Per-signal weights for transfer confidence scoring",
     )
@@ -392,7 +390,7 @@ class MatchingSettings(BaseModel):
     @classmethod
     def validate_transfer_weights(cls, v: dict[str, float]) -> dict[str, float]:
         """Ensure all required scoring keys are present and sum to 1.0."""
-        required = {"date_distance", "keyword", "roundness", "pair_frequency"}
+        required = {"date_distance", "keyword"}
         missing = required - v.keys()
         if missing:
             raise ValueError(f"transfer_signal_weights missing keys: {missing}")

--- a/src/moneybin/matching/engine.py
+++ b/src/moneybin/matching/engine.py
@@ -373,8 +373,6 @@ class TransactionMatcher:
                 match_signals={
                     "date_distance": round(pair.date_distance_score, 4),
                     "keyword": round(pair.keyword_score, 4),
-                    "roundness": round(pair.amount_roundness_score, 4),
-                    "pair_frequency": round(pair.pair_frequency_score, 4),
                 },
                 match_type=transfer_match_type,
                 match_tier=None,

--- a/src/moneybin/matching/transfer.py
+++ b/src/moneybin/matching/transfer.py
@@ -1,7 +1,7 @@
 """Transfer detection: candidate blocking and confidence scoring.
 
 Tier 4 of the matching pipeline. Finds transactions from different accounts
-with opposite signs and the same absolute amount, scores them on four signals,
+with opposite signs and the same absolute amount, scores them on two signals,
 and returns scored candidate pairs for 1:1 assignment.
 """
 
@@ -93,8 +93,6 @@ class TransferCandidatePair:
     description_b: str
     date_distance_score: float
     keyword_score: float
-    amount_roundness_score: float
-    pair_frequency_score: float
     confidence_score: float
 
 
@@ -116,31 +114,6 @@ def compute_keyword_score(desc_a: str, desc_b: str) -> float:
     return 0.0
 
 
-def compute_amount_roundness(amount: Decimal) -> float:
-    """Score based on how round the transfer amount is."""
-    abs_amount = abs(amount)
-    if abs_amount % 100 == 0:
-        return 1.0
-    if abs_amount % 10 == 0:
-        return 0.7
-    if abs_amount % 1 == 0:
-        return 0.5
-    return 0.3
-
-
-def compute_pair_frequency(
-    account_id_a: str,
-    account_id_b: str,
-    pair_counts: dict[tuple[str, str], int],
-    max_count: int,
-) -> float:
-    """Score based on how often this account pair appears in the batch."""
-    sorted_ids = sorted([account_id_a, account_id_b])
-    key: tuple[str, str] = (sorted_ids[0], sorted_ids[1])
-    count = pair_counts.get(key, 0)
-    return min(1.0, count / max(max_count, 1))
-
-
 def compute_date_score(date_distance_days: int, date_window_days: int) -> float:
     """Score based on temporal proximity within the date window."""
     if date_window_days <= 0:
@@ -152,17 +125,10 @@ def compute_transfer_confidence(
     *,
     date_score: float,
     keyword_score: float,
-    amount_roundness: float,
-    pair_frequency: float,
     weights: dict[str, float],
 ) -> float:
-    """Compute transfer confidence from four pre-computed, weighted signals."""
-    return (
-        weights["date_distance"] * date_score
-        + weights["keyword"] * keyword_score
-        + weights["roundness"] * amount_roundness
-        + weights["pair_frequency"] * pair_frequency
-    )
+    """Compute transfer confidence from two pre-computed, weighted signals."""
+    return weights["date_distance"] * date_score + weights["keyword"] * keyword_score
 
 
 def get_candidates_transfers(
@@ -233,10 +199,7 @@ def get_candidates_transfers(
                 acct_a,
             ))
 
-    # Pass 1: filter rows and build pair-frequency counts (needed for scoring).
-    filtered: list[dict[str, Any]] = []
-    pair_counts: dict[tuple[str, str], int] = {}
-
+    results: list[TransferCandidatePair] = []
     for row in rows:
         stid_a, st_a, so_a, acct_a, desc_a, amount_a = row[:6]
         stid_b, st_b, so_b, acct_b, desc_b, _amount_b, date_dist = row[6:]
@@ -250,61 +213,31 @@ def get_candidates_transfers(
         if (st_a, stid_a, acct_a, st_b, stid_b, acct_b) in rejected_set:
             continue
 
-        filtered.append({
-            "stid_a": stid_a,
-            "st_a": st_a,
-            "so_a": so_a,
-            "acct_a": acct_a,
-            "desc_a": desc_a,
-            "amount_a": amount_a,
-            "stid_b": stid_b,
-            "st_b": st_b,
-            "so_b": so_b,
-            "acct_b": acct_b,
-            "desc_b": desc_b,
-            "date_dist": int(date_dist),
-        })
-        sorted_accts = sorted([acct_a, acct_b])
-        freq_key: tuple[str, str] = (sorted_accts[0], sorted_accts[1])
-        pair_counts[freq_key] = pair_counts.get(freq_key, 0) + 1
-
-    max_count = max(pair_counts.values()) if pair_counts else 1
-    # Pass 2: score each candidate using pair-frequency data from pass 1.
-    results: list[TransferCandidatePair] = []
-    for p in filtered:
-        abs_amount = abs(p["amount_a"])
-        kw_score = compute_keyword_score(p["desc_a"] or "", p["desc_b"] or "")
-        roundness = compute_amount_roundness(abs_amount)
-        pair_freq = compute_pair_frequency(
-            p["acct_a"], p["acct_b"], pair_counts, max_count
-        )
-        d_score = compute_date_score(p["date_dist"], date_window_days)
+        abs_amount = abs(amount_a)
+        kw_score = compute_keyword_score(desc_a or "", desc_b or "")
+        d_score = compute_date_score(int(date_dist), date_window_days)
         confidence = compute_transfer_confidence(
             date_score=d_score,
             keyword_score=kw_score,
-            amount_roundness=roundness,
-            pair_frequency=pair_freq,
             weights=signal_weights,
         )
 
         results.append(
             TransferCandidatePair(
-                source_transaction_id_a=p["stid_a"],
-                source_type_a=p["st_a"],
-                source_origin_a=p["so_a"],
-                account_id_a=p["acct_a"],
-                source_transaction_id_b=p["stid_b"],
-                source_type_b=p["st_b"],
-                source_origin_b=p["so_b"],
-                account_id_b=p["acct_b"],
+                source_transaction_id_a=stid_a,
+                source_type_a=st_a,
+                source_origin_a=so_a,
+                account_id_a=acct_a,
+                source_transaction_id_b=stid_b,
+                source_type_b=st_b,
+                source_origin_b=so_b,
+                account_id_b=acct_b,
                 amount=abs_amount,
-                date_distance_days=p["date_dist"],
-                description_a=p["desc_a"] or "",
-                description_b=p["desc_b"] or "",
+                date_distance_days=int(date_dist),
+                description_a=desc_a or "",
+                description_b=desc_b or "",
                 date_distance_score=d_score,
                 keyword_score=kw_score,
-                amount_roundness_score=roundness,
-                pair_frequency_score=pair_freq,
                 confidence_score=confidence,
             )
         )

--- a/tests/moneybin/matching/test_assignment.py
+++ b/tests/moneybin/matching/test_assignment.py
@@ -49,8 +49,6 @@ def _transfer_pair(
         description_b="TRANSFER",
         date_distance_score=1.0,
         keyword_score=0.5,
-        amount_roundness_score=1.0,
-        pair_frequency_score=1.0,
         confidence_score=score,
     )
 
@@ -151,8 +149,6 @@ class TestAssignGreedyTransfers:
                 description_b="TRANSFER",
                 date_distance_score=1.0,
                 keyword_score=0.5,
-                amount_roundness_score=1.0,
-                pair_frequency_score=1.0,
                 confidence_score=0.90,
             ),
             TransferCandidatePair(
@@ -170,8 +166,6 @@ class TestAssignGreedyTransfers:
                 description_b="DEPOSIT",
                 date_distance_score=0.67,
                 keyword_score=0.5,
-                amount_roundness_score=1.0,
-                pair_frequency_score=0.5,
                 confidence_score=0.70,
             ),
         ]
@@ -198,8 +192,6 @@ class TestAssignGreedyTransfers:
                 description_b="TRANSFER",
                 date_distance_score=1.0,
                 keyword_score=1.0,
-                amount_roundness_score=1.0,
-                pair_frequency_score=1.0,
                 confidence_score=0.95,
             ),
             TransferCandidatePair(
@@ -217,8 +209,6 @@ class TestAssignGreedyTransfers:
                 description_b="TRANSFER",
                 date_distance_score=1.0,
                 keyword_score=1.0,
-                amount_roundness_score=1.0,
-                pair_frequency_score=1.0,
                 confidence_score=0.90,
             ),
         ]
@@ -244,8 +234,6 @@ class TestAssignGreedyTransfers:
                 description_b="TRANSFER",
                 date_distance_score=1.0,
                 keyword_score=1.0,
-                amount_roundness_score=1.0,
-                pair_frequency_score=1.0,
                 confidence_score=0.95,
             ),
             TransferCandidatePair(
@@ -263,8 +251,6 @@ class TestAssignGreedyTransfers:
                 description_b="TRANSFER",
                 date_distance_score=0.67,
                 keyword_score=1.0,
-                amount_roundness_score=1.0,
-                pair_frequency_score=1.0,
                 confidence_score=0.85,
             ),
         ]

--- a/tests/moneybin/matching/test_config_matching.py
+++ b/tests/moneybin/matching/test_config_matching.py
@@ -11,7 +11,7 @@ class TestTransferSettings:
 
     def test_transfer_review_threshold_default(self) -> None:
         settings = MatchingSettings()
-        assert settings.transfer_review_threshold == 0.70
+        assert settings.transfer_review_threshold == 0.55
 
     def test_transfer_review_threshold_custom(self) -> None:
         settings = MatchingSettings(transfer_review_threshold=0.85)
@@ -26,27 +26,21 @@ class TestTransferSettings:
     def test_transfer_signal_weights_default(self) -> None:
         settings = MatchingSettings()
         assert settings.transfer_signal_weights == {
-            "date_distance": 0.4,
-            "keyword": 0.3,
-            "roundness": 0.15,
-            "pair_frequency": 0.15,
+            "date_distance": 0.6,
+            "keyword": 0.4,
         }
 
     def test_transfer_signal_weights_custom(self) -> None:
         custom = {
-            "date_distance": 0.5,
-            "keyword": 0.25,
-            "roundness": 0.15,
-            "pair_frequency": 0.1,
+            "date_distance": 0.7,
+            "keyword": 0.3,
         }
         settings = MatchingSettings(transfer_signal_weights=custom)
         assert settings.transfer_signal_weights == custom
 
     def test_transfer_signal_weights_missing_key(self) -> None:
         with pytest.raises(ValidationError, match="missing keys"):
-            MatchingSettings(
-                transfer_signal_weights={"date_distance": 0.5, "keyword": 0.5}
-            )
+            MatchingSettings(transfer_signal_weights={"date_distance": 1.0})
 
     def test_transfer_signal_weights_negative(self) -> None:
         with pytest.raises(ValidationError, match="negative values"):
@@ -54,8 +48,6 @@ class TestTransferSettings:
                 transfer_signal_weights={
                     "date_distance": 1.2,
                     "keyword": -0.2,
-                    "roundness": 0.0,
-                    "pair_frequency": 0.0,
                 }
             )
 
@@ -65,7 +57,5 @@ class TestTransferSettings:
                 transfer_signal_weights={
                     "date_distance": 0.5,
                     "keyword": 0.4,
-                    "roundness": 0.2,
-                    "pair_frequency": 0.2,
                 }
             )

--- a/tests/moneybin/matching/test_config_matching.py
+++ b/tests/moneybin/matching/test_config_matching.py
@@ -59,3 +59,18 @@ class TestTransferSettings:
                     "keyword": 0.4,
                 }
             )
+
+    def test_transfer_signal_weights_rejects_legacy_keys(self) -> None:
+        # An upgraded env var still carrying the retired 4-signal shape sums
+        # to 1.0 and includes both required keys, so the older validator
+        # passed it — but compute_transfer_confidence only reads
+        # date_distance + keyword, silently capping max confidence below 1.0.
+        with pytest.raises(ValidationError, match="unrecognised keys"):
+            MatchingSettings(
+                transfer_signal_weights={
+                    "date_distance": 0.4,
+                    "keyword": 0.3,
+                    "roundness": 0.15,
+                    "pair_frequency": 0.15,
+                }
+            )

--- a/tests/moneybin/matching/test_transfer.py
+++ b/tests/moneybin/matching/test_transfer.py
@@ -10,19 +10,15 @@ import pytest
 from moneybin.database import Database
 from moneybin.matching.transfer import (
     TransferCandidatePair,
-    compute_amount_roundness,
     compute_date_score,
     compute_keyword_score,
-    compute_pair_frequency,
     compute_transfer_confidence,
     get_candidates_transfers,
 )
 
 _DEFAULT_WEIGHTS: dict[str, float] = {
-    "date_distance": 0.4,
-    "keyword": 0.3,
-    "roundness": 0.15,
-    "pair_frequency": 0.15,
+    "date_distance": 0.6,
+    "keyword": 0.4,
 }
 
 
@@ -54,56 +50,6 @@ class TestComputeKeywordScore:
         assert compute_keyword_score("MARCH WIRELESS", "PURCHASE") == 0.0
 
 
-class TestComputeAmountRoundness:
-    """Tests for amount roundness scoring."""
-
-    def test_divisible_by_100(self) -> None:
-        assert compute_amount_roundness(Decimal("500")) == 1.0
-        assert compute_amount_roundness(Decimal("1000")) == 1.0
-
-    def test_divisible_by_10(self) -> None:
-        assert compute_amount_roundness(Decimal("50")) == 0.7
-        assert compute_amount_roundness(Decimal("130")) == 0.7
-
-    def test_whole_dollar(self) -> None:
-        assert compute_amount_roundness(Decimal("42")) == 0.5
-        assert compute_amount_roundness(Decimal("7")) == 0.5
-
-    def test_fractional(self) -> None:
-        assert compute_amount_roundness(Decimal("42.50")) == 0.3
-        assert compute_amount_roundness(Decimal("99.99")) == 0.3
-
-
-class TestComputePairFrequency:
-    """Tests for account pair frequency scoring."""
-
-    def test_single_pair(self) -> None:
-        counts = {("acct1", "acct2"): 1}
-        score = compute_pair_frequency("acct1", "acct2", counts, max_count=1)
-        assert score == 1.0
-
-    def test_frequent_pair(self) -> None:
-        counts = {("acct1", "acct2"): 5, ("acct1", "acct3"): 2}
-        score = compute_pair_frequency("acct1", "acct2", counts, max_count=5)
-        assert score == 1.0
-
-    def test_infrequent_pair(self) -> None:
-        counts = {("acct1", "acct2"): 5, ("acct1", "acct3"): 2}
-        score = compute_pair_frequency("acct1", "acct3", counts, max_count=5)
-        assert score == pytest.approx(0.4)  # type: ignore[reportUnknownMemberType] — pytest.approx stub incomplete
-
-    def test_order_independent(self) -> None:
-        counts = {("acct1", "acct2"): 3}
-        score_ab = compute_pair_frequency("acct1", "acct2", counts, max_count=3)
-        score_ba = compute_pair_frequency("acct2", "acct1", counts, max_count=3)
-        assert score_ab == score_ba
-
-    def test_unknown_pair(self) -> None:
-        counts = {("acct1", "acct2"): 3}
-        score = compute_pair_frequency("acct3", "acct4", counts, max_count=3)
-        assert score == 0.0
-
-
 class TestComputeTransferConfidence:
     """Tests for combined transfer confidence scoring."""
 
@@ -111,8 +57,6 @@ class TestComputeTransferConfidence:
         score = compute_transfer_confidence(
             date_score=compute_date_score(0, 3),
             keyword_score=1.0,
-            amount_roundness=1.0,
-            pair_frequency=1.0,
             weights=_DEFAULT_WEIGHTS,
         )
         assert score == pytest.approx(1.0)  # type: ignore[reportUnknownMemberType] — pytest.approx stub incomplete
@@ -121,8 +65,6 @@ class TestComputeTransferConfidence:
         score = compute_transfer_confidence(
             date_score=compute_date_score(3, 3),
             keyword_score=0.0,
-            amount_roundness=0.0,
-            pair_frequency=0.0,
             weights=_DEFAULT_WEIGHTS,
         )
         assert score == pytest.approx(0.0)  # type: ignore[reportUnknownMemberType] — pytest.approx stub incomplete
@@ -131,15 +73,11 @@ class TestComputeTransferConfidence:
         same_day = compute_transfer_confidence(
             date_score=compute_date_score(0, 3),
             keyword_score=0.5,
-            amount_roundness=0.5,
-            pair_frequency=0.5,
             weights=_DEFAULT_WEIGHTS,
         )
         one_day = compute_transfer_confidence(
             date_score=compute_date_score(1, 3),
             keyword_score=0.5,
-            amount_roundness=0.5,
-            pair_frequency=0.5,
             weights=_DEFAULT_WEIGHTS,
         )
         assert same_day > one_day
@@ -148,14 +86,10 @@ class TestComputeTransferConfidence:
         weights = {
             "date_distance": 1.0,
             "keyword": 0.0,
-            "roundness": 0.0,
-            "pair_frequency": 0.0,
         }
         score = compute_transfer_confidence(
             date_score=compute_date_score(0, 3),
             keyword_score=1.0,
-            amount_roundness=1.0,
-            pair_frequency=1.0,
             weights=weights,
         )
         assert score == pytest.approx(1.0)  # type: ignore[reportUnknownMemberType] — pytest.approx stub incomplete
@@ -166,8 +100,6 @@ class TestComputeTransferConfidence:
                 score = compute_transfer_confidence(
                     date_score=compute_date_score(days, 3),
                     keyword_score=kw,
-                    amount_roundness=0.5,
-                    pair_frequency=0.5,
                     weights=_DEFAULT_WEIGHTS,
                 )
                 assert 0.0 <= score <= 1.0
@@ -454,7 +386,7 @@ class TestGetCandidatesTransfers:
         )
         assert len(candidates) == 0
 
-    def test_scores_all_four_signals(self, transfer_table: Database) -> None:
+    def test_scores_both_signals(self, transfer_table: Database) -> None:
         _insert_transfer_row(
             transfer_table,
             source_transaction_id="csv_chk1",
@@ -481,8 +413,6 @@ class TestGetCandidatesTransfers:
         pair = candidates[0]
         assert pair.date_distance_score == 1.0
         assert pair.keyword_score > 0.0
-        assert pair.amount_roundness_score == 1.0
-        assert pair.pair_frequency_score > 0.0
         assert 0.0 < pair.confidence_score <= 1.0
 
     def test_debit_side_is_a_credit_side_is_b(self, transfer_table: Database) -> None:

--- a/tests/moneybin/matching/test_transfer_integration.py
+++ b/tests/moneybin/matching/test_transfer_integration.py
@@ -132,8 +132,6 @@ class TestTransferPipeline:
         signals = json.loads(pending[0]["match_signals"])
         assert "date_distance" in signals
         assert "keyword" in signals
-        assert "roundness" in signals
-        assert "pair_frequency" in signals
 
     def test_cross_institution_ach_with_date_offset(self, db: Database) -> None:
         """Cross-institution ACH with 2-day offset, different descriptions."""


### PR DESCRIPTION
## Summary
Cut two weak scoring signals from transfer detection (`amount_roundness_score` and `pair_frequency_score`) and re-weight the remaining two. Part of a 9-PR complexity audit cleanup. Simplifies the scorer and removes unstable behavior from `pair_frequency` (within-batch-only — backfills produced different scores than incremental syncs).

## Impact
- **Detection behavior changes.** Transfers are now scored on `date_distance` (weight 0.6) + `keyword` (weight 0.4) only. Review threshold lowered from 0.70 to 0.55 to preserve approximate review-queue size.
- `TransferCandidatePair` no longer carries `amount_roundness_score` or `pair_frequency_score` fields — code accessing those breaks.
- The two-pass `get_candidates_transfers` is now single-pass; the `pair_counts` dict was the only reason for the second pass.
- Threshold remains tunable via `MONEYBIN_MATCHING__TRANSFER_REVIEW_THRESHOLD`.

## Changes

### Cut signals + re-weight
- Delete `amount_roundness_score`, `pair_frequency_score` fields from `TransferCandidatePair`
- Delete `compute_amount_roundness`, `compute_pair_frequency` functions
- `compute_transfer_confidence` signature: now `(date_score, keyword_score, weights)` only
- `MatchingSettings.transfer_signal_weights` default → `{date_distance: 0.6, keyword: 0.4}`. Validator updated to require exactly these two keys.
- `MatchingSettings.transfer_review_threshold` default → 0.55 (was 0.70)
- `TransactionMatcher.match_signals` dict trimmed to the two surviving keys

### Spec doc
- `docs/specs/matching-transfer-detection.md`: scoring table drops the two cut rows; levers table updated; configuration default updated; Open Questions resolves "confidence score formula" (the 2-signal model is canonical) and clarifies the keyword list is retained as-is
- Env var override example annotated to explain `0.65` is illustrative ("raise to tighten" / "lower to relax") — default is now `0.55`

### Tests
- Drop unit tests for the cut signal functions (9 tests)
- Update `test_transfer.py`, `test_config_matching.py`, `test_transfer_integration.py`, `test_assignment.py` to remove field references and threshold expectations
- Keyword machinery (50-word longest-first regex), `is_match`/`is_review` boundary semantics preserved

## Testing
`make check test` — 2462 passed, 0 failed locally. Synthetic ground-truth scenario test (`tests/scenarios/test_transfer_detection.py`, marked `slow + scenarios`) was not run here since it requires the full SQLMesh pipeline. Analytic check: a same-day transfer with 2 keyword matches scores `0.6×1.0 + 0.4×0.8 = 0.92` — well above the 0.55 threshold. Marginal cases (date=0.5, keyword=0.5 → 0.50) drop out, which was already true under the prior 4-signal formula at 0.70.

## Notes
- The 50-word longest-first keyword regex is intentionally retained — the maintenance-prone compound phrases are doing real recall work; trimming them was out of scope.
- If precision/recall on the synthetic ground-truth scenario degrades materially after this lands, retune the default threshold via the env var.