### PR TITLE
Add app.pdf_formats doctor integrity checks

### DIFF
--- a/src/moneybin/extractors/pdf/fingerprint.py
+++ b/src/moneybin/extractors/pdf/fingerprint.py
@@ -115,13 +115,21 @@ def _unique_table_headers(doc: PdfDocument) -> list[str]:
     return list(dict.fromkeys(target.header))
 
 
+# The complete, closed set of page-count buckets ``_page_bucket`` can emit, in
+# ascending order. Public because consumers that validate a stored fingerprint
+# against what ``compute_fingerprint`` could produce (e.g. the doctor
+# ``app_pdf_formats_fingerprint_shape`` invariant) must check ``page_bucket``
+# membership against this exact vocabulary — keep it the single source of truth.
+PAGE_BUCKETS: tuple[str, str, str] = ("1", "2-3", "4+")
+
+
 def _page_bucket(n: int) -> str:
-    """Map a page count to a coarse bucket string."""
+    """Map a page count to a coarse bucket string from ``PAGE_BUCKETS``."""
     if n <= 1:
-        return "1"
+        return PAGE_BUCKETS[0]
     if n <= 3:
-        return "2-3"
-    return "4+"
+        return PAGE_BUCKETS[1]
+    return PAGE_BUCKETS[2]
 
 
 def compute_fingerprint(doc: PdfDocument) -> dict[str, Any]:

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -906,26 +906,27 @@ class DoctorService:
         return InvariantResult(name=name, status="pass", detail=None, affected_ids=[])
 
     def _run_pdf_formats_fingerprint_shape(self) -> InvariantResult:
-        """Flag ``app.pdf_formats.layout_fingerprint`` rows missing required keys.
+        """Flag ``app.pdf_formats.layout_fingerprint`` rows that can never match.
 
         The replay path indexes formats by fingerprint (issuer + ordered headers
-        + page_bucket) — a row whose fingerprint is missing any of those three
-        keys, whose ``headers`` is not a JSON array of strings, or whose
-        ``issuer`` or ``page_bucket`` is not a JSON string, can never match a
-        future import and stays dead in the table. Surfacing it at doctor time
-        lets an operator delete or re-derive before the format silently rots.
+        + page_bucket) using canonical JSON equality. A row whose fingerprint
+        is missing any of those three keys, carries any extra key, has
+        ``headers`` not a JSON array of strings, or whose ``issuer`` or
+        ``page_bucket`` is not a JSON string, can never match a future import
+        and stays dead in the table. Surfacing it at doctor time lets an
+        operator delete or re-derive before the format silently rots.
         """
         name = "app_pdf_formats_fingerprint_shape"
         # DuckDB JSON probes: json_extract returns NULL for absent keys, and
         # json_type names the type of the value at a path ("ARRAY", "VARCHAR",
-        # etc.). The required keys, the two string-typed keys, and headers
-        # being a string-only array are checked in one SQL pass per row —
-        # compute_fingerprint() emits string issuer/page_bucket and a string
-        # headers list, so a bypass row with any other type in those positions
-        # (e.g. {"issuer": ["Chase"]} or {"headers": [1]}) could never match a
-        # future import and stays dead in the table. The headers per-element
-        # check uses TRY_CAST so a non-array headers value (already caught by
-        # the prior json_type guard) doesn't error here.
+        # etc.). The required keys, the two string-typed keys, headers being
+        # a string-only array, and the key set being exactly three keys are
+        # checked in one SQL pass per row — compute_fingerprint() returns a
+        # dict with exactly {issuer, headers, page_bucket}, and the match path
+        # uses canonical JSON equality, so any extra key, missing key, wrong
+        # type, or non-string header element makes the row dead in the table.
+        # The headers per-element check uses TRY_CAST so a non-array headers
+        # value (already caught by the prior json_type guard) doesn't error.
         try:
             rows = self._db.execute(
                 f"""
@@ -937,6 +938,7 @@ class DoctorService:
                    OR json_type(layout_fingerprint, '$.headers') != 'ARRAY'
                    OR json_type(layout_fingerprint, '$.issuer') != 'VARCHAR'
                    OR json_type(layout_fingerprint, '$.page_bucket') != 'VARCHAR'
