### PR TITLE
Fix dead spec links surfaced by #229 link-checker

### DIFF
--- a/docs/decisions/003-mcp-primary-interface.md
+++ b/docs/decisions/003-mcp-primary-interface.md
@@ -58,4 +58,4 @@ The same DuckDB database is directly accessible via:
 
 - [MCP Read Tools Spec](../specs/archived/mcp-read-tools.md) -- Implemented read tools
 - [MCP Write Tools Spec](../specs/archived/mcp-write-tools.md) -- Implemented write tools
-- [MCP Tier 1 Tools Spec](../specs/mcp-tier1-tools.md) -- Next tools to implement
+- [MCP Architecture Spec](../specs/mcp-architecture.md) -- Tool taxonomy, design patterns, and namespace conventions

--- a/docs/specs/mcp-architecture.md
+++ b/docs/specs/mcp-architecture.md
@@ -1,7 +1,7 @@
 # MCP Architecture & Design
 
 > Companions: [`privacy-and-ai-trust.md`](privacy-and-ai-trust.md) (AI data flow tiers, consent model), [`moneybin-mcp.md`](moneybin-mcp.md) (concrete tool/prompt/resource definitions), [`extension-contracts.md`](extension-contracts.md) (contributor-facing surface — packages and reports register tools into this server via entry points), [ADR-003: MCP Primary Interface](../decisions/003-mcp-primary-interface.md)
-> Supersedes: [`mcp-tier1-tools.md`](mcp-tier1-tools.md) (prototype-era tool list), [`archived/mcp-read-tools.md`](archived/mcp-read-tools.md), [`archived/mcp-write-tools.md`](archived/mcp-write-tools.md)
+> Supersedes: `mcp-tier1-tools.md` (prototype-era tool list), [`archived/mcp-read-tools.md`](archived/mcp-read-tools.md), [`archived/mcp-write-tools.md`](archived/mcp-write-tools.md)
 
 ## Purpose
 
@@ -640,7 +640,7 @@ These decisions and their rationale should be documented in the 12-month plan.
 
 | Spec | Disposition |
 |---|---|
-| [`mcp-tier1-tools.md`](mcp-tier1-tools.md) | Superseded. Prototype-era tool list designed before the privacy framework. Tool concepts that survive are redesigned in `moneybin-mcp.md`. |
+| `mcp-tier1-tools.md` | Superseded. Prototype-era tool list designed before the privacy framework. Tool concepts that survive are redesigned in `moneybin-mcp.md`. |
 | [`archived/mcp-read-tools.md`](archived/mcp-read-tools.md) | Historical record of the prototype. Implementation will be replaced. |
 | [`archived/mcp-write-tools.md`](archived/mcp-write-tools.md) | Historical record of the prototype. Implementation will be replaced. |
 

--- a/docs/specs/sync-overview.md
+++ b/docs/specs/sync-overview.md
@@ -674,7 +674,7 @@ Integration tests require a coordinated test environment: a running moneybin-ser
 
 ### Synthetic data interaction
 
-The [`testing-and-validation-overview.md`](testing-and-validation-overview.md) umbrella spec deferred Plaid Sandbox testing to this spec. The testing strategy here completes that contract: golden-file payloads captured from sandbox for offline unit tests, live sandbox for integration tests.
+The [`testing-overview.md`](testing-overview.md) umbrella spec deferred Plaid Sandbox testing to this spec. The testing strategy here completes that contract: golden-file payloads captured from sandbox for offline unit tests, live sandbox for integration tests.
 
 ---
 

--- a/docs/specs/testing-anonymized-data.md
+++ b/docs/specs/testing-anonymized-data.md
@@ -18,7 +18,7 @@ This spec fills that gap. It is a **peer child spec** of `testing-overview.md` a
 ### Primary use cases
 
 1. **Automated bug reports.** When a user files a bug, the support flow (manual today, eventually automated via an agent loop) produces an anonymized snapshot of the relevant slice of their database. The snapshot becomes a fixture under `tests/scenarios/data/fixtures/<bug-id>/`. A scenario authored against that fixture per [`testing-scenario-comprehensive.md`](testing-scenario-comprehensive.md)'s recipe gives permanent regression coverage.
-2. **Format-compatibility seeds.** Anonymized real CSV/OFX exports populate `tests/fixtures/csv_formats/` per the deferred [`testing-csv-fixtures.md`](testing-csv-fixtures.md).
+2. **Format-compatibility seeds.** Anonymized real CSV/OFX exports populate `tests/fixtures/csv_formats/` per the deferred `testing-csv-fixtures.md`.
 3. **Distribution-faithful evaluation corpora.** Categorization and matching evaluations run against anonymized real data alongside synthetic personas, providing a sanity check that scores aren't gaming the synthetic generator's biases.
 
 ### Why this is a separate engine


### PR DESCRIPTION
## Summary

Fixes four dead links in docs/specs that pointed to spec files which were renamed or consolidated away. Surfaced by the link-checker run during #229's pre-push review. Small and docs-only.

## Changes

- `docs/specs/mcp-architecture.md` — unlink `mcp-tier1-tools.md` (superseded; plain-text reference now)
- `docs/decisions/003-mcp-primary-interface.md` — repoint `mcp-tier1-tools.md` link to `mcp-architecture.md` (its successor)
- `docs/specs/sync-overview.md` — repoint `testing-and-validation-overview.md` to `testing-overview.md` (current filename)
- `docs/specs/testing-anonymized-data.md` — unlink `testing-csv-fixtures.md` (planned but unwritten; plain-text reference now)

## Test plan

- [ ] Pre-commit hooks passed (ruff-format, eof, trailing-whitespace).
- [ ] All 4 links now either resolve to existing files or are plain-text references with no broken `[]()` syntax.
