### PR TITLE
Make AI reviewer state approval contract on every review

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -42,8 +42,10 @@ jobs:
               for new code paths, violations of explicit project rules. Gates merge; cannot ship as-is.
 
             - 🟡 **CONSIDER** — substantive quality concerns: design issues, refactoring opportunities,
-              potential bugs that aren't certain, missing edge-case handling. Author/agent decides per
-              finding: fix-in-PR (when bounded) or defer (when fixing would meaningfully expand scope).
+              potential bugs that aren't certain, missing edge-case handling. CONSIDER gates approval
+              (see the Approval contract below): the author either fixes it in-PR or proposes a
+              deferral, which you must accept and resolve the thread before approving — a CONSIDER is
+              never silently ignored.
 
             - 🔵 **NIT** — small consistency issues: docstring formatting, list-marker inconsistency,
               naming drift, minor style. These ARE valuable — they catch real oversights — but they
@@ -79,9 +81,43 @@ jobs:
             Only resolve threads where the fix is clearly present — leave threads open if
             the issue is partially addressed or still present.
 
-            After resolving threads, if your review found no new issues and all previously-raised
-            threads are now resolved, submit an approval: gh pr review --approve --body "All issues resolved."
-            If any threads remain open or you found new issues, do not approve.
+            ## Approval contract — spell it out on every review
+
+            A PR is approved IF AND ONLY IF zero 🔴 MUST FIX AND zero 🟡 CONSIDER items
+            remain open. Only 🔵 NIT findings never block approval. A 🟡 CONSIDER is
+            "resolved" by a code fix OR by you accepting an explicit deferral and resolving
+            its thread. State this contract on every review so the author always knows exactly
+            what stands between the PR and approval — never leave the verdict implicit.
+
+            The goal is a genuine approval on almost every PR. When the contract is met you
+            MUST approve — do not withhold approval once zero 🔴/🟡 remain.
+
+            Submit your verdict as a review (NOT a bare issue comment), choosing the mechanism
+            by the most severe open finding so the PR's latest-review state reflects reality:
+
+            - Zero 🔴 and zero 🟡 remaining (all prior threads resolved) → approve. This also
+              clears any CHANGES_REQUESTED you previously posted.
+                gh pr review --approve --body "<body>"
+              Body MUST open with this exact line:
+                ✅ APPROVED — all 🔴 MUST FIX and 🟡 CONSIDER resolved.
+              then note any non-blocking remainder, e.g. "1 🔵 NIT (non-blocking)."
+
+            - A SEVERE 🔴 is open (security, data-loss/corruption, shipped-broken correctness,
+              or a broken public contract) → request changes (a hard block):
+                gh pr review --request-changes --body "<body>"
+
+            - Only NON-severe 🔴 and/or 🟡 are open → post a review comment (verdict without
+              freezing the PR):
+                gh pr review --comment --body "<body>"
+
+            For both NOT-APPROVED mechanisms, the body MUST open with this exact line
+            (N = open 🔴 count, M = open 🟡 count):
+                ❌ NOT APPROVED — N 🔴 MUST FIX + M 🟡 CONSIDER gate approval:
+              followed by an enumerated list of each blocking item (one line each, with
+              file:line), then this closing line:
+                🔵 NIT findings do not block approval.
+
+            Every review must end in exactly one verdict line (✅ APPROVED or ❌ NOT APPROVED).
 
       - name: Interactive @claude mentions
         if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')
@@ -126,8 +162,28 @@ jobs:
             Only resolve threads where the fix is clearly present — leave
             threads open if the issue is partially addressed or still present.
 
-            After resolving threads, if no new issues remain and all
-            previously-raised threads are now resolved, submit an approval:
-              gh pr review --approve --body "All issues resolved."
-            If any threads remain open or you found new issues, do not approve —
-            post a summary comment instead describing what's outstanding.
+            ## Approval contract — spell it out on every review
+
+            A PR is approved IF AND ONLY IF zero 🔴 MUST FIX AND zero 🟡 CONSIDER
+            remain open. Only 🔵 NIT never blocks. A 🟡 is resolved by a fix OR by
+            you accepting a deferral and resolving its thread. State this on every
+            review; the goal is a genuine approval on almost every PR, so when the
+            contract is met you MUST approve — do not withhold.
+
+            Submit your verdict as a review, choosing the mechanism by the most
+            severe open finding:
+
+            - Zero 🔴 and zero 🟡 → approve (this clears any CHANGES_REQUESTED you
+              previously posted):
+                gh pr review --approve --body "<body>"
+              Body opens: ✅ APPROVED — all 🔴 MUST FIX and 🟡 CONSIDER resolved.
+            - A SEVERE 🔴 open (security, data-loss, shipped-broken correctness,
+              broken public contract) → gh pr review --request-changes --body "<body>"
+            - Only non-severe 🔴 and/or 🟡 open → gh pr review --comment --body "<body>"
+
+            Both NOT-APPROVED bodies open (N = open 🔴, M = open 🟡):
+                ❌ NOT APPROVED — N 🔴 MUST FIX + M 🟡 CONSIDER gate approval:
+              then an enumerated list (one line each, file:line), then:
+                🔵 NIT findings do not block approval.
+
+            Every review ends in exactly one verdict line (✅ APPROVED or ❌ NOT APPROVED).


### PR DESCRIPTION
## Summary

The AI code-review workflow (`.github/workflows/ai-review.yml`) now states the
approval contract explicitly on every review and ends each review with one
verdict line, so a contributor always knows exactly what gates approval.

- Every review ends in `✅ APPROVED` or `❌ NOT APPROVED — N 🔴 + M 🟡 gate
  approval:` with the blocking items enumerated (file:line).
- 🟡 CONSIDER gates approval alongside 🔴 MUST FIX; only 🔵 NIT is non-blocking
  (a 🟡 resolves via a fix or an accepted deferral).
- Verdict mechanism scales with severity: severe 🔴 → `--request-changes`,
  non-severe 🔴/🟡 → `--comment`, clean → `--approve` (which clears any prior
  change-request).
- The reviewer must approve once the contract is met — the goal is a genuine
  approval on almost every PR.

Applies to both the automated-review and `@claude` interactive steps.

## Test plan

- [ ] On a follow-up PR (after this merges), confirm the review ends with an
      explicit verdict line.
- [ ] A review with only 🔵 NIT findings still approves.
- [ ] A severe 🔴 produces `--request-changes`; a non-severe 🔴/🟡 produces a
      `--comment` verdict; zero 🔴/🟡 produces `--approve`.
- [ ] An `@claude` re-review applies the same contract.