### PR TITLE
Add investments domain specs (M3B) and reconcile references

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -163,10 +163,11 @@ The largest competitive moat. M3B does not ship until cost-basis output ties to 
 
 | Area | Status | Notes |
 |---|---|---|
-| Holdings, FIFO lots, realized/unrealized gain/loss | 🗓️ | |
-| Short-term / long-term classification | 🗓️ | |
-| Yahoo + CoinGecko price feeds | 🗓️ | |
-| Plaid Investments product wiring | 🗓️ | Gated on this milestone. |
+| Securities, ledger, lots, realized gain/loss, holdings (cost basis) | 📐 | [`investments-data-model.md`](specs/investments-data-model.md) — foundation child (Pillars A+B) |
+| Short-term / long-term classification | 📐 | Foundation child; oldest-first per-lot under every method |
+| Unrealized gain/loss + Yahoo/CoinGecko price feeds | 🗓️ | Pillar C — `investments-price-feeds.md` (planned) |
+| Holdings in net worth | 🗓️ | Pillar D — `investments-net-worth.md` (planned) |
+| Plaid Investments product wiring | 🗓️ | Gated on the foundation contracts. |
 
 ---
 

--- a/docs/specs/2026-05-13-plaid-sync-design.md
+++ b/docs/specs/2026-05-13-plaid-sync-design.md
@@ -905,7 +905,7 @@ Client PR (this branch) and server PR ship paired. Until the server endpoints la
 - `sync schedule` commands (Phase 2 — automation track in `sync-overview.md` build order)
 - E2E encryption (Phase 3 — gated on server implementing client-side key exchange). `sync key rotate` stub stays in CLI. Open design question for Phase 3: whether key rotation can be MCP-exposed safely (no passphrase material in the LLM context — the agent triggers rotation; new keys generated locally; public key goes server-via-HTTPS — but operational consistency with `db_unlock`/`db_rotate_key` (which DO require passphrases) argues for CLI-only uniformity). Decision deferred to the Phase 3 spec.
 - Post-quantum cryptography (Phase 4 — designed in `sync-overview.md`)
-- Plaid Investments product (separate spec, gated on `investment-tracking.md`)
+- Plaid Investments product (separate spec, gated on `investments-overview.md`)
 - Plaid Liabilities product
 - SimpleFIN, MX, TrueLayer integration (Phase 2/3 — `connect_type` discriminator is in place for forward compat; `POST /sync/connect/submit` endpoint and the `token_paste` client path are NOT in this PR)
 - Local web server callback for OAuth on the CLI (Phase 1 polish — no server API changes needed; deferred)

--- a/docs/specs/2026-05-13-plaid-sync-design.md
+++ b/docs/specs/2026-05-13-plaid-sync-design.md
@@ -905,7 +905,7 @@ Client PR (this branch) and server PR ship paired. Until the server endpoints la
 - `sync schedule` commands (Phase 2 — automation track in `sync-overview.md` build order)
 - E2E encryption (Phase 3 — gated on server implementing client-side key exchange). `sync key rotate` stub stays in CLI. Open design question for Phase 3: whether key rotation can be MCP-exposed safely (no passphrase material in the LLM context — the agent triggers rotation; new keys generated locally; public key goes server-via-HTTPS — but operational consistency with `db_unlock`/`db_rotate_key` (which DO require passphrases) argues for CLI-only uniformity). Decision deferred to the Phase 3 spec.
 - Post-quantum cryptography (Phase 4 — designed in `sync-overview.md`)
-- Plaid Investments product (separate spec, gated on `investments-overview.md`)
+- Plaid Investments product (separate spec, gated on `investments-data-model.md`)
 - Plaid Liabilities product
 - SimpleFIN, MX, TrueLayer integration (Phase 2/3 — `connect_type` discriminator is in place for forward compat; `POST /sync/connect/submit` endpoint and the `token_paste` client path are NOT in this PR)
 - Local web server callback for OAuth on the CLI (Phase 1 polish — no server API changes needed; deferred)

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -69,6 +69,13 @@ Single source of truth for spec status. Update this table when a spec's status c
 | `categorization-ml.md` | Feature | planned | Pillar D: local ML-powered categorization |
 | `merchant-entity-resolution.md` | Feature | planned | Evolve merchants from pattern-to-category cache to first-class entities; multi-pattern matching, automated discovery, query-time resolution |
 
+## Investments
+
+| Spec | Type | Status | Summary |
+|---|---|---|---|
+| [Overview](investments-overview.md) | Umbrella | draft | Milestone M3B keystone. Four pillars: (A) investment data model, (B) cost-basis & gain/loss engine, (C) price feeds & valuation, (D) net-worth integration. A+B ship first and reach the "ties to a real 1099-B" bar **without** a price feed (realized gain/loss is ledger-derived). Fixes the contracts ~6 gated specs wait on (Plaid Investments sync, portfolio/holdings reports, investment matching/transfers, investment OFX, holdings-in-net-worth). Asset/investment dividing line: market ticker → investment. |
+| [Investment Data Model & Cost-Basis Engine](investments-data-model.md) | Feature | draft | Foundation child (Pillars A+B). `core.dim_securities` (surrogate `security_id` + resolution chain), `core.fct_investment_transactions` ledger (closed `type` taxonomy), derived `core.fct_investment_lots` / `core.fct_realized_gains` / `core.dim_holdings` (Invariant 8). FIFO + specific-ID + average-cost as elections over one lot grain; manual entry via `raw.investment_transactions`; top-level `investments` CLI/MCP group. Mirrors the broker's method (no IRS-policy enforcement); `currency` column lands now, FX deferred to M3C. Moves the lot-selection override home from `app.us_tax_*` to core `app.lot_selections`. |
+
 ## Privacy & Security
 
 | Spec | Type | Status | Summary |
@@ -95,7 +102,7 @@ Single source of truth for spec status. Update this table when a spec's status c
 | [Overview](sync-overview.md) | Umbrella | in-progress | Provider-agnostic sync framework: interaction model, SyncClient, CLI/MCP surface, E2E encryption design, provider contract. Phase 1 shipped via `sync-plaid.md`; Phase 2 scheduling unstarted; Phases 3-4 (E2E + post-quantum) remain design sketches. Supersedes archived `sync-client-integration` spec. |
 | [Plaid Provider](sync-plaid.md) | Feature | implemented | First sync provider: Plaid Transactions. Raw schemas, staging views, core integration, Plaid Hosted Link flow, error codes. M3A Phase 1 shipped. |
 | `sync-simplefin.md` | Feature | planned | SimpleFIN aggregator provider (alternative to Plaid). **Deferred 2026-05-16** (internal roadmap review): no implementation work until M3A produces 30 days of real Plaid data from a real user — provider-ladder elaboration ahead of real user evidence is speculative. Spec may be drafted earlier; engineering work waits for the gate. |
-| `sync-plaid-investments.md` | Feature | planned | Plaid Investments product (gated on `investment-tracking.md`) |
+| `sync-plaid-investments.md` | Feature | planned | Plaid Investments product (gated on `investments-data-model.md`) |
 
 ## Connect (Live External Sources)
 

--- a/docs/specs/architecture-shared-primitives.md
+++ b/docs/specs/architecture-shared-primitives.md
@@ -10,7 +10,7 @@
 
 Twelve cross-cutting primitives have crystallized through Levels 0–1 — a connection factory, a secret store, a service-layer contract, a table registry, a response envelope, an MCP decorator and privacy middleware, observability hooks, a sanitized log formatter, an ingestion primitive, a settings model, SQLMesh layer conventions, and a scenario fixture format. Each is referenced by ≥3 callers across the codebase and is implicitly assumed by every new feature spec.
 
-This spec names the primitives, their invariants, and the layer conventions they live within. It does not introduce new behavior. Its job is to remove ambiguity from every subsequent spec — `transaction-curation.md`, `investment-tracking.md`, `multi-currency.md`, `sync-plaid.md` rewrite — so authors cite the contract instead of re-deriving it.
+This spec names the primitives, their invariants, and the layer conventions they live within. It does not introduce new behavior. Its job is to remove ambiguity from every subsequent spec — `transaction-curation.md`, `investments-data-model.md`, `multi-currency.md`, `sync-plaid.md` rewrite — so authors cite the contract instead of re-deriving it.
 
 It is **not** a feature spec. There is no implementation plan. The two narrow naming changes called out below ride along with this spec landing.
 

--- a/docs/specs/asset-tracking.md
+++ b/docs/specs/asset-tracking.md
@@ -11,7 +11,7 @@ Track non-financial physical assets (real estate, vehicles, valuables) with peri
 
 Net worth is incomplete without physical assets. The [net worth spec](reports-net-worth.md) provides balance tracking for financial accounts (checking, savings, credit cards, loans), but a house, car, or piece of jewelry has no account, no transactions, and no institution. Its value comes from periodic appraisals or estimates, not from summing debits and credits.
 
-The dividing line between assets and investments: **if the value comes from a market ticker, it's an investment. If it comes from an appraisal or estimate, it's an asset.** Gold ETFs, crypto, and brokerage holdings belong in the future `investment-tracking.md` spec. Houses, cars, and jewelry belong here.
+The dividing line between assets and investments: **if the value comes from a market ticker, it's an investment. If it comes from an appraisal or estimate, it's an asset.** Gold ETFs, crypto, and brokerage holdings belong in the `investments-overview.md` initiative. Houses, cars, and jewelry belong here.
 
 Related specs and docs:
 - [`reports-net-worth.md`](reports-net-worth.md) — balance tracking and `reports.net_worth`; this spec extends it to include physical assets
@@ -405,7 +405,7 @@ Deferred to v2, same as balance assertion write tools in the net worth spec. The
 
 ## Out of Scope
 
-- **Investment holdings** — brokerage accounts, 401k, IRA, crypto, commodities (gold/silver). Market-priced instruments belong in `investment-tracking.md`. The dividing line: if the value comes from a market ticker, it's an investment; if from an appraisal or estimate, it's an asset.
+- **Investment holdings** — brokerage accounts, 401k, IRA, crypto, commodities (gold/silver). Market-priced instruments belong in `investments-overview.md`. The dividing line: if the value comes from a market ticker, it's an investment; if from an appraisal or estimate, it's an asset.
 - **Automated valuation integrations** — Zillow, KBB, and similar APIs. The data model supports them (raw → prep → core pipeline), but no provider is built in v1. Adding one is a separate child spec.
 - **Asset depreciation schedules** — automatic depreciation calculations (straight-line, declining balance). Users can model this via periodic valuations.
 - **Insurance tracking** — policy details, coverage amounts, premium costs. Related but separate domain.

--- a/docs/specs/extension-contracts.md
+++ b/docs/specs/extension-contracts.md
@@ -184,11 +184,13 @@ description: |
   wash-sale detection, estimated quarterly payments, qualified dividends.
 capabilities:
   writes:
-    - app.us_tax_*               # filing-status config, lot-selection overrides
+    - app.us_tax_*               # filing-status config, wash-sale adjustments
     - reports.us_tax_*           # Schedule D, wash-sale flags
   reads:
     - core.dim_holdings
     - core.fct_investment_transactions
+    - core.fct_realized_gains    # Schedule D inputs (realized gain/loss per lot)
+    - app.lot_selections         # core lot-selection overrides (cost basis is core, not this package)
     - core.fct_transactions      # deductible-categorization data
     - core.dim_currencies
   network: []

