### PR TITLE
Add concurrency guard to AI review workflow

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -7,6 +7,16 @@ on:
   issue_comment:
     types: [created]
 
+# Serialize reviews per PR: when a review is already running, a new push waits for
+# it to finish instead of spinning up a second, overlapping review. cancel-in-progress
+# is false so the in-progress review always completes; GitHub holds only the latest
+# queued trigger (older queued pushes are superseded — only the newest code matters).
+# Interactive @claude mentions are keyed per-comment so each runs on its own and is
+# never queued-then-dropped behind a push.
+concurrency:
+  group: ai-review-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}-${{ github.event_name == 'issue_comment' && github.event.comment.id || 'review' }}
+  cancel-in-progress: false
+
 jobs:
   review:
     name: Claude Review


### PR DESCRIPTION
## Summary
The AI Code Review workflow re-runs on every push (`synchronize`), so rapid pushes to a PR can spin up multiple overlapping reviews — wasted compute and duplicate review comments. This adds a `concurrency` guard that serializes reviews per PR: when a review is in progress, a new push waits for it to finish, then runs on the newer code. `cancel-in-progress: false` keeps the running review alive; GitHub holds only the latest queued trigger (older queued pushes are superseded). Interactive `@claude` mentions are keyed per-comment so each runs independently and is never queued-then-dropped behind a push.

## Test plan
- [ ] CI passes on this PR.
- [ ] Push two commits in quick succession; confirm the Actions tab shows one review running and the second **pending** (not a second concurrent run).
- [ ] Confirm the queued review runs after the first finishes, against the newer commit.
- [ ] Confirm an `@claude` mention still triggers a review and isn't blocked by an in-progress push review.