+                   OR json_array_length(json_keys(layout_fingerprint)) != 3
                    OR list_aggregate(
                         list_transform(
                           TRY_CAST(layout_fingerprint -> '$.headers' AS JSON[]),
@@ -962,8 +964,8 @@ class DoctorService:
                 detail=(
                     f"{len(affected)} pdf_formats row(s) carry a "
                     "layout_fingerprint missing issuer/headers/page_bucket, "
-                    "whose headers is not an array of strings, or whose "
-                    "issuer/page_bucket is not a string"
+                    "carrying extra keys, whose headers is not an array of "
+                    "strings, or whose issuer/page_bucket is not a string"
                 ),
                 affected_ids=affected,
             )

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -28,6 +28,7 @@ from moneybin.tables import (
     INT_TRANSACTIONS_UNIONED,
     MANUAL_TRANSACTIONS,
     MATCH_DECISIONS,
+    PDF_FORMATS,
     PROPOSED_RULES,
     TABULAR_FORMATS,
     TRANSACTION_CATEGORIES,
@@ -222,6 +223,10 @@ class DoctorService:
                 full=full,
             ),
             self._run_app_audit_coverage(IMPORTS, "import_id", full=full),
+            self._run_app_audit_coverage(PDF_FORMATS, "name", full=full),
+            self._run_pdf_formats_recipe_validity(),
+            self._run_pdf_formats_bounds(),
+            self._run_pdf_formats_fingerprint_shape(),
             self._run_user_categories_uniqueness(),
             self._run_user_merchants_orphans(),
             self._run_proposed_rules_rule_fk(),
@@ -793,6 +798,151 @@ class DoctorService:
                 detail=(
                     f"{len(affected)} budgets row(s) reference a "
                     "category_id absent from core.dim_categories"
+                ),
+                affected_ids=affected,
+            )
+        return InvariantResult(name=name, status="pass", detail=None, affected_ids=[])
+
+    def _run_pdf_formats_recipe_validity(self) -> InvariantResult:
+        """Flag ``app.pdf_formats.extraction_recipe`` rows that fail Recipe schema.
+
+        Every stored recipe is replayed by the deterministic executor on later
+        imports, so a row whose JSON no longer round-trips through
+        ``Recipe.model_validate`` is a silent landmine — it survives until the
+        next matching fingerprint arrives, then the replay raises and the file
+        falls back to the seed path. Surfacing it at doctor time lets an operator
+        either re-derive (delete + replay first contact) or restore from
+        ``app.audit_log`` undo before the next import.
+        """
+        name = "app_pdf_formats_recipe_validity"
+        try:
+            rows = self._db.execute(
+                f"""
+                SELECT name, CAST(extraction_recipe AS VARCHAR)
+                FROM {PDF_FORMATS.full_name}
+                ORDER BY name
+                """  # noqa: S608  # TableRef constant, no user input
+            ).fetchall()
+        except Exception as e:  # noqa: BLE001 — table may not exist before first write
+            return InvariantResult(
+                name=name,
+                status="skipped",
+                detail=f"recipe validity check unavailable: {e}",
+                affected_ids=[],
+            )
+        # Imported lazily — extractors.pdf.recipe pulls in pydantic + the `regex`
+        # package, which is unnecessary cost for doctor runs against installs
+        # whose pdf_formats table is empty (the no-rows branch above returns
+        # early).
+        from moneybin.extractors.pdf.recipe import Recipe  # noqa: PLC0415
+
+        bad: list[str] = []
+        for name_, recipe_json in rows:
+            try:
+                Recipe.model_validate_json(recipe_json)
+            except Exception:  # noqa: BLE001 — pydantic ValidationError + JSONDecodeError + bound-validator ValueErrors
+                bad.append(str(name_))
+        if bad:
+            return InvariantResult(
+                name=name,
+                status="fail",
+                detail=(
+                    f"{len(bad)} pdf_formats row(s) carry an extraction_recipe "
+                    "that no longer validates against Recipe"
+                ),
+                affected_ids=bad,
+            )
+        return InvariantResult(name=name, status="pass", detail=None, affected_ids=[])
+
+    def _run_pdf_formats_bounds(self) -> InvariantResult:
+        """Flag ``app.pdf_formats`` rows that violate numeric/temporal bounds.
+
+        Three invariants the schema cannot express as cheap CHECK constraints
+        (``last_used_at >= created_at`` cuts across two columns, and a CHECK
+        on a defaulted INTEGER doesn't catch raw bypass writes that supply an
+        explicit out-of-range value):
+
+        - ``version >= 1`` — ``save_new`` inserts at 1; ``bump_version`` only
+          increments. A row at 0 or negative is corruption.
+        - ``times_used >= 0`` — monotonically incremented by ``record_use``.
+          Negative counts are corruption.
+        - ``last_used_at >= created_at`` when ``last_used_at`` is set —
+          last-use can never precede creation by the table's own clock.
+        """
+        name = "app_pdf_formats_bounds"
+        try:
+            rows = self._db.execute(
+                f"""
+                SELECT name
+                FROM {PDF_FORMATS.full_name}
+                WHERE version < 1
+                   OR times_used < 0
+                   OR (last_used_at IS NOT NULL AND last_used_at < created_at)
+                ORDER BY name
+                """  # noqa: S608  # TableRef constant, no user input
+            ).fetchall()
+        except Exception as e:  # noqa: BLE001 — table may not exist before first write
+            return InvariantResult(
+                name=name,
+                status="skipped",
+                detail=f"bounds check unavailable: {e}",
+                affected_ids=[],
+            )
+        if rows:
+            affected = [str(r[0]) for r in rows]
+            return InvariantResult(
+                name=name,
+                status="fail",
+                detail=(
+                    f"{len(affected)} pdf_formats row(s) violate version/"
+                    "times_used/timestamp ordering bounds"
+                ),
+                affected_ids=affected,
+            )
+        return InvariantResult(name=name, status="pass", detail=None, affected_ids=[])
+
+    def _run_pdf_formats_fingerprint_shape(self) -> InvariantResult:
+        """Flag ``app.pdf_formats.layout_fingerprint`` rows missing required keys.
+
+        The replay path indexes formats by fingerprint (issuer + ordered headers
+        + page_bucket) — a row whose fingerprint is missing any of those three
+        keys, or whose ``headers`` is not a JSON array, can never match a future
+        import and stays dead in the table. Surfacing it at doctor time lets an
+        operator delete or re-derive before the format silently rots.
+        """
+        name = "app_pdf_formats_fingerprint_shape"
+        # DuckDB JSON probes: json_extract returns NULL for absent keys, and
+        # json_type names the type of the value at a path ("ARRAY", "VARCHAR",
+        # etc.). The three required keys + headers-is-array are checked in one
+        # SQL pass per row.
+        try:
+            rows = self._db.execute(
+                f"""
+                SELECT name
+                FROM {PDF_FORMATS.full_name}
+                WHERE json_extract(layout_fingerprint, '$.issuer') IS NULL
+                   OR json_extract(layout_fingerprint, '$.headers') IS NULL
+                   OR json_extract(layout_fingerprint, '$.page_bucket') IS NULL
+                   OR json_type(layout_fingerprint, '$.headers') != 'ARRAY'
+                ORDER BY name
+                """  # noqa: S608  # TableRef constant, no user input
+            ).fetchall()
+        except Exception as e:  # noqa: BLE001 — table may not exist before first write
+            return InvariantResult(
+                name=name,
+                status="skipped",
+                detail=f"fingerprint shape check unavailable: {e}",
+                affected_ids=[],
+            )
+        if rows:
+            affected = [str(r[0]) for r in rows]
+            return InvariantResult(
+                name=name,
+                status="fail",
+                detail=(
+                    f"{len(affected)} pdf_formats row(s) carry a "
+                    "layout_fingerprint missing issuer/headers/page_bucket "
+                    "or whose headers is not an array"
                 ),
                 affected_ids=affected,
             )

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -13,7 +13,7 @@ from moneybin.audits import recipes as recipe_registry
 from moneybin.config import get_settings
 from moneybin.database import Database, sqlmesh_context
 from moneybin.errors import RecoveryAction