--- a/docs/specs/extension-contracts.md
+++ b/docs/specs/extension-contracts.md
@@ -184,7 +184,7 @@ description: |
   wash-sale detection, estimated quarterly payments, qualified dividends.
 capabilities:
   writes:
-    - app.us_tax_*               # filing-status config, wash-sale adjustments
+    - app.us_tax_*               # filing-status config (wash-sale state lands when the us_tax child spec designs it)
     - reports.us_tax_*           # Schedule D, wash-sale flags
   reads:
     - core.dim_holdings

--- a/docs/specs/investments-data-model.md
+++ b/docs/specs/investments-data-model.md
@@ -93,6 +93,13 @@ Related specs:
 
 ## Data Model
 
+> **Precision convention.** Quantity, price, and per-unit-cost columns use
+> `DECIMAL(28,10)` rather than `architecture-shared-primitives.md` Layer Rule 6's
+> `DECIMAL(18,8)`. This is a deliberate, domain-driven deviation: crypto positions
+> need full fractional-unit precision (sub-satoshi quantities, sub-cent token prices),
+> which the fiat-oriented `18,8` default truncates. Money *amounts* (`amount`, `fees`,
+> `cost_basis*`) keep the standard `DECIMAL(18,2)`.
+
 ### New table: `app.securities`
 
 Manually-maintained security catalog. Managed via CLI (`investments securities add/set`).
@@ -286,7 +293,7 @@ Columns:
   security_id       VARCHAR          -- FK to core.dim_securities (grain)
   quantity          DECIMAL(28,10)   -- Total open units (Σ remaining_quantity)
   cost_basis        DECIMAL(18,2)    -- Total open basis (Σ cost_basis_remaining)
