### PR TITLE
Fix keychain-sensitive privacy tests

### DIFF
--- a/docs/specs/privacy-data-classification.md
+++ b/docs/specs/privacy-data-classification.md
@@ -65,11 +65,12 @@ from context. The full registry lives in
 `src/moneybin/privacy/taxonomy.py`; this table only covers the entries
 that required a call.
 
-The audit was conducted by static enumeration of `sqlmesh/models/core/`
-and `src/moneybin/sql/schema/app_*.sql` — the keychain was unavailable
-in the sandbox, so a live `duckdb_columns()` enumeration could not be
-performed. Migrations through V013 were reviewed and do not add columns
-beyond what the schema files declare.
+The audit was initially conducted by static enumeration of
+`sqlmesh/models/core/` and `src/moneybin/sql/schema/app_*.sql`. CI now
+enforces the live catalog contract through
+`tests/moneybin/test_privacy/test_classification_registry_coverage.py`,
+which opens an encrypted temporary database with a test secret store and
+compares `duckdb_columns()` against `CLASSIFICATION` in both directions.
 
 ### `_id`-suffixed columns
 

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -287,6 +287,12 @@ class Database:
         self._closed = False
         self._read_only = read_only
 
+        if read_only and not db_path.exists():
+            raise DatabaseNotInitializedError(
+                f"Database not found at {db_path}.\n"
+                f"Run 'moneybin db init' to initialize it first."
+            )
+
         store = secret_store or SecretStore()
 
         global _cached_encryption_key  # noqa: PLW0603
@@ -304,11 +310,6 @@ class Database:
             _cached_encryption_key = encryption_key
 
         if read_only:
-            if not db_path.exists():
-                raise DatabaseNotInitializedError(
-                    f"Database not found at {db_path}.\n"
-                    f"Run 'moneybin db init' to initialize it first."
-                )
             self._conn = duckdb.connect()
             _attach_encrypted(
                 self._conn, build_attach_sql(db_path, encryption_key, read_only=True)

--- a/tests/moneybin/test_database.py
+++ b/tests/moneybin/test_database.py
@@ -14,6 +14,7 @@ from moneybin.database import (
     Database,
     DatabaseKeyError,
     DatabaseLockError,
+    DatabaseNotInitializedError,
     get_database,
 )
 
@@ -156,6 +157,21 @@ class TestDatabaseInit:
         db_path = db_dir / "moneybin.duckdb"
         with pytest.raises(DatabaseKeyError, match="encryption key"):
             Database(db_path, secret_store=store)
+
+    def test_read_only_missing_file_does_not_consult_secret_store(
+        self, db_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing read-only DB reports initialization state before key lookup."""
+        import moneybin.database as db_module
+
+        monkeypatch.setattr(db_module, "_cached_encryption_key", None)
+        store = MagicMock()
+        db_path = db_dir / "missing.duckdb"
+
+        with pytest.raises(DatabaseNotInitializedError, match="Database not found"):
+            Database(db_path, read_only=True, secret_store=store)
+
+        store.get_key.assert_not_called()
 
 
 class TestDatabaseOperations:

--- a/tests/moneybin/test_privacy/test_classification_registry_coverage.py
+++ b/tests/moneybin/test_privacy/test_classification_registry_coverage.py
@@ -1,0 +1,57 @@
+"""Live catalog coverage for the privacy classification registry."""
+
+from __future__ import annotations
+
+from moneybin.database import Database
+from moneybin.privacy.taxonomy import CLASSIFICATION
+
+_TARGET_SCHEMAS = {"app", "core"}
+
+
+def _catalog_columns(db: Database) -> set[tuple[str, str, str]]:
+    rows = db.execute(
+        """
+        SELECT schema_name, table_name, column_name
+        FROM duckdb_columns()
+        WHERE schema_name IN ('app', 'core')
+        """
+    ).fetchall()
+    return {(schema, table, column) for schema, table, column in rows}
+
+
+def _registry_columns() -> set[tuple[str, str, str]]:
+    return {
+        (schema, table, column)
+        for (schema, table), columns in CLASSIFICATION.items()
+        if schema in _TARGET_SCHEMAS
+        for column in columns
+    }
+
+
+def _format_columns(columns: set[tuple[str, str, str]]) -> str:
+    return "\n".join(
+        f"- {schema}.{table}.{column}" for schema, table, column in sorted(columns)
+    )
+
+
+def test_classification_registry_covers_every_app_and_core_column(
+    schema_catalog_db: Database,
+) -> None:
+    """Every live app/core column must have a privacy classification."""
+    missing = _catalog_columns(schema_catalog_db) - _registry_columns()
+
+    assert not missing, (
+        f"CLASSIFICATION is missing live catalog columns:\n{_format_columns(missing)}"
+    )
+
+
+def test_classification_registry_has_no_stale_app_or_core_columns(
+    schema_catalog_db: Database,
+) -> None:
+    """Registry entries must point at columns that still exist."""
+    stale = _registry_columns() - _catalog_columns(schema_catalog_db)
+
+    assert not stale, (
+        "CLASSIFICATION contains stale columns not present in the catalog:\n"
+        f"{_format_columns(stale)}"
+    )

--- a/tests/moneybin/test_privacy/test_classification_registry_coverage.py
+++ b/tests/moneybin/test_privacy/test_classification_registry_coverage.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import pytest
+
 from moneybin.database import Database
 from moneybin.privacy.taxonomy import CLASSIFICATION
+
+pytestmark = pytest.mark.unit
 
 _TARGET_SCHEMAS = {"app", "core"}
 
@@ -13,10 +17,13 @@ def _catalog_columns(db: Database) -> set[tuple[str, str, str]]:
         """
         SELECT schema_name, table_name, column_name
         FROM duckdb_columns()
-        WHERE schema_name IN ('app', 'core')
         """
     ).fetchall()
-    return {(schema, table, column) for schema, table, column in rows}
+    return {
+        (schema, table, column)
+        for schema, table, column in rows
+        if schema in _TARGET_SCHEMAS
+    }
 
 
 def _registry_columns() -> set[tuple[str, str, str]]:

--- a/tests/moneybin/test_privacy/test_privacy_middleware_perf_probe.py
+++ b/tests/moneybin/test_privacy/test_privacy_middleware_perf_probe.py
@@ -10,6 +10,8 @@ import pytest
 from moneybin.database import DatabaseKeyError, DatabaseNotInitializedError
 from tests.scenarios import test_privacy_middleware_perf as perf
 
+pytestmark = pytest.mark.unit
+
 
 def test_persona_probe_does_not_skip_database_key_errors(
     monkeypatch: pytest.MonkeyPatch,
@@ -65,3 +67,45 @@ def test_persona_probe_skips_missing_profile(
 
     assert reason is not None
     assert "requires an active MoneyBin profile" in reason
+
+
+def test_persona_probe_skips_missing_fct_transactions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An untransformed DB with no core table is a setup skip."""
+    import duckdb
+
+    @contextmanager
+    def _raise_missing_table(*, read_only: bool) -> Generator[object, None, None]:
+        assert read_only is True
+        raise duckdb.CatalogException(
+            "Table with name fct_transactions does not exist!"
+        )
+        yield
+
+    monkeypatch.setattr(perf, "get_database", _raise_missing_table)
+
+    reason = perf._persona_db_skip_reason()  # pyright: ignore[reportPrivateUsage]
+
+    assert reason is not None
+    assert "core.fct_transactions" in reason
+
+
+def test_persona_probe_reraises_unrelated_catalog_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unexpected catalog failures are infrastructure errors, not setup skips."""
+    import duckdb
+
+    @contextmanager
+    def _raise_unrelated_catalog_error(
+        *, read_only: bool
+    ) -> Generator[object, None, None]:
+        assert read_only is True
+        raise duckdb.CatalogException("Catalog Error: unexpected schema failure")
+        yield
+
+    monkeypatch.setattr(perf, "get_database", _raise_unrelated_catalog_error)
+
+    with pytest.raises(duckdb.CatalogException, match="unexpected schema failure"):
+        perf._persona_db_skip_reason()  # pyright: ignore[reportPrivateUsage]

--- a/tests/moneybin/test_privacy/test_privacy_middleware_perf_probe.py
+++ b/tests/moneybin/test_privacy/test_privacy_middleware_perf_probe.py
@@ -91,6 +91,26 @@ def test_persona_probe_skips_missing_fct_transactions(
     assert "core.fct_transactions" in reason
 
 
+def test_persona_probe_skips_missing_core_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An initialized but untransformed DB is a setup skip."""
+    import duckdb
+
+    @contextmanager
+    def _raise_missing_schema(*, read_only: bool) -> Generator[object, None, None]:
+        assert read_only is True
+        raise duckdb.CatalogException("Schema with name core does not exist!")
+        yield
+
+    monkeypatch.setattr(perf, "get_database", _raise_missing_schema)
+
+    reason = perf._persona_db_skip_reason()  # pyright: ignore[reportPrivateUsage]
+
+    assert reason is not None
+    assert "core.fct_transactions" in reason
+
+
 def test_persona_probe_reraises_unrelated_catalog_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -108,4 +128,21 @@ def test_persona_probe_reraises_unrelated_catalog_errors(
     monkeypatch.setattr(perf, "get_database", _raise_unrelated_catalog_error)
 
     with pytest.raises(duckdb.CatalogException, match="unexpected schema failure"):
+        perf._persona_db_skip_reason()  # pyright: ignore[reportPrivateUsage]
+
+
+def test_persona_probe_reraises_malformed_profile_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed profile config is an infrastructure error, not a setup skip."""
+
+    @contextmanager
+    def _raise_config_error(*, read_only: bool) -> Generator[object, None, None]:
+        assert read_only is True
+        raise ValueError("Configuration error for profile 'bad': invalid path")
+        yield
+
+    monkeypatch.setattr(perf, "get_database", _raise_config_error)
+
+    with pytest.raises(ValueError, match="Configuration error"):
         perf._persona_db_skip_reason()  # pyright: ignore[reportPrivateUsage]

--- a/tests/moneybin/test_privacy/test_privacy_middleware_perf_probe.py
+++ b/tests/moneybin/test_privacy/test_privacy_middleware_perf_probe.py
@@ -1,0 +1,67 @@
+"""Regression coverage for the privacy perf persona availability probe."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+
+import pytest
+
+from moneybin.database import DatabaseKeyError, DatabaseNotInitializedError
+from tests.scenarios import test_privacy_middleware_perf as perf
+
+
+def test_persona_probe_does_not_skip_database_key_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sandbox/keychain failures must fail visibly, not become skipped perf tests."""
+
+    @contextmanager
+    def _raise_key_error(*, read_only: bool) -> Generator[object, None, None]:
+        assert read_only is True
+        raise DatabaseKeyError("key unavailable")
+        yield
+
+    monkeypatch.setattr(perf, "get_database", _raise_key_error)
+
+    with pytest.raises(DatabaseKeyError, match="key unavailable"):
+        perf._persona_db_skip_reason()  # pyright: ignore[reportPrivateUsage]
+
+
+def test_persona_probe_skips_missing_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A genuinely absent persona DB remains an intentional perf-test skip."""
+
+    @contextmanager
+    def _raise_missing_db(*, read_only: bool) -> Generator[object, None, None]:
+        assert read_only is True
+        raise DatabaseNotInitializedError("missing database")
+        yield
+
+    monkeypatch.setattr(perf, "get_database", _raise_missing_db)
+
+    reason = perf._persona_db_skip_reason()  # pyright: ignore[reportPrivateUsage]
+
+    assert reason is not None
+    assert "requires a populated persona DB" in reason
+    assert "moneybin synthetic generate family" in reason
+
+
+def test_persona_probe_skips_missing_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Running perf tests without MONEYBIN_PROFILE is a setup skip."""
+
+    @contextmanager
+    def _raise_no_profile(*, read_only: bool) -> Generator[object, None, None]:
+        assert read_only is True
+        raise RuntimeError("No profile set. Call set_current_profile() first.")
+        yield
+
+    monkeypatch.setattr(perf, "get_database", _raise_no_profile)
+
+    reason = perf._persona_db_skip_reason()  # pyright: ignore[reportPrivateUsage]
+
+    assert reason is not None
+    assert "requires an active MoneyBin profile" in reason

--- a/tests/scenarios/test_privacy_middleware_perf.py
+++ b/tests/scenarios/test_privacy_middleware_perf.py
@@ -38,10 +38,10 @@ from __future__ import annotations
 from datetime import date, timedelta
 from pathlib import Path
 
+import duckdb
 import pytest
 
-from moneybin.database import get_database
-from moneybin.errors import DatabaseKeyError
+from moneybin.database import DatabaseNotInitializedError, get_database
 from moneybin.privacy.redaction import redact_records
 from moneybin.privacy.sql_lineage import (
     expand_star,
@@ -68,36 +68,55 @@ TOTAL_REGRESSION_PCT = 20.0
 # reports_networth_history when called without dates.
 _HISTORY_FROM = date.today() - timedelta(days=365)
 _HISTORY_TO = date.today()
+_PERSONA_SETUP_HINT = (
+    "set MONEYBIN_HOME + MONEYBIN_PROFILE and run "
+    "`moneybin synthetic generate family --seed 8229 --years 3 "
+    "&& moneybin transform apply` first"
+)
 
 
-def _persona_db_available() -> bool:
-    """Probe whether a populated persona DB is reachable.
+def _persona_db_skip_reason() -> str | None:
+    """Return why the perf persona DB is absent, or ``None`` when ready.
 
     The runner opens the configured DB read-only and runs a cheap count
-    against ``core.fct_transactions``. Anything that prevents that — no
-    profile, sealed DB, empty DB, missing core tables — counts as
-    unavailable and the test skips.
+    against ``core.fct_transactions``. Missing DBs, empty DBs, and DBs
+    without transformed core tables skip because the perf baseline is not
+    meaningful there. Key/open failures are not caught; those are real
+    infrastructure problems and must fail visibly.
     """
     try:
         with get_database(read_only=True) as db:
             (count,) = db.execute(
                 "SELECT COUNT(*) FROM core.fct_transactions"
             ).fetchone() or (0,)
-            return count > 0
-    except (DatabaseKeyError, Exception):  # noqa: BLE001 — any open/query error → skip
-        return False
+    except DatabaseNotInitializedError:
+        return (
+            f"perf baseline test requires a populated persona DB; {_PERSONA_SETUP_HINT}"
+        )
+    except RuntimeError as e:
+        if "No profile set" not in str(e):
+            raise
+        return f"perf baseline test requires an active MoneyBin profile; {_PERSONA_SETUP_HINT}"
+    except duckdb.CatalogException as e:
+        if "fct_transactions" not in str(e):
+            raise
+        return (
+            "perf baseline test requires transformed core.fct_transactions; "
+            f"{_PERSONA_SETUP_HINT}"
+        )
+
+    if count <= 0:
+        return (
+            f"perf baseline test requires a populated persona DB; {_PERSONA_SETUP_HINT}"
+        )
+    return None
 
 
 @pytest.mark.perf
 def test_privacy_middleware_within_budget() -> None:
     """Re-run baseline flows post-middleware; assert deltas within budget."""
-    if not _persona_db_available():
-        pytest.skip(
-            "perf baseline test requires a populated persona DB; set "
-            "MONEYBIN_HOME + MONEYBIN_PROFILE and run "
-            "`moneybin synthetic generate family --seed 8229 --years 3 "
-            "&& moneybin transform apply` first"
-        )
+    if reason := _persona_db_skip_reason():
+        pytest.skip(reason)
 
     baseline = read_baseline(BASELINE_PATH)
 
@@ -185,13 +204,8 @@ def test_sql_query_lineage_overhead_within_budget() -> None:
     is independently derived (the PR's own contract: lineage adds ≤ P50_BUDGET_MS
     p50), not a paste of observed numbers.
     """
-    if not _persona_db_available():
-        pytest.skip(
-            "perf lineage test requires a populated persona DB; set "
-            "MONEYBIN_HOME + MONEYBIN_PROFILE and run "
-            "`moneybin synthetic generate family --seed 8229 --years 3 "
-            "&& moneybin transform apply` first"
-        )
+    if reason := _persona_db_skip_reason():
+        pytest.skip(reason)
 
     def _raw() -> object:
         with get_database(read_only=True) as db:

--- a/tests/scenarios/test_privacy_middleware_perf.py
+++ b/tests/scenarios/test_privacy_middleware_perf.py
@@ -81,8 +81,8 @@ def _persona_db_skip_reason() -> str | None:
     The runner opens the configured DB read-only and runs a cheap count
     against ``core.fct_transactions``. Missing DBs, empty DBs, and DBs
     without transformed core tables skip because the perf baseline is not
-    meaningful there. Key/open failures are not caught; those are real
-    infrastructure problems and must fail visibly.
+    meaningful there. Key/open failures and malformed profile config are
+    not caught; those are infrastructure problems and must fail visibly.
     """
     try:
         with get_database(read_only=True) as db:
@@ -94,11 +94,13 @@ def _persona_db_skip_reason() -> str | None:
             f"perf baseline test requires a populated persona DB; {_PERSONA_SETUP_HINT}"
         )
     except RuntimeError as e:
+        # Keep in sync with config.py _get_settings() when no profile is active.
         if "No profile set" not in str(e):
             raise
         return f"perf baseline test requires an active MoneyBin profile; {_PERSONA_SETUP_HINT}"
     except duckdb.CatalogException as e:
-        if "fct_transactions" not in str(e):
+        message = str(e)
+        if "fct_transactions" not in message and "Schema with name core" not in message:
             raise
         return (
             "perf baseline test requires transformed core.fct_transactions; "


### PR DESCRIPTION
## Summary

Fix keychain-sensitive privacy test behavior by distinguishing missing local setup from real keychain or database-open failures.

## Changes

- Check read-only database existence before consulting the secret store, so an absent DB reports initialization state without touching keychain-backed secrets.
- Narrow privacy perf persona skips to genuine setup gaps: missing DB, missing active profile, missing transformed core table, or empty persona data.
- Let database key/open failures fail visibly instead of being converted into skipped perf tests.
- Add live catalog coverage that compares `duckdb_columns()` for app/core columns against the privacy `CLASSIFICATION` registry in both directions.
- Update the privacy classification spec to document the live catalog coverage.

## Test plan

- `uv run pytest tests/moneybin/test_database.py tests/moneybin/test_privacy/test_classification_registry_coverage.py tests/moneybin/test_privacy/test_privacy_middleware_perf_probe.py tests/scenarios/test_privacy_middleware_perf.py -v`
- `uv run pyright src/moneybin/database.py tests/moneybin/test_database.py tests/moneybin/test_privacy/test_classification_registry_coverage.py tests/moneybin/test_privacy/test_privacy_middleware_perf_probe.py tests/scenarios/test_privacy_middleware_perf.py`
- `make format`
- `make lint`
- `make check test`

## Breaking changes

None.