-from moneybin.extractors.pdf.fingerprint import serialize_fingerprint
+from moneybin.extractors.pdf.fingerprint import PAGE_BUCKETS, serialize_fingerprint
 from moneybin.tables import (
     ACCOUNT_SETTINGS,
     AUDIT_LOG,
@@ -67,8 +67,9 @@ def _is_live_fingerprint(raw: str | None) -> bool:
     """Return whether ``raw`` is a fingerprint the replay path could match.
 
     A live fingerprint is both structurally what ``compute_fingerprint``
-    produces (exactly ``issuer``/``headers``/``page_bucket`` with string
-    ``issuer``/``page_bucket`` and a string-only ``headers`` list) and
+    produces (exactly ``issuer``/``headers``/``page_bucket`` with a string
+    ``issuer``, a string-only ``headers`` list, and a ``page_bucket`` drawn
+    from ``PAGE_BUCKETS`` — the only values the producer emits) and
     byte-for-byte the canonical encoding ``serialize_fingerprint`` emits — the
     lookup compares it textually. See ``_run_pdf_formats_fingerprint_shape``
     for why both halves are required.
@@ -84,7 +85,7 @@ def _is_live_fingerprint(raw: str | None) -> bool:
     fp = cast("dict[str, Any]", loaded)
     if frozenset(fp) != _FINGERPRINT_KEYS:
         return False
-    if not isinstance(fp["issuer"], str) or not isinstance(fp["page_bucket"], str):
+    if not isinstance(fp["issuer"], str) or fp["page_bucket"] not in PAGE_BUCKETS:
         return False
     headers = fp["headers"]
     if not isinstance(headers, list) or not all(isinstance(h, str) for h in headers):
@@ -945,12 +946,13 @@ class DoctorService:
         which DuckDB evaluates as a *textual* match against the canonical string
         ``serialize_fingerprint`` emits. A stored fingerprint is therefore live
         only if it is both (1) structurally what ``compute_fingerprint``
-        produces — exactly ``issuer``/``headers``/``page_bucket``, with string
-        ``issuer``/``page_bucket`` and a string-only ``headers`` list — and (2)
-        byte-for-byte that canonical serialization. Any other shape (missing or
-        extra key, wrong value type) or any non-canonical encoding (different
-        key order, extra whitespace) is dead in the table and can never match a
-        future import. Validating against ``serialize_fingerprint`` itself ties
+        produces — exactly ``issuer``/``headers``/``page_bucket``, with a string
+        ``issuer``, a string-only ``headers`` list, and a ``page_bucket`` from
+        the producer's closed ``PAGE_BUCKETS`` set — and (2) byte-for-byte that
+        canonical serialization. Any other shape (missing or extra key, wrong
+        value type, out-of-domain ``page_bucket``) or any non-canonical encoding
+        (different key order, extra whitespace) is dead in the table and can
+        never match a future import. Validating against ``serialize_fingerprint`` itself ties
         this invariant to the one encoding the replay path actually searches
         for, instead of re-enumerating corruption modes one SQL predicate at a
         time. Surfacing a dead row at doctor time lets an operator delete or

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass, replace
-from typing import Literal
+from typing import Any, Literal, cast
 
 from sqlglot import exp
 
@@ -12,6 +13,7 @@ from moneybin.audits import recipes as recipe_registry
 from moneybin.config import get_settings
 from moneybin.database import Database, sqlmesh_context
 from moneybin.errors import RecoveryAction
+from moneybin.extractors.pdf.fingerprint import serialize_fingerprint
 from moneybin.tables import (
     ACCOUNT_SETTINGS,
     AUDIT_LOG,
@@ -57,6 +59,37 @@ _BALANCE_ASSERTIONS_PK_EXPR = (
 # dynamic SQL), closing the door before a future caller passes a tainted value.
 _ALLOWED_UPDATED_EXPRS = frozenset({"GREATEST(decided_at, reversed_at)"})
 _ALLOWED_PK_EXPRS = frozenset({_BALANCE_ASSERTIONS_PK_EXPR})
+
+_FINGERPRINT_KEYS = frozenset({"issuer", "headers", "page_bucket"})
+
+
+def _is_live_fingerprint(raw: str | None) -> bool:
+    """Return whether ``raw`` is a fingerprint the replay path could match.
+
+    A live fingerprint is both structurally what ``compute_fingerprint``
+    produces (exactly ``issuer``/``headers``/``page_bucket`` with string
+    ``issuer``/``page_bucket`` and a string-only ``headers`` list) and
+    byte-for-byte the canonical encoding ``serialize_fingerprint`` emits — the
+    lookup compares it textually. See ``_run_pdf_formats_fingerprint_shape``
+    for why both halves are required.
+    """
+    if raw is None:
+        return False
+    try:
+        loaded = json.loads(raw)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(loaded, dict):
+        return False
+    fp = cast("dict[str, Any]", loaded)
+    if frozenset(fp) != _FINGERPRINT_KEYS:
+        return False
+    if not isinstance(fp["issuer"], str) or not isinstance(fp["page_bucket"], str):
+        return False
+    headers = fp["headers"]
+    if not isinstance(headers, list) or not all(isinstance(h, str) for h in headers):
+        return False
+    return serialize_fingerprint(fp) == raw
 
 
 @dataclass(frozen=True)
@@ -908,44 +941,27 @@ class DoctorService:
     def _run_pdf_formats_fingerprint_shape(self) -> InvariantResult:
         """Flag ``app.pdf_formats.layout_fingerprint`` rows that can never match.
 
-        The replay path indexes formats by fingerprint (issuer + ordered headers
-        + page_bucket) using canonical JSON equality. A row whose fingerprint
-        is missing any of those three keys, carries any extra key, has
-        ``headers`` not a JSON array of strings, or whose ``issuer`` or
-        ``page_bucket`` is not a JSON string, can never match a future import
-        and stays dead in the table. Surfacing it at doctor time lets an
-        operator delete or re-derive before the format silently rots.
+        The replay path looks a format up with ``layout_fingerprint = ?::JSON``,
+        which DuckDB evaluates as a *textual* match against the canonical string
+        ``serialize_fingerprint`` emits. A stored fingerprint is therefore live
+        only if it is both (1) structurally what ``compute_fingerprint``
+        produces — exactly ``issuer``/``headers``/``page_bucket``, with string
+        ``issuer``/``page_bucket`` and a string-only ``headers`` list — and (2)
+        byte-for-byte that canonical serialization. Any other shape (missing or
+        extra key, wrong value type) or any non-canonical encoding (different
+        key order, extra whitespace) is dead in the table and can never match a
+        future import. Validating against ``serialize_fingerprint`` itself ties
+        this invariant to the one encoding the replay path actually searches
+        for, instead of re-enumerating corruption modes one SQL predicate at a
+        time. Surfacing a dead row at doctor time lets an operator delete or
+        re-derive before the format silently rots.
         """
         name = "app_pdf_formats_fingerprint_shape"
-        # DuckDB JSON probes: json_extract returns NULL for absent keys, and
-        # json_type names the type of the value at a path ("ARRAY", "VARCHAR",
-        # etc.). The required keys, the two string-typed keys, headers being
-        # a string-only array, and the key set being exactly three keys are
-        # checked in one SQL pass per row — compute_fingerprint() returns a
-        # dict with exactly {issuer, headers, page_bucket}, and the match path
-        # uses canonical JSON equality, so any extra key, missing key, wrong
-        # type, or non-string header element makes the row dead in the table.
-        # The headers per-element check uses TRY_CAST so a non-array headers
-        # value (already caught by the prior json_type guard) doesn't error.
         try:
             rows = self._db.execute(
                 f"""
-                SELECT name
+                SELECT name, CAST(layout_fingerprint AS VARCHAR)
                 FROM {PDF_FORMATS.full_name}
-                WHERE json_extract(layout_fingerprint, '$.issuer') IS NULL
-                   OR json_extract(layout_fingerprint, '$.headers') IS NULL
-                   OR json_extract(layout_fingerprint, '$.page_bucket') IS NULL
-                   OR json_type(layout_fingerprint, '$.headers') != 'ARRAY'
-                   OR json_type(layout_fingerprint, '$.issuer') != 'VARCHAR'
-                   OR json_type(layout_fingerprint, '$.page_bucket') != 'VARCHAR'
-                   OR json_array_length(json_keys(layout_fingerprint)) != 3
-                   OR list_aggregate(
-                        list_transform(
-                          TRY_CAST(layout_fingerprint -> '$.headers' AS JSON[]),
-                          h -> json_type(h) IS DISTINCT FROM 'VARCHAR'
-                        ),
-                        'bool_or'
-                      ) = TRUE
                 ORDER BY name
                 """  # noqa: S608  # TableRef constant, no user input
             ).fetchall()
@@ -956,18 +972,17 @@ class DoctorService:
                 detail=f"fingerprint shape check unavailable: {e}",
                 affected_ids=[],
             )
-        if rows:
-            affected = [str(r[0]) for r in rows]
+        bad = [str(name_) for name_, raw in rows if not _is_live_fingerprint(raw)]
+        if bad:
             return InvariantResult(
                 name=name,
                 status="fail",
                 detail=(
-                    f"{len(affected)} pdf_formats row(s) carry a "
-                    "layout_fingerprint missing issuer/headers/page_bucket, "
-                    "carrying extra keys, whose headers is not an array of "
-                    "strings, or whose issuer/page_bucket is not a string"
+                    f"{len(bad)} pdf_formats row(s) carry a layout_fingerprint "
+                    "that is malformed or is not the canonical serialization "
+                    "the replay path matches on"
                 ),
-                affected_ids=affected,
+                affected_ids=bad,
             )
         return InvariantResult(name=name, status="pass", detail=None, affected_ids=[])
 

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -830,6 +830,10 @@ class DoctorService:
                 detail=f"recipe validity check unavailable: {e}",
                 affected_ids=[],
             )
+        if not rows:
+            return InvariantResult(
+                name=name, status="pass", detail=None, affected_ids=[]
+            )
         # Imported lazily — extractors.pdf.recipe pulls in pydantic + the `regex`
         # package, which is unnecessary cost for doctor runs against installs
         # whose pdf_formats table is empty (the no-rows branch above returns
@@ -906,15 +910,19 @@ class DoctorService:
 
         The replay path indexes formats by fingerprint (issuer + ordered headers
         + page_bucket) — a row whose fingerprint is missing any of those three
-        keys, or whose ``headers`` is not a JSON array, can never match a future
-        import and stays dead in the table. Surfacing it at doctor time lets an
+        keys, whose ``headers`` is not a JSON array, or whose ``issuer`` or
+        ``page_bucket`` is not a JSON string, can never match a future import
+        and stays dead in the table. Surfacing it at doctor time lets an
         operator delete or re-derive before the format silently rots.
         """
         name = "app_pdf_formats_fingerprint_shape"
         # DuckDB JSON probes: json_extract returns NULL for absent keys, and
         # json_type names the type of the value at a path ("ARRAY", "VARCHAR",
-        # etc.). The three required keys + headers-is-array are checked in one
-        # SQL pass per row.
+        # etc.). The three required keys, headers-is-array, and the two string
+        # keys' VARCHAR types are checked in one SQL pass per row —
+        # compute_fingerprint() always emits string issuer/page_bucket, so a
+        # bypass row with e.g. {"issuer": ["Chase"]} could never match a future
+        # import and stays dead in the table.
         try:
             rows = self._db.execute(
                 f"""
@@ -924,6 +932,8 @@ class DoctorService:
                    OR json_extract(layout_fingerprint, '$.headers') IS NULL
                    OR json_extract(layout_fingerprint, '$.page_bucket') IS NULL
                    OR json_type(layout_fingerprint, '$.headers') != 'ARRAY'
+                   OR json_type(layout_fingerprint, '$.issuer') != 'VARCHAR'
+                   OR json_type(layout_fingerprint, '$.page_bucket') != 'VARCHAR'
                 ORDER BY name
                 """  # noqa: S608  # TableRef constant, no user input
             ).fetchall()
@@ -941,8 +951,9 @@ class DoctorService:
                 status="fail",
                 detail=(
                     f"{len(affected)} pdf_formats row(s) carry a "
-                    "layout_fingerprint missing issuer/headers/page_bucket "
-                    "or whose headers is not an array"
+                    "layout_fingerprint missing issuer/headers/page_bucket, "
+                    "whose headers is not an array, or whose issuer/"
+                    "page_bucket is not a string"
                 ),
                 affected_ids=affected,
             )

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -910,19 +910,22 @@ class DoctorService:
 
         The replay path indexes formats by fingerprint (issuer + ordered headers
         + page_bucket) — a row whose fingerprint is missing any of those three