-  average_cost      DECIMAL(28,10)   -- cost_basis / quantity (display convenience)
+  average_cost      DECIMAL(28,10)   -- cost_basis / quantity; (28,10) not Rule-6 (18,8) on purpose — crypto fractional-unit precision propagates through the ratio
   currency          VARCHAR          -- Denominating currency
   updated_at        TIMESTAMP        -- Row freshness
 ```
@@ -300,6 +307,14 @@ Columns:
 All three methods are computations over `core.fct_investment_lots`. The engine walks
 the ledger per (account, security) in trade-date order, opening lots on acquisitions
 and consuming them on disposals.
+
+> **The method set is intentionally closed to the three v1 methods.** The
+> `cost_basis_method` `CHECK` (on `app.securities` and `app.account_settings`) allows
+> only `fifo`, `specific`, `average` on purpose — electing a method the engine does not
+> implement would silently miscompute basis, so the constraint is a guard, not an
+> oversight. HIFO/LIFO (listed as future methods in `investments-overview.md`) are added
+> by widening the `CHECK` when their engine paths ship — a lightweight `app.*` migration,
+> the same deliberate trade-off as `security_type`.
 
 ### Short-term / long-term split (shared across all methods)
 

--- a/docs/specs/investments-data-model.md
+++ b/docs/specs/investments-data-model.md
@@ -1,0 +1,611 @@
+# Feature: Investment Data Model & Cost-Basis Engine
+
+## Status
+draft
+
+## Goal
+
+Establish the securities dimension and the investment-transaction ledger, then
+derive lots, holdings, and **realized** gain/loss (short- and long-term) from that
+ledger — reproducing broker numbers well enough to reconcile against a real 1099-B.
+This is the foundation child of the investments initiative (Pillars A + B of
+[`investments-overview.md`](investments-overview.md)). It deliberately stops short
+of market-price valuation: realized gain/loss needs no price feed, so the 1099-B bar
+is reachable here, while unrealized value and net-worth integration follow as
+separate children.
+
+## Background
+
+Investments are the keystone of milestone M3B and the single most-referenced
+unwritten contract in the repo (see [`investments-overview.md`](investments-overview.md)
+for the full gate list). This spec fixes the contracts those gated specs wait on:
+the security identity key, the ledger shape and its `type` taxonomy, and the
+lot/holding derivation.
+
+The crucial scoping insight (from the overview): **realized gain/loss is computed
+entirely from the ledger** — a sale's proceeds versus the cost of the lots it
+consumes, both recorded events — so it requires no market price. Only *unrealized*
+gain/loss needs a current price, which is Pillar C's job.
+
+Related specs:
+- [`investments-overview.md`](investments-overview.md) — umbrella; vision, pillars, cross-cutting contracts
+- [`asset-tracking.md`](asset-tracking.md) — the asset/investment dividing line; sibling net-worth contributor
+- [`architecture-shared-primitives.md`](architecture-shared-primitives.md) — layer conventions; **Invariant 8** (derivations live in SQLMesh, never snapshotted into `app.*`)
+- [`identifiers.md`](../../.claude/rules/identifiers.md) — surrogate keys (truncated UUID4) and content hashes
+- [`account-management.md`](account-management.md) — `app.account_settings`, extended here with the cost-basis-method default
+- [`moneybin-cli.md`](moneybin-cli.md) — promotes the placeholder `accounts investments` to a **top-level `investments` group**
+- [`extension-contracts.md`](extension-contracts.md) — `us_tax` package consumes `core.dim_holdings` + `core.fct_investment_transactions`
+
+## Requirements
+
+1. **Security catalog in `app.securities`.** A manually-maintained catalog keyed on a
+   stable surrogate `security_id` (truncated UUID4). Ticker, CUSIP, ISIN, FIGI, and
+   `coingecko_id` are nullable *attributes*, never the key.
+2. **Five security types for v1:** `equity`, `etf`, `mutual_fund`, `bond`, `crypto`,
+   plus `other`. Extensible by adding values without migration.
+3. **Identity resolution chain.** Free-text or partial security references resolve to
+   a `security_id` via CUSIP/ISIN → ticker+exchange → name fuzzy, mirroring the
+   institution-resolution chain in `smart-import-financial.md`. v1 resolves against
+   `app.securities` (manual-only); the contract is multi-source-ready.
+4. **Investment-transaction ledger in `core.fct_investment_transactions`.** One row
+   per investment event. The only authored/ingested surface; everything else derives
+   from it.
+5. **Closed `type` taxonomy** (one-way-door enum), mapped from OFX `<INVTRANLIST>` and
+   Plaid so importers slot in cleanly: `buy`, `sell`, `reinvest`, `dividend`,
+   `interest`, `capital_gain_distribution`, `transfer_in`, `transfer_out`, `split`,
+   `fee`, `return_of_capital`, `other`.
+6. **Sign conventions.** `quantity` is signed: positive for acquisitions
+   (`buy`/`reinvest`/`transfer_in`), negative for disposals (`sell`/`transfer_out`),
+   NULL for cash-only events. `amount` follows the existing accounting convention
+   (negative = cash out, e.g. a buy; positive = cash in, e.g. a sell or dividend).
+   `amount` is the *total* cash effect **including** fees; the `fees` breakout is the
+   portion that increases cost basis on acquisitions and reduces proceeds on disposals.
+   So a buy's cost basis is `|amount|` and a sell's net proceeds is `amount`.
+7. **Manual entry via raw.** Manual entry writes `raw.investment_transactions`
+   (`source_type = 'manual'`) → `prep.stg_*` → `core.fct_investment_transactions`,
+   following the CLI-imperative / MCP-declarative-set pattern from
+   `transaction-curation.md`. Future importers (Plaid, OFX) write the same raw table.
+8. **Derived lots in `core.fct_investment_lots`** (Invariant 8). Each acquisition
+   opens a lot; disposals consume lots per the elected method. Each lot carries a
+   stable content-hash `lot_id` so specific-ID overrides can reference it.
+9. **Derived realized gains in `core.fct_realized_gains`.** One row per
+   (disposal, consumed lot) pair — the 1099-B grain: proceeds, cost basis, gain/loss,
+   acquisition/disposal dates, and short-/long-term classification.
+10. **Derived holdings in `core.dim_holdings`** — current open quantity + cost basis
+    per (account, security); the sum of open lots. *(Name locked by `extension-contracts.md`.)*
+11. **Three cost-basis methods:** FIFO, specific identification, average cost — all
+    computations over the same lot ledger (see [Cost-Basis Engine](#cost-basis-engine)).
+12. **Method election** at per-account default (`app.account_settings.default_cost_basis_method`)
+    + per-security override (`app.securities.cost_basis_method`). Resolution:
+    per-security → per-account → global FIFO. Average cost validates to fund/ETF types.
+13. **Specific-ID overrides in `app.lot_selections`** — core `app.*` state (cost basis
+    is core, not the `us_tax` package; see the overview's open-question on reconciling
+    `extension-contracts.md`).
+14. **Mirror, don't enforce.** v1 reproduces the broker's reported method; it does not
+    enforce IRS election lock-in or wash-sale rules.
+15. **Currency column** on ledger, lots, gains, and holdings now; no FX conversion
+    (deferred to M3C).
+16. **CLI commands** under a top-level `investments` group (see CLI Interface).
+17. **MCP tools** under the `investments_*` namespace (see MCP Interface).
+18. **All commands support `--output json`** for non-interactive / agent parity.
+
+## Data Model
+
+### New table: `app.securities`
+
+Manually-maintained security catalog. Managed via CLI (`investments securities add/set`).
+
+```sql
+CREATE TABLE IF NOT EXISTS app.securities (
+    security_id VARCHAR NOT NULL PRIMARY KEY,           -- Stable surrogate (truncated UUID4, 12 hex); never derived from ticker
+    name VARCHAR NOT NULL,                              -- Human-readable label ("Apple Inc.", "Bitcoin")
+    security_type VARCHAR NOT NULL CHECK (security_type IN ('equity', 'etf', 'mutual_fund', 'bond', 'crypto', 'other')), -- Instrument classification
+    ticker VARCHAR,                                     -- Exchange ticker ("AAPL"); nullable, not unique (tickers get reused)
+    exchange VARCHAR,                                   -- Listing exchange ("NASDAQ"); disambiguates duplicate tickers
+    cusip VARCHAR,                                      -- 9-char CUSIP if supplied by user data; licensed — accepted, never redistributed
+    isin VARCHAR,                                       -- ISIN if supplied; international identifier
+    figi VARCHAR,                                       -- OpenFIGI identifier (open mapping aid); nullable
+    coingecko_id VARCHAR,                               -- CoinGecko slug for crypto price lookup (Pillar C); nullable
+    cost_basis_method VARCHAR CHECK (cost_basis_method IN ('fifo', 'specific', 'average')), -- Per-security election override; NULL falls back to account default
+    currency VARCHAR NOT NULL DEFAULT 'USD',            -- Instrument's denominating currency; no FX conversion in v1
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, -- When the catalog entry was created
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP  -- When last modified; service must set explicitly on UPDATE (DuckDB has no ON UPDATE trigger)
+);
+```
+
+### New table: `raw.investment_transactions`
+
+Immutable ingestion records. Manual entry and (future) importers both write here.
+Carries unresolved source-text security references — resolution to `security_id`
+happens at the `core` boundary.
+
+```sql
+CREATE TABLE IF NOT EXISTS raw.investment_transactions (
+    source_id VARCHAR NOT NULL,                -- Source-provided ID (OFX FITID, Plaid id) or content hash for manual; unique per source
+    source_type VARCHAR NOT NULL,              -- Origin tag: 'manual', 'ofx', 'plaid' (closed vocabulary, per matching-overview)
+    source_origin VARCHAR,                     -- Institution/connection scope ("fidelity_brokerage", Plaid item_id); scopes matching
+    account_ref VARCHAR NOT NULL,              -- Source account reference; resolved to dim_accounts in staging
+    security_ticker VARCHAR,                   -- Raw ticker as supplied; input to resolution chain
+    security_cusip VARCHAR,                    -- Raw CUSIP as supplied; input to resolution chain
+    security_name VARCHAR,                     -- Raw security name as supplied; input to resolution chain
+    txn_type VARCHAR NOT NULL,                 -- Raw transaction type; mapped to the core taxonomy in staging
+    trade_date DATE NOT NULL,                  -- Trade date (drives holding period); NOT settlement date
+    settlement_date DATE,                      -- Settlement date if supplied; informational
+    original_acquisition_date DATE,            -- For transfer_in: shares' original acquisition date (holding period transfers in); NULL otherwise
+    quantity DECIMAL(28, 10),                  -- Units (high precision for fractional shares / crypto); signed in core
+    price DECIMAL(28, 10),                     -- Per-unit price; NULL for non-priced events
+    amount DECIMAL(18, 2),                     -- Cash effect; signed in core
+    fees DECIMAL(18, 2),                       -- Commissions/fees component; folded into cost basis
+    currency VARCHAR,                          -- Denominating currency as supplied
+    description VARCHAR,                        -- Free-text description from source
+    source_file VARCHAR,                       -- File path/URL for imported sources; NULL for manual
+    extracted_at TIMESTAMP,                    -- When fetched/entered
+    loaded_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, -- When written to raw
+    PRIMARY KEY (source_id, source_type)       -- One row per (source id, source) pair; mirrors transaction raw tables
+);
+```
+
+### New table: `app.lot_selections`
+
+Specific-identification overrides. Core `app.*` state (cost basis is core). Records,
+for a disposal, which lots to draw from and how much from each.
+
+```sql
+CREATE TABLE IF NOT EXISTS app.lot_selections (
+    investment_transaction_id VARCHAR NOT NULL, -- FK to the disposal row in core.fct_investment_transactions
+    lot_id VARCHAR NOT NULL,                     -- FK to core.fct_investment_lots; the chosen lot
+    quantity DECIMAL(28, 10) NOT NULL,          -- Units to draw from this lot for this disposal
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, -- When the selection was recorded
+    PRIMARY KEY (investment_transaction_id, lot_id) -- One selection per (disposal, lot) pair
+);
+```
+
+### Modified table: `app.account_settings`
+
+Adds the per-account cost-basis-method default (per `account-management.md`).
+
+```sql
+ALTER TABLE app.account_settings
+    ADD COLUMN default_cost_basis_method VARCHAR
+        CHECK (default_cost_basis_method IN ('fifo', 'specific', 'average')); -- Per-account default; NULL → global FIFO
+```
+
+### SQLMesh model: `core.dim_securities` (VIEW)
+
+v1 projects the manual catalog; structured as a union so importers add CTEs later
+(same extension pattern as `core.fct_asset_valuations`).
+
+```sql
+MODEL (
+  name core.dim_securities,
+  kind VIEW
+);
+
+SELECT
+  security_id,        -- Stable surrogate key
+  name,               -- Display name
+  security_type,      -- equity | etf | mutual_fund | bond | crypto | other
+  ticker,             -- Display/lookup ticker (carry the ID per identifiers.md Guard 1)
+  exchange,           -- Listing exchange
+  cusip,              -- Licensed identifier; present only if user-supplied
+  isin,               -- International identifier
+  figi,               -- OpenFIGI mapping
+  coingecko_id,       -- Crypto price-lookup slug (Pillar C)
+  currency            -- Denominating currency
+FROM app.securities
+-- Future: UNION ALL resolved securities from prep.stg_plaid__securities, etc.
+```
+
+### SQLMesh model: `core.fct_investment_transactions` (TABLE)
+
+The canonical ledger. Resolves `account_ref` → `account_id` and the raw security
+refs → `security_id` (resolution chain), maps `txn_type` → the core taxonomy, and
+applies the sign conventions.
+
+```
+Columns:
+  investment_transaction_id  VARCHAR          -- Canonical ID (source-provided or content hash)
+  account_id                 VARCHAR          -- FK to core.dim_accounts
+  security_id                VARCHAR          -- FK to core.dim_securities; NULL for cash-only events (account fee, cash interest)
+  trade_date                 DATE             -- Trade date; drives holding-period classification
+  settlement_date            DATE             -- Settlement date; informational
+  original_acquisition_date  DATE             -- transfer_in only: original acquisition date; lot uses COALESCE(this, trade_date)
+  type                       VARCHAR          -- Closed taxonomy (see Requirement 5)
+  quantity                   DECIMAL(28,10)   -- Signed units: + acquire, − dispose, NULL cash-only
+  price                      DECIMAL(28,10)   -- Per-unit price; NULL for non-priced events
+  amount                     DECIMAL(18,2)    -- Signed cash effect: − out (buy), + in (sell/dividend)
+  fees                       DECIMAL(18,2)    -- Fee/commission component folded into basis
+  currency                   VARCHAR          -- Denominating currency; no FX in v1
+  source_type                VARCHAR          -- Origin tag (manual | ofx | plaid)
+  source_origin              VARCHAR          -- Institution/connection scope
+  description                VARCHAR          -- Free-text description
+  updated_at                 TIMESTAMP        -- Row freshness per core-updated-at-convention
+```
+
+### SQLMesh model: `core.fct_investment_lots` (TABLE, derived)
+
+Each acquisition opens a lot; disposals consume open lots per the resolved method.
+Likely a **Python SQLMesh model** — the consumption logic (FIFO cursor, average-cost
+running aggregate, specific-ID override lookup) is awkward in pure SQL (see Open
+Questions). Lot identity is a content hash so it is stable across rebuilds and
+referenceable by `app.lot_selections`.
+
+```
+Columns:
+  lot_id                  VARCHAR          -- Content hash of (account_id, security_id, acquisition_date, source acquisition txn id); prefix "lot_"
+  account_id              VARCHAR          -- FK to core.dim_accounts
+  security_id             VARCHAR          -- FK to core.dim_securities
+  acquisition_date        DATE             -- Trade date of the opening event; drives ST/LT
+  acquisition_type        VARCHAR          -- buy | reinvest | transfer_in
+  original_quantity       DECIMAL(28,10)   -- Units when the lot opened
+  remaining_quantity      DECIMAL(28,10)   -- Open units after disposals consumed (0 when fully closed)
+  cost_basis_total        DECIMAL(18,2)    -- Total basis of original_quantity, including fees
+  cost_basis_remaining    DECIMAL(18,2)    -- Basis attributable to remaining_quantity
+  cost_basis_method       VARCHAR          -- Resolved method that governed this lot's consumption
+  currency                VARCHAR          -- Denominating currency
+  is_open                 BOOLEAN          -- remaining_quantity > 0
+  source_transaction_id   VARCHAR          -- FK to the opening core.fct_investment_transactions row
+  updated_at              TIMESTAMP        -- Row freshness
+```
+
+### SQLMesh model: `core.fct_realized_gains` (TABLE, derived)
+
+The 1099-B grain: one row per (disposal, consumed lot) pair. This is the
+reconciliation surface.
+
+```
+Columns:
+  realized_gain_id    VARCHAR          -- Content hash of (disposal txn id, lot_id)
+  account_id          VARCHAR          -- FK to core.dim_accounts
+  security_id         VARCHAR          -- FK to core.dim_securities
+  disposal_txn_id     VARCHAR          -- FK to the disposing core.fct_investment_transactions row
+  lot_id              VARCHAR          -- FK to core.fct_investment_lots consumed
+  quantity            DECIMAL(28,10)   -- Units drawn from this lot for this disposal
+  acquisition_date    DATE             -- Lot acquisition date (holding-period start)
+  disposal_date       DATE             -- Disposal trade date (holding-period end)
+  proceeds            DECIMAL(18,2)    -- Sale proceeds attributable to this quantity (net of fees)
+  cost_basis          DECIMAL(18,2)    -- Cost basis attributable to this quantity (method-dependent)
+  gain_loss           DECIMAL(18,2)    -- proceeds − cost_basis (signed; − is a loss)
+  term                VARCHAR          -- 'short' (held ≤ 1 year) | 'long' (held > 1 year)
+  cost_basis_method   VARCHAR          -- Method that produced this basis
+  currency            VARCHAR          -- Denominating currency
+  updated_at          TIMESTAMP        -- Row freshness
+```
+
+### SQLMesh model: `core.dim_holdings` (VIEW, derived)
+
+Current positions — the sum of open lots per (account, security). No date dimension;
+it is the "now" snapshot, rebuilt on every run. Daily-valued history
+(`core.fct_holdings_daily`) is Pillar C.
+
+```
+Columns:
+  account_id        VARCHAR          -- FK to core.dim_accounts (grain)
+  security_id       VARCHAR          -- FK to core.dim_securities (grain)
+  quantity          DECIMAL(28,10)   -- Total open units (Σ remaining_quantity)
+  cost_basis        DECIMAL(18,2)    -- Total open basis (Σ cost_basis_remaining)
+  average_cost      DECIMAL(28,10)   -- cost_basis / quantity (display convenience)
+  currency          VARCHAR          -- Denominating currency
+  updated_at        TIMESTAMP        -- Row freshness
+```
+
+> **Unrealized gain/loss** (`quantity × current_price − cost_basis`) is intentionally
+> absent here — it requires a price, which Pillar C (`investments-price-feeds.md`)
+> supplies. `dim_holdings` v1 carries cost basis only.
+
+## Cost-Basis Engine
+
+All three methods are computations over `core.fct_investment_lots`. The engine walks
+the ledger per (account, security) in trade-date order, opening lots on acquisitions
+and consuming them on disposals.
+
+### Short-term / long-term split (shared across all methods)
+
+Holding period is always determined per-lot, oldest-first, regardless of method —
+only the *basis number* differs. A disposal held ≤ 1 year from the lot's
+`acquisition_date` is `short`; > 1 year is `long`. A single disposal can split across
+both terms when it consumes multiple lots.
+
+### Method: FIFO (default)
+
+Disposals consume open lots in ascending `acquisition_date`. Each consumed slice
+contributes its actual per-unit basis. The simplest path and the IRS default.
+
+### Method: Specific identification
+
+Before falling back to FIFO order, the engine reads `app.lot_selections` for the
+disposal. Selected lots are consumed in the specified quantities; any unselected
+remainder falls back to FIFO. This unlocks tax-loss harvesting and ST/LT control.
+Shares the FIFO consumption machinery — it is an override on consumption order, not a
+separate engine.
+
+### Method: Average cost
+
+Basis per disposed unit = (remaining pooled cost ÷ remaining pooled units) at the
+moment of disposal — a running average that every acquisition/reinvestment mutates.
+The ST/LT split still walks lots oldest-first (only the basis is averaged). Validated
+to `mutual_fund` / `etf` security types. This is the one genuinely distinct
+computation; it adds a single derived path, not a parallel system.
+
+### Mirror, don't enforce (v1)
+
+The engine reproduces the elected method to match broker output. It does **not**
+enforce IRS election lock-in, average-cost switching restrictions, or wash-sale
+adjustments. Those are out of scope (wash sales belong to the `us_tax` package).
+
+### Corporate actions
+
+- `split` adjusts open-lot `original_quantity`/`remaining_quantity` by the split ratio
+  while preserving `cost_basis_total` (per-unit basis changes, total does not).
+- `return_of_capital` reduces `cost_basis_remaining` without creating a disposal.
+- `reinvest` opens a new lot (acquisition) and records income.
+- `transfer_in` opens a lot whose `acquisition_date` is the shares' **original**
+  acquisition date (holding period transfers with the shares — it is *not* reset to
+  the transfer date), carrying the supplied basis. Manual entry therefore accepts an
+  `--acquired DATE` (original acquisition) and `--basis AMOUNT` for transfers; the
+  ledger persists the original date in `original_acquisition_date`, and the lot uses
+  `COALESCE(original_acquisition_date, trade_date)`. `transfer_out` consumes lots
+  without proceeds (no realized gain).
+
+## CLI Interface
+
+All commands under a top-level `investments` group (promoting the placeholder
+`accounts investments` in [`moneybin-cli.md`](moneybin-cli.md), peer to `accounts`,
+`transactions`, and `assets`). All support `--output json`.
+
+### Ledger
+
+```
+moneybin investments add --account <id|name> --security <ticker|name> \
+    --type buy --date 2024-01-15 --quantity 10 --price 150.00 \
+    [--fees 4.95] [--currency USD] [--notes "..."]
+```
+- Records one event in `raw.investment_transactions` (`source_type=manual`); resolves
+  `--security` via the resolution chain, prompting to create a catalog entry if unknown.
+
+```
+moneybin investments list [--account <id|name>] [--security <ticker|name>] \
+    [--type buy] [--from DATE] [--to DATE] [--output json|table]
+```
+- Lists ledger events (the canonical `core.fct_investment_transactions`).
+
+### Positions & lots
+
+```
+moneybin investments holdings [--account <id|name>] [--output json|table]
+```
+- Current positions: quantity, cost basis, average cost. *(Market value / unrealized
+  gain appear once Pillar C ships; v1 shows cost basis only and says so.)*
+
+```
+moneybin investments lots [--account <id|name>] [--security <ticker|name>] \
+    [--open | --all] [--output json|table]
+```
+- Lots with remaining quantity and basis. Default: open lots only.
+
+```
+moneybin investments lots select <disposal_txn_id> --lot <lot_id> --quantity N [--yes]
+```
+- Records a specific-identification override in `app.lot_selections`.
+
+### Gains
+
+```
+moneybin investments gains [--account <id|name>] [--security <ticker|name>] \
+    [--from DATE] [--to DATE] [--term short|long] [--output json|table]
+```
+- Realized gain/loss (the 1099-B surface) from `core.fct_realized_gains`.
+
+### Cost-basis method election (no dedicated verb)
+
+The method is a *field*, not its own operation (per `surface-design.md`):
+- **Per-account default** → `moneybin accounts set <id> --default-cost-basis-method fifo|specific|average`
+  (the unified `accounts set` partial-update entry point from `account-management.md`).
+- **Per-security override** → `moneybin investments securities set <id> --method fifo|specific|average`
+  (`average` validates to fund/ETF security types).
+
+### Securities catalog
+
+```
+moneybin investments securities list [--type equity] [--output json|table]
+moneybin investments securities add --name "Apple Inc." --type equity \
+    --ticker AAPL [--exchange NASDAQ] [--cusip ...] [--coingecko-id ...]
+moneybin investments securities set <security_id> [--name ...] [--ticker ...] \
+    [--cusip ...] [--method fifo|specific|average]
+```
+
+### Example output
+
+```
+$ moneybin investments holdings --account fidelity_brokerage
+
+Security   Qty      Cost Basis   Avg Cost   Method
+AAPL       15.000   $2,475.00    $165.00    fifo
+VTSAX      210.450  $24,800.00   $117.84    average
+BTC        0.500    $18,000.00   $36,000.00 specific
+
+  ℹ️  Market value and unrealized gain require price feeds (coming in Pillar C).
+```
+
+```
+$ moneybin investments gains --account fidelity_brokerage --from 2024-01-01
+
+Date         Security  Qty     Proceeds    Basis       Gain/Loss   Term
+2024-06-12   AAPL      5.000   $950.00     $750.00     +$200.00    long
+2024-09-03   BTC       0.250   $9,500.00   $9,000.00   +$500.00    short
+
+  Realized 2024: +$700.00  (long +$200.00 / short +$500.00)
+```
+
+## MCP Interface
+
+Namespace `investments_*`, following [`mcp-architecture.md`](mcp-architecture.md)
+conventions (response envelope, sensitivity tiers). Functional parity with the CLI
+(same outcomes reachable), not 1:1 naming.
+
+### Read tools
+
+**`investments`** — List ledger events.
+- Params: `account` (optional), `security` (optional), `type` (optional), `from`/`to` (optional DATE)
+- Sensitivity: `medium` (positions/amounts)
+
+**`investments_holdings`** — Current positions with cost basis.
+- Params: `account` (optional)
+- Sensitivity: `medium`
+
+**`investments_lots`** — Open/closed lots.
+- Params: `account` (optional), `security` (optional), `open_only` (BOOLEAN, default true)
+- Sensitivity: `medium`
+
+**`investments_gains`** — Realized gain/loss (1099-B surface).
+- Params: `account` (optional), `security` (optional), `from`/`to` (optional DATE), `term` (optional)
+- Sensitivity: `medium`
+
+**`investments_securities`** — The catalog.
+- Params: `security_type` (optional)
+- Sensitivity: `low` (reference data, no amounts)
+
+### Write tools
+
+Per `surface-design.md` — one tool per operation shape, no polymorphic `*_set` catch-all.
+
+**`investments_record`** — Shape 3 (discrete batch event). Record one or more investment
+events; resolves securities, reports unresolved refs in `warnings`.
+
+**`investments_securities_set`** — Shape 1b (entity upsert). Create-or-update one
+catalog entry, including its `cost_basis_method` per-security override.
+
+**`investments_lots_select`** — Shape 1a (collection state-set). Set the full set of
+`(lot_id, quantity)` selections for one disposal (delete by omission).
+
+The **per-account default** cost-basis method is a field on `accounts_set`
+(`default_cost_basis_method`), not a separate tool — same reasoning as the CLI.
+
+### Response envelope
+
+Standard envelope from [`mcp-architecture.md`](mcp-architecture.md), e.g. for
+`investments_holdings`:
+
+```json
+{
+  "summary": {
+    "total_count": 3,
+    "sensitivity": "medium",
+    "display_currency": "USD",
+    "warnings": ["Market value/unrealized gain unavailable until price feeds ship"]
+  },
+  "data": [...],
+  "actions": ["Use investments_lots for per-lot basis", "Use investments_gains for realized gain/loss"]
+}
+```
+
+## Testing Strategy
+
+### Tier 1 — Unit tests
+
+- **Security resolution:** CUSIP/ISIN → ticker+exchange → name fuzzy precedence;
+  ambiguity raises (per `identifiers.md` Guard 2); unknown ref creates-or-prompts.
+- **Ledger ingestion:** raw → core mapping of `txn_type` → taxonomy; sign conventions
+  for each type; cash-only events (NULL `security_id`/`quantity`).
+- **FIFO:** known buys + sells produce correct consumed lots, basis, and ST/LT split,
+  including a disposal that splits across short and long terms.
+- **Specific-ID:** `app.lot_selections` overrides FIFO order; partial selection falls
+  back to FIFO for the remainder.
+- **Average cost:** running average across buys + reinvestments; disposal basis;
+  ST/LT still oldest-first; validation rejects `average` on `equity`.
+- **Corporate actions:** split adjusts quantities preserving total basis;
+  return_of_capital reduces basis; transfer_in carries basis + acquisition date;
+  transfer_out realizes no gain.
+- **Holdings:** Σ open lots equals `dim_holdings` quantity/basis; fully-closed lots
+  drop out.
+- **Method election resolution:** per-security → per-account → global FIFO.
+
+### Tier 2 — Synthetic data verification
+
+- Scenario tests under `tests/scenarios/` (run via `make test-scenarios`) with a
+  persona holding a mix of FIFO stocks and an average-cost fund, verifying
+  `fct_investment_lots`, `fct_realized_gains`, and `dim_holdings` against ground truth.
+- A **1099-B reconciliation scenario**: a hand-labeled fixture modeling a real
+  brokerage year (buys, sells, reinvested dividends, a split), with expected realized
+  gains per term that the engine must match exactly. This is the headline M3B test.
+
+### Tier 3 — Integration
+
+- End-to-end: `investments securities add` → `investments add` (several events) →
+  `sqlmesh run` → `investments holdings` / `gains` reflect the ledger.
+- Specific-ID flow: record a sell → `investments lots select` → `sqlmesh run` →
+  `gains` reflects the chosen lots.
+- Method change: `investments securities set <id> --method average` on a fund →
+  `sqlmesh run` → basis recomputes.
+
+## Dependencies
+
+- [`investments-overview.md`](investments-overview.md) — umbrella contracts this child implements
+- [`architecture-shared-primitives.md`](architecture-shared-primitives.md) — Invariant 8; layer + `updated_at` conventions
+- [`account-management.md`](account-management.md) — `app.account_settings` (extended with the method default)
+- [`database-migration.md`](database-migration.md) — new tables + the `app.account_settings` ALTER
+- [`privacy-data-protection.md`](privacy-data-protection.md) — investment data encrypted at rest via `Database`
+- [`moneybin-cli.md`](moneybin-cli.md) — `investments` top-level group (promotes the placeholder)
+- `core.dim_accounts` — ledger and lots FK existing accounts
+
+## Out of Scope
+
+- **Market-price valuation / unrealized gain** — Pillar C (`investments-price-feeds.md`).
+- **Holdings in net worth** — Pillar D (`investments-net-worth.md`).
+- **Plaid / OFX import** — separate children; they write the same `raw.investment_transactions`.
+- **Options, margin, short positions, derivatives** — future.
+- **Wash sales, Schedule D, qualified-dividend logic** — the `us_tax` package.
+- **IRS election-policy enforcement** — v1 mirrors the broker.
+- **Multi-currency FX conversion** — M3C (the `currency` column lands now; conversion does not).
+- **Investment-transaction dedup / transfer detection** — matching children, against this contract.
+
+## Implementation Plan
+
+### Files to Create
+
+- `src/moneybin/sql/schema/app_securities.sql` — DDL for `app.securities`
+- `src/moneybin/sql/schema/raw_investment_transactions.sql` — DDL for the raw ledger
+- `src/moneybin/sql/schema/app_lot_selections.sql` — DDL for `app.lot_selections`
+- `sqlmesh/models/core/dim_securities.sql` — securities VIEW
+- `sqlmesh/models/prep/stg_investment_transactions.sql` — staging VIEW (resolve + map + sign)
+- `sqlmesh/models/core/fct_investment_transactions.sql` — canonical ledger
+- `sqlmesh/models/core/fct_investment_lots.py` — derived lots (Python model; cost-basis engine)
+- `sqlmesh/models/core/fct_realized_gains.py` — derived realized gains
+- `sqlmesh/models/core/dim_holdings.sql` — derived positions VIEW
+- `src/moneybin/services/investment_service.py` — security resolution, manual entry, method election, lot selection
+- `src/moneybin/cli/commands/investments.py` — `investments` command group
+- `src/moneybin/mcp/tools/investments.py` — `investments_*` tools
+- `tests/test_investment_service.py`, `tests/test_cli_investments.py`, `tests/test_cost_basis_engine.py`
+- `tests/scenarios/investments_1099b/` — the 1099-B reconciliation scenario
+
+### Files to Modify
+
+- `src/moneybin/cli/main.py` — register the `investments` group
+- `src/moneybin/sql/schema.py` — register new DDL + the `app.account_settings` ALTER
+- `src/moneybin/tables.py` — add table constants (`DIM_SECURITIES`, `FCT_INVESTMENT_TRANSACTIONS`, `FCT_INVESTMENT_LOTS`, `FCT_REALIZED_GAINS`, `DIM_HOLDINGS`)
+- `src/moneybin/metrics/registry.py` — instrumentation for ingestion + cost-basis runs (per `observability.md`)
+- `docs/specs/INDEX.md`, `docs/roadmap.md` — status + milestone rows
+
+### Key Decisions
+
+1. **Lots are the universal grain; method is an election.** Every method is a
+   computation over the same lot ledger, so picking fewer methods never forces a
+   schema migration. The lot grain removes ambiguity rather than adding flexibility.
+2. **Realized gain/loss needs no price feed.** The foundation child hits the 1099-B
+   bar from the ledger alone; valuation is a later pillar.
+3. **Surrogate `security_id` + resolution chain.** Identity survives ticker churn,
+   handles crypto, and respects licensed-identifier constraints — coherent with the
+   merchant/institution resolution patterns already in the codebase.
+4. **Derived, never snapshotted (Invariant 8).** Lots, gains, and holdings rebuild
+   from the ledger + `app.*` on every run. The only `app.*` state is the catalog, the
+   method election, and lot selections.
+5. **Mirror the broker, don't enforce IRS policy.** Keeps average cost bounded to one
+   derived path and keeps tax-policy surface in the `us_tax` package.
+6. **Lot-selection override is core, not the tax package.** Cost basis is core, so the
+   override that determines it must be too — reconciling the `extension-contracts.md`
+   inconsistency noted in the overview.
+7. **Currency column now, FX later.** A one-way-door column added pre-emptively to
+   avoid a breaking `core` migration in M3C.
+8. **Top-level `investments` CLI/MCP group.** A four-pillar domain is a peer of
+   `accounts`/`transactions`/`assets`, not a subtree under `accounts`.
+```

