### PR TITLE
Require read_only kwarg on database connection openers

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -9,7 +9,7 @@ paths: ["**/*.sql", "sqlmesh/**", "src/moneybin/sql/**", "src/moneybin/database.
 
 **Never call `duckdb.connect()` directly.** Use the `Database` class (`src/moneybin/database.py`) via `get_database()` for all database access. The `Database` class handles encryption key retrieval, encrypted file attachment, extension loading, schema initialization, and migrations.
 
-Connections are **short-lived and purpose-declared** — acquire, use, release immediately via the context manager:
+Connections are **short-lived and purpose-declared** — acquire, use, release immediately via the context manager. The `read_only` argument is **required** on both `Database.__init__()` and `get_database()`; there is no default. Every call site declares intent explicitly.
 
 ```python
 from moneybin.database import get_database
@@ -21,7 +21,7 @@ with get_database(read_only=True) as db:
     )
 
 # write path — exclusive (~79 ms); retries up to max_wait on contention
-with get_database() as db:
+with get_database(read_only=False) as db:
     db.execute("INSERT INTO app.some_table ...")
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ M2 closing out and M3 underway. M2A curator state shipped (transaction notes, ta
   `known_format_reuse_total{channel}`, `revalidation_failure_total{channel}`.
 
 ### Changed
+- **`Database.__init__()` and `get_database()` now require `read_only` as a
+  keyword-only argument.** The prior `read_only: bool = False` default is
+  removed; every call site declares intent explicitly. This is the physical
+  enforcement that complements the SQL allowlists at MCP/CLI boundaries —
+  read surfaces open with `ATTACH ... READ_ONLY`, not just by convention.
+  Internal API change only; no external callers. See
+  [`docs/specs/database-writer-coordination.md`](docs/specs/database-writer-coordination.md)
+  and [ADR-010](docs/decisions/010-writer-coordination.md).
 - **GSheet alias limit tightened from 63 to 56 chars** (#228) so the
   generated `gsheet_<alias>` view name fits DuckDB's 63-char identifier
   limit. A pre-existing gsheet connection with a 57–63 char alias will

--- a/docs/specs/database-writer-coordination.md
+++ b/docs/specs/database-writer-coordination.md
@@ -5,6 +5,8 @@ implemented
 
 > **Tool-name drift since this spec landed.** The pattern is unchanged — every MCP tool acquires its own `get_database(read_only=...)` connection — but several tool names referenced in the body have evolved through coherence passes: noun-only reads (PR #172 dropped `_list`), `transactions_categorize_apply` → `_commit` (PR #171), per-field account writes consolidated into `accounts_set` (PR #170/#171), `refresh_run` umbrella retiring `transform_apply` from the user-intent layer (PR #173). The classification rule (read vs. write) is still the source of truth; the example lists below reflect today's surface.
 
+> **Required-kwarg hardening (PR #XXX).** `Database.__init__()` and `get_database()` now require `read_only` as a keyword-only argument; the prior `read_only: bool = False` default is removed. Every caller declares intent explicitly. Read-only enforcement at every read site is the trust boundary protected by this change — the SQL allowlists at MCP/CLI boundaries remain as defense-in-depth, but `ATTACH ... READ_ONLY` is the physical guard. The mechanism is the type system (no separate lint rule); pyright in `make check` fails any call site that omits the kwarg.
+
 ## Goal
 
 Implement [ADR-010](../decisions/010-writer-coordination.md): replace the long-lived read-write singleton in `database.py` with short-lived, purpose-declared connections. Every caller acquires a connection, does its work, and releases it. Read-only connections skip `init_schemas()` and `refresh_views()` (~14 ms overhead) and coexist across processes. Write connections are exclusive (~79 ms) and retry on lock contention up to 5 seconds.
@@ -20,8 +22,8 @@ Implement [ADR-010](../decisions/010-writer-coordination.md): replace the long-l
 
 1. `Database(read_only=True)` skips `init_schemas()`, `refresh_views()`, and all migrations; opens DuckDB with `READ_ONLY` flag.
 2. `Database(read_only=True)` raises `DatabaseNotInitializedError` before any DuckDB operation if `db_path` does not exist.
-3. `Database(read_only=False)` (default) behaves identically to the current `Database.__init__()` sequence.
-4. `get_database(read_only, max_wait)` creates a new `Database` per call; no singleton.
+3. `Database(read_only=False)` behaves identically to the current `Database.__init__()` sequence.
+4. `get_database(*, read_only, max_wait)` creates a new `Database` per call; no singleton. `read_only` is a required keyword-only argument with no default.
 5. `get_database()` retries on `DatabaseLockError` with exponential backoff (start 50 ms, ×1.5, cap 500 ms) until `max_wait` is exhausted, then re-raises `DatabaseLockError` with a message that names the blocking process if `lsof` can identify it, falling back to a generic hint if not.
 6. The encryption key retrieved from `SecretStore` is cached in process memory after the first successful retrieval; never re-fetched within the process lifetime.
 7. All `get_database()` callers use the context-manager protocol to ensure connections are released immediately after use.
@@ -32,6 +34,7 @@ Implement [ADR-010](../decisions/010-writer-coordination.md): replace the long-l
 12. The atexit metrics flush opens a fresh connection only if the database was accessed during the session.
 13. `DatabaseNotInitializedError` is caught at all CLI error handlers alongside `DatabaseKeyError`, displayed as a one-line message with no traceback.
 14. The `.claude/rules/database.md` connection-management section is updated to reflect the new per-operation model.
+15. `Database.__init__()` and `get_database()` both require `read_only` as a keyword-only argument; there is no default. All call sites declare intent explicitly. Pyright catches any missing kwarg at type-check time.
 
 ## Implementation Plan
 
@@ -78,7 +81,7 @@ def __init__(
     self,
     db_path: Path,
     *,
-    read_only: bool = False,
+    read_only: bool,
     secret_store: SecretStore | None = None,
     no_auto_upgrade: bool = False,
 ) -> None:
@@ -134,7 +137,8 @@ _migration_check_done: bool = False
 
 
 def get_database(
-    read_only: bool = False,
+    *,
+    read_only: bool,
     max_wait: float = 5.0,
 ) -> Database:
     global _database_accessed, _migration_check_done
@@ -323,7 +327,7 @@ with get_database(read_only=True) as db:
 
 After (write):
 ```python
-with get_database() as db:
+with get_database(read_only=False) as db:
     return SomeService(db).write_operation()
 ```
 
@@ -390,7 +394,7 @@ with handle_cli_errors():
 
 # write command
 with handle_cli_errors():
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         SomeService(db).write_operation()
 ```
 
@@ -409,7 +413,7 @@ def sqlmesh_command(
 ) -> Generator[Database, None, None]:
     logger.info(f"⚙️  {operation}...")
     try:
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             yield db
         logger.info(f"✅ {success or f'{operation} completed'}")
     except typer.Exit:

--- a/docs/specs/database-writer-coordination.md
+++ b/docs/specs/database-writer-coordination.md
@@ -5,7 +5,7 @@ implemented
 
 > **Tool-name drift since this spec landed.** The pattern is unchanged — every MCP tool acquires its own `get_database(read_only=...)` connection — but several tool names referenced in the body have evolved through coherence passes: noun-only reads (PR #172 dropped `_list`), `transactions_categorize_apply` → `_commit` (PR #171), per-field account writes consolidated into `accounts_set` (PR #170/#171), `refresh_run` umbrella retiring `transform_apply` from the user-intent layer (PR #173). The classification rule (read vs. write) is still the source of truth; the example lists below reflect today's surface.
 
-> **Required-kwarg hardening (PR #XXX).** `Database.__init__()` and `get_database()` now require `read_only` as a keyword-only argument; the prior `read_only: bool = False` default is removed. Every caller declares intent explicitly. Read-only enforcement at every read site is the trust boundary protected by this change — the SQL allowlists at MCP/CLI boundaries remain as defense-in-depth, but `ATTACH ... READ_ONLY` is the physical guard. The mechanism is the type system (no separate lint rule); pyright in `make check` fails any call site that omits the kwarg.
+> **Required-kwarg hardening (PR #234).** `Database.__init__()` and `get_database()` now require `read_only` as a keyword-only argument; the prior `read_only: bool = False` default is removed. Every caller declares intent explicitly. Read-only enforcement at every read site is the trust boundary protected by this change — the SQL allowlists at MCP/CLI boundaries remain as defense-in-depth, but `ATTACH ... READ_ONLY` is the physical guard. The mechanism is the type system (no separate lint rule); pyright in `make check` fails any call site that omits the kwarg.
 
 ## Goal
 

--- a/scripts/backfill_categorization_links.py
+++ b/scripts/backfill_categorization_links.py
@@ -162,7 +162,7 @@ def backfill(db: Database) -> dict[str, int]:
 
 
 if __name__ == "__main__":
-    db = get_database()
+    db = get_database(read_only=False)
     logger.info("Backfilling categorization links")
 
     result = backfill(db)

--- a/src/moneybin/cli/commands/accounts/__init__.py
+++ b/src/moneybin/cli/commands/accounts/__init__.py
@@ -261,7 +261,7 @@ def accounts_set(
                 raise typer.Exit(2)
 
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             # Decimal conversion inside the handler so InvalidOperation surfaces
             # via classify_user_error rather than as a raw traceback.
             _add(

--- a/src/moneybin/cli/commands/accounts/balance.py
+++ b/src/moneybin/cli/commands/accounts/balance.py
@@ -118,7 +118,7 @@ def accounts_balance_assert(
     """Assert a balance for an account on a specific date."""
     parsed_date: _date
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             parsed_date = _date.fromisoformat(assertion_date)
             parsed_amount = Decimal(amount)
             result = BalanceService(db).assert_balance(
@@ -168,7 +168,7 @@ def accounts_balance_assertion_delete(
     """Delete a balance assertion. Silent no-op if no row exists."""
     parsed_date: _date
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             parsed_date = _date.fromisoformat(assertion_date)
             BalanceService(db).delete_assertion(account_id, parsed_date, actor="cli")
     typer.echo(

--- a/src/moneybin/cli/commands/categories/__init__.py
+++ b/src/moneybin/cli/commands/categories/__init__.py
@@ -73,7 +73,7 @@ def categories_delete(
     # Both imports resolve BEFORE the delete: an import failure after a
     # committed deletion would strand the user with no confirmation/envelope.
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             CategorizationService(db).delete_category(
                 category_id, force=force, actor="cli"
             )

--- a/src/moneybin/cli/commands/db.py
+++ b/src/moneybin/cli/commands/db.py
@@ -421,7 +421,7 @@ def db_info(
 
     # Open database to get table info
     try:
-        with Database(db_path, secret_store=store) as db:
+        with Database(db_path, secret_store=store, read_only=True) as db:
             tables = db.execute("""
                 SELECT table_schema, table_name
                 FROM information_schema.tables
@@ -599,7 +599,7 @@ def db_restore(
 
     store = SecretStore()
     try:
-        with Database(db_path, secret_store=store):
+        with Database(db_path, secret_store=store, read_only=True):
             pass
         logger.info(f"✅ Database restored from {selected_path.name}")
     except DatabaseKeyError:
@@ -693,7 +693,7 @@ def db_unlock() -> None:
         logger.info("💡 Run 'moneybin db init --passphrase' to create a new database.")
         raise typer.Exit(1)
     try:
-        with Database(settings.database.path, secret_store=store):
+        with Database(settings.database.path, secret_store=store, read_only=True):
             pass
         from moneybin.database import (  # noqa: PLC0415 — defer to avoid cold-start cost
             invalidate_encryption_key_cache,

--- a/src/moneybin/cli/commands/import_cmd.py
+++ b/src/moneybin/cli/commands/import_cmd.py
@@ -313,7 +313,7 @@ def import_files_command(
     data: dict[str, Any] = {}
     try:
         with handle_cli_errors():
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 svc = ImportService(db)
                 # Single-path invocations always use import_file directly so
                 # ImportConfirmationRequiredError can bubble to the CLI handler.
@@ -702,7 +702,7 @@ def import_confirm_command(
 
     try:
         with handle_cli_errors():
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 result = ImportService(
                     db
                 ).import_file(
@@ -925,7 +925,7 @@ def import_revert(
             raise typer.Exit(0)
 
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             result = ImportService(db).revert(import_id)
 
     status = result.get("status")
@@ -1253,7 +1253,7 @@ def formats_delete(
             raise typer.Exit(0)
 
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             deleted = delete_format_from_db(db, name, actor="cli")
 
     if not deleted:

--- a/src/moneybin/cli/commands/import_inbox.py
+++ b/src/moneybin/cli/commands/import_inbox.py
@@ -69,7 +69,7 @@ def inbox_default(
     from moneybin.database import get_database  # noqa: PLC0415
 
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             result = InboxService(db=db, settings=get_settings()).sync()
 
     if output == OutputFormat.JSON:

--- a/src/moneybin/cli/commands/import_labels.py
+++ b/src/moneybin/cli/commands/import_labels.py
@@ -40,7 +40,7 @@ def import_labels_add(
 
     try:
         with handle_cli_errors():
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 updated = ImportService(db).add_labels(import_id, labels, actor="cli")
     except ValueError as e:
         typer.echo(f"❌ {e}", err=True)
@@ -69,7 +69,7 @@ def import_labels_remove(
 
     try:
         with handle_cli_errors():
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 updated = ImportService(db).remove_labels(
                     import_id, labels, actor="cli"
                 )
@@ -101,7 +101,7 @@ def import_labels_list(
     from moneybin.services.import_service import ImportService
 
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=True) as db:
             svc = ImportService(db)
             if import_id is not None:
                 labels = svc.list_labels(import_id)

--- a/src/moneybin/cli/commands/migrate.py
+++ b/src/moneybin/cli/commands/migrate.py
@@ -30,7 +30,7 @@ def migrate_apply(
 ) -> None:
     """Apply pending database migrations."""
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             runner = MigrationRunner(db)
 
             if dry_run:

--- a/src/moneybin/cli/commands/privacy/grant.py
+++ b/src/moneybin/cli/commands/privacy/grant.py
@@ -51,7 +51,7 @@ def privacy_grant(
             abort=True,
         )
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             result = ConsentService(db).grant_consent(
                 feature_category=category,
                 backend=resolved_backend,

--- a/src/moneybin/cli/commands/privacy/revoke.py
+++ b/src/moneybin/cli/commands/privacy/revoke.py
@@ -34,7 +34,7 @@ def privacy_revoke(
             abort=True,
         )
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             result = ConsentService(db).revoke_consent(
                 feature_category=category,
                 backend=resolved_backend,

--- a/src/moneybin/cli/commands/privacy/revoke_all.py
+++ b/src/moneybin/cli/commands/privacy/revoke_all.py
@@ -24,7 +24,7 @@ def privacy_revoke_all(
     if not yes:
         typer.confirm("Revoke ALL active consent grants?", abort=True)
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             count = ConsentService(db).revoke_all(actor="cli.privacy_revoke_all")
     if output == OutputFormat.JSON:
         render_or_json(

--- a/src/moneybin/cli/commands/refresh.py
+++ b/src/moneybin/cli/commands/refresh.py
@@ -71,7 +71,7 @@ def refresh_command(
     # service code that accepts ``list[str]`` works unchanged.
     steps: list[str] | None = [s.value for s in step] if step else None
 
-    with handle_cli_errors(), get_database() as db:
+    with handle_cli_errors(), get_database(read_only=False) as db:
         result = refresh(db, steps=steps)
     requested = expand_steps(steps)
 

--- a/src/moneybin/cli/commands/synthetic.py
+++ b/src/moneybin/cli/commands/synthetic.py
@@ -78,7 +78,7 @@ def _run_generate(
                 get_database,  # noqa: PLC0415 — deferred import
             )
 
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 # Check if profile already has data
                 try:
                     row = db.execute(
@@ -211,7 +211,7 @@ def synthetic_reset(
                 get_database,  # noqa: PLC0415 — deferred import
             )
 
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 # Safety check: only reset profiles created by the generator
                 try:
                     gt_row = db.execute(

--- a/src/moneybin/cli/commands/system/audit.py
+++ b/src/moneybin/cli/commands/system/audit.py
@@ -145,7 +145,7 @@ def system_audit_undo(
     from moneybin.services.undo_service import UndoService
 
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             result = UndoService(db).undo(operation_id, actor="cli")
 
     def _render_text(_: object) -> None:

--- a/src/moneybin/cli/commands/system/doctor.py
+++ b/src/moneybin/cli/commands/system/doctor.py
@@ -51,7 +51,11 @@ def doctor_command(
     invariants pass or warn; exits 1 when any fail.
     """
     with handle_cli_errors():
-        with get_database(read_only=True) as db:
+        # read_only=False matches the MCP system_doctor tool: DoctorService
+        # initializes a SQLMesh Context which may write internal state tables
+        # on first init; a read-only connection silently marks SQLMesh audits
+        # as unavailable.
+        with get_database(read_only=False) as db:
             report = DoctorService(db).run_all(verbose=verbose, full=full)
 
     status_icon = {"pass": "✅", "fail": "❌", "warn": "⚠️ ", "skipped": "⏭️ "}

--- a/src/moneybin/cli/commands/system/doctor.py
+++ b/src/moneybin/cli/commands/system/doctor.py
@@ -51,7 +51,7 @@ def doctor_command(
     invariants pass or warn; exits 1 when any fail.
     """
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=True) as db:
             report = DoctorService(db).run_all(verbose=verbose, full=full)
 
     status_icon = {"pass": "✅", "fail": "❌", "warn": "⚠️ ", "skipped": "⏭️ "}

--- a/src/moneybin/cli/commands/transactions/categorize/__init__.py
+++ b/src/moneybin/cli/commands/transactions/categorize/__init__.py
@@ -213,7 +213,7 @@ def categorize_commit(
 
     if items:
         with handle_cli_errors():
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 result = CategorizationService(db).categorize_items(items)
     else:
         result = CategorizationResult(applied=0, skipped=0, errors=0, error_details=[])
@@ -301,7 +301,7 @@ def categorize_run(
         raise typer.Exit(2)
 
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             data = CategorizationService(db).categorize_run(methods=typed_methods)
 
     payload = CategorizeRunPayload(
@@ -420,7 +420,7 @@ def stats(
     from moneybin.services.categorization import CategorizationService
 
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=True) as db:
             coverage = CategorizationService(db).categorization_stats()
 
     if output == OutputFormat.JSON:

--- a/src/moneybin/cli/commands/transactions/categorize/auto.py
+++ b/src/moneybin/cli/commands/transactions/categorize/auto.py
@@ -88,7 +88,7 @@ def categorize_auto_accept(
         raise typer.Exit(2)
 
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             svc = AutoRuleService(db)
             if accept_all or reject_all:
                 pending_ids = [

--- a/src/moneybin/cli/commands/transactions/categorize/commit_from_file.py
+++ b/src/moneybin/cli/commands/transactions/categorize/commit_from_file.py
@@ -103,7 +103,7 @@ def categorize_commit_from_file(
         from moneybin.services.categorization import CategorizationService
 
         with handle_cli_errors():
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 result = CategorizationService(db).categorize_items(items)
     else:
         result = CategorizationResult(applied=0, skipped=0, errors=0, error_details=[])

--- a/src/moneybin/cli/commands/transactions/categorize/rules.py
+++ b/src/moneybin/cli/commands/transactions/categorize/rules.py
@@ -95,7 +95,7 @@ def rules_apply() -> None:
     from moneybin.services.categorization import CategorizationService
 
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             stats = CategorizationService(db).categorize_pending()
             if stats["total"] > 0:
                 logger.info(
@@ -212,7 +212,7 @@ def rules_create(
 
     with handle_cli_errors():
         validated, parse_errors = validate_rule_items(rules)
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             result = CategorizationService(db).create_rules(
                 validated, reapply=reapply, actor="cli"
             )
@@ -264,7 +264,7 @@ def rules_delete(
     )
 
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             deactivated = CategorizationService(db).deactivate_rule(
                 rule_id, reapply=reapply, actor="cli"
             )

--- a/src/moneybin/cli/commands/transactions/create.py
+++ b/src/moneybin/cli/commands/transactions/create.py
@@ -90,7 +90,7 @@ def transactions_create(
 
     try:
         with handle_cli_errors():
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 svc = TransactionService(db)
                 batch = svc.create_manual_batch([entry], actor="cli")
                 row = batch.results[0]

--- a/src/moneybin/cli/commands/transactions/matches.py
+++ b/src/moneybin/cli/commands/transactions/matches.py
@@ -91,7 +91,7 @@ def matches_run(
     """Run matcher against existing transactions."""
     try:
         with handle_cli_errors():
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 result = MatchingService(db).run(
                     auto_accept_transfers=auto_accept_transfers, actor="cli"
                 )
@@ -173,7 +173,7 @@ def matches_undo(
 
     try:
         with handle_cli_errors():
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 MatchingService(db).undo(match_id, reversed_by="user", actor="cli")
                 logger.info(f"Reversed match {match_id[:8]}...")
     except ValueError as e:
@@ -191,7 +191,7 @@ def matches_set(
         logger.error("❌ --status must be 'accepted' or 'rejected'")
         raise typer.Exit(2)
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             MatchingService(db).set_status(match_id, status=status, actor="cli")
     logger.info(f"✅ Set match {match_id[:8]}... to {status}")
 
@@ -210,7 +210,7 @@ def matches_backfill(
     """One-time scan of all existing transactions for latent duplicates."""
     try:
         with handle_cli_errors():
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 count = db.execute(
                     f"SELECT COUNT(*) FROM {INT_TRANSACTIONS_UNIONED.full_name}"  # noqa: S608 — TableRef constant
                 ).fetchone()

--- a/src/moneybin/cli/commands/transactions/notes.py
+++ b/src/moneybin/cli/commands/transactions/notes.py
@@ -54,7 +54,7 @@ def transactions_notes_add(
 
     try:
         with handle_cli_errors():
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 note = TransactionService(db).add_note(
                     transaction_id, text, actor="cli"
                 )
@@ -114,7 +114,7 @@ def transactions_notes_edit(
 
     try:
         with handle_cli_errors():
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 note = TransactionService(db).edit_note(note_id, text, actor="cli")
     except LookupError as e:
         typer.echo(f"❌ {e}", err=True)
@@ -149,7 +149,7 @@ def transactions_notes_delete(
 
     try:
         with handle_cli_errors():
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 TransactionService(db).delete_note(note_id, actor="cli")
     except LookupError as e:
         typer.echo(f"❌ {e}", err=True)

--- a/src/moneybin/cli/commands/transactions/review.py
+++ b/src/moneybin/cli/commands/transactions/review.py
@@ -95,7 +95,7 @@ def _review_matches_noninteractive(
         raise typer.Exit(2)
 
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             svc = MatchingService(db)
             if confirm_all:
                 n = svc.accept_all_pending(actor="cli")

--- a/src/moneybin/cli/commands/transactions/splits.py
+++ b/src/moneybin/cli/commands/transactions/splits.py
@@ -72,7 +72,7 @@ def transactions_splits_add(
 
     try:
         with handle_cli_errors():
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 svc = TransactionService(db)
                 split = svc.add_split(
                     transaction_id,
@@ -150,7 +150,7 @@ def transactions_splits_remove(
 
     try:
         with handle_cli_errors():
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 svc = TransactionService(db)
                 # Look up parent before delete so we can report residual after.
                 parent = db.conn.execute(
@@ -202,7 +202,7 @@ def transactions_splits_clear(
             raise typer.Exit(0)
 
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             TransactionService(db).clear_splits(transaction_id, actor="cli")
 
     if output == OutputFormat.JSON:

--- a/src/moneybin/cli/commands/transactions/tags.py
+++ b/src/moneybin/cli/commands/transactions/tags.py
@@ -40,7 +40,7 @@ def transactions_tags_add(
 
     try:
         with handle_cli_errors():
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 added = TransactionService(db).add_tags(
                     transaction_id, tags, actor="cli"
                 )
@@ -74,7 +74,7 @@ def transactions_tags_remove(
     from moneybin.services.transaction_service import TransactionService
 
     with handle_cli_errors():
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             removed = TransactionService(db).remove_tags(
                 transaction_id, tags, actor="cli"
             )
@@ -161,7 +161,7 @@ def transactions_tags_rename(
 
     try:
         with handle_cli_errors():
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 result = TransactionService(db).rename_tag(old, new, actor="cli")
     except ValueError as e:
         typer.echo(f"❌ {e}", err=True)

--- a/src/moneybin/cli/commands/transform.py
+++ b/src/moneybin/cli/commands/transform.py
@@ -96,7 +96,7 @@ def transform_apply(
     from moneybin.protocol.envelope import build_envelope  # noqa: PLC0415
     from moneybin.services.transform_service import TransformService  # noqa: PLC0415
 
-    with handle_cli_errors(), get_database() as db:
+    with handle_cli_errors(), get_database(read_only=False) as db:
         result = TransformService(db).apply()
 
     if output == OutputFormat.JSON:
@@ -257,7 +257,7 @@ def transform_audit(
     from moneybin.protocol.envelope import build_envelope  # noqa: PLC0415
     from moneybin.services.transform_service import TransformService  # noqa: PLC0415
 
-    with handle_cli_errors(), get_database() as db:
+    with handle_cli_errors(), get_database(read_only=False) as db:
         result = TransformService(db).audit(start, end)
 
     if output == OutputFormat.JSON:

--- a/src/moneybin/cli/utils.py
+++ b/src/moneybin/cli/utils.py
@@ -177,7 +177,7 @@ def sqlmesh_command(
 
     logger.info(f"⚙️  {label}...")
     try:
-        with operation(), get_database() as db:
+        with operation(), get_database(read_only=False) as db:
             yield db
         logger.info(f"✅ {success or f'{label} completed'}")
     except typer.Exit:

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -8,8 +8,10 @@ Usage::
 
     from moneybin.database import get_database
 
-    db = get_database(read_only=True)
-    db.execute("SELECT * FROM core.fct_transactions WHERE account_id = ?", [acct_id])
+    with get_database(read_only=True) as db:
+        db.execute(
+            "SELECT * FROM core.fct_transactions WHERE account_id = ?", [acct_id]
+        )
 
 Never call ``duckdb.connect()`` directly. See the data-protection spec
 (``docs/specs/privacy-data-protection.md``) for the full design.
@@ -75,6 +77,10 @@ def build_attach_sql(
     read_only: bool = False,
 ) -> str:
     """Build a DuckDB ATTACH statement for an encrypted database.
+
+    SQL-building helper, not a connection opener — the ``read_only`` default
+    here is intentional and matches DuckDB's own ATTACH default. Connection
+    openers (``Database.__init__``, ``get_database``) require ``read_only``.
 
     Single-quote escapes the path and key to prevent injection. The alias
     is double-quoted via sqlglot as defense in depth. All three parameters
@@ -782,7 +788,7 @@ def get_database(
     """Create and return a new short-lived Database connection.
 
     Each call opens a fresh connection; callers must close it when done
-    (``with get_database() as db: ...`` closes automatically).
+    (``with get_database(read_only=...) as db: ...`` closes automatically).
 
     Both read-only and write connections retry on DatabaseLockError with
     exponential backoff (start 50 ms, ×1.5, cap 500 ms) until max_wait is

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -8,7 +8,7 @@ Usage::
 
     from moneybin.database import get_database
 
-    db = get_database()
+    db = get_database(read_only=True)
     db.execute("SELECT * FROM core.fct_transactions WHERE account_id = ?", [acct_id])
 
 Never call ``duckdb.connect()`` directly. See the data-protection spec
@@ -259,7 +259,7 @@ class Database:
         self,
         db_path: Path,
         *,
-        read_only: bool = False,
+        read_only: bool,
         secret_store: SecretStore | None = None,
         no_auto_upgrade: bool | None = None,
     ) -> None:
@@ -775,7 +775,8 @@ def database_was_written() -> bool:
 
 
 def get_database(
-    read_only: bool = False,
+    *,
+    read_only: bool,
     max_wait: float = 5.0,
 ) -> "Database":
     """Create and return a new short-lived Database connection.
@@ -868,7 +869,7 @@ def sqlmesh_context(
 
     Usage::
 
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             with sqlmesh_context(db) as ctx:
                 ctx.plan(auto_apply=True, no_prompts=True)
 
@@ -1085,7 +1086,9 @@ def init_db(
             # after _KEY_NAME succeeded still triggers the rollback below.
             store.set_key(_KEY_NAME, encryption_key)
             store.set_key(SALT_NAME, base64.b64encode(salt).decode())
-            with Database(db_path, secret_store=store, no_auto_upgrade=False) as db:
+            with Database(
+                db_path, read_only=False, secret_store=store, no_auto_upgrade=False
+            ) as db:
                 from moneybin.seeds import materialize_seeds
 
                 materialize_seeds(db)
@@ -1147,7 +1150,9 @@ def init_db(
                 )
 
         try:
-            with Database(db_path, secret_store=store, no_auto_upgrade=False) as db:
+            with Database(
+                db_path, read_only=False, secret_store=store, no_auto_upgrade=False
+            ) as db:
                 from moneybin.seeds import materialize_seeds
 
                 materialize_seeds(db)

--- a/src/moneybin/mcp/server.py
+++ b/src/moneybin/mcp/server.py
@@ -138,7 +138,7 @@ def check_schema_at_boot() -> None:
     # changes (see sqlmesh.core.context.Context.plan_builder
     # `always_include_local_changes` docstring), so it would no-op against
     # the very drift we need to fix.
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         result = TransformService(db).apply()
     if not result.applied:
         # apply() soft-fails by returning applied=False with the SQLMesh

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -194,7 +194,7 @@ def accounts_set(
             )
         for field in clear_fields:
             kwargs[field] = CLEAR
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         settings, warnings = AccountService(db).settings_update(
             account_id,
             actor="mcp",
@@ -308,7 +308,7 @@ def accounts_balance_assert(
     """
     parsed_date = _date.fromisoformat(assertion_date)
     parsed_balance = Decimal(str(balance))
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         result = BalanceService(db).assert_balance(
             account_id=account_id,
             assertion_date=parsed_date,
@@ -330,7 +330,7 @@ def accounts_balance_assertion_delete(
         assertion_date: ISO date (YYYY-MM-DD)
     """
     parsed_date = _date.fromisoformat(assertion_date)
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         BalanceService(db).delete_assertion(account_id, parsed_date, actor="mcp")
     return build_envelope(
         data=BalanceAssertionDeletePayload(

--- a/src/moneybin/mcp/tools/budget.py
+++ b/src/moneybin/mcp/tools/budget.py
@@ -34,7 +34,7 @@ def budget_set(
         monthly_amount: Monthly spending target in USD (as string, e.g. "200.00").
         start_month: First active month (YYYY-MM). Defaults to current month.
     """
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         service = BudgetService(db)
         result = service.set_budget(
             category=category,

--- a/src/moneybin/mcp/tools/categories.py
+++ b/src/moneybin/mcp/tools/categories.py
@@ -39,7 +39,7 @@ def categories_create(
     category: str, subcategory: str | None = None, description: str | None = None
 ) -> ResponseEnvelope[CategoryCreatePayload]:
     """Create a custom category or subcategory (non-default, active by default)."""
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         category_id = CategorizationService(db).create_category(
             category,
             subcategory=subcategory,
@@ -76,7 +76,7 @@ def categories_set(
         is_active: Whether the category is selectable for new
             categorizations.
     """
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         CategorizationService(db).toggle_category(
             category_id,
             is_active=is_active,
@@ -100,7 +100,7 @@ def categories_delete(
             budget rows; if False (default), refuse when references
             exist.
     """
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         CategorizationService(db).delete_category(category_id, force=force, actor="mcp")
     return build_envelope(
         data=CategoryDeletePayload(

--- a/src/moneybin/mcp/tools/curation.py
+++ b/src/moneybin/mcp/tools/curation.py
@@ -165,7 +165,7 @@ def transactions_create(
     batch before any insert — a single bad row aborts the whole batch.
     """
     prepared = _prepare_manual_entries(transactions)
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         result = TransactionService(db).create_manual_batch(prepared, actor="mcp")
     return build_envelope(
         data=ManualBatchPayload(
@@ -190,7 +190,7 @@ def transactions_notes_add(
     transaction_id: str, text: str
 ) -> ResponseEnvelope[NotePayload]:
     """Append a note to a transaction. Returns the created note row."""
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         note = TransactionService(db).add_note(transaction_id, text, actor="mcp")
     return build_envelope(data=_note_payload(note))
 
@@ -198,7 +198,7 @@ def transactions_notes_add(
 @mcp_tool(read_only=False)
 def transactions_notes_edit(note_id: str, text: str) -> ResponseEnvelope[NotePayload]:
     """Update an existing note's text. Returns the updated row."""
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         note = TransactionService(db).edit_note(note_id, text, actor="mcp")
     return build_envelope(data=_note_payload(note))
 
@@ -206,7 +206,7 @@ def transactions_notes_edit(note_id: str, text: str) -> ResponseEnvelope[NotePay
 @mcp_tool(read_only=False, destructive=True, idempotent=False)
 def transactions_notes_delete(note_id: str) -> ResponseEnvelope[NoteDeletePayload]:
     """Delete a note by ID. Hard-delete; raises LookupError if the note is gone."""
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         TransactionService(db).delete_note(note_id, actor="mcp")
     return build_envelope(data=NoteDeletePayload(note_id=note_id))
 
@@ -222,7 +222,7 @@ def transactions_tags_set(
     a single DuckDB transaction. The returned payload is the sorted final
     tag list — the diff itself is captured in the audit log.
     """
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         final = TransactionService(db).set_tags(transaction_id, tags, actor="mcp")
     return build_envelope(data=TagsPayload(transaction_id=transaction_id, tags=final))
 
@@ -232,7 +232,7 @@ def transactions_tags_rename(
     old_tag: str, new_tag: str
 ) -> ResponseEnvelope[TagRenamePayload]:
     """Rename a tag globally. Emits one parent + N child audit events."""
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         res = TransactionService(db).rename_tag(old_tag, new_tag, actor="mcp")
     return build_envelope(
         data=TagRenamePayload(
@@ -254,7 +254,7 @@ def transactions_splits_set(
     ``subcategory``, and ``note`` are optional. Order is preserved.
     """
     prepared = _prepare_splits(splits)
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         out = TransactionService(db).set_splits(transaction_id, prepared, actor="mcp")
     return build_envelope(data=SplitsPayload(splits=[_split_row(s) for s in out]))
 
@@ -268,7 +268,7 @@ def import_labels_set(
     Replaces the import's label set and emits one full-row ``import.set`` audit
     row (Invariant 10) capturing the complete before/after labels.
     """
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         final = ImportService(db).set_labels(import_id, labels, actor="mcp")
     return build_envelope(
         data=ImportLabelsSetPayload(import_id=import_id, labels=final)

--- a/src/moneybin/mcp/tools/import_inbox.py
+++ b/src/moneybin/mcp/tools/import_inbox.py
@@ -64,7 +64,7 @@ def import_inbox_sync(refresh: bool = True) -> ResponseEnvelope[ImportInboxSyncP
     """
     from moneybin.config import get_settings
 
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         service = InboxService(db=db, settings=get_settings())
         sync_result = service.sync(refresh=refresh)
 

--- a/src/moneybin/mcp/tools/import_tools.py
+++ b/src/moneybin/mcp/tools/import_tools.py
@@ -149,7 +149,7 @@ def import_files(
         # branch's transforms_error wiring.
         loaded_import_id: str | None = None
         try:
-            with get_database() as db:
+            with get_database(read_only=False) as db:
                 one = ImportService(db).import_file(
                     validated[0],
                     refresh=False,
@@ -279,7 +279,7 @@ def import_files(
                 transforms_error=transforms_error,
             )
     else:
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             batch = ImportService(db).import_files(
                 [str(p) for p in validated],
                 refresh=refresh,
@@ -455,7 +455,7 @@ def import_revert(import_id: str) -> ResponseEnvelope[ImportRevertPayload]:
     """
     from moneybin.services.import_service import ImportService  # noqa: PLC0415
 
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         result = ImportService(db).revert(import_id)
     status = result.get("status")
 
@@ -586,7 +586,7 @@ def import_confirm(
         )
 
     try:
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             result = ImportService(db).import_file(
                 path,
                 confirm=accept,

--- a/src/moneybin/mcp/tools/merchants.py
+++ b/src/moneybin/mcp/tools/merchants.py
@@ -64,7 +64,7 @@ def merchants_create(
     skipped = 0
     error_details: list[dict[str, str]] = []
 
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         service = CategorizationService(db)
         for item in merchants:
             raw_pattern = str(item.get("raw_pattern", "")).strip()

--- a/src/moneybin/mcp/tools/privacy.py
+++ b/src/moneybin/mcp/tools/privacy.py
@@ -55,7 +55,7 @@ def privacy_consent_grant(
             Re-granting an existing active category+backend is a no-op and does
             NOT change the mode; revoke then grant again to change it.
     """
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         result = ConsentService(db).grant_consent(
             feature_category=category,
             backend=backend,
@@ -84,7 +84,7 @@ def privacy_consent_revoke(
         category: The feature category to revoke.
         backend: AI backend; defaults to the configured default backend.
     """
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         result = ConsentService(db).revoke_consent(
             feature_category=category,
             backend=backend,

--- a/src/moneybin/mcp/tools/refresh.py
+++ b/src/moneybin/mcp/tools/refresh.py
@@ -54,7 +54,7 @@ def refresh_run(
     both accept a list parameter to scope which sub-operations execute,
     both default to the full set, both raise on unknown member names.
     """
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         result = refresh(db, steps=list(steps) if steps is not None else None)
     return refresh_envelope(result, requested=expand_steps(steps))
 

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -217,7 +217,7 @@ def system_doctor(full: bool = False) -> ResponseEnvelope[SystemDoctorPayload]:
     from moneybin.database import get_database
     from moneybin.services.doctor_service import DoctorService
 
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         report = DoctorService(db).run_all(verbose=False, full=full)
 
     actions: list[str] = []
@@ -280,7 +280,7 @@ def system_audit_undo(operation_id: str) -> ResponseEnvelope[SystemAuditUndoPayl
     from moneybin.database import get_database
     from moneybin.services.undo_service import UndoService
 
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         result = UndoService(db).undo(operation_id, actor="mcp")
     return build_envelope(
         data=SystemAuditUndoPayload(

--- a/src/moneybin/mcp/tools/transactions.py
+++ b/src/moneybin/mcp/tools/transactions.py
@@ -164,7 +164,7 @@ def transactions_matches_set(
         status: 'accepted' folds the pair via dedup; 'rejected' keeps both and
             prevents re-proposal.
     """
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         MatchingService(db).set_status(match_id, status=status, actor="mcp")
     return build_envelope(
         data=MatchSetPayload(match_id=match_id, match_status=status),
@@ -273,7 +273,7 @@ def transactions_matches_run() -> ResponseEnvelope[MatchRunPayload]:
     finalize each with transactions_matches_set. Does not auto-accept. Reverse an
     accepted match via `moneybin transactions matches undo` (no MCP undo tool yet).
     """
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         result = MatchingService(db).run(actor="mcp")
     return build_envelope(
         data=MatchRunPayload(

--- a/src/moneybin/mcp/tools/transactions_categorize.py
+++ b/src/moneybin/mcp/tools/transactions_categorize.py
@@ -213,7 +213,7 @@ def transactions_categorize_commit(
         )
 
     validated, parse_errors = validate_items(items)
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         result = CategorizationService(db).categorize_items(validated)
     result.merge_parse_errors(parse_errors)
     return build_envelope(
@@ -243,7 +243,7 @@ def transactions_categorize_rules_create(
             False; only future categorizations are affected.
     """
     validated, parse_errors = validate_rule_items(rules)
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         result = CategorizationService(db).create_rules(
             validated, reapply=reapply, actor="mcp"
         )
@@ -273,7 +273,7 @@ def transactions_categorize_rules_delete(
             to be re-evaluated. Default False; existing categorizations are
             left untouched.
     """
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         deactivated = CategorizationService(db).deactivate_rule(
             rule_id, reapply=reapply, actor="mcp"
         )
@@ -317,7 +317,7 @@ def transactions_categorize_auto_accept(
         accept: Proposal IDs to accept and promote to active rules.
         reject: Proposal IDs to reject and dismiss.
     """
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         result = AutoRuleService(db).accept(
             accept=accept or [],
             reject=reject or [],
@@ -344,7 +344,7 @@ def transactions_categorize_run(
         methods: Engines to run in the listed order. Defaults to
             ["rules", "merchants"].
     """
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         data = CategorizationService(db).categorize_run(methods=methods)
     payload = CategorizeRunPayload(
         applied_by_method=data["applied_by_method"], total_applied=data["total_applied"]

--- a/src/moneybin/mcp/tools/transform.py
+++ b/src/moneybin/mcp/tools/transform.py
@@ -101,7 +101,7 @@ def transform_audit(start: str, end: str) -> ResponseEnvelope[TransformAuditPayl
     """
     from moneybin.services.transform_service import TransformService
 
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         result = TransformService(db).audit(start, end)
     return build_envelope(
         data=TransformAuditPayload(

--- a/src/moneybin/observability.py
+++ b/src/moneybin/observability.py
@@ -114,7 +114,7 @@ def flush_metrics() -> None:
 
         if not database_was_written():
             return
-        with get_database(max_wait=2.0) as db:
+        with get_database(read_only=False, max_wait=2.0) as db:
             flush_to_duckdb(db)
     except Exception:  # noqa: BLE001  # best-effort shutdown flush; DB may be unavailable
         logger.debug("Metrics flush on exit failed", exc_info=True)

--- a/src/moneybin/services/inbox_service.py
+++ b/src/moneybin/services/inbox_service.py
@@ -115,7 +115,7 @@ class InboxService:
         from moneybin.config import get_settings
         from moneybin.database import get_database
 
-        return cls(db=get_database(), settings=get_settings())
+        return cls(db=get_database(read_only=False), settings=get_settings())
 
     @classmethod
     def for_active_profile_no_db(cls) -> InboxService:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -363,7 +363,7 @@ def match_status(env: dict[str, str], match_id: str) -> str | None:
             _workflow_db_path(env),
             secret_store=mock_store,
             no_auto_upgrade=True,
-            read_only=False,
+            read_only=True,
         ) as db:
             row = get_match_decision(db, match_id)
     finally:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -323,7 +323,10 @@ def seed_pending_match(env: dict[str, str], match_id: str) -> None:
     invalidate_encryption_key_cache()
     try:
         with Database(
-            _workflow_db_path(env), secret_store=mock_store, no_auto_upgrade=True
+            _workflow_db_path(env),
+            secret_store=mock_store,
+            no_auto_upgrade=True,
+            read_only=False,
         ) as db:
             MatchDecisionsRepo(db).insert(
                 match_id=match_id,
@@ -357,7 +360,10 @@ def match_status(env: dict[str, str], match_id: str) -> str | None:
     invalidate_encryption_key_cache()
     try:
         with Database(
-            _workflow_db_path(env), secret_store=mock_store, no_auto_upgrade=True
+            _workflow_db_path(env),
+            secret_store=mock_store,
+            no_auto_upgrade=True,
+            read_only=False,
         ) as db:
             row = get_match_decision(db, match_id)
     finally:

--- a/tests/e2e/test_concurrent_access.py
+++ b/tests/e2e/test_concurrent_access.py
@@ -65,7 +65,9 @@ def concurrent_db(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, str]:
     mock_store = MagicMock()
     mock_store.get_key.return_value = _TEST_KEY
 
-    db = Database(db_path, secret_store=mock_store, no_auto_upgrade=True)
+    db = Database(
+        db_path, secret_store=mock_store, no_auto_upgrade=True, read_only=False
+    )
     db.execute("CREATE TABLE IF NOT EXISTS ping (x INTEGER)")
     db.close()
 

--- a/tests/e2e/test_concurrent_access.py
+++ b/tests/e2e/test_concurrent_access.py
@@ -151,7 +151,7 @@ def test_write_write_contention_retries(
     mock_store = MagicMock()
     mock_store.get_key.return_value = key
 
-    with Database(db_path, secret_store=mock_store, no_auto_upgrade=True) as db:
+    with Database(db_path, read_only=False, secret_store=mock_store, no_auto_upgrade=True) as db:
         open("{signal_path}", "w").close()
         time.sleep(3)
     sys.exit(0)
@@ -183,7 +183,7 @@ def test_write_write_contention_retries(
 
     while time.monotonic() < deadline:
         try:
-            db = Database(db_path, secret_store=mock_store, no_auto_upgrade=True)
+            db = Database(db_path, read_only=False, secret_store=mock_store, no_auto_upgrade=True)
             break
         except DatabaseLockError as e:
             last_exc = e
@@ -286,7 +286,7 @@ def test_read_only_holder_blocks_write_then_succeeds(
 
     while time.monotonic() < deadline:
         try:
-            db = Database(db_path, secret_store=mock_store, no_auto_upgrade=True)
+            db = Database(db_path, read_only=False, secret_store=mock_store, no_auto_upgrade=True)
             break
         except DatabaseLockError as e:
             last_exc = e

--- a/tests/e2e/test_e2e_gsheet_lifecycle.py
+++ b/tests/e2e/test_e2e_gsheet_lifecycle.py
@@ -77,6 +77,7 @@ def lifecycle_db(tmp_path: Path) -> Generator[Database, None, None]:
         tmp_path / "gsheet-lifecycle.duckdb",
         secret_store=secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     try:
         yield db

--- a/tests/e2e/test_e2e_reports.py
+++ b/tests/e2e/test_e2e_reports.py
@@ -116,7 +116,12 @@ def reports_env(e2e_home: Path) -> Iterator[dict[str, str]]:
     # the original on exit so we don't leak the e2e key into other tests.
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr("moneybin.database._cached_encryption_key", None)
-        db = Database(db_path, secret_store=_FixedKeyStore(), no_auto_upgrade=True)  # pyright: ignore[reportArgumentType]  # minimal SecretStore stand-in
+        db = Database(
+            db_path,
+            secret_store=_FixedKeyStore(),  # pyright: ignore[reportArgumentType]  # minimal SecretStore stand-in
+            no_auto_upgrade=True,
+            read_only=False,
+        )
         try:
             db.execute("CREATE SCHEMA IF NOT EXISTS reports")
             for ddl in _STUB_VIEWS:

--- a/tests/integration/test_categorize_assist.py
+++ b/tests/integration/test_categorize_assist.py
@@ -28,7 +28,7 @@ def _make_secret_store() -> MagicMock:
 
 def _make_db(tmp_path: Path) -> tuple[Database, MagicMock]:
     store = _make_secret_store()
-    db = Database(tmp_path / "test.duckdb", secret_store=store)
+    db = Database(tmp_path / "test.duckdb", secret_store=store, read_only=False)
     return db, store
 
 

--- a/tests/integration/test_categorize_assist_cli.py
+++ b/tests/integration/test_categorize_assist_cli.py
@@ -31,7 +31,12 @@ def _make_secret_store() -> MagicMock:
 def _make_db_with_uncategorized(tmp_path: Path) -> tuple[Database, MagicMock]:
     """Test DB with two uncategorized transactions, no categorizations recorded."""
     store = _make_secret_store()
-    db = Database(tmp_path / "test.duckdb", secret_store=store, no_auto_upgrade=True)
+    db = Database(
+        tmp_path / "test.duckdb",
+        secret_store=store,
+        no_auto_upgrade=True,
+        read_only=False,
+    )
     db.execute(  # noqa: S608  # test input, not executing SQL
         """
         CREATE TABLE IF NOT EXISTS core.fct_transactions (

--- a/tests/integration/test_categorize_commit_cli.py
+++ b/tests/integration/test_categorize_commit_cli.py
@@ -62,7 +62,7 @@ def _seed_one_transaction(db: Database) -> str:
 def _make_db(tmp_path: Path) -> tuple[Database, MagicMock]:
     """Create a seeded test database and return (db, secret_store)."""
     store = _make_secret_store()
-    db = Database(tmp_path / "test.duckdb", secret_store=store)
+    db = Database(tmp_path / "test.duckdb", secret_store=store, read_only=False)
     return db, store
 
 

--- a/tests/integration/test_categorize_export_apply.py
+++ b/tests/integration/test_categorize_export_apply.py
@@ -38,7 +38,7 @@ def _make_db_with_uncategorized(
 ) -> tuple[Database, MagicMock]:
     """Create a seeded test database with uncategorized transactions."""
     store = _make_secret_store()
-    db = Database(tmp_path / "test.duckdb", secret_store=store)
+    db = Database(tmp_path / "test.duckdb", secret_store=store, read_only=False)
 
     db.execute(  # noqa: S608  # test input, not executing SQL
         """

--- a/tests/integration/test_categorize_run_cli.py
+++ b/tests/integration/test_categorize_run_cli.py
@@ -35,7 +35,12 @@ def _make_db(tmp_path: Path) -> tuple[Database, MagicMock]:
     the bare table the service reads from.
     """
     store = _make_secret_store()
-    db = Database(tmp_path / "test.duckdb", secret_store=store, no_auto_upgrade=True)
+    db = Database(
+        tmp_path / "test.duckdb",
+        secret_store=store,
+        no_auto_upgrade=True,
+        read_only=False,
+    )
     db.execute(
         """
         CREATE TABLE IF NOT EXISTS core.fct_transactions (

--- a/tests/integration/test_import_service_batch.py
+++ b/tests/integration/test_import_service_batch.py
@@ -26,7 +26,7 @@ def _make_secret_store() -> MagicMock:
 def _build_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Database:
     secret_store = _make_secret_store()
     db_path = tmp_path / "batch.duckdb"
-    db = Database(db_path, secret_store=secret_store)
+    db = Database(db_path, secret_store=secret_store, read_only=False)
     mock_settings = MagicMock()
     mock_settings.database.path = db_path
     monkeypatch.setattr("moneybin.database.get_settings", lambda: mock_settings)

--- a/tests/integration/test_integration_existing.py
+++ b/tests/integration/test_integration_existing.py
@@ -44,7 +44,7 @@ def mock_store(encryption_key: str) -> MagicMock:
 def encrypted_db(tmp_path: Path, mock_store: MagicMock) -> Database:
     """Real encrypted database with base schemas initialized."""
     db_path = tmp_path / "integration.duckdb"
-    db = Database(db_path, secret_store=mock_store)
+    db = Database(db_path, secret_store=mock_store, read_only=False)
     return db
 
 
@@ -117,7 +117,7 @@ class TestPassphraseRoundTrip:
         assert "DATABASE__ENCRYPTION_KEY" in keychain
 
         # Write some test data
-        db = Database(db_path, secret_store=fake_store)
+        db = Database(db_path, secret_store=fake_store, read_only=False)
         db.execute("CREATE TABLE raw.test_data (id INTEGER, val VARCHAR)")
         db.execute("INSERT INTO raw.test_data VALUES (1, 'hello')")
         db.close()
@@ -133,7 +133,7 @@ class TestPassphraseRoundTrip:
         assert "DATABASE__ENCRYPTION_KEY" in keychain
 
         # Step 4: Verify data is accessible
-        db2 = Database(db_path, secret_store=fake_store)
+        db2 = Database(db_path, secret_store=fake_store, read_only=False)
         try:
             row = db2.execute("SELECT val FROM raw.test_data WHERE id = 1").fetchone()
             assert row is not None
@@ -195,7 +195,7 @@ class TestKeyRotation:
         keychain["DATABASE__ENCRYPTION_KEY"] = initial_key
 
         # Create database and insert data
-        db = Database(db_path, secret_store=fake_store)
+        db = Database(db_path, secret_store=fake_store, read_only=False)
         db.execute("CREATE TABLE raw.test_data (id INTEGER, val VARCHAR)")
         db.execute("INSERT INTO raw.test_data VALUES (42, 'pre-rotation')")
         db.close()
@@ -210,7 +210,7 @@ class TestKeyRotation:
         assert len(new_key) == 64  # 32 bytes hex
 
         # Verify data is accessible with new key
-        db2 = Database(db_path, secret_store=fake_store)
+        db2 = Database(db_path, secret_store=fake_store, read_only=False)
         try:
             row = db2.execute("SELECT val FROM raw.test_data WHERE id = 42").fetchone()
             assert row is not None

--- a/tests/integration/test_mcp_import_files.py
+++ b/tests/integration/test_mcp_import_files.py
@@ -27,7 +27,7 @@ def _setup_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Build an encrypted test DB and patch get_database()/Path.home()."""
     secret_store = _make_secret_store()
     db_path = tmp_path / "mcp_files.duckdb"
-    Database(db_path, secret_store=secret_store).close()
+    Database(db_path, secret_store=secret_store, read_only=False).close()
 
     mock_settings = MagicMock()
     mock_settings.database.path = db_path

--- a/tests/integration/test_scenario_import_dim_freshness.py
+++ b/tests/integration/test_scenario_import_dim_freshness.py
@@ -32,7 +32,7 @@ def _secret_store() -> MagicMock:
 
 def _build_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Database:
     db_path = tmp_path / "dim_freshness.duckdb"
-    db = Database(db_path, secret_store=_secret_store())
+    db = Database(db_path, secret_store=_secret_store(), read_only=False)
     settings = MagicMock()
     settings.database.path = db_path
     monkeypatch.setattr("moneybin.database.get_settings", lambda: settings)

--- a/tests/integration/test_scenario_sync_dim_freshness.py
+++ b/tests/integration/test_scenario_sync_dim_freshness.py
@@ -45,7 +45,7 @@ def _secret_store() -> MagicMock:
 
 def _build_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Database:
     db_path = tmp_path / "sync_freshness.duckdb"
-    db = Database(db_path, secret_store=_secret_store())
+    db = Database(db_path, secret_store=_secret_store(), read_only=False)
     settings = MagicMock()
     settings.database.path = db_path
     monkeypatch.setattr("moneybin.database.get_settings", lambda: settings)

--- a/tests/integration/test_schema_drift.py
+++ b/tests/integration/test_schema_drift.py
@@ -38,7 +38,7 @@ def test_boot_check_runs_self_heal_under_real_sqlmesh(
     secret_store.get_key.return_value = "integration-test-key-0123456789abcdef"
 
     db_path = tmp_path / "drift.duckdb"
-    db = Database(db_path, secret_store=secret_store)
+    db = Database(db_path, secret_store=secret_store, read_only=False)
 
     # sqlmesh_context() reads get_settings().database.path to key the
     # adapter cache. Point it at this test DB so SQLMesh reuses the

--- a/tests/integration/test_tabular_description_regression.py
+++ b/tests/integration/test_tabular_description_regression.py
@@ -33,7 +33,7 @@ def test_tabular_import_preserves_description(
     secret_store.get_key.return_value = "integration-test-key-0123456789abcdef"
 
     db_path = tmp_path / "tabular_desc.duckdb"
-    db = Database(db_path, secret_store=secret_store)
+    db = Database(db_path, secret_store=secret_store, read_only=False)
 
     # get_settings().database.path is used by sqlmesh_context() to key the
     # adapter injection; point it at this test DB so SQLMesh reuses our

--- a/tests/moneybin/conftest.py
+++ b/tests/moneybin/conftest.py
@@ -150,6 +150,7 @@ def schema_catalog_db(
         tmp_path / "schema_catalog.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables_raw(database.conn)
     apply_core_table_comments(database)
@@ -289,7 +290,12 @@ def module_db(
     mock_store.get_key.return_value = "test-encryption-key-for-unit-tests"
 
     db_path = tmp_path_factory.mktemp("module_db") / "test.duckdb"
-    database = Database(db_path, secret_store=mock_store, no_auto_upgrade=True)
+    database = Database(
+        db_path,
+        secret_store=mock_store,
+        no_auto_upgrade=True,
+        read_only=False,
+    )
     yield database
     database.close()
 
@@ -354,6 +360,11 @@ def db(tmp_path: Path, mock_secret_store: MagicMock) -> Generator[Database, None
         A Database instance ready for test queries.
     """
     db_path = tmp_path / "test.duckdb"
-    database = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
+    database = Database(
+        db_path,
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
+    )
     yield database
     database.close()

--- a/tests/moneybin/matching/test_engine.py
+++ b/tests/moneybin/matching/test_engine.py
@@ -84,6 +84,7 @@ def db(tmp_path: Path, mock_secret_store: MagicMock) -> Generator[Database, None
         tmp_path / "test.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     yield database
     database.close()

--- a/tests/moneybin/matching/test_int_matched_model.py
+++ b/tests/moneybin/matching/test_int_matched_model.py
@@ -170,6 +170,7 @@ def matched_db(
         tmp_path / "test_matched.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     database.execute(_PREP_SCHEMA_DDL)
     database.execute(_UNIONED_STUB_DDL)

--- a/tests/moneybin/matching/test_manual_exemption.py
+++ b/tests/moneybin/matching/test_manual_exemption.py
@@ -25,6 +25,7 @@ def db(tmp_path: Path, mock_secret_store: MagicMock) -> Generator[Database, None
         tmp_path / "test.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     yield database
     database.close()

--- a/tests/moneybin/matching/test_matching_service.py
+++ b/tests/moneybin/matching/test_matching_service.py
@@ -26,6 +26,7 @@ def db(tmp_path: Path, mock_secret_store: MagicMock) -> Generator[Database, None
         tmp_path / "test.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     yield database
     database.close()

--- a/tests/moneybin/matching/test_persistence.py
+++ b/tests/moneybin/matching/test_persistence.py
@@ -34,6 +34,7 @@ def db(tmp_path: Path, mock_secret_store: MagicMock) -> Generator[Database, None
         tmp_path / "test.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     yield database
     database.close()

--- a/tests/moneybin/matching/test_priority.py
+++ b/tests/moneybin/matching/test_priority.py
@@ -18,6 +18,7 @@ def db(tmp_path: Path, mock_secret_store: MagicMock) -> Generator[Database, None
         tmp_path / "test.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     yield database
     database.close()

--- a/tests/moneybin/matching/test_scoring.py
+++ b/tests/moneybin/matching/test_scoring.py
@@ -22,6 +22,7 @@ def db(tmp_path: Path, mock_secret_store: MagicMock) -> Generator[Database, None
         tmp_path / "test.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     yield database
     database.close()

--- a/tests/moneybin/matching/test_transfer.py
+++ b/tests/moneybin/matching/test_transfer.py
@@ -112,6 +112,7 @@ def db(tmp_path: Path, mock_secret_store: MagicMock) -> Generator[Database, None
         tmp_path / "test.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     yield database
     database.close()

--- a/tests/moneybin/matching/test_transfer_integration.py
+++ b/tests/moneybin/matching/test_transfer_integration.py
@@ -24,6 +24,7 @@ def db(tmp_path: Path, mock_secret_store: MagicMock) -> Generator[Database, None
         tmp_path / "test.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     yield database
     database.close()

--- a/tests/moneybin/test_cli/_curation_helpers.py
+++ b/tests/moneybin/test_cli/_curation_helpers.py
@@ -26,6 +26,7 @@ def make_curation_db(tmp_path: Path) -> Database:
         tmp_path / "curation.duckdb",
         secret_store=mock_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables_raw(database.conn)
     database.conn.execute(

--- a/tests/moneybin/test_cli/test_import_command.py
+++ b/tests/moneybin/test_cli/test_import_command.py
@@ -16,7 +16,8 @@ runner = CliRunner()
 
 
 @contextmanager
-def _fake_db_ctx() -> Generator[object, None, None]:
+def _fake_db_ctx(read_only: bool = False) -> Generator[object, None, None]:
+    _ = read_only
     yield object()
 
 

--- a/tests/moneybin/test_cli/test_sql_command.py
+++ b/tests/moneybin/test_cli/test_sql_command.py
@@ -34,7 +34,12 @@ def seeded_db(tmp_path: Path) -> Generator[Database, None, None]:
     """A Database with core.* tables and one account row to mask."""
     store = MagicMock()
     store.get_key.return_value = "test-encryption-key-for-unit-tests"
-    db = Database(tmp_path / "sql_cli.duckdb", secret_store=store, no_auto_upgrade=True)
+    db = Database(
+        tmp_path / "sql_cli.duckdb",
+        secret_store=store,
+        no_auto_upgrade=True,
+        read_only=False,
+    )
     create_core_tables_raw(db.conn)
     apply_core_table_comments(db)
     create_core_dim_stub_views(db)

--- a/tests/moneybin/test_connectors/test_gsheet/conftest.py
+++ b/tests/moneybin/test_connectors/test_gsheet/conftest.py
@@ -18,7 +18,9 @@ def in_memory_db(
 ) -> Generator[Database, None, None]:
     """Test Database with the full base schema (raw + app + core scaffolding)."""
     db_path = tmp_path / "gsheet_test.duckdb"
-    database = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
+    database = Database(
+        db_path, secret_store=mock_secret_store, no_auto_upgrade=True, read_only=False
+    )
     yield database
     database.close()
 

--- a/tests/moneybin/test_database.py
+++ b/tests/moneybin/test_database.py
@@ -85,7 +85,12 @@ class TestDatabaseInit:
     ) -> None:
         """New database file is created and encrypted."""
         db_path = db_dir / "moneybin.duckdb"
-        db = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
+        db = Database(
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
+        )
         try:
             assert db_path.exists()
             mock_secret_store.get_key.assert_called_once_with(
@@ -101,7 +106,12 @@ class TestDatabaseInit:
         if sys.platform == "win32":
             pytest.skip("File permissions not enforced on Windows")
         db_path = db_dir / "moneybin.duckdb"
-        db = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
+        db = Database(
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
+        )
         try:
             mode = db_path.stat().st_mode & 0o777
             assert mode == 0o600
@@ -113,7 +123,12 @@ class TestDatabaseInit:
     ) -> None:
         """Database file cannot be opened without the encryption key."""
         db_path = db_dir / "moneybin.duckdb"
-        db = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
+        db = Database(
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
+        )
         db.execute("CREATE TABLE test_data (id INTEGER, name VARCHAR)")
         db.execute("INSERT INTO test_data VALUES (1, 'Alice')")
         db.close()
@@ -129,7 +144,12 @@ class TestDatabaseInit:
     ) -> None:
         """Schema initialization runs on first open."""
         db_path = db_dir / "moneybin.duckdb"
-        db = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
+        db = Database(
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
+        )
         try:
             # init_schemas creates the raw, core, and app schemas
             result = db.execute(
@@ -156,7 +176,7 @@ class TestDatabaseInit:
         store.get_key.side_effect = SecretNotFoundError("not found")
         db_path = db_dir / "moneybin.duckdb"
         with pytest.raises(DatabaseKeyError, match="encryption key"):
-            Database(db_path, secret_store=store)
+            Database(db_path, secret_store=store, read_only=False)
 
     def test_read_only_missing_file_does_not_consult_secret_store(
         self, db_dir: Path, monkeypatch: pytest.MonkeyPatch
@@ -183,7 +203,10 @@ class TestDatabaseOperations:
     ) -> Generator[Database, None, None]:
         db_path = db_dir / "moneybin.duckdb"
         database = Database(
-            db_path, secret_store=mock_secret_store, no_auto_upgrade=True
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
         )
         yield database
         database.close()
@@ -214,7 +237,12 @@ class TestDatabaseOperations:
     ) -> None:
         """After close(), conn access raises."""
         db_path = db_dir / "moneybin.duckdb"
-        db = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
+        db = Database(
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
+        )
         db.close()
         with pytest.raises(RuntimeError, match="closed"):
             _ = db.conn
@@ -229,7 +257,10 @@ class TestIngestDataframe:
     ) -> Generator[Database, None, None]:
         db_path = db_dir / "moneybin.duckdb"
         database = Database(
-            db_path, secret_store=mock_secret_store, no_auto_upgrade=True
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
         )
         database.execute(
             "CREATE TABLE test_items (id INTEGER, name VARCHAR, score DECIMAL(5,2))"
@@ -327,7 +358,10 @@ class TestRunSqlmeshMigrate:
     ) -> Generator[Database, None, None]:
         db_path = db_dir / "moneybin.duckdb"
         database = Database(
-            db_path, secret_store=mock_secret_store, no_auto_upgrade=True
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
         )
         yield database
         database.close()
@@ -433,7 +467,12 @@ class TestDatabaseReadOnly:
     ) -> None:
         db_path = tmp_path / "ro.duckdb"
         # Create a real DB first (write mode)
-        db = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
+        db = Database(
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
+        )
         db.close()
         # Open read-only; init_schemas should NOT be called
         mock_init = mocker.patch("moneybin.schema.init_schemas")
@@ -446,7 +485,10 @@ class TestDatabaseReadOnly:
     ) -> None:
         db_path = tmp_path / "rw.duckdb"
         with Database(
-            db_path, secret_store=mock_secret_store, no_auto_upgrade=True
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
         ) as db:
             db.execute("CREATE TABLE test_ro (id INTEGER)")
             db.execute("INSERT INTO test_ro VALUES (42)")
@@ -469,11 +511,21 @@ class TestEncryptionKeyCache:
         monkeypatch.setattr(db_module, "_cached_encryption_key", None)
         db_path = tmp_path / "cached.duckdb"
         # First open — calls store.get_key once
-        db1 = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
+        db1 = Database(
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
+        )
         db1.close()
         call_count_after_first = mock_secret_store.get_key.call_count
         # Second open — key is cached; store.get_key NOT called again
-        db2 = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
+        db2 = Database(
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
+        )
         db2.close()
         assert mock_secret_store.get_key.call_count == call_count_after_first
         # Cleanup cache
@@ -493,7 +545,12 @@ class TestActiveWriteSlot:
 
         monkeypatch.setattr(db_module, "_active_write_conn", None)
         db_path = tmp_path / "wslot.duckdb"
-        db = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
+        db = Database(
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
+        )
         # Manually register (get_database() will do this; testing close() cleanup)
         with db_module._active_write_lock:  # pyright: ignore[reportPrivateUsage]  # test-only: verify deregistration
             db_module._active_write_conn = db  # type: ignore[reportPrivateUsage]  # test-only
@@ -512,7 +569,12 @@ class TestActiveWriteSlot:
         other = MagicMock(name="other_conn")
         monkeypatch.setattr(db_module, "_active_write_conn", other)
         db_path = tmp_path / "wslot2.duckdb"
-        db = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
+        db = Database(
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
+        )
         db.close()
         # Some other conn was registered — our close() shouldn't clear it
         assert db_module._active_write_conn is other  # type: ignore[reportPrivateUsage]  # test-only
@@ -537,7 +599,12 @@ class TestSqlmeshContext:
         assert params[0] == "db", f"Expected first param to be 'db', got '{params[0]}'"
 
         db_path = tmp_path / "sqm.duckdb"
-        db = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
+        db = Database(
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
+        )
         # Verify the new signature doesn't raise TypeError — that's the key assertion.
         # We don't actually run SQLMesh (no config); just check the call shape.
         try:
@@ -575,9 +642,9 @@ class TestGetDatabaseNew:
         monkeypatch.setattr("moneybin.database.get_settings", lambda: mock_settings)
         monkeypatch.setattr("moneybin.database.SecretStore", lambda: mock_secret_store)
 
-        db1 = get_database()
+        db1 = get_database(read_only=False)
         db1.close()  # close before opening second to avoid DuckDB single-writer conflict
-        db2 = get_database()
+        db2 = get_database(read_only=False)
         assert db1 is not db2  # no singleton — each call creates a new instance
         db2.close()
 
@@ -621,7 +688,7 @@ class TestGetDatabaseNew:
             "moneybin.database.time.monotonic", iter([0.0, 0.1, 0.2, 1.0]).__next__
         )
 
-        db = get_database(max_wait=5.0)
+        db = get_database(read_only=False, max_wait=5.0)
         assert call_count == 3
         assert len(sleep_calls) == 2
         # Exponential backoff: 0.05 then 0.075
@@ -662,7 +729,7 @@ class TestGetDatabaseNew:
         monkeypatch.setattr("moneybin.database.time.sleep", lambda d: None)  # pyright: ignore[reportUnknownArgumentType, reportUnknownLambdaType]
 
         with pytest.raises(DatabaseLockError, match="Could not acquire"):
-            get_database(max_wait=5.0)
+            get_database(read_only=False, max_wait=5.0)
 
     def test_registers_active_write_conn(
         self,
@@ -683,7 +750,7 @@ class TestGetDatabaseNew:
         monkeypatch.setattr("moneybin.database.get_settings", lambda: mock_settings)
         monkeypatch.setattr("moneybin.database.SecretStore", lambda: mock_secret_store)
 
-        db = get_database()
+        db = get_database(read_only=False)
         assert db_module._active_write_conn is db  # pyright: ignore[reportPrivateUsage]
         db.close()
         assert db_module._active_write_conn is None  # pyright: ignore[reportPrivateUsage]
@@ -699,7 +766,12 @@ class TestGetDatabaseNew:
         # First create the DB in write mode
         db_path = tmp_path / "ro_slot.duckdb"
         monkeypatch.setattr(db_module, "_cached_encryption_key", None)
-        Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True).close()
+        Database(
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
+        ).close()
 
         monkeypatch.setattr(db_module, "_active_write_conn", None)
         monkeypatch.setattr(db_module, "_database_accessed", False)
@@ -785,7 +857,10 @@ class TestDatabaseIntegration:
         db_path = tmp_path / "int_ro.duckdb"
         # Create DB and add data
         with Database(
-            db_path, secret_store=mock_secret_store, no_auto_upgrade=True
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
         ) as db:
             db.execute("CREATE TABLE test_int (id INTEGER, val VARCHAR)")
             db.execute("INSERT INTO test_int VALUES (1, 'hello')")
@@ -801,12 +876,18 @@ class TestDatabaseIntegration:
         """Write connection writes; subsequent read-only connection sees the change."""
         db_path = tmp_path / "int_rw.duckdb"
         with Database(
-            db_path, secret_store=mock_secret_store, no_auto_upgrade=True
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
         ) as db:
             db.execute("CREATE TABLE tracked (n INTEGER)")
 
         with Database(
-            db_path, secret_store=mock_secret_store, no_auto_upgrade=True
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
         ) as db:
             db.execute("INSERT INTO tracked VALUES (42)")
 
@@ -819,18 +900,31 @@ class TestDatabaseIntegration:
     ) -> None:
         """After 'with Database(...) as db: pass', opening a new write connection succeeds."""
         db_path = tmp_path / "int_ctx.duckdb"
-        with Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True):
+        with Database(
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
+        ):
             pass
 
         # Open and close via context manager
         with Database(
-            db_path, secret_store=mock_secret_store, no_auto_upgrade=True
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
         ) as db1:
             pass
         assert db1._closed  # pyright: ignore[reportPrivateUsage]
 
         # Second write connection opens immediately (no lock held)
-        db2 = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
+        db2 = Database(
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
+        )
         db2.close()
 
     def test_read_only_on_missing_file_raises_not_initialized(

--- a/tests/moneybin/test_database_interrupt.py
+++ b/tests/moneybin/test_database_interrupt.py
@@ -16,7 +16,10 @@ def test_interrupt_and_reset_calls_interrupt_then_closes(
     tmp_path: Path, mock_secret_store: MagicMock
 ) -> None:
     db = Database(
-        tmp_path / "t.duckdb", secret_store=mock_secret_store, no_auto_upgrade=True
+        tmp_path / "t.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     real_conn = db._conn  # pyright: ignore[reportPrivateUsage]
     assert real_conn is not None
@@ -36,7 +39,10 @@ def test_module_helper_fires_on_active_write_conn(
 ) -> None:
     monkeypatch.setattr(db_module, "_active_write_conn", None)
     db = Database(
-        tmp_path / "t2.duckdb", secret_store=mock_secret_store, no_auto_upgrade=True
+        tmp_path / "t2.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     # Register as active write conn
     with db_module._active_write_lock:  # pyright: ignore[reportPrivateUsage]

--- a/tests/moneybin/test_dedup_integration.py
+++ b/tests/moneybin/test_dedup_integration.py
@@ -28,6 +28,7 @@ def db(tmp_path: Path, mock_secret_store: MagicMock) -> Generator[Database, None
         tmp_path / "test.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     yield database
     database.close()

--- a/tests/moneybin/test_mcp/conftest.py
+++ b/tests/moneybin/test_mcp/conftest.py
@@ -41,7 +41,10 @@ def _mcp_db_template(  # pyright: ignore[reportUnusedFunction]  # pytest fixture
     template_path = template_dir / "template.duckdb"
 
     database = Database(
-        template_path, secret_store=_make_mock_store(), no_auto_upgrade=True
+        template_path,
+        secret_store=_make_mock_store(),
+        no_auto_upgrade=True,
+        read_only=False,
     )
     conn = database.conn
     create_core_tables_raw(conn)

--- a/tests/moneybin/test_mcp/conftest.py
+++ b/tests/moneybin/test_mcp/conftest.py
@@ -104,10 +104,10 @@ def mcp_db(
     a connection open during test body execution.
 
     Tests that need per-test setup (INSERTs, CREATE VIEW, etc.) must use the
-    ``get_database()`` context manager and close it before calling any MCP
-    tool:
+    ``get_database(read_only=False)`` context manager and close it before
+    calling any MCP tool:
 
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             db.execute("INSERT ...")
         result = await some_tool()
     """

--- a/tests/moneybin/test_mcp/test_accounts.py
+++ b/tests/moneybin/test_mcp/test_accounts.py
@@ -37,7 +37,7 @@ def _seed_named_account(
     ACC001/ACC002 with display_name=NULL, so resolve tests need to seed their
     own rows to exercise display_name and institution_name matches.
     """
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         db.execute(
             """
             INSERT INTO core.dim_accounts (
@@ -133,7 +133,9 @@ class TestAccountsResolve:
         empty_path = tmp_path / "empty.duckdb"
 
         # Set up an empty DB at the path
-        empty = Database(empty_path, secret_store=store, no_auto_upgrade=True)
+        empty = Database(
+            empty_path, secret_store=store, no_auto_upgrade=True, read_only=False
+        )
         create_core_tables_raw(empty.conn)
         empty.close()
 

--- a/tests/moneybin/test_mcp/test_categorization_tools.py
+++ b/tests/moneybin/test_mcp/test_categorization_tools.py
@@ -97,12 +97,12 @@ class TestCategorySetWritePath:
 
     @pytest.mark.unit
     async def test_set_default_category_writes_override(self, mcp_db: Path) -> None:
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             seed_categories_view(db)
 
         await categories_set(category_id="FND", is_active=False)
 
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             rows = db.execute(
                 "SELECT category_id, is_active FROM app.category_overrides"
             ).fetchall()
@@ -112,7 +112,7 @@ class TestCategorySetWritePath:
     async def test_set_user_category_updates_user_categories(
         self, mcp_db: Path
     ) -> None:
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             seed_categories_view(db)
             db.execute("""
                 INSERT INTO app.user_categories
@@ -122,7 +122,7 @@ class TestCategorySetWritePath:
 
         await categories_set(category_id="CUSTOM1", is_active=False)
 
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             rows = db.execute(
                 "SELECT is_active FROM app.user_categories WHERE category_id = ?",
                 ["CUSTOM1"],
@@ -140,7 +140,7 @@ class TestCategoriesDeleteTool:
 
     @pytest.mark.unit
     async def test_deletes_unreferenced_user_category(self, mcp_db: Path) -> None:
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             db.execute(
                 "INSERT INTO app.user_categories "
                 "(category_id, category, subcategory, is_active) "
@@ -161,7 +161,7 @@ class TestCategoriesDeleteTool:
 
     @pytest.mark.unit
     async def test_default_category_returns_error_envelope(self, mcp_db: Path) -> None:
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             seed_categories_view(db)
         envelope = (await categories_delete(category_id="FND")).to_dict()
         assert envelope["status"] == "error"
@@ -171,7 +171,7 @@ class TestCategoriesDeleteTool:
     async def test_force_cascade_clears_transaction_reference(
         self, mcp_db: Path
     ) -> None:
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             db.execute(
                 "INSERT INTO app.user_categories "
                 "(category_id, category, subcategory, is_active) "
@@ -235,7 +235,7 @@ class TestTransactionsCategorizeCommit:
         self, mcp_db: Path
     ) -> None:
         """Commit tool accepts items and writes categorizations."""
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             db.execute(
                 """
                 INSERT INTO core.fct_transactions
@@ -292,7 +292,7 @@ class TestCategorizePendingSortParam:
 
     @staticmethod
     def _install_view_with_transactions() -> None:
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             db.execute("CREATE SCHEMA IF NOT EXISTS reports")
             db.execute("""
                 CREATE OR REPLACE VIEW reports.uncategorized_queue AS

--- a/tests/moneybin/test_mcp/test_curation_tools.py
+++ b/tests/moneybin/test_mcp/test_curation_tools.py
@@ -50,7 +50,7 @@ def _seed_transaction(
     Opens and closes its own write connection so callers don't hold an open
     connection when the MCP tool runs.
     """
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         db.execute(
             """
             INSERT INTO core.fct_transactions (
@@ -79,7 +79,7 @@ def _seed_transaction(
 
 def _seed_import(import_id: str = "IMP_TEST_001") -> str:
     """Insert one raw.import_log row that import_labels_set can attach to."""
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         db.execute(
             """
             INSERT INTO raw.import_log (
@@ -221,7 +221,7 @@ class TestTagsSetAndRename:
         # one tag.remove for 'a' (round 2). Round 3 is a no-op.
         # target_id is the row PK ("TXN_TAG_1:<tag>", row-grain cascade), so filter
         # by action + the transaction prefix rather than an exact target_id match.
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             events = AuditService(db).list_events(action_pattern="tag.%", limit=100)
         for_txn = [e for e in events if (e.target_id or "").startswith("TXN_TAG_1:")]
         adds = [e for e in for_txn if e.action == "tag.add"]

--- a/tests/moneybin/test_mcp/test_sql_query_lineage.py
+++ b/tests/moneybin/test_mcp/test_sql_query_lineage.py
@@ -28,7 +28,7 @@ def _run(sql: str) -> ResponseEnvelope[Any]:
 @pytest.fixture()
 def _seeded_txn(mcp_db: object) -> None:  # type: ignore[type-arg]
     """Insert one transaction row so amount-based tests have data."""
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         db.execute("""
             INSERT INTO core.fct_transactions
                 (transaction_id, account_id, transaction_date, amount,
@@ -152,7 +152,7 @@ def test_truncation_sets_has_more(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When results exceed the row cap, has_more is true and total_count > returned."""
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         db.execute("""
             INSERT INTO core.fct_transactions
                 (transaction_id, account_id, transaction_date, amount,

--- a/tests/moneybin/test_mcp/test_system_status_gsheet.py
+++ b/tests/moneybin/test_mcp/test_system_status_gsheet.py
@@ -25,7 +25,7 @@ def _insert_connection(
 ) -> None:
     """Insert a connection row directly (bypasses audited repo for test speed)."""
     spreadsheet_id = spreadsheet_id or f"ss_{connection_id}"
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         db.execute(
             """
             INSERT INTO app.gsheet_connections (

--- a/tests/moneybin/test_mcp/test_system_status_transforms.py
+++ b/tests/moneybin/test_mcp/test_system_status_transforms.py
@@ -16,7 +16,7 @@ def _seed_pending_import(import_id: str = "IMP_PENDING_001") -> None:
     triggers pending. Seed a raw.ofx_accounts row with a future
     extracted_at so the new signal fires.
     """
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         db.execute(
             """
             INSERT INTO raw.import_log (
@@ -82,7 +82,7 @@ async def test_system_status_surfaces_schema_drift_when_columns_missing(
     mcp_db: object,
 ) -> None:
     """schema_drift block lists missing columns when drift is detected."""
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         db.execute("ALTER TABLE core.dim_accounts DROP COLUMN display_name")
     env = await system_status()
     data = env.to_dict()["data"]
@@ -96,7 +96,7 @@ async def test_system_status_surfaces_schema_drift_when_columns_missing(
 @pytest.mark.unit
 async def test_system_status_action_hint_for_schema_drift(mcp_db: object) -> None:
     """Actions array includes a refresh remediation hint when drift detected."""
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         db.execute("ALTER TABLE core.dim_accounts DROP COLUMN display_name")
     env = await system_status()
     actions = env.to_dict()["actions"]
@@ -109,7 +109,7 @@ def test_check_schema_at_boot_self_heals_drift(mcp_db: object, mocker: object) -
     from moneybin.mcp.server import check_schema_at_boot
     from moneybin.services.transform_service import ApplyResult, TransformService
 
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         db.execute("ALTER TABLE core.dim_accounts DROP COLUMN display_name")
 
     def _fake_apply(svc: TransformService) -> ApplyResult:
@@ -133,7 +133,7 @@ def test_check_schema_at_boot_raises_when_heal_does_not_resolve(
     from moneybin.mcp.server import check_schema_at_boot
     from moneybin.services.transform_service import ApplyResult, TransformService
 
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         db.execute("ALTER TABLE core.dim_accounts DROP COLUMN display_name")
 
     def _fake_apply(svc: TransformService) -> ApplyResult:
@@ -154,7 +154,7 @@ def test_check_schema_at_boot_propagates_apply_failure(
     from moneybin.mcp.server import check_schema_at_boot
     from moneybin.services.transform_service import ApplyResult, TransformService
 
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         db.execute("ALTER TABLE core.dim_accounts DROP COLUMN display_name")
 
     def _failing_apply(svc: TransformService) -> ApplyResult:

--- a/tests/moneybin/test_mcp/test_system_tools.py
+++ b/tests/moneybin/test_mcp/test_system_tools.py
@@ -155,7 +155,7 @@ async def test_system_doctor_orphan_state_emits_executable_actions(
     from moneybin.database import get_database
     from moneybin.mcp.tools.system import system_doctor
 
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         db.execute(
             "INSERT INTO app.transaction_notes "  # noqa: S608  # test input
             "(note_id, transaction_id, text, author) "
@@ -195,7 +195,7 @@ def _make_tag_op(tag: str = "trip") -> str:
     from moneybin.repositories.transaction_tags_repo import TransactionTagsRepo
     from moneybin.services.mutation_context import operation
 
-    with get_database() as db, operation() as op:
+    with get_database(read_only=False) as db, operation() as op:
         TransactionTagsRepo(db).add(transaction_id="txn_1", tag=tag, actor="cli")
     return op
 
@@ -206,7 +206,7 @@ def _make_note_op() -> str:
     from moneybin.repositories.transaction_notes_repo import TransactionNotesRepo
     from moneybin.services.mutation_context import operation
 
-    with get_database() as db, operation() as op:
+    with get_database(read_only=False) as db, operation() as op:
         TransactionNotesRepo(db).add(
             transaction_id="txn_1", note_id="n1", text="hi", actor="cli"
         )
@@ -222,7 +222,7 @@ def _make_note_edit_op() -> str:
     from moneybin.repositories.transaction_notes_repo import TransactionNotesRepo
     from moneybin.services.mutation_context import operation
 
-    with get_database() as db, operation() as op:
+    with get_database(read_only=False) as db, operation() as op:
         TransactionNotesRepo(db).edit(note_id="n1", text="edited", actor="cli")
     return op
 
@@ -351,7 +351,7 @@ async def test_audit_get_hint_distinguishes_unresolvable(mcp_db: object) -> None
     from moneybin.services.audit_service import AuditService
     from moneybin.services.mutation_context import operation
 
-    with get_database() as db, operation() as op:
+    with get_database(read_only=False) as db, operation() as op:
         AuditService(db).record_audit_event(
             action="manual.create",
             target=("raw", "manual_transactions", "imp_1"),
@@ -375,7 +375,7 @@ async def test_audit_get_hint_for_marker_only(mcp_db: object) -> None:
     from moneybin.services.audit_service import AuditService
     from moneybin.services.mutation_context import operation
 
-    with get_database() as db, operation() as op:
+    with get_database(read_only=False) as db, operation() as op:
         AuditService(db).record_audit_event(
             action="tag.rename",
             target=("app", "transaction_tags", None),

--- a/tests/moneybin/test_mcp/test_tool_timeouts.py
+++ b/tests/moneybin/test_mcp/test_tool_timeouts.py
@@ -194,13 +194,20 @@ async def test_back_to_back_call_after_timeout_succeeds(
 
     # Create the test DB once — quick_tool will open fresh connections to it.
     db_path = tmp_path / "t.duckdb"
-    Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True).close()
+    Database(
+        db_path, secret_store=mock_secret_store, no_auto_upgrade=True, read_only=False
+    ).close()
 
     from contextlib import contextmanager
 
     @contextmanager
     def _fake_get_database(read_only: bool = False, **_: object):  # type: ignore[misc]
-        conn = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
+        conn = Database(
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
+        )
         if not read_only:
             with db_module._active_write_lock:  # pyright: ignore[reportPrivateUsage]
                 db_module._active_write_conn = conn  # pyright: ignore[reportPrivateUsage]

--- a/tests/moneybin/test_mcp/test_tools.py
+++ b/tests/moneybin/test_mcp/test_tools.py
@@ -105,7 +105,7 @@ class TestToolRegistration:
     @pytest.mark.unit
     async def test_sql_query_returns_envelope(self, mcp_db: Path) -> None:
 
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             db.conn.execute(_INSERT_TRANSACTIONS)
 
         # Also exercise registration to ensure no smoke errors.

--- a/tests/moneybin/test_mcp/test_transactions_tools.py
+++ b/tests/moneybin/test_mcp/test_transactions_tools.py
@@ -80,7 +80,7 @@ async def test_matches_pending_component_key_present(mcp_db: object) -> None:
     import json
     from datetime import UTC, datetime
 
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         for match_id, stid_a, stype_a, stid_b, stype_b, acct in [
             ("mc_ab", "t1", "csv", "t2", "ofx", "ACC001"),
             ("mc_bc", "t2", "ofx", "t3", "tiller", "ACC001"),
@@ -149,7 +149,7 @@ async def test_matches_pending_dedup_group_count_zero_for_transfer_scope(
     import json
     from datetime import UTC, datetime
 
-    with get_database() as db:
+    with get_database(read_only=False) as db:
         db.execute(
             """
             INSERT INTO app.match_decisions (

--- a/tests/moneybin/test_mcp/test_v1_tools.py
+++ b/tests/moneybin/test_mcp/test_v1_tools.py
@@ -33,7 +33,7 @@ class TestCategorizePendingGet:
 
     @staticmethod
     def _install_view() -> None:
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             _create_reports_schema(db)
             db.conn.execute("""
                 CREATE OR REPLACE VIEW reports.uncategorized_queue AS
@@ -100,7 +100,7 @@ class TestCategorizePendingGet:
     @staticmethod
     def _install_resolver_accounts() -> None:
         """Add display_name / collision-pair rows to core.dim_accounts."""
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             db.conn.execute("""
                 INSERT INTO core.dim_accounts
                     (account_id, source_type, display_name, archived)
@@ -116,7 +116,7 @@ class TestCategorizePendingGet:
         # The resolver must translate "Alpha" → "A1" before binding to SQL.
         self._install_view()
         self._install_resolver_accounts()
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             db.conn.execute("""
                 CREATE OR REPLACE VIEW reports.uncategorized_queue AS
                 SELECT
@@ -171,7 +171,7 @@ class TestCategorizePendingGet:
         # Pre-first-import case: drop fct_transactions so the resolver can
         # tell "no data yet" apart from "schema drift". Returns empty data
         # with an "import first" action hint, not an error.
-        with get_database() as db:
+        with get_database(read_only=False) as db:
             db.conn.execute("DROP TABLE core.fct_transactions")
         result = await transactions_categorize_pending()
         parsed = result.to_dict()

--- a/tests/moneybin/test_migrations.py
+++ b/tests/moneybin/test_migrations.py
@@ -543,7 +543,9 @@ class TestAutoUpgrade:
         with patch(
             "moneybin.database.importlib.metadata.version", return_value="1.0.0"
         ):
-            database = Database(db_path, secret_store=mock_secret_store)
+            database = Database(
+                db_path, secret_store=mock_secret_store, read_only=False
+            )
         try:
             row = database.execute(
                 "SELECT version FROM app.versions WHERE component = 'moneybin'"
@@ -562,14 +564,14 @@ class TestAutoUpgrade:
         with patch(
             "moneybin.database.importlib.metadata.version", return_value="1.0.0"
         ):
-            db1 = Database(db_path, secret_store=mock_secret_store)
+            db1 = Database(db_path, secret_store=mock_secret_store, read_only=False)
             db1.close()
 
         # Second init at version 2.0.0 — should trigger migration sequence
         with patch(
             "moneybin.database.importlib.metadata.version", return_value="2.0.0"
         ):
-            db2 = Database(db_path, secret_store=mock_secret_store)
+            db2 = Database(db_path, secret_store=mock_secret_store, read_only=False)
         try:
             row = db2.execute(
                 "SELECT version, previous_version FROM app.versions "
@@ -596,7 +598,7 @@ class TestAutoUpgrade:
         with patch(
             "moneybin.database.importlib.metadata.version", return_value="1.0.0"
         ):
-            db1 = Database(db_path, secret_store=mock_secret_store)
+            db1 = Database(db_path, secret_store=mock_secret_store, read_only=False)
             # Simulate "a migration was never recorded" by deleting one applied
             # row from schema_migrations. On next open the runner.pending()
             # check should re-apply it without any version bump.
@@ -616,7 +618,7 @@ class TestAutoUpgrade:
         with patch(
             "moneybin.database.importlib.metadata.version", return_value="1.0.0"
         ):
-            db2 = Database(db_path, secret_store=mock_secret_store)
+            db2 = Database(db_path, secret_store=mock_secret_store, read_only=False)
         try:
             count = db2.execute(
                 "SELECT COUNT(*) FROM app.schema_migrations WHERE version = ?",
@@ -645,7 +647,9 @@ class TestAutoUpgrade:
             patch("moneybin.database.importlib.metadata.version", return_value="1.0.0"),
             patch("moneybin.database.get_settings", return_value=mock_settings),
         ):
-            database = Database(db_path, secret_store=mock_secret_store)
+            database = Database(
+                db_path, secret_store=mock_secret_store, read_only=False
+            )
         try:
             row = database.execute(
                 "SELECT COUNT(*) FROM app.versions WHERE component = 'moneybin'"

--- a/tests/moneybin/test_reports/conftest.py
+++ b/tests/moneybin/test_reports/conftest.py
@@ -23,7 +23,12 @@ def reports_db(tmp_path: Path) -> Generator[Database, None, None]:
     """A Database with classified core tables and a reports.* test view."""
     store = MagicMock()
     store.get_key.return_value = "test-encryption-key-for-unit-tests"
-    db = Database(tmp_path / "reports.duckdb", secret_store=store, no_auto_upgrade=True)
+    db = Database(
+        tmp_path / "reports.duckdb",
+        secret_store=store,
+        no_auto_upgrade=True,
+        read_only=False,
+    )
     create_core_tables_raw(db.conn)
     db.execute(
         """

--- a/tests/moneybin/test_schema.py
+++ b/tests/moneybin/test_schema.py
@@ -22,7 +22,9 @@ def test_init_does_not_fail_when_existing_table_missing_new_columns(
     """
     db_path = tmp_path / "moneybin.duckdb"
 
-    db = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
+    db = Database(
+        db_path, secret_store=mock_secret_store, no_auto_upgrade=True, read_only=False
+    )
     try:
         db.execute("ALTER TABLE raw.ofx_institutions DROP COLUMN import_id")
         db.execute("ALTER TABLE raw.ofx_institutions DROP COLUMN source_type")
@@ -30,7 +32,9 @@ def test_init_does_not_fail_when_existing_table_missing_new_columns(
     finally:
         db.close()
 
-    db2 = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=False)
+    db2 = Database(
+        db_path, secret_store=mock_secret_store, no_auto_upgrade=False, read_only=False
+    )
     try:
         cols = {
             row[0]
@@ -58,7 +62,9 @@ def test_init_does_not_fail_when_proposed_rules_missing_rule_id(
     """
     db_path = tmp_path / "moneybin.duckdb"
 
-    db = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=True)
+    db = Database(
+        db_path, secret_store=mock_secret_store, no_auto_upgrade=True, read_only=False
+    )
     try:
         # DuckDB refuses ALTER ... DROP COLUMN while any index exists on
         # the table, so drop both indexes; the schema file recreates the
@@ -70,7 +76,9 @@ def test_init_does_not_fail_when_proposed_rules_missing_rule_id(
     finally:
         db.close()
 
-    db2 = Database(db_path, secret_store=mock_secret_store, no_auto_upgrade=False)
+    db2 = Database(
+        db_path, secret_store=mock_secret_store, no_auto_upgrade=False, read_only=False
+    )
     try:
         cols = {
             row[0]

--- a/tests/moneybin/test_services/test_account_service.py
+++ b/tests/moneybin/test_services/test_account_service.py
@@ -92,6 +92,7 @@ def account_db(tmp_path: Path) -> Generator[Database, None, None]:
         tmp_path / "test.duckdb",
         secret_store=mock_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     conn = database.conn
     create_core_tables_raw(conn)
@@ -243,6 +244,7 @@ def test_db(
         tmp_path / "test.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables(database)
     database.execute(
@@ -289,6 +291,7 @@ class TestEmptyResults:
             tmp_path / "test.duckdb",
             secret_store=mock_store,
             no_auto_upgrade=True,
+            read_only=False,
         )
         create_core_tables_raw(database.conn)
         yield database
@@ -555,6 +558,7 @@ def extended_db(
         tmp_path / "extended_test.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables(database)
     try:

--- a/tests/moneybin/test_services/test_auto_rule_service.py
+++ b/tests/moneybin/test_services/test_auto_rule_service.py
@@ -81,7 +81,10 @@ def real_db(tmp_path: Path) -> Generator[Database, None, None]:
     mock_store = MagicMock()
     mock_store.get_key.return_value = "test-key"
     db = Database(
-        tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables(db)
     yield db

--- a/tests/moneybin/test_services/test_balance_service.py
+++ b/tests/moneybin/test_services/test_balance_service.py
@@ -31,6 +31,7 @@ def assertion_db(
         tmp_path / "assertion_test.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables(database)
     database.execute(

--- a/tests/moneybin/test_services/test_budget_service.py
+++ b/tests/moneybin/test_services/test_budget_service.py
@@ -33,6 +33,7 @@ def budget_db(tmp_path: Path) -> Generator[Database, None, None]:
         tmp_path / "test.duckdb",
         secret_store=mock_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     conn = database.conn
     create_core_tables_raw(conn)

--- a/tests/moneybin/test_services/test_categorization_audit.py
+++ b/tests/moneybin/test_services/test_categorization_audit.py
@@ -26,7 +26,10 @@ def db(tmp_path: Path) -> Database:
     mock_store = MagicMock()
     mock_store.get_key.return_value = "test-key"
     database = Database(
-        tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables(database)
     return database

--- a/tests/moneybin/test_services/test_categorization_service.py
+++ b/tests/moneybin/test_services/test_categorization_service.py
@@ -72,7 +72,10 @@ def db(tmp_path: Path) -> Database:
     mock_store = MagicMock()
     mock_store.get_key.return_value = "test-encryption-key-for-tests"
     database = Database(
-        tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     # Core tables are managed by SQLMesh in production; create concrete
     # tables here so tests can INSERT fixture data directly.
@@ -638,7 +641,10 @@ def real_db(tmp_path: Path) -> Database:
     mock_store = MagicMock()
     mock_store.get_key.return_value = "test-key"
     db = Database(
-        tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables(db)
     return db
@@ -892,6 +898,7 @@ def test_categorize_items_uses_constant_number_of_db_calls(
         tmp_path / "perf.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables(db)
     # Seed 25 transactions and 25 corresponding category items.
@@ -950,6 +957,7 @@ def test_categorize_items_dedupes_merchant_creation_within_batch(
         tmp_path / "dedup.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables(db)
     for i in range(3):
@@ -1089,7 +1097,10 @@ def db_with_uncategorized_txns(
 ) -> Database:
     """Database seeded with 10 uncategorized transactions in core.fct_transactions."""
     db = Database(
-        tmp_path / "assist.duckdb", secret_store=mock_secret_store, no_auto_upgrade=True
+        tmp_path / "assist.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables(db)
     descriptions = [

--- a/tests/moneybin/test_services/test_categorization_service_writes.py
+++ b/tests/moneybin/test_services/test_categorization_service_writes.py
@@ -28,7 +28,10 @@ def db(tmp_path: Path) -> Database:
     mock_store = MagicMock()
     mock_store.get_key.return_value = "test-key"
     database = Database(
-        tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables(database)
     return database

--- a/tests/moneybin/test_services/test_categorization_updated_at.py
+++ b/tests/moneybin/test_services/test_categorization_updated_at.py
@@ -23,7 +23,10 @@ def db(tmp_path: Path) -> Database:
     mock_store = MagicMock()
     mock_store.get_key.return_value = "test-key"
     database = Database(
-        tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables(database)
     return database

--- a/tests/moneybin/test_services/test_doctor_service.py
+++ b/tests/moneybin/test_services/test_doctor_service.py
@@ -83,6 +83,7 @@ def doctor_db(tmp_path: Path) -> Generator[Database, None, None]:
         tmp_path / "doctor.duckdb",
         secret_store=mock_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables(database)
     # Seed one valid account and two transactions (both resolve)

--- a/tests/moneybin/test_services/test_exemplar_accumulator.py
+++ b/tests/moneybin/test_services/test_exemplar_accumulator.py
@@ -28,7 +28,10 @@ def real_db(tmp_path: Path) -> Database:
     mock_store = MagicMock()
     mock_store.get_key.return_value = "test-key"
     db = Database(
-        tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables(db)
     return db

--- a/tests/moneybin/test_services/test_import_service.py
+++ b/tests/moneybin/test_services/test_import_service.py
@@ -22,6 +22,7 @@ def db(tmp_path: Path) -> Generator[Database, None, None]:
         tmp_path / "labels.duckdb",
         secret_store=mock_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     yield database
     database.close()

--- a/tests/moneybin/test_services/test_source_precedence.py
+++ b/tests/moneybin/test_services/test_source_precedence.py
@@ -32,7 +32,10 @@ def real_db(tmp_path: Path) -> Database:
     mock_store = MagicMock()
     mock_store.get_key.return_value = "test-key"
     db = Database(
-        tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables(db)
     return db

--- a/tests/moneybin/test_services/test_spending_service.py
+++ b/tests/moneybin/test_services/test_spending_service.py
@@ -23,7 +23,10 @@ def empty_db(tmp_path: Path) -> Generator[Database, None, None]:
     mock_store = MagicMock()
     mock_store.get_key.return_value = "test-encryption-key-256bit-placeholder"
     database = Database(
-        tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables_raw(database.conn)
     yield database
@@ -36,7 +39,10 @@ def spending_db(tmp_path: Path) -> Generator[Database, None, None]:
     mock_store = MagicMock()
     mock_store.get_key.return_value = "test-encryption-key-256bit-placeholder"
     database = Database(
-        tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     conn = database.conn
     create_core_tables_raw(conn)

--- a/tests/moneybin/test_services/test_system_service.py
+++ b/tests/moneybin/test_services/test_system_service.py
@@ -40,6 +40,7 @@ def system_db(tmp_path: Path) -> Generator[Database, None, None]:
         tmp_path / "test.duckdb",
         secret_store=mock_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     conn = database.conn
     create_core_tables_raw(conn)
@@ -118,6 +119,7 @@ def test_status_date_range_empty_db(tmp_path: Path) -> None:
         tmp_path / "empty.duckdb",
         secret_store=mock_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables_raw(database.conn)
     try:
@@ -223,6 +225,7 @@ def test_status_transforms_pending_when_raw_newer_than_dim(
         tmp_path / "pending.duckdb",
         secret_store=mock_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     try:
         create_core_tables_raw(database.conn)
@@ -247,6 +250,7 @@ def test_status_transforms_not_pending_after_apply(tmp_path: Path) -> None:
         tmp_path / "fresh.duckdb",
         secret_store=mock_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     try:
         create_core_tables_raw(database.conn)
@@ -272,6 +276,7 @@ def test_status_transforms_pending_false_with_no_imports(tmp_path: Path) -> None
         tmp_path / "empty.duckdb",
         secret_store=mock_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     try:
         # No core.dim_accounts and no imports → freshness returns pending=False.

--- a/tests/moneybin/test_services/test_tabular_import_service.py
+++ b/tests/moneybin/test_services/test_tabular_import_service.py
@@ -124,6 +124,7 @@ def test_resolve_account_via_matcher_uses_existing_id_on_match(
         tmp_path / "match.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     try:
         db.execute("""
@@ -157,6 +158,7 @@ def test_resolve_account_via_matcher_creates_new_when_no_candidates(
         tmp_path / "new.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     try:
         # Confirm the table exists so this exercises the empty-table path,
@@ -185,6 +187,7 @@ def test_resolve_account_via_matcher_auto_accepts_top_candidate(
         tmp_path / "fuzzy.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     try:
         db.execute("""
@@ -220,6 +223,7 @@ def test_resolve_account_via_matcher_warns_and_falls_back_when_not_auto(
         tmp_path / "fuzzy2.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     try:
         db.execute("""
@@ -263,6 +267,7 @@ class TestTabularConfirmationFlow:
             tmp_path / "conf_flow.duckdb",
             secret_store=mock_secret_store,
             no_auto_upgrade=True,
+            read_only=False,
         )
 
     def test_low_confidence_raises_confirmation_required(

--- a/tests/moneybin/test_services/test_transaction_get.py
+++ b/tests/moneybin/test_services/test_transaction_get.py
@@ -24,7 +24,10 @@ def txn_db(tmp_path: Path) -> Generator[Database, None, None]:
     mock_store = MagicMock()
     mock_store.get_key.return_value = "test-encryption-key-256bit-placeholder"
     database = Database(
-        tmp_path / "test.duckdb", secret_store=mock_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     conn = database.conn
     create_core_tables_raw(conn)
@@ -248,7 +251,10 @@ class TestTransactionGet:
         mock_store = MagicMock()
         mock_store.get_key.return_value = "test-encryption-key-256bit-placeholder"
         db = Database(
-            tmp_path / "src_cat.duckdb", secret_store=mock_store, no_auto_upgrade=True
+            tmp_path / "src_cat.duckdb",
+            secret_store=mock_store,
+            no_auto_upgrade=True,
+            read_only=False,
         )
         create_core_tables_raw(db.conn)
         # T_src: source-provided category ('Groceries'), categorized_by=NULL (no user/AI/rule)
@@ -281,7 +287,10 @@ class TestTransactionGet:
         mock_store = MagicMock()
         mock_store.get_key.return_value = "test-encryption-key-256bit-placeholder"
         db = Database(
-            tmp_path / "memo.duckdb", secret_store=mock_store, no_auto_upgrade=True
+            tmp_path / "memo.duckdb",
+            secret_store=mock_store,
+            no_auto_upgrade=True,
+            read_only=False,
         )
         create_core_tables_raw(db.conn)
         db.conn.execute("""

--- a/tests/moneybin/test_services/test_transaction_service.py
+++ b/tests/moneybin/test_services/test_transaction_service.py
@@ -33,6 +33,7 @@ def transaction_db(tmp_path: Path) -> Generator[Database, None, None]:
         tmp_path / "test.duckdb",
         secret_store=mock_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     conn = database.conn
     create_core_tables_raw(conn)
@@ -90,6 +91,7 @@ class TestEmptyResults:
             tmp_path / "test.duckdb",
             secret_store=mock_store,
             no_auto_upgrade=True,
+            read_only=False,
         )
         create_core_tables_raw(database.conn)
         yield database

--- a/tests/moneybin/test_services/test_transform_service.py
+++ b/tests/moneybin/test_services/test_transform_service.py
@@ -42,6 +42,7 @@ def _open_db(tmp_path: Path, mock_secret_store: MagicMock) -> Database:
         tmp_path / "test.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
 
 

--- a/tests/moneybin/test_synthetic/test_engine.py
+++ b/tests/moneybin/test_synthetic/test_engine.py
@@ -117,6 +117,7 @@ class TestGeneratorEngineWithDB:
             tmp_path / "test.duckdb",
             secret_store=mock_secret_store,
             no_auto_upgrade=True,
+            read_only=False,
         )
         yield db
         db.close()

--- a/tests/moneybin/test_synthetic/test_writer.py
+++ b/tests/moneybin/test_synthetic/test_writer.py
@@ -67,6 +67,7 @@ class TestSyntheticWriter:
             tmp_path / "test.duckdb",
             secret_store=mock_secret_store,
             no_auto_upgrade=True,
+            read_only=False,
         )
         yield db
         db.close()

--- a/tests/moneybin/test_validation/test_assertions_completeness.py
+++ b/tests/moneybin/test_validation/test_assertions_completeness.py
@@ -18,7 +18,10 @@ from moneybin.validation.assertions.completeness import (
 def db(tmp_path: Path, mock_secret_store: MagicMock) -> Database:
     """Provide a test Database with a txn table."""
     database = Database(
-        tmp_path / "test.duckdb", secret_store=mock_secret_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     database.execute("CREATE TABLE txn (id INT, amount DECIMAL(18,2), note VARCHAR)")
     return database
@@ -28,7 +31,10 @@ def db(tmp_path: Path, mock_secret_store: MagicMock) -> Database:
 def src_db(tmp_path: Path, mock_secret_store: MagicMock) -> Database:
     """Provide a test Database with a ``source_type`` column (the assertion default)."""
     database = Database(
-        tmp_path / "src.duckdb", secret_store=mock_secret_store, no_auto_upgrade=True
+        tmp_path / "src.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     database.execute("CREATE TABLE t (id INT, source_type VARCHAR)")
     return database

--- a/tests/moneybin/test_validation/test_assertions_distribution.py
+++ b/tests/moneybin/test_validation/test_assertions_distribution.py
@@ -19,7 +19,10 @@ from moneybin.validation.assertions.distribution import (
 def db(tmp_path: Path, mock_secret_store: MagicMock) -> Database:
     """Provide a test Database with an amount/category table."""
     database = Database(
-        tmp_path / "test.duckdb", secret_store=mock_secret_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     database.execute("CREATE TABLE t (amount DECIMAL(18,2), category VARCHAR)")
     database.execute(
@@ -70,6 +73,7 @@ def coverage_db(tmp_path: Path, mock_secret_store: MagicMock) -> Database:
         tmp_path / "coverage.duckdb",
         secret_store=mock_secret_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     database.execute("CREATE SCHEMA IF NOT EXISTS core")
     database.execute("CREATE SCHEMA IF NOT EXISTS prep")

--- a/tests/moneybin/test_validation/test_assertions_domain.py
+++ b/tests/moneybin/test_validation/test_assertions_domain.py
@@ -22,7 +22,10 @@ from moneybin.validation.assertions.domain import (
 def continuity_db(tmp_path: Path, mock_secret_store: MagicMock) -> Database:
     """Provide a test Database with a simple date/account table."""
     database = Database(
-        tmp_path / "test.duckdb", secret_store=mock_secret_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     database.execute("CREATE TABLE txns (account_id VARCHAR, transaction_date DATE)")
     return database
@@ -32,7 +35,10 @@ def continuity_db(tmp_path: Path, mock_secret_store: MagicMock) -> Database:
 def txn_db(tmp_path: Path, mock_secret_store: MagicMock) -> Database:
     """Provide a test Database with core.fct_transactions."""
     database = Database(
-        tmp_path / "test.duckdb", secret_store=mock_secret_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     database.execute("CREATE SCHEMA IF NOT EXISTS core")
     database.execute(
@@ -174,7 +180,10 @@ def test_date_continuity_flags_account_with_all_null_dates(
 def db(tmp_path: Path, mock_secret_store: MagicMock) -> Database:
     """Provide an empty test Database for tests that create their own table ``t``."""
     return Database(
-        tmp_path / "test.duckdb", secret_store=mock_secret_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
 
 

--- a/tests/moneybin/test_validation/test_assertions_integrity.py
+++ b/tests/moneybin/test_validation/test_assertions_integrity.py
@@ -18,7 +18,10 @@ from moneybin.validation.assertions.integrity import (
 def db(tmp_path: Path, mock_secret_store: MagicMock) -> Database:
     """Provide a test Database with parent/child tables."""
     database = Database(
-        tmp_path / "test.duckdb", secret_store=mock_secret_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     database.execute("CREATE TABLE parent (id INT)")
     database.execute("INSERT INTO parent VALUES (1), (2), (3)")

--- a/tests/moneybin/test_validation/test_assertions_schema.py
+++ b/tests/moneybin/test_validation/test_assertions_schema.py
@@ -21,7 +21,10 @@ from moneybin.validation.assertions.schema import (
 def db(tmp_path: Path, mock_secret_store: MagicMock) -> Database:
     """Provide a test Database with a table covering INTEGER, VARCHAR, and DECIMAL types."""
     database = Database(
-        tmp_path / "test.duckdb", secret_store=mock_secret_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     database.execute("CREATE TABLE t (id INTEGER, name VARCHAR, amount DECIMAL(18,2))")
     database.execute(

--- a/tests/moneybin/test_validation/test_assertions_uniqueness.py
+++ b/tests/moneybin/test_validation/test_assertions_uniqueness.py
@@ -15,7 +15,10 @@ from moneybin.validation.assertions.uniqueness import assert_no_duplicates
 def db(tmp_path: Path, mock_secret_store: MagicMock) -> Database:
     """Provide a test Database with parent/child tables."""
     database = Database(
-        tmp_path / "test.duckdb", secret_store=mock_secret_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
     database.execute("CREATE TABLE parent (id INT)")
     database.execute("INSERT INTO parent VALUES (1), (2), (3)")

--- a/tests/moneybin/test_validation/test_expectations_matching.py
+++ b/tests/moneybin/test_validation/test_expectations_matching.py
@@ -20,7 +20,10 @@ def _make_db(tmp_path: Path, mock_secret_store: MagicMock, name: str) -> Databas
     # init_schemas runs automatically and creates app.* tables; meta/core/prep
     # schemas are created but have no tables yet — we add them below.
     return Database(
-        tmp_path / name, secret_store=mock_secret_store, no_auto_upgrade=True
+        tmp_path / name,
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
 
 

--- a/tests/moneybin/test_validation/test_expectations_transactions.py
+++ b/tests/moneybin/test_validation/test_expectations_transactions.py
@@ -20,7 +20,10 @@ from moneybin.validation.result import ExpectationResult
 def _make_db(tmp_path: Path, mock_secret_store: MagicMock, name: str) -> Database:
     # init_schemas creates app.* tables; core/meta schemas are present but empty.
     return Database(
-        tmp_path / name, secret_store=mock_secret_store, no_auto_upgrade=True
+        tmp_path / name,
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
 
 

--- a/tests/privacy/conftest.py
+++ b/tests/privacy/conftest.py
@@ -33,6 +33,7 @@ def populated_db(tmp_path: Path) -> Generator[Database, None, None]:
         tmp_path / "privacy.duckdb",
         secret_store=mock_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
     create_core_tables_raw(database.conn)
     apply_core_table_comments(database)

--- a/tests/privacy/test_init_schemas_integration.py
+++ b/tests/privacy/test_init_schemas_integration.py
@@ -18,6 +18,7 @@ def fresh_db(tmp_path: Path) -> Database:
         tmp_path / "fresh.duckdb",
         secret_store=mock_store,
         no_auto_upgrade=True,
+        read_only=False,
     )
 
 

--- a/tests/scenarios/_runner/runner.py
+++ b/tests/scenarios/_runner/runner.py
@@ -168,7 +168,7 @@ def run_scenario(
                 # lock (e.g. transform_via_subprocess spawns a subprocess that
                 # needs the write lock). Re-open only when that happens.
                 if db._closed:  # pyright: ignore[reportPrivateUsage]
-                    db = get_database()
+                    db = get_database(read_only=False)
         except Exception as exc:  # noqa: BLE001 — surface as halted result
             # Don't use logger.exception — tracebacks may include local
             # variables holding amounts/descriptions (PII rule).
@@ -264,7 +264,7 @@ def _bootstrap_database() -> Database:
     clear_settings_cache()
     set_current_profile("scenario")
 
-    return get_database()
+    return get_database(read_only=False)
 
 
 def _resolve_runtime_args(args: dict[str, Any], *, tmpdir: str) -> dict[str, Any]:

--- a/tests/scenarios/_runner_tests/test_harnesses.py
+++ b/tests/scenarios/_runner_tests/test_harnesses.py
@@ -27,7 +27,10 @@ def mock_secret_store() -> MagicMock:
 @pytest.fixture()
 def db(tmp_path: Path, mock_secret_store: MagicMock) -> Database:
     return Database(
-        tmp_path / "test.duckdb", secret_store=mock_secret_store, no_auto_upgrade=True
+        tmp_path / "test.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
     )
 
 

--- a/tests/scenarios/test_migration_roundtrip.py
+++ b/tests/scenarios/test_migration_roundtrip.py
@@ -67,14 +67,14 @@ def test_migration_roundtrip_preserves_row_counts() -> None:
         run_step("transform", scenario.setup, db, env=env)
 
         db.close()
-        db = get_database()
+        db = get_database(read_only=False)
         pre = {tbl: _row_count(db, tbl) for tbl in tracked_tables}
 
         run_step("migrate", scenario.setup, db, env=env)
         run_step("match", scenario.setup, db, env=env)
 
         db.close()
-        db = get_database()
+        db = get_database(read_only=False)
         post = {tbl: _row_count(db, tbl) for tbl in tracked_tables}
         db.close()
 


### PR DESCRIPTION
## Summary

Make `read_only` a required, keyword-only argument on both `Database.__init__()` and `get_database()`. Remove the prior `bool = False` default. Sweep all ~262 call sites across `src/moneybin/` and `tests/` to declare intent explicitly.

This is the trust-boundary fix from workstream #3 of the M0B writer-coordination hardening pass: every read surface now physically opens `ATTACH ... READ_ONLY`, not just by SQL-allowlist convention. The implicit `False` default that let new read sites silently open in write mode is gone.

## Background

The kickoff for M0B's hardening pass recommended an ast-grep / pytest lint rule to detect read sites missing `read_only=True`. After working through the design, I deviated: **required-kwarg is strictly more durable**.

- Pyright (already in `make check`) is the gate — no new mechanism to maintain.
- The implicit default *is* the trap; removing it eliminates the bug class instead of detecting it.
- Custom lints have false positives, false negatives, and drift of their own.
- Matches design-principles.md: "Abstractions remove ambiguity; they don't add flexibility."

The migration cost is bounded and mechanical: every implicit caller now declares its mode. A future contributor cannot reintroduce the bug.

## Changes

- **Contract** (`src/moneybin/database.py`): `read_only` becomes a required, keyword-only argument on both signatures. All in-file callers updated.
- **Sweep** (208 call sites across `src/moneybin/{mcp,cli,services,connectors,observability.py,utils}/` + 3 e2e subprocess workers that text-grep missed): every caller declares `read_only=True` or `read_only=False`. Classifications followed the writer-coordination spec's "Files to Modify" table for pre-existing sites; code-level rules (SELECT/list_*/get_* → True; INSERT/UPDATE/DELETE/create_*/set_*/commit/apply/run → False; mixed scope → False) for sites added since.
- **Tests** (175 sites across 81 test files): all defaulted to `read_only=False` (test fixtures are universally write-mode); one mock context manager (`_fake_db_ctx` in `test_import_command.py`) gained the `read_only` parameter.
- **Docs**: `docs/specs/database-writer-coordination.md` gets an additive "Required-kwarg hardening" callout, updated signature snippets, updated caller-pattern examples, and a new Requirement #15. `.claude/rules/database.md` connection-management section updated. CHANGELOG `Changed` entry.

## Test plan

- [x] `make check` (format + lint + pyright): 0 errors, 3 pre-existing reportlab warnings.
- [x] `make test` (unit): 3780 passed, 4 pre-existing skips, 0 failed.
- [x] `make test-e2e`: 274 passed, 1 pre-existing skip, 0 failed.
- [x] `make test-scenarios`: 45 passed.
- [ ] Reviewer should spot-check 2-3 sweep classifications by reading the body of the corresponding service method — the read-vs-write call is the load-bearing decision.