-        keys, whose ``headers`` is not a JSON array, or whose ``issuer`` or
-        ``page_bucket`` is not a JSON string, can never match a future import
-        and stays dead in the table. Surfacing it at doctor time lets an
-        operator delete or re-derive before the format silently rots.
+        keys, whose ``headers`` is not a JSON array of strings, or whose
+        ``issuer`` or ``page_bucket`` is not a JSON string, can never match a
+        future import and stays dead in the table. Surfacing it at doctor time
+        lets an operator delete or re-derive before the format silently rots.
         """
         name = "app_pdf_formats_fingerprint_shape"
         # DuckDB JSON probes: json_extract returns NULL for absent keys, and
         # json_type names the type of the value at a path ("ARRAY", "VARCHAR",
-        # etc.). The three required keys, headers-is-array, and the two string
-        # keys' VARCHAR types are checked in one SQL pass per row —
-        # compute_fingerprint() always emits string issuer/page_bucket, so a
-        # bypass row with e.g. {"issuer": ["Chase"]} could never match a future
-        # import and stays dead in the table.
+        # etc.). The required keys, the two string-typed keys, and headers
+        # being a string-only array are checked in one SQL pass per row —
+        # compute_fingerprint() emits string issuer/page_bucket and a string
+        # headers list, so a bypass row with any other type in those positions
+        # (e.g. {"issuer": ["Chase"]} or {"headers": [1]}) could never match a
+        # future import and stays dead in the table. The headers per-element
+        # check uses TRY_CAST so a non-array headers value (already caught by
+        # the prior json_type guard) doesn't error here.
         try:
             rows = self._db.execute(
                 f"""