--- a/docs/specs/investments-data-model.md
+++ b/docs/specs/investments-data-model.md
@@ -410,11 +410,14 @@ moneybin investments lots [--account <id|name>] [--security <ticker|name>] \
 
 ```
 moneybin investments lots select <disposal_txn_id> --lot <lot_id>:<quantity> [--lot <lot_id>:<quantity> ...] [--yes]
+moneybin investments lots select <disposal_txn_id> --clear [--yes]
 ```
 - Sets the **full** specific-identification selection for the disposal in
   `app.lot_selections` — a declarative state-set (Shape 1a): the listed `(lot,
   quantity)` pairs **replace** any prior selection for that disposal (delete by
   omission), identical in semantics to the `investments_lots_select` MCP tool.
+  `--clear` submits the empty set, removing all overrides for the disposal and
+  reverting it to FIFO (the CLI equivalent of the MCP tool's empty `selections=[]`).
   Unselected remainder falls back to FIFO. (Both surfaces are declarative-set here —
   there is no additive variant, to keep CLI and MCP outcomes identical.)
 
@@ -513,7 +516,8 @@ events; resolves securities, reports unresolved refs in `warnings`.
 catalog entry, including its `cost_basis_method` per-security override.
 
 **`investments_lots_select`** — Shape 1a (collection state-set). Set the full set of
-`(lot_id, quantity)` selections for one disposal (delete by omission).
+`(lot_id, quantity)` selections for one disposal (delete by omission); an empty
+`selections=[]` clears all overrides and reverts the disposal to FIFO.
 
 The **per-account default** cost-basis method is a field on `accounts_set`
 (`default_cost_basis_method`), not a separate tool — same reasoning as the CLI.

--- a/docs/specs/investments-data-model.md
+++ b/docs/specs/investments-data-model.md
@@ -42,7 +42,9 @@ Related specs:
    stable surrogate `security_id` (truncated UUID4). Ticker, CUSIP, ISIN, FIGI, and
    `coingecko_id` are nullable *attributes*, never the key.
 2. **Five security types for v1:** `equity`, `etf`, `mutual_fund`, `bond`, `crypto`,
-   plus `other`. Extensible by adding values without migration.
+   plus `other`. New types are added by extending the `CHECK` constraint (a
+   lightweight migration via `database-migration.md`); the `other` escape hatch
+   absorbs unanticipated instruments without one.
 3. **Identity resolution chain.** Free-text or partial security references resolve to
    a `security_id` via CUSIP/ISIN → ticker+exchange → name fuzzy, mirroring the
    institution-resolution chain in `smart-import-financial.md`. v1 resolves against
@@ -327,6 +329,14 @@ The ST/LT split still walks lots oldest-first (only the basis is averaged). Vali
 to `mutual_fund` / `etf` security types. This is the one genuinely distinct
 computation; it adds a single derived path, not a parallel system.
 
+**`core.fct_realized_gains` grain under average cost.** There is no lot-specific
+basis when pooling, but the table keeps its uniform (disposal × consumed lot) grain:
+lots are still traversed oldest-first to assign each slice's holding period, and each
+resulting row carries the **pooled average** basis rather than the lot's actual cost.
+`lot_id` records the lot that supplied the holding-period attribution, not a
+lot-specific cost. This reconciles with broker 1099-Bs, which report one blended-basis
+figure per disposal, split into short- and long-term portions.
+
 ### Mirror, don't enforce (v1)
 
 The engine reproduces the elected method to match broker output. It does **not**
@@ -384,9 +394,14 @@ moneybin investments lots [--account <id|name>] [--security <ticker|name>] \
 - Lots with remaining quantity and basis. Default: open lots only.
 
 ```
-moneybin investments lots select <disposal_txn_id> --lot <lot_id> --quantity N [--yes]
+moneybin investments lots select <disposal_txn_id> --lot <lot_id>:<quantity> [--lot <lot_id>:<quantity> ...] [--yes]
 ```
-- Records a specific-identification override in `app.lot_selections`.
+- Sets the **full** specific-identification selection for the disposal in
+  `app.lot_selections` — a declarative state-set (Shape 1a): the listed `(lot,
+  quantity)` pairs **replace** any prior selection for that disposal (delete by
+  omission), identical in semantics to the `investments_lots_select` MCP tool.
+  Unselected remainder falls back to FIFO. (Both surfaces are declarative-set here —
+  there is no additive variant, to keep CLI and MCP outcomes identical.)
 
 ### Gains
 
@@ -399,10 +414,17 @@ moneybin investments gains [--account <id|name>] [--security <ticker|name>] \
 ### Cost-basis method election (no dedicated verb)
 
 The method is a *field*, not its own operation (per `surface-design.md`):
-- **Per-account default** → `moneybin accounts set <id> --default-cost-basis-method fifo|specific|average`
-  (the unified `accounts set` partial-update entry point from `account-management.md`).
+- **Per-account default** → `moneybin accounts set <id> --default-cost-basis-method fifo|specific|average`.
 - **Per-security override** → `moneybin investments securities set <id> --method fifo|specific|average`
   (`average` validates to fund/ETF security types).
+
+> **Surface extension to `account-management.md`.** The `--default-cost-basis-method`
+> flag on `accounts set`, the matching `default_cost_basis_method` parameter on the
+> `accounts_set` MCP tool, and the `app.account_settings.default_cost_basis_method`
+> column (the ALTER above) are all **added by this spec** — `account-management.md`
+> (status `implemented`) does not yet carry them. Implementing this spec updates the
+> accounts command, the `accounts_set` tool, and the `account-management.md` surface
+> tables accordingly.
 
 ### Securities catalog
 
@@ -580,10 +602,13 @@ Standard envelope from [`mcp-architecture.md`](mcp-architecture.md), e.g. for
 
 ### Files to Modify
 
-- `src/moneybin/cli/main.py` — register the `investments` group
+- `src/moneybin/cli/main.py` — register the top-level `investments` group
+- `src/moneybin/cli/commands/accounts/investments.py` — **remove** the placeholder stub (relocated to the top-level group)
+- `src/moneybin/cli/commands/accounts/*` + `src/moneybin/mcp/tools/accounts*` — add `--default-cost-basis-method` flag to `accounts set` and the matching `accounts_set` parameter
 - `src/moneybin/sql/schema.py` — register new DDL + the `app.account_settings` ALTER
 - `src/moneybin/tables.py` — add table constants (`DIM_SECURITIES`, `FCT_INVESTMENT_TRANSACTIONS`, `FCT_INVESTMENT_LOTS`, `FCT_REALIZED_GAINS`, `DIM_HOLDINGS`)
 - `src/moneybin/metrics/registry.py` — instrumentation for ingestion + cost-basis runs (per `observability.md`)
+- `docs/specs/account-management.md` — document the `accounts set` / `accounts_set` cost-basis-method extension + the new `app.account_settings` column
 - `docs/specs/INDEX.md`, `docs/roadmap.md` — status + milestone rows
 
 ### Key Decisions

--- a/docs/specs/investments-overview.md
+++ b/docs/specs/investments-overview.md
@@ -1,0 +1,249 @@
+# Investments — Overview
+
+> Last updated: 2026-05-24 — initial draft. Umbrella doc for the investments
+> initiative (milestone M3B). Child specs listed in [The four pillars](#the-four-pillars)
+> are written separately; the foundation child is [`investments-data-model.md`](investments-data-model.md).
+> Status: draft
+> Type: Umbrella
+> Companions: [`asset-tracking.md`](asset-tracking.md) (the asset/investment dividing
+> line), [`reports-net-worth.md`](reports-net-worth.md) (net worth integration target),
+> [`matching-overview.md`](matching-overview.md) (peer entity-resolution initiative),
+> [`architecture-shared-primitives.md`](architecture-shared-primitives.md) (layer + Invariant 8),
+> [`extension-contracts.md`](extension-contracts.md) (`us_tax` package consumes core
+> investment tables).
+
+## Purpose
+
+Investments is MoneyBin's largest competitive moat: a personal-finance platform
+that produces **cost-basis output reconcilable against a real 1099-B**, computed
+independently from the user's own transaction ledger rather than trusted blindly
+from a broker feed. This doc fixes the vision, the data-model contract, the scope
+boundary, and the build order. Design and implementation details live in the
+child specs it points to.
+
+This is the keystone of milestone **M3B**. At least six already-written specs gate
+on it: Plaid Investments sync, portfolio/holdings reports, investment-transaction
+dedup and transfer detection, investment OFX (`<INVSTMTRS>`) import, and net-worth
+holdings valuation. None of them can proceed until the contracts here are fixed.
+
+## Vision
+
+> **Every position, lot, and realized gain is derived from a single investment
+> transaction ledger — explainable, reproducible, and tying out to the 1099-B the
+> broker sends. What MoneyBin computes, the user can verify.**
+
+Four commitments:
+
+1. **The ledger is the source of truth.** `core.fct_investment_transactions` is the
+   one authored/ingested surface. Lots, holdings, and gain/loss are *derived* from
+   it in SQLMesh — never snapshotted into mutable `app.*` state (shared-primitives
+   Invariant 8).
+2. **Cost basis is computed, not just stored.** MoneyBin reproduces realized gain/loss
+   from the ledger so it can reconcile against (and detect drift from) broker-reported
+   numbers, and project the tax impact of a sale *before* it happens.
+3. **Method-agnostic by construction.** The lot grain supports FIFO, specific
+   identification, and average cost as computations over the same data. Picking fewer
+   methods for v1 costs no rework later.
+4. **1099-B is the bar.** M3B does not close until cost-basis output ties to a real
+   1099-B end-to-end. Reconciliation, not plausibility, is the success metric.
+
+## The asset / investment dividing line
+
+Inherited verbatim from [`asset-tracking.md`](asset-tracking.md):
+
+> **If the value comes from a market ticker, it's an investment. If it comes from
+> an appraisal or estimate, it's an asset.**
+
+Brokerage holdings, ETFs, mutual funds, bonds, and crypto are investments (this
+initiative). Houses, cars, and jewelry are assets (`asset-tracking.md`). Both
+contribute to net worth, through different daily-valuation pipelines that meet only
+at the `reports.net_worth` aggregation.
+
+## Core as the analytics layer
+
+Investments extends the `raw` → `prep` → `core` progression with a securities
+dimension and an investment-transaction fact, then derives lots, holdings, and
+valuation on top. Consumers (CLI, MCP, the `us_tax` package, reports) read from
+`core` only.
+
+| Table/view | Type | Grain | Purpose |
+|---|---|---|---|
+| `core.dim_securities` | Dimension | One real-world security | Mastered instrument reference; resolves ticker/CUSIP/ISIN/crypto refs to a stable surrogate `security_id` |
+| `core.fct_investment_transactions` | Fact | One investment event | The ledger: buys, sells, dividends, reinvests, splits, transfers, fees |
+| `core.fct_investment_lots` | Fact (derived) | One open/closed tax lot | Each acquisition opens a lot; disposals consume lots per the elected method; carries realized gain/loss + ST/LT split |
+| `core.dim_holdings` | Dimension (derived) | One position (account × security) | Current open quantity + cost basis; sum of open lots. *(Name locked by `extension-contracts.md`.)* |
+| `core.fct_holdings_daily` | Fact (derived) | One position per day | Daily-valued time series (holdings × price). **Pillar C** — needs price feeds. *(Name locked by `architecture-shared-primitives.md`.)* |
+
+Mutable user state lives in `app.*`: the manual-entry security catalog, the
+cost-basis-method election, and specific-lot selection overrides. Everything in
+`core` is rebuilt deterministically from `app.*` + `raw.*` on every SQLMesh run.
+
+## The four pillars
+
+| Pillar | Purpose | Needs price feed? | Child spec |
+|---|---|---|---|
+| **A. Investment data model** | The securities dimension + the investment-transaction ledger (raw → prep → core), plus manual entry | No | [`investments-data-model.md`](investments-data-model.md) *(foundation child — A+B)* |
+| **B. Cost-basis & gain/loss engine** | Derived lots; FIFO + specific-ID + average-cost; realized gain/loss; short-term/long-term split | No | [`investments-data-model.md`](investments-data-model.md) *(ships with A)* |
+| **C. Price feeds & valuation** | Yahoo + CoinGecko ingestion → append-only `core.fct_security_prices`; `core.fct_holdings_daily`; unrealized gain/loss | Yes (it *is* the feed) | `investments-price-feeds.md` *(planned)* |
+| **D. Net-worth integration** | Holdings valuation into `reports.net_worth` / `fct_balances` | Yes (consumes C) | `investments-net-worth.md` *(planned)* |
+
+### Already-carved children (gated stubs)
+
+These exist as planned specs that gate on the contracts above:
+
+- `sync-plaid-investments.md` — Plaid Investments product (holdings, securities, investment transactions).
+- Investment OFX import — `<INVSTMTRS>` handling, a child of `smart-import-financial.md`.
+- Portfolio/holdings reports — `reports.portfolio`, `reports.holdings`, gated per `reports-recipe-library.md`.
+- Investment-transaction dedup + transfer detection — children of the matching initiative.
+
+### The foundation boundary (why A+B ship first, without a price feed)
+
+The single most important scoping insight: **realized gain/loss needs no market
+price.** It is computed entirely from the ledger — a sale's proceeds versus the
+cost of the consumed lots, both of which are recorded events. Only *unrealized*
+gain/loss (paper value of what you still hold) requires a current price.
+
+Therefore the foundation child (Pillar A + B) reaches the M3B "ties to a real
+1099-B end-to-end" bar **without** Pillar C. Price feeds (C) and net-worth
+integration (D) become clean follow-on children that add valuation on top of an
+already-correct cost-basis engine.
+
+## Cross-cutting concerns
+
+Every pillar honors these. Detailed design lives in the child specs.
+
+### Cost-basis method is a stored election, not hardcoded logic
+
+Lots are the universal grain. The "method" only decides which lots a disposal
+draws from and how their basis is summed:
+
+| Method | Rule over lots | Typical use |
+|---|---|---|
+| FIFO | Oldest lots first | IRS default; most brokerages for stocks |
+| Specific identification | User-/broker-selected lots, else FIFO | Tax-loss harvesting; controlling ST/LT |
+| Average cost | Pool basis across lots (IRS: funds/ETFs only) | Vanguard/Fidelity mutual-fund default |
+| HIFO / LIFO | Highest / last lots first | Crypto tax minimization (future) |
+
+The **short-term/long-term split walks lots oldest-first under every method** — only
+the basis *number* changes. The election is recorded at per-account default
+(`app.account_settings`) + per-security override (`app.securities`), so a user can
+hold FIFO stocks and average-cost funds in the same account.
+
+### MoneyBin mirrors the broker's method; it does not enforce IRS policy
+
+For v1, MoneyBin reproduces whatever method the broker reported (read from the
+1099-B / Plaid / OFX). It does **not** police IRS election rules — no average-cost
+lock-in, no "you can't switch back," no double-category sub-variants. That policy
+surface is what would balloon average cost into a large feature, and it is not a
+reconciliation tool's job.
+
+### Security identity: surrogate key + resolution chain
+
+`core.dim_securities` keys on a stable surrogate `security_id` (truncated UUID4,
+mirroring `dim_merchants`). Ticker, CUSIP, ISIN, FIGI, and `coingecko_id` are
+*attributes*, not the key — tickers get reused and renamed, CUSIP/ISIN are licensed
+and US/international-centric, and crypto has none of them. Incoming references
+resolve to the surrogate via a chain (CUSIP/ISIN → ticker+exchange → name fuzzy),
+mirroring the institution-resolution chain in `smart-import-financial.md`. Licensed
+identifiers (CUSIP/ISIN) that arrive in the user's own data are stored and used, but
+MoneyBin ships no CUSIP/ISIN lookup database.
+
+### Prices are an append-only history, not a cache
+
+Pillar C stores daily closes in an append-only `core.fct_security_prices` (daily
+grain). A historical close is immutable, so this is a backfill-once / extend-daily
+record, not a cache with invalidation logic. Volume is trivial for DuckDB (≈100
+securities × 252 trading days × 10 years ≈ 126k rows). Today's live value can come
+from a real-time call or short cache; everything past is stored. Raw vs.
+split/dividend-adjusted prices is a Pillar C concern (cost basis uses raw ledger
+data; charts often use adjusted).
+
+### Currency: column now, conversion later
+
+A `currency` column lands on the ledger, lots, prices, and holdings in the
+foundation child — adding it to `core` later is a breaking migration. v1 assumes a
+single reporting currency and does no FX. Multi-currency conversion is **M3C**
+(`multi-currency`, future). Same "lock the schema, stage the algorithm" move as the
+cost-basis methods.
+
+## In scope (the initiative)
+
+- A securities dimension with multi-source identity resolution.
+- An investment-transaction ledger (manual entry in the foundation child; Plaid/OFX
+  as separate children).
+- Derived lots, holdings, realized + unrealized gain/loss, ST/LT classification.
+- FIFO, specific-identification, and average-cost methods.
+- Daily price history (Yahoo equities/ETFs/funds; CoinGecko crypto).
+- Net-worth integration of holdings valuation.
+- CLI + MCP surface under a top-level `investments` group.
+
+## Out of scope
+
+- **Options** (exercise/assignment/expiration) — distinct modeling, not in the M3B
+  bar. Reserved for a later child.
+- **Wash-sale detection / Schedule D** — owned by the `us_tax` package
+  (`extension-contracts.md`), which consumes the core tables defined here.
+- **Multi-currency FX conversion** — M3C. The `currency` column lands now; conversion
+  does not.
+- **IRS election-policy enforcement** — MoneyBin mirrors the broker's method (see
+  cross-cutting above).
+- **Margin / short positions / derivatives** beyond plain long holdings — future.
+- **Brokerage order execution** — MoneyBin records history; it never places trades.
+
+## Build order & rationale
+
+1. **Foundation child A+B** ([`investments-data-model.md`](investments-data-model.md))
+   — securities dimension, ledger, lots, and the three-method cost-basis engine with
+   manual entry. Reaches the 1099-B bar. Fixes every schema contract the gated
+   children wait on.
+2. **Pillar C** (`investments-price-feeds.md`) — append-only price history, daily
+   valuation, unrealized gain/loss.
+3. **Pillar D** (`investments-net-worth.md`) — holdings valuation into
+   `reports.net_worth`.
+4. **Already-carved children** (Plaid sync, OFX import, portfolio reports, matching)
+   — proceed against the now-fixed contracts, in any order. M3B closes when the
+   milestone's promise (1099-B reconciliation + holdings in net worth) is met.
+
+## Success criteria
+
+- **1099-B reconciliation (headline).** For a real brokerage account, MoneyBin's
+  realized gain/loss per lot — short-term and long-term — ties to the broker's 1099-B
+  under the broker's reported method.
+- **Ledger-derived correctness.** Holdings, lots, and gain/loss are fully rebuildable
+  from `core.fct_investment_transactions` + `app.*` on every SQLMesh run; no derived
+  state is authoritative.
+- **Method coverage.** FIFO, specific-ID, and average-cost all produce correct ST/LT
+  splits over the same lot ledger.
+- **Net worth completeness.** Once Pillar D ships, `reports.net_worth` includes
+  market-valued holdings alongside cash and physical assets.
+- **Contract stability.** The gated children (sync, import, reports, matching) build
+  against the core tables here without schema changes.
+
+## Open questions
+
+Cross-cutting decisions deferred to child specs or to resolve during implementation.
+
+- **Lot-selection override home — resolved.** The canonical lot-selection override
+  lives in a **core** `app.*` table (`app.lot_selections` in the foundation child),
+  not the `us_tax` package — cost basis is core, and a non-US user with no `us_tax`
+  installed still must pick lots to determine realized gain. `extension-contracts.md`
+  has been corrected to drop "lot-selection overrides" from the `us_tax` write set
+  (it now reads `app.lot_selections` + `core.fct_realized_gains` for Schedule D);
+  `us_tax` keeps only tax-specific config (filing status, wash-sale adjustments).
+- **`dim_securities` source model.** v1 is manual-only (`app.securities` → `core.dim_securities`).
+  When Plaid/OFX importers arrive, `dim_securities` becomes a multi-source union with
+  cross-source resolution (mirroring `fct_transactions`). The foundation child fixes
+  the surrogate-key contract; the union/dedup mechanics are detailed when the first
+  importer lands.
+- **Lots model: SQL vs Python.** The lot-consumption engine (FIFO cursor, average-cost
+  running aggregate, specific-ID override lookup) may be a Python SQLMesh model rather
+  than pure SQL, mirroring the matching engine's hybrid posture. Foundation-child
+  decision.
+- **Realized gain/loss surface grain — resolved.** The foundation child uses a
+  separate `core.fct_realized_gains` fact (one row per disposal × consumed lot — the
+  1099-B grain), rather than overloading columns onto `core.fct_investment_lots`.
+- **Adjusted vs raw price storage (Pillar C).** Store raw closes and adjust on read,
+  or store both raw and split/dividend-adjusted series. Pillar C decision.
+- **Cross-source security resolution thresholds.** The fuzzy step (name match when no
+  CUSIP/ticker) needs scoring + a review posture, mirroring matching. Deferred to the
+  first importer child.

--- a/docs/specs/investments-overview.md
+++ b/docs/specs/investments-overview.md
@@ -70,9 +70,10 @@ valuation on top. Consumers (CLI, MCP, the `us_tax` package, reports) read from
 |---|---|---|---|
 | `core.dim_securities` | Dimension | One real-world security | Mastered instrument reference; resolves ticker/CUSIP/ISIN/crypto refs to a stable surrogate `security_id` |
 | `core.fct_investment_transactions` | Fact | One investment event | The ledger: buys, sells, dividends, reinvests, splits, transfers, fees |
-| `core.fct_investment_lots` | Fact (derived) | One open/closed tax lot | Each acquisition opens a lot; disposals consume lots per the elected method; carries realized gain/loss + ST/LT split |
+| `core.fct_investment_lots` | Fact (derived) | One open/closed tax lot | Each acquisition opens a lot; disposals consume lots per the elected method; carries cost basis and remaining quantity (no gain/loss columns) |
+| `core.fct_realized_gains` | Fact (derived) | One (disposal × consumed lot) pair | The 1099-B grain: proceeds, cost basis, gain/loss, short/long-term split |
 | `core.dim_holdings` | Dimension (derived) | One position (account × security) | Current open quantity + cost basis; sum of open lots. *(Name locked by `extension-contracts.md`.)* |
-| `core.fct_holdings_daily` | Fact (derived) | One position per day | Daily-valued time series (holdings × price). **Pillar C** — needs price feeds. *(Name locked by `architecture-shared-primitives.md`.)* |
+| `core.fct_holdings_daily` | Fact (derived) | One position per day | Daily-valued time series (holdings × price). **Pillar C** — needs price feeds. *(Planned name; illustrative in `architecture-shared-primitives.md`, not yet a locked contract.)* |
 
 Mutable user state lives in `app.*`: the manual-entry security catalog, the
 cost-basis-method election, and specific-lot selection overrides. Everything in

--- a/docs/specs/matching-overview.md
+++ b/docs/specs/matching-overview.md
@@ -103,7 +103,7 @@ Un-merge restores the previously separate gold rows and their individual provena
 Explicitly deferred. Revisit per pillar as the initiative matures.
 
 - **Cross-currency transfer detection** — requires FX conversion + fuzzy amount matching with FX tolerance. Deferred to the multi-currency initiative.
-- **Same-record dedup for investment lots/holdings** — depends on investment-tracking spec. Reserved for later.
+- **Same-record dedup for investment lots/holdings** — depends on `investments-data-model.md`. Reserved for later.
 - **Same-record dedup for accounts** — `dim_accounts` already handles this via `account_id` partitioning. If fuzzy account matching is needed later, it's a small spec of its own.
 - **Merchant normalization** — different concern (attribute normalization, not record identity). Owned by `core.dim_merchants` (thin view over `app.user_merchants`) / categorization pipeline.
 - **Categorization** — happens after matching. Separate spec.

--- a/docs/specs/matching-same-record-dedup.md
+++ b/docs/specs/matching-same-record-dedup.md
@@ -384,7 +384,7 @@ Env var overrides follow the `MONEYBIN_` convention:
 - **Transfer detection** — pillar B, separate spec (`matching-transfer-detection.md`). Different semantics: links two records rather than collapsing them.
 - **Per-field or per-transaction merge overrides** — v1 uses a single global source-priority ranking. Enhancement spec if needed.
 - **ML/learned matching** — v1 uses deterministic scoring. Learned promotions deferred per umbrella spec.
-- **Investment transaction dedup** — depends on investment-tracking spec.
+- **Investment transaction dedup** — depends on `investments-data-model.md`.
 - **Account-level dedup** — `dim_accounts` already handles this via `account_id` partitioning.
 - **MCP tools** — Phase 2. CLI-only for v1.
 

--- a/docs/specs/matching-transfer-detection.md
+++ b/docs/specs/matching-transfer-detection.md
@@ -415,7 +415,7 @@ Requirements for the synthetic data generator (`testing-synthetic-data.md`) to s
 - **Many-to-one / one-to-many transfers** — e.g., paycheck + bonus -> one deposit. v1 is 1:1 pairs only. Future enhancement.
 - **Auto-confirmation (v2 learned promotions)** — after user confirms N matches of the same pattern, offer to auto-confirm. Deferred per umbrella spec. v1 is always-review.
 - **Same-record dedup** — pillar A+C, sibling spec. Different semantics: collapses records rather than linking them.
-- **Investment transaction transfers** — depends on investment-tracking spec.
+- **Investment transaction transfers** — depends on `investments-data-model.md`.
 
 ## Future Enhancements
 

--- a/docs/specs/moneybin-cli.md
+++ b/docs/specs/moneybin-cli.md
@@ -185,11 +185,22 @@ moneybin [--profile NAME] [--verbose] <command> [--output text|json] [--quiet] [
 |   |   +-- assertion-delete <account_id> <date> [--yes]
 |   |   +-- reconcile [--account ID] [--threshold AMOUNT]
 |   |   +-- history --account ID [--from DATE] [--to DATE]
-|   +-- investments                -- (future spec, gated on investment-tracking.md)
 |
 +-- assets                         -- (future spec) Physical assets (real estate, vehicles, valuables)
 |                                     Workflows defined in asset-tracking.md.
 |                                     Contributes to reports networth alongside accounts.
+|
++-- investments                    -- (future spec) Brokerage/crypto holdings, lots, cost basis
+|                                     Workflows defined in investments-data-model.md.
+|                                     Contributes to reports networth via holdings valuation.
+|   +-- add                        -- Record an investment event (buy/sell/dividend/transfer/...)
+|   +-- list                       -- List ledger events
+|   +-- holdings                   -- Current positions (cost basis; market value when price feeds land)
+|   +-- lots [--open|--all]        -- Tax lots with remaining quantity + basis
+|   |   +-- select <disposal_id> --lot <lot_id> --quantity N   -- Specific-ID override
+|   +-- gains                      -- Realized gain/loss (the 1099-B surface)
+|   +-- securities                 -- Security catalog
+|       +-- list / add / set       -- Manage catalog (set carries --method per-security override)
 |
 +-- transactions
 |   +-- list                       -- List transactions [--account ID] [--from] [--to]
@@ -641,7 +652,7 @@ This is a hard cut. No aliases, no deprecation period. v1 paths break in the sam
 | `track networth history` | `reports networth-history` | |
 | `track budget *` | `budget *` | Top-level (mutation); reports → `reports budget` |
 | `track recurring *` | `transactions recurring *` | Pattern detection on transactions |
-| `track investments *` | `accounts investments *` | Holdings as account-typed entity |
+| `track investments *` | `investments *` | Top-level domain group (4-pillar: holdings, lots, cost basis) per `investments-data-model.md` |
 | `matches *` | `transactions matches *` | Workflow on transactions |
 | `categorize *` (workflow + rules + auto + ml) | `transactions categorize *` | Workflow on transactions |
 | `categorize categories / create-category / toggle-category` | `categories list / create / set / delete` | Reference-data taxonomy → top-level entity group |
@@ -773,7 +784,7 @@ Reserve the namespace. Users see the command in `--help` but get a clear message
 | `track balance` / `track networth` | `reports-net-worth.md` |
 | `track budget` | `budget-tracking.md` |
 | `track recurring` | Future spec |
-| `track investments` | Future spec (gated on `investment-tracking.md`) |
+| `investments` | [`investments-data-model.md`](investments-data-model.md) (draft) |
 | `export` | Future spec |
 | `stats` | `observability.md` (depends on metrics tables) |
 | `db migrate` | `database-migration.md` |
@@ -790,7 +801,7 @@ These commands are fully implemented when their owning spec is implemented. The 
 | `track networth show/history` | `reports-net-worth.md` | Updated from original top-level `networth` placement |
 | `track budget *` | `budget-tracking.md` | CLI TBD when spec matures |
 | `track recurring *` | Future spec | Recurring transaction detection |
-| `track investments *` | Future spec | Gated on `investment-tracking.md` |
+| `investments add/list/holdings/lots/gains/securities` | [`investments-data-model.md`](investments-data-model.md) | Top-level group (was placeholder `accounts investments`); implementation lands with the foundation child |
 | `sync login/logout/connect/disconnect/pull/status/schedule/rotate-key` | `sync-overview.md` | Full sync implementation |
 | `export *` | Future spec | Export to CSV, Excel, Google Sheets |
 | `stats` | `observability.md` | Depends on metrics tables and instrumentation |

--- a/docs/specs/moneybin-cli.md
+++ b/docs/specs/moneybin-cli.md
@@ -197,7 +197,7 @@ moneybin [--profile NAME] [--verbose] <command> [--output text|json] [--quiet] [
 |   +-- list                       -- List ledger events
 |   +-- holdings                   -- Current positions (cost basis; market value when price feeds land)
 |   +-- lots [--open|--all]        -- Tax lots with remaining quantity + basis
-|   |   +-- select <disposal_id> --lot <lot_id> --quantity N   -- Specific-ID override
+|   |   +-- select <disposal_id> --lot <lot_id>:<qty> [--lot ...]  -- Replace lot selection (declarative set; multi-lot)
 |   +-- gains                      -- Realized gain/loss (the 1099-B surface)
 |   +-- securities                 -- Security catalog
 |       +-- list / add / set       -- Manage catalog (set carries --method per-security override)

--- a/docs/specs/moneybin-cli.md
+++ b/docs/specs/moneybin-cli.md
@@ -732,7 +732,7 @@ Restructure-only. Move and rename existing commands to the new tree; rename MCP 
 | Pull `categorize merchants *` and `categorize create-merchants` → top-level `merchants` group | Promote to entity group |
 | Move `track budget` → `budget` (top-level, still stub) | Rename + flatten |
 | Move `track recurring` → `transactions recurring` (still stub) | Reparent |
-| Move `track investments` → `accounts investments` (still stub) | Reparent |
+| Add top-level `investments` group (placeholder; workflows owned by `investments-data-model.md`); supersedes the `accounts investments` stub | New CLI module |
 | Dissolve `track` group | Delete CLI module |
 | Add `reports` group with stubbed subcommands (`spending`, `cashflow`, `budget`) | New CLI module, all stubs |
 | Rename MCP tools to path-prefix-verb-suffix convention | Update tool registry, regenerate client configs via `mcp install` |

--- a/docs/specs/reports-net-worth.md
+++ b/docs/specs/reports-net-worth.md
@@ -328,7 +328,7 @@ This lets the scenario suite (`make test-scenarios`) validate that `fct_balances
 
 ## Out of Scope
 
-- **Investment holdings in net worth** — M3B concern. Net worth v1 is cash-only. Investment tracking (`investment-tracking.md`, M3B) will extend `fct_balances` with holdings valuation when it ships.
+- **Investment holdings in net worth** — M3B concern. Net worth v1 is cash-only. Investment tracking (`investments-overview.md`, M3B — Pillar D net-worth integration) will extend `fct_balances` with holdings valuation when it ships.
 - **Multi-currency conversion** — M3C concern. All balances assumed single-currency for v1. Multi-currency (`multi-currency.md`, M3C) will add home-currency conversion to `fct_balances_daily`.
 - **Balance forecasting/projection** — "What will my net worth be in 6 months?" is a separate feature requiring trend extrapolation.
 - **Balance alerts/notifications** — "Notify me when balance drops below X" is out of scope for the data model spec.

--- a/docs/specs/reports-recipe-library.md
+++ b/docs/specs/reports-recipe-library.md
@@ -638,7 +638,7 @@ The two PRs can be reviewed in parallel once both specs are written, but PR 1 mu
 - **Multi-currency rollups.** Owned by future `multi-currency.md` (M3). All `reports.*` v1 models assume profile currency. See `architecture-shared-primitives.md` §Open Architectural Questions (b).
 - **Forecast/projection models.** "What will my net worth be in 6 months?" is a separate concern (forecasting); recipe library is descriptive analytics only.
 - **Cancellation-as-a-service workflow.** Rocket Money-style cancellation concierge is out of scope and will likely never be in scope (it's their business model, not ours).
-- **Portfolio/holdings reports.** Gated on `investment-tracking.md`. Will land as `reports.portfolio`, `reports.holdings`, etc. once the schema decisions there are made.
+- **Portfolio/holdings reports.** Gated on `investments-data-model.md`. Will land as `reports.portfolio`, `reports.holdings`, etc. once the schema decisions there are made.
 - **Tax reports.** Owned by `tax-*.md` specs (separate top-level CLI group per `moneybin-cli.md` v2; `tax` is not nested under `reports`).
 
 ## Dependencies

--- a/docs/specs/smart-import-financial.md
+++ b/docs/specs/smart-import-financial.md
@@ -388,7 +388,7 @@ The original phase 1 (schema) and phase 2 (`import_log` extraction) are ~1 file 
 
 - **QIF support** — legacy Quicken text format. User-confirmed: modern formats only in v1. Defer until requested.
 - **IIF support** — QuickBooks Desktop interchange. Tabular-shaped, would route through tabular pipeline if added; not in v1.
-- **Investment-account OFX** (`<INVSTMTRS>`) — current extractor handles bank/credit only; investment OFX gates on `investment-tracking.md` and is its own spec.
+- **Investment-account OFX** (`<INVSTMTRS>`) — current extractor handles bank/credit only; investment OFX gates on `investments-data-model.md` and is its own spec.
 - **PDF statement import** — covered by `smart-import-pdf.md`.
 - **AI-assisted parsing fallback** — covered by `smart-import-ai-parsing.md`.
 - **Unifying `raw.ofx_*` and `raw.tabular_*` into a single schema** — explicitly rejected. See Background.

--- a/docs/specs/sync-overview.md
+++ b/docs/specs/sync-overview.md
@@ -726,7 +726,7 @@ Phase 1 of this spec maps to **M3A — Plaid Transactions sync** in [`docs/roadm
 
 | Provider | Child spec | Status | Notes |
 |---|---|---|---|
-| Plaid | [`sync-plaid.md`](sync-plaid.md) | Draft | First provider. Transactions product only (v1). Investments/Liabilities are future child specs gated on `investments-data-model.md`. |
+| Plaid | [`sync-plaid.md`](sync-plaid.md) | Draft | First provider. Transactions product only (v1). Investments is a future child gated on `investments-data-model.md`; Liabilities is a separate future child (no investments dependency). |
 | SimpleFIN | `sync-simplefin.md` | Planned | Alternative aggregator used by Actual Budget. Lower coverage but no per-institution fees. |
 | MX | `sync-mx.md` | Planned | Enterprise-grade aggregator. Potential alternative to Plaid for hosted tier. |
 

--- a/docs/specs/sync-overview.md
+++ b/docs/specs/sync-overview.md
@@ -726,7 +726,7 @@ Phase 1 of this spec maps to **M3A — Plaid Transactions sync** in [`docs/roadm
 
 | Provider | Child spec | Status | Notes |
 |---|---|---|---|
-| Plaid | [`sync-plaid.md`](sync-plaid.md) | Draft | First provider. Transactions product only (v1). Investments/Liabilities are future child specs gated on `investment-tracking.md`. |
+| Plaid | [`sync-plaid.md`](sync-plaid.md) | Draft | First provider. Transactions product only (v1). Investments/Liabilities are future child specs gated on `investments-overview.md`. |
 | SimpleFIN | `sync-simplefin.md` | Planned | Alternative aggregator used by Actual Budget. Lower coverage but no per-institution fees. |
 | MX | `sync-mx.md` | Planned | Enterprise-grade aggregator. Potential alternative to Plaid for hosted tier. |
 
@@ -759,7 +759,7 @@ Infrastructure spec. The `Database` class that sync loaders write through handle
 Not designed here. Architectural constraints noted so the current design does not preclude them.
 
 1. **`sync push`** — multi-device sync. Push encrypted DuckDB state (or deltas) to the server so another device can pull it. Would add `moneybin sync push` command and bidirectional protocol extensions.
-2. **Plaid Investments** — sync holdings, securities, and investment transactions. Gated on `investment-tracking.md` spec (M3B). New child spec: `sync-plaid-investments.md`.
+2. **Plaid Investments** — sync holdings, securities, and investment transactions. Gated on `investments-data-model.md` (M3B). New child spec: `sync-plaid-investments.md`.
 3. **Plaid Liabilities** — sync loan, mortgage, and credit card debt details. Separate child spec.
 4. **Webhook-based sync** — server pushes notifications when new data is available, eliminating polling. Requires a client-side listener or notification mechanism.
 5. **Integration test environment** — coordinated setup for running server-dependent tests. Separate spec covering docker-compose, Auth0 test tenant, sandbox credential management.

--- a/docs/specs/sync-overview.md
+++ b/docs/specs/sync-overview.md
@@ -726,7 +726,7 @@ Phase 1 of this spec maps to **M3A — Plaid Transactions sync** in [`docs/roadm
 
 | Provider | Child spec | Status | Notes |
 |---|---|---|---|
-| Plaid | [`sync-plaid.md`](sync-plaid.md) | Draft | First provider. Transactions product only (v1). Investments/Liabilities are future child specs gated on `investments-overview.md`. |
+| Plaid | [`sync-plaid.md`](sync-plaid.md) | Draft | First provider. Transactions product only (v1). Investments/Liabilities are future child specs gated on `investments-data-model.md`. |
 | SimpleFIN | `sync-simplefin.md` | Planned | Alternative aggregator used by Actual Budget. Lower coverage but no per-institution fees. |
 | MX | `sync-mx.md` | Planned | Enterprise-grade aggregator. Potential alternative to Plaid for hosted tier. |
 

--- a/docs/specs/sync-plaid.md
+++ b/docs/specs/sync-plaid.md
@@ -532,7 +532,7 @@ These fixtures should be generated deterministically (seeded) and stored as gold
 
 | Exclusion | Reason |
 |---|---|
-| Plaid Investments product | Gated on `investments-overview.md`. Future child spec: `sync-plaid-investments.md`. |
+| Plaid Investments product | Gated on `investments-data-model.md` (needs the ledger/securities/holdings contracts). Future child spec: `sync-plaid-investments.md`. |
 | Plaid Liabilities product | Future child spec. |
 | E2E encryption of sync payloads | Designed in `sync-overview.md`. Implementation gated on moneybin-server Phase 5. |
 | Webhook-based real-time sync | Polling is sufficient for MVP. Server would need webhook receiver infrastructure. |

--- a/docs/specs/sync-plaid.md
+++ b/docs/specs/sync-plaid.md
@@ -532,7 +532,7 @@ These fixtures should be generated deterministically (seeded) and stored as gold
 
 | Exclusion | Reason |
 |---|---|
-| Plaid Investments product | Gated on `investment-tracking.md` spec. Future child spec: `sync-plaid-investments.md`. |
+| Plaid Investments product | Gated on `investments-overview.md`. Future child spec: `sync-plaid-investments.md`. |
 | Plaid Liabilities product | Future child spec. |
 | E2E encryption of sync payloads | Designed in `sync-overview.md`. Implementation gated on moneybin-server Phase 5. |
 | Webhook-based real-time sync | Polling is sufficient for MVP. Server would need webhook receiver infrastructure. |


### PR DESCRIPTION
## Summary

Initiates the investments domain (milestone **M3B** — the largest competitive moat). Adds the umbrella spec plus its foundation feature spec, and reconciles the rest of the spec tree to point at them. Both new specs are `draft` status — this is design work, not implementation.

The foundation child (Pillars A+B) is scoped so that **realized gain/loss — the 1099-B reconciliation bar — is computed from the transaction ledger alone, needing no price feed.** Price feeds and net-worth integration become clean follow-on children.

## Background

`investment-tracking.md` was the single most-referenced *unwritten* spec in the repo — at least six specs gated on it (Plaid Investments sync, portfolio/holdings reports, investment matching/transfers, investment OFX import, holdings-in-net-worth), yet the file never existed. This PR replaces that placeholder gate with a real umbrella + foundation child, following the Overview-umbrella + feature-children shape every other large domain already uses (Smart Import, Matching, Categorization, Sync, Testing).

Key decisions captured: lots-as-grain with cost-basis method as a stored **election** (FIFO + specific-ID + average-cost as computations over one lot ledger); surrogate `security_id` + resolution chain for identity; append-only price history (not a cache); `currency` column now / FX deferred to M3C; MoneyBin **mirrors** the broker's method rather than enforcing IRS election policy.

## Changes

- **New specs:** `investments-overview.md` (umbrella, four pillars) and `investments-data-model.md` (foundation child — securities dimension, ledger + `type` taxonomy, derived lots/realized-gains/holdings, three-method cost-basis engine, top-level `investments` CLI/MCP surface).
- **Surface placement:** `moneybin-cli.md` promotes `investments` from a placeholder nested under `accounts` to a top-level group (peer of `accounts`/`transactions`/`assets`), migration-table rows updated.
- **Contradiction fix:** `extension-contracts.md` — lot-selection overrides move from the `us_tax` package to core (`app.lot_selections`), since cost basis is core; `us_tax` now *reads* them plus `core.fct_realized_gains` for Schedule D.
- **Reference reconciliation:** 14 `investment-tracking.md` gate references across 12 specs repointed (schema gates → data-model, domain gates → overview); INDEX + roadmap (M3B) entries added.

## Test plan

- [ ] `grep -rn "investment-tracking\.md" docs/ | grep -v worktrees` returns nothing (verified locally).
- [ ] New specs' internal links resolve; the three named planned specs (`investments-price-feeds.md`, `investments-net-worth.md`, `sync-plaid-investments.md`) are intentionally not-yet-created.
- [ ] INDEX.md Investments section and roadmap M3B rows render correctly.
- [ ] Reviewer: sanity-check the core design decisions — method-as-election, security identity (surrogate + resolution chain), top-level `investments` placement, and the `extension-contracts.md` lot-selection move.
- [ ] Pre-commit hooks pass (markdown; no code touched).