@@ -934,6 +937,13 @@ class DoctorService:
                    OR json_type(layout_fingerprint, '$.headers') != 'ARRAY'
                    OR json_type(layout_fingerprint, '$.issuer') != 'VARCHAR'
                    OR json_type(layout_fingerprint, '$.page_bucket') != 'VARCHAR'
+                   OR list_aggregate(
+                        list_transform(
+                          TRY_CAST(layout_fingerprint -> '$.headers' AS JSON[]),
+                          h -> json_type(h) IS DISTINCT FROM 'VARCHAR'
+                        ),
+                        'bool_or'
+                      ) = TRUE
                 ORDER BY name
                 """  # noqa: S608  # TableRef constant, no user input
             ).fetchall()
@@ -952,8 +962,8 @@ class DoctorService:
                 detail=(
                     f"{len(affected)} pdf_formats row(s) carry a "
                     "layout_fingerprint missing issuer/headers/page_bucket, "
-                    "whose headers is not an array, or whose issuer/"
-                    "page_bucket is not a string"
+                    "whose headers is not an array of strings, or whose "
+                    "issuer/page_bucket is not a string"
                 ),
                 affected_ids=affected,
             )

--- a/tests/moneybin/test_services/test_doctor_app_integrity.py
+++ b/tests/moneybin/test_services/test_doctor_app_integrity.py
@@ -951,6 +951,25 @@ def test_pdf_formats_fingerprint_shape_flags_object_header_element(
     assert "bad_hdr_obj" in result.affected_ids
 
 
+def test_pdf_formats_fingerprint_shape_flags_extra_keys(db: Database) -> None:
+    # canonical 3 keys + an extra key — get_by_fingerprint serializes the
+    # match key with exactly 3 fields, so canonical JSON equality misses
+    # this row even though every required field is well-formed.
+    _bypass_pdf_format(
+        db,
+        name="extra_key",
+        layout_fingerprint={
+            "issuer": "x",
+            "headers": ["A"],
+            "page_bucket": "1",
+            "extra": "junk",
+        },
+    )
+    result = DoctorService(db)._run_pdf_formats_fingerprint_shape()
+    assert result.status == "fail"
+    assert "extra_key" in result.affected_ids
+
+
 def test_pdf_formats_fingerprint_shape_passes_for_repo_saved_row(
     db: Database,
 ) -> None:

--- a/tests/moneybin/test_services/test_doctor_app_integrity.py
+++ b/tests/moneybin/test_services/test_doctor_app_integrity.py
@@ -970,6 +970,36 @@ def test_pdf_formats_fingerprint_shape_flags_extra_keys(db: Database) -> None:
     assert "extra_key" in result.affected_ids
 
 
+def test_pdf_formats_fingerprint_shape_flags_non_canonical_serialization(
+    db: Database,
+) -> None:
+    # Structurally valid (3 string keys, string headers) but keys are NOT in
+    # serialize_fingerprint's sorted order, so the textual `layout_fingerprint
+    # = ?::JSON` lookup the replay path uses can never match this row.
+    _bypass_pdf_format(
+        db,
+        name="non_canonical",
+        layout_fingerprint='{"page_bucket": "1", "issuer": "x", "headers": ["A"]}',
+    )
+    result = DoctorService(db)._run_pdf_formats_fingerprint_shape()
+    assert result.status == "fail"
+    assert "non_canonical" in result.affected_ids
+
+
+def test_pdf_formats_fingerprint_shape_passes_for_canonical_bypass_row(
+    db: Database,
+) -> None:
+    # Negative control: a bypass row whose fingerprint IS the canonical
+    # serialization is shape-valid (audit-coverage flags the bypass, not the
+    # fingerprint-shape check) — the round-trip check must not over-flag it.
+    canonical = json.dumps(
+        {"issuer": "x", "headers": ["A", "B"], "page_bucket": "1"}, sort_keys=True
+    )
+    _bypass_pdf_format(db, name="canonical_bypass", layout_fingerprint=canonical)
+    result = DoctorService(db)._run_pdf_formats_fingerprint_shape()
+    assert result.status == "pass"
+
+
 def test_pdf_formats_fingerprint_shape_passes_for_repo_saved_row(
     db: Database,
 ) -> None:

--- a/tests/moneybin/test_services/test_doctor_app_integrity.py
+++ b/tests/moneybin/test_services/test_doctor_app_integrity.py
@@ -986,6 +986,21 @@ def test_pdf_formats_fingerprint_shape_flags_non_canonical_serialization(
     assert "non_canonical" in result.affected_ids
 
 
+def test_pdf_formats_fingerprint_shape_flags_out_of_domain_page_bucket(
+    db: Database,
+) -> None:
+    # Structurally valid and canonically serialized, but page_bucket is not one
+    # of compute_fingerprint's buckets ({"1","2-3","4+"}), so no real import can
+    # ever produce this fingerprint — it is dead in the table.
+    canonical = json.dumps(
+        {"issuer": "x", "headers": ["A"], "page_bucket": "0"}, sort_keys=True
+    )
+    _bypass_pdf_format(db, name="bad_bucket_value", layout_fingerprint=canonical)
+    result = DoctorService(db)._run_pdf_formats_fingerprint_shape()
+    assert result.status == "fail"
+    assert "bad_bucket_value" in result.affected_ids
+
+
 def test_pdf_formats_fingerprint_shape_passes_for_canonical_bypass_row(
     db: Database,
 ) -> None:

--- a/tests/moneybin/test_services/test_doctor_app_integrity.py
+++ b/tests/moneybin/test_services/test_doctor_app_integrity.py
@@ -868,6 +868,38 @@ def test_pdf_formats_fingerprint_shape_flags_non_array_headers(db: Database) -> 
     assert "bad_headers" in result.affected_ids
 
 
+def test_pdf_formats_fingerprint_shape_flags_non_string_issuer(db: Database) -> None:
+    _bypass_pdf_format(
+        db,
+        name="bad_issuer",
+        layout_fingerprint={
+            "issuer": ["Chase"],  # array instead of string — can never match
+            "headers": ["A"],
+            "page_bucket": "1",
+        },
+    )
+    result = DoctorService(db)._run_pdf_formats_fingerprint_shape()
+    assert result.status == "fail"
+    assert "bad_issuer" in result.affected_ids
+
+
+def test_pdf_formats_fingerprint_shape_flags_non_string_page_bucket(
+    db: Database,
+) -> None:
+    _bypass_pdf_format(
+        db,
+        name="bad_bucket",
+        layout_fingerprint={
+            "issuer": "x",
+            "headers": ["A"],
+            "page_bucket": 1,  # number instead of string — can never match
+        },
+    )
+    result = DoctorService(db)._run_pdf_formats_fingerprint_shape()
+    assert result.status == "fail"
+    assert "bad_bucket" in result.affected_ids
+
+
 def test_pdf_formats_fingerprint_shape_passes_for_repo_saved_row(
     db: Database,
 ) -> None:

--- a/tests/moneybin/test_services/test_doctor_app_integrity.py
+++ b/tests/moneybin/test_services/test_doctor_app_integrity.py
@@ -11,8 +11,10 @@ check added with the repository layer. Uses the function-scoped ``db`` fixture
 # pyright: reportPrivateUsage=false
 from __future__ import annotations
 
+import json
 from datetime import date
 from decimal import Decimal
+from typing import Any
 
 import pytest
 
@@ -23,6 +25,7 @@ from moneybin.repositories.budgets_repo import BudgetsRepo
 from moneybin.repositories.categorization_rules_repo import CategorizationRulesRepo
 from moneybin.repositories.imports_repo import ImportsRepo
 from moneybin.repositories.match_decisions_repo import MatchDecisionsRepo
+from moneybin.repositories.pdf_formats_repo import PdfFormatsRepo
 from moneybin.repositories.proposed_rules_repo import ProposedRulesRepo
 from moneybin.repositories.tabular_formats_repo import TabularFormatsRepo
 from moneybin.repositories.transaction_categories_repo import (
@@ -41,6 +44,7 @@ from moneybin.tables import (
     CATEGORIZATION_RULES,
     IMPORTS,
     MATCH_DECISIONS,
+    PDF_FORMATS,
     PROPOSED_RULES,
     TABULAR_FORMATS,
     TRANSACTION_CATEGORIES,
@@ -525,6 +529,10 @@ def test_run_all_includes_app_integrity_invariants(db: Database) -> None:
     assert "app_balance_assertions_account_fk" in names
     assert "app_budgets_category_fk" in names
     assert "app_match_decisions_account_fk" in names
+    assert "app_audit_coverage_pdf_formats" in names
+    assert "app_pdf_formats_recipe_validity" in names
+    assert "app_pdf_formats_bounds" in names
+    assert "app_pdf_formats_fingerprint_shape" in names
 
 
 # ---------------------------------------------------------------------------
@@ -666,4 +674,203 @@ def test_budgets_category_fk_passes_for_resolved_and_null(db: Database) -> None:
         actor="cli",
     )
     result = DoctorService(db)._run_budgets_category_fk()
+    assert result.status == "pass"
+
+
+# ---------------------------------------------------------------------------
+# Batch D: pdf_formats (Invariant 10 PR 12 — Phase 2a follow-up)
+# ---------------------------------------------------------------------------
+
+_VALID_RECIPE: dict[str, Any] = {
+    "row_region": {"start_anchor": "Date", "end_anchor": "Total:"},
+    "row_split": r"\s{2,}",
+    "fields": [
+        {
+            "name": "date",
+            "pattern": r"\d{2}/\d{2}",
+            "cast": "date",
+            "date_format": "%m/%d",
+        },
+        {"name": "amount", "pattern": r"-?\d+\.\d{2}", "cast": "decimal"},
+    ],
+    "sign_convention": "negative_is_expense",
+    "routing": "transactions",
+}
+
+_VALID_FINGERPRINT: dict[str, Any] = {
+    "issuer": "chase",
+    "headers": ["Date", "Description", "Amount"],
+    "page_bucket": "2-3",
+}
+
+
+def _bypass_pdf_format(
+    db: Database,
+    *,
+    name: str,
+    extraction_recipe: dict[str, Any] | str = _VALID_RECIPE,
+    layout_fingerprint: dict[str, Any] | str | None = None,
+    version: int = 1,
+    times_used: int = 1,
+    last_used_at: str | None = None,
+    created_offset_seconds: int = 0,
+    days_ago: int = 0,
+) -> None:
+    """Insert an app.pdf_formats row WITHOUT an audit row (simulated bypass).
+
+    ``extraction_recipe`` / ``layout_fingerprint`` accept dicts (JSON-encoded
+    here) or pre-built JSON strings (lets tests inject malformed payloads).
+    ``last_used_at`` is an ISO timestamp literal or ``None``.
+    ``created_offset_seconds`` lets a test push ``last_used_at`` before
+    ``created_at`` for the bounds check.
+    """
+    recipe_json = (
+        extraction_recipe
+        if isinstance(extraction_recipe, str)
+        else json.dumps(extraction_recipe)
+    )
+    fp = layout_fingerprint if layout_fingerprint is not None else _VALID_FINGERPRINT
+    fp_json = fp if isinstance(fp, str) else json.dumps(fp)
+    last_used_sql = f"TIMESTAMP '{last_used_at}'" if last_used_at else "NULL"
+    db.execute(
+        f"INSERT INTO app.pdf_formats "  # noqa: S608  # test input, not executing user SQL
+        f"(name, institution_name, document_kind, layout_fingerprint, front_end, "
+        f" extraction_recipe, routing, number_format, source, version, times_used, "
+        f" last_used_at, created_at, updated_at) "
+        f"VALUES (?, ?, ?, ?::JSON, ?, ?::JSON, ?, ?, ?, ?, ?, "
+        f" {last_used_sql}, "
+        f" now()::TIMESTAMP - (? * INTERVAL 1 DAY) "
+        f"   + ({created_offset_seconds} * INTERVAL 1 SECOND), "
+        f" now()::TIMESTAMP - (? * INTERVAL 1 DAY))",
+        [
+            name,
+            "Issuer",
+            "checking_statement",
+            fp_json,
+            "text",
+            recipe_json,
+            "transactions",
+            "us",
+            "detected",
+            version,
+            times_used,
+            days_ago,
+            days_ago,
+        ],
+    )
+
+
+def _save_pdf_format(repo: PdfFormatsRepo, *, name: str) -> None:
+    repo.save_new(
+        name,
+        _VALID_RECIPE,
+        fingerprint=_VALID_FINGERPRINT,
+        institution_name="Chase",
+        document_kind="checking_statement",
+        front_end="text",
+        routing="transactions",
+        actor="cli",
+    )
+
+
+def test_audit_coverage_passes_for_repo_mutated_pdf_format(db: Database) -> None:
+    _save_pdf_format(PdfFormatsRepo(db), name="chase_checking")
+    result = DoctorService(db)._run_app_audit_coverage(PDF_FORMATS, "name")
+    assert result.status == "pass"
+
+
+def test_audit_coverage_flags_bypass_pdf_format(db: Database) -> None:
+    _bypass_pdf_format(db, name="bypass_pdf")
+    result = DoctorService(db)._run_app_audit_coverage(PDF_FORMATS, "name")
+    assert result.status == "fail"
+    assert "bypass_pdf" in result.affected_ids
+
+
+def test_pdf_formats_recipe_validity_flags_corrupt_recipe(db: Database) -> None:
+    # extraction_recipe that's missing every required Recipe field —
+    # Recipe.model_validate(json.loads(...)) must reject it.
+    _bypass_pdf_format(db, name="corrupt_recipe", extraction_recipe={"oops": True})
+    result = DoctorService(db)._run_pdf_formats_recipe_validity()
+    assert result.status == "fail"
+    assert "corrupt_recipe" in result.affected_ids
+
+
+def test_pdf_formats_recipe_validity_passes_for_valid_recipe(db: Database) -> None:
+    _save_pdf_format(PdfFormatsRepo(db), name="valid_recipe")
+    result = DoctorService(db)._run_pdf_formats_recipe_validity()
+    assert result.status == "pass"
+
+
+def test_pdf_formats_bounds_flags_zero_version(db: Database) -> None:
+    _bypass_pdf_format(db, name="bad_version", version=0)
+    result = DoctorService(db)._run_pdf_formats_bounds()
+    assert result.status == "fail"
+    assert "bad_version" in result.affected_ids
+
+
+def test_pdf_formats_bounds_flags_negative_times_used(db: Database) -> None:
+    _bypass_pdf_format(db, name="bad_count", times_used=-1)
+    result = DoctorService(db)._run_pdf_formats_bounds()
+    assert result.status == "fail"
+    assert "bad_count" in result.affected_ids
+
+
+def test_pdf_formats_bounds_flags_last_used_before_created(db: Database) -> None:
+    # last_used_at literal in 2020 + created_at = now() → last_used_at < created_at.
+    _bypass_pdf_format(db, name="time_reversed", last_used_at="2020-01-01 00:00:00")
+    result = DoctorService(db)._run_pdf_formats_bounds()
+    assert result.status == "fail"
+    assert "time_reversed" in result.affected_ids
+
+
+def test_pdf_formats_bounds_passes_for_repo_saved_row(db: Database) -> None:
+    _save_pdf_format(PdfFormatsRepo(db), name="sane_bounds")
+    result = DoctorService(db)._run_pdf_formats_bounds()
+    assert result.status == "pass"
+
+
+def test_pdf_formats_fingerprint_shape_flags_missing_page_bucket(
+    db: Database,
+) -> None:
+    _bypass_pdf_format(
+        db,
+        name="no_bucket",
+        layout_fingerprint={"issuer": "x", "headers": ["A"]},  # page_bucket missing
+    )
+    result = DoctorService(db)._run_pdf_formats_fingerprint_shape()
+    assert result.status == "fail"
+    assert "no_bucket" in result.affected_ids
+
+
+def test_pdf_formats_fingerprint_shape_flags_missing_issuer(db: Database) -> None:
+    _bypass_pdf_format(
+        db,
+        name="no_issuer",
+        layout_fingerprint={"headers": ["A"], "page_bucket": "1"},
+    )
+    result = DoctorService(db)._run_pdf_formats_fingerprint_shape()
+    assert result.status == "fail"
+    assert "no_issuer" in result.affected_ids
+
+
+def test_pdf_formats_fingerprint_shape_flags_non_array_headers(db: Database) -> None:
+    _bypass_pdf_format(
+        db,
+        name="bad_headers",
+        layout_fingerprint={
+            "issuer": "x",
+            "headers": "Date,Amount",  # string instead of array
+            "page_bucket": "1",
+        },
+    )
+    result = DoctorService(db)._run_pdf_formats_fingerprint_shape()
+    assert result.status == "fail"
+    assert "bad_headers" in result.affected_ids
+
+
+def test_pdf_formats_fingerprint_shape_passes_for_repo_saved_row(
+    db: Database,
+) -> None:
+    _save_pdf_format(PdfFormatsRepo(db), name="good_fp")
+    result = DoctorService(db)._run_pdf_formats_fingerprint_shape()
     assert result.status == "pass"

--- a/tests/moneybin/test_services/test_doctor_app_integrity.py
+++ b/tests/moneybin/test_services/test_doctor_app_integrity.py
@@ -900,6 +900,57 @@ def test_pdf_formats_fingerprint_shape_flags_non_string_page_bucket(
     assert "bad_bucket" in result.affected_ids
 
 
+def test_pdf_formats_fingerprint_shape_flags_numeric_header_element(
+    db: Database,
+) -> None:
+    _bypass_pdf_format(
+        db,
+        name="bad_hdr_int",
+        layout_fingerprint={
+            "issuer": "x",
+            "headers": [1, "B"],  # numeric element — can never match list[str]
+            "page_bucket": "1",
+        },
+    )
+    result = DoctorService(db)._run_pdf_formats_fingerprint_shape()
+    assert result.status == "fail"
+    assert "bad_hdr_int" in result.affected_ids
+
+
+def test_pdf_formats_fingerprint_shape_flags_null_header_element(
+    db: Database,
+) -> None:
+    _bypass_pdf_format(
+        db,
+        name="bad_hdr_null",
+        layout_fingerprint={
+            "issuer": "x",
+            "headers": [None],  # null element — can never match list[str]
+            "page_bucket": "1",
+        },
+    )
+    result = DoctorService(db)._run_pdf_formats_fingerprint_shape()
+    assert result.status == "fail"
+    assert "bad_hdr_null" in result.affected_ids
+
+
+def test_pdf_formats_fingerprint_shape_flags_object_header_element(
+    db: Database,
+) -> None:
+    _bypass_pdf_format(
+        db,
+        name="bad_hdr_obj",
+        layout_fingerprint={
+            "issuer": "x",
+            "headers": [{"k": 1}],  # object element — can never match
+            "page_bucket": "1",
+        },
+    )
+    result = DoctorService(db)._run_pdf_formats_fingerprint_shape()
+    assert result.status == "fail"
+    assert "bad_hdr_obj" in result.affected_ids
+
+
 def test_pdf_formats_fingerprint_shape_passes_for_repo_saved_row(
     db: Database,
 ) -> None:

--- a/tests/moneybin/test_services/test_doctor_service.py
+++ b/tests/moneybin/test_services/test_doctor_service.py
@@ -700,16 +700,18 @@ def test_run_all_returns_expected_invariants(
     monkeypatch.setattr("moneybin.services.doctor_service.sqlmesh_context", _fake_ctx)
     svc = DoctorService(doctor_db)
     report = svc.run_all()
-    # 3 sqlmesh audits + dedup_reconciliation + categorization + 21 app.* integrity
+    # 3 sqlmesh audits + dedup_reconciliation + categorization + 25 app.* integrity
     # checks (audit coverage for user_categories / category_overrides /
     # gsheet_connections / user_merchants / categorization_rules / proposed_rules /
     # transaction_categories / account_settings / balance_assertions / budgets /
-    # tabular_formats / match_decisions / imports + user_categories uniqueness +
-    # user_merchants orphans + proposed_rules->rule FK + transaction_categories->fct
-    # FK + account_settings->dim_accounts FK + balance_assertions->dim_accounts FK +
-    # budgets->dim_categories FK + match_decisions->dim_accounts FK) +
-    # orphan_app_state (PR4: scans transaction_notes / transaction_tags vs core).
-    assert len(report.invariants) == 27
+    # tabular_formats / match_decisions / imports / pdf_formats + user_categories
+    # uniqueness + user_merchants orphans + proposed_rules->rule FK +
+    # transaction_categories->fct FK + account_settings->dim_accounts FK +
+    # balance_assertions->dim_accounts FK + budgets->dim_categories FK +
+    # match_decisions->dim_accounts FK + pdf_formats recipe-validity / bounds /
+    # fingerprint-shape) + orphan_app_state (PR4: scans transaction_notes /
+    # transaction_tags vs core).
+    assert len(report.invariants) == 31
     names = [r.name for r in report.invariants]
     assert "fct_transactions_fk_integrity" in names
     assert "fct_transactions_sign_convention" in names


### PR DESCRIPTION
## Summary

Phase 2a (PR #233) added `app.pdf_formats` + `PdfFormatsRepo` but deferred doctor coverage. This wires four new integrity checks so corruption surfaces at `moneybin db doctor`, not at the next replay against a matching fingerprint.

- **`app_audit_coverage_pdf_formats`** — the generic Invariant-10 audit-coverage check (rows mutated without a paired `app.audit_log` entry).
- **`app_pdf_formats_recipe_validity`** — every stored `extraction_recipe` round-trips through `Recipe.model_validate`. A row whose recipe drifted past the current Pydantic schema is a silent landmine until the next matching import.
- **`app_pdf_formats_bounds`** — `version >= 1`, `times_used >= 0`, and `last_used_at >= created_at` when both set. CHECK constraints can't express the cross-column case and don't catch raw-bypass INSERTs with explicit out-of-range values.
- **`app_pdf_formats_fingerprint_shape`** — every `layout_fingerprint` carries `issuer` + `headers` + `page_bucket`, and `headers` is a JSON array. A row missing any of those can never match a future import and stays dead.

The recipe-validity helper lazy-imports `moneybin.extractors.pdf.recipe` so the doctor cold-path doesn't pay for pydantic + the `regex` package on installs whose `pdf_formats` table is empty.

## Test plan

- [x] 95 passing across `test_doctor_app_integrity.py` + `test_doctor_service.py` + `test_doctor_orphan_app_state.py` + `test_cli/test_doctor.py`
- [x] Full unit suite green (3936 passed, 4 pre-existing skips)
- [x] `make check` clean (format + lint + pyright 0 errors)
- [x] Bypass-row detection asserted for every new check (raw INSERT with corrupt recipe / out-of-bounds version / non-array headers / etc.)
- [x] Repo-mutated-row passing asserted for every new check (round-trip through `PdfFormatsRepo.save_new`)
- [x] `run_all` count assertion in `test_doctor_service.py` bumped 27 → 31 to match the four added invariants