### PR TITLE
Add smart-import-pdf bridge egress side (Phase 2b)

### DIFF
--- a/docs/specs/privacy-and-ai-trust.md
+++ b/docs/specs/privacy-and-ai-trust.md
@@ -77,27 +77,31 @@ Every path where data might leave the user's machine falls into one of four tier
 
 ### Tier 3 — Programmatic, real data
 
-**Examples:** Smart Import pillar F sends a file preview to AI for parsing when heuristics fail. Future: autonomous AI analysis runs (scheduled spending summaries, anomaly detection).
+**Examples:** Future autonomous AI analysis runs (scheduled spending summaries, anomaly detection) once the in-process cloud rung (separate `AIBackend`) lands.
+
+**Status:** Not used by any v1 surface. The smart-import-pdf path that earlier drafts placed here uses the **bridge-to-driving-agent** model below instead — a different trust shape that doesn't fit the redacted-preview promise.
 
 **Data state:** Real financial data, sent by the system — not in response to a direct user question.
-**Consent:** Per-invocation with redacted preview. Every call shows:
+**Consent (when this tier activates):** Per-invocation with redacted preview. Every call shows:
 - What will be sent (redacted preview of the actual payload)
 - Where it will be sent (backend name and provider privacy stance)
 - What response shape is expected (e.g., "column mapping," not raw transactions)
 
-The user confirms, declines, or switches backend each time. No persistent consent for tier 3 in v1. If a single user action (e.g., one file import) would trigger multiple AI calls, the consent prompt covers the full set of calls for that action — not one prompt per internal API call.
+The user confirms, declines, or switches backend each time. No persistent consent for tier 3 in v1. If a single user action would trigger multiple AI calls, the consent prompt covers the full set of calls for that action — not one prompt per internal API call.
 
-**Consent prompt example:**
-> Smart Import couldn't auto-detect the format of `chase_2024.csv`.
->
-> To parse this file, MoneyBin can send a preview to **Anthropic (Claude)**:
-> - **Rows:** 5 sample rows (of 1,240 total)
-> - **Masked:** Account numbers replaced with `****XXXX`, amounts with synthetic values
-> - **Visible to AI:** Column headers, date formats, description text, transaction structure
->
-> **Privacy:** Anthropic does not train on API data.
->
-> Send preview? [y/N] or switch backend [b]
+### Bridge-to-driving-agent (smart-import-pdf, Phase 2b)
+
+**Examples:** Native-text PDF whose deterministic recipe extraction can't reconcile, or whose saved recipe broke — the document is handed to the same agent the user is *already* driving MoneyBin with, the agent proposes a Recipe + rows, and `import_confirm` ratifies. See `smart-import-pdf.md` Reqs 14–16.
+
+**Trust model — distinct from Tier 3.** The recipient is not a new third-party backend MoneyBin chose to send data to; it is the LLM host already running the user's MoneyBin session. The user established trust with that host at session start (by typing into it, granting MCP tool access, etc.). The bridge surfaces the document *to that same host* — no new egress relationship is created, and no new privacy stance applies. Tier 3's per-invocation consent-with-redacted-preview is the wrong shape: there is nothing to redact *against*, because the host is already the user's trusted agent.
+
+**Honest egress — no "redacted preview" claim.** The values are the payload. MoneyBin states plainly that proceeding will surface the document's content (text lines + table headers + a small per-table row sample) to the driving agent. There is no synthesized-values preview, no claim of masking. The user's choice is binary: proceed (the agent reads the document) or fall back to the seed path (`raw.pdf_seeds` JSON, queryable but not routed to transactions). Standalone-identifier masking (SSN, full account numbers) before egress is a deferred best-effort lever (Req 16) that becomes meaningful when the in-process cloud rung lands; until then, no masking is applied.
+
+**Local-first guarantee (Req 15).** Every native-text PDF that the deterministic rung extracts cleanly imports with **zero network calls and no bridge hand-off**. The bridge is reached only when the deterministic rung produces a bridge-eligible failure (low confidence, replay reconciliation failure, auto-derive reconciliation failure, incomplete balance metadata). Verifiable from the audit log — a `SELECT * FROM app.audit_log WHERE action = 'smart_import_parse'` returns zero rows for a deterministic-only session.
+
+**Transparency + audit (Req 14).** Every bridge hand-off writes one `app.audit_log` row (action: `smart_import_parse`, actor: `system`, target: `raw.pdf_seeds/<file>`, context carrying the routing reason + confidence) and increments `moneybin_pdf_bridge_egress_total{outcome="proposed"}`. No silent send: the egress event is recoverable, reportable, and replayable independently of whether the agent ratifies.
+
+**Transparency notice in the payload.** The bridge payload itself carries the transparency notice as a typed field (`BridgeRequest.transparency_notice`) — not buried convention, not optional formatting. The driving agent surfaces it to the user before invoking `import_confirm`; the user proceeds or declines.
 
 ## Provider profiles
 

--- a/docs/specs/privacy-and-ai-trust.md
+++ b/docs/specs/privacy-and-ai-trust.md
@@ -91,7 +91,7 @@ The user confirms, declines, or switches backend each time. No persistent consen
 
 ### Bridge-to-driving-agent (smart-import-pdf, Phase 2b)
 
-**Examples:** Native-text PDF whose deterministic recipe extraction can't reconcile, or whose saved recipe broke — the document is handed to the same agent the user is *already* driving MoneyBin with, the agent proposes a Recipe + rows, and `import_confirm` ratifies. See `smart-import-pdf.md` Reqs 14–16.
+**Examples:** Native-text PDF whose deterministic recipe extraction can't reconcile, or whose saved recipe broke — the document is handed to the same agent the user is *already* driving MoneyBin with, the agent proposes a Recipe + rows, and `import_confirm` ratifies (apply arm in follow-up PR). See `smart-import-pdf.md` Reqs 14–16.
 
 **Trust model — distinct from Tier 3.** The recipient is not a new third-party backend MoneyBin chose to send data to; it is the LLM host already running the user's MoneyBin session. The user established trust with that host at session start (by typing into it, granting MCP tool access, etc.). The bridge surfaces the document *to that same host* — no new egress relationship is created, and no new privacy stance applies. Tier 3's per-invocation consent-with-redacted-preview is the wrong shape: there is nothing to redact *against*, because the host is already the user's trusted agent.
 

--- a/src/moneybin/extractors/pdf/bridge.py
+++ b/src/moneybin/extractors/pdf/bridge.py
@@ -135,6 +135,8 @@ def parse_bridge_response(payload: object) -> BridgeResponse:
     raw_rows = payload["rows"]
     if not isinstance(raw_rows, list):
         raise ValueError("bridge response 'rows' must be a list")
+    if not all(isinstance(r, dict) for r in raw_rows):
+        raise ValueError("bridge response 'rows' must be a list of dicts")
     # raw_recipe / raw_rows pass isinstance checks above; cast for pyright since
     # the source dict (untrusted JSON) types its values as object.
     typed_recipe = cast(dict[str, Any], raw_recipe)

--- a/src/moneybin/extractors/pdf/bridge.py
+++ b/src/moneybin/extractors/pdf/bridge.py
@@ -1,0 +1,146 @@
+"""Bridge payload + response shapes for Phase 2b PDF escalation (Reqs 8, 9, 14).
+
+When the deterministic rung can't extract confidently from a native-text PDF,
+or when a saved recipe stopped reconciling, MoneyBin escalates to the agent
+the user is *already* driving the host with. The bridge carries the document
+to the agent, the agent proposes a Recipe + rows, and ``import_confirm``
+ratifies.
+
+This module owns the two data-shape contracts:
+
+- ``BridgeRequest`` — what MoneyBin sends out (the egress payload). Wraps the
+  document text, a per-table preview, the layout fingerprint, the transparency
+  notice (Req 14, surfaced explicitly so the agent cannot accidentally elide
+  it), and a request kind ("propose_recipe" on first contact vs.
+  "replay_failed_re_derive" when a saved recipe broke).
+- ``BridgeResponse`` — what the agent sends back: a Pydantic-validated Recipe
+  plus the rows it extracted.
+
+Architecture note: this module intentionally does NOT import from the
+service layer. The service constructs the egress envelope by wrapping a
+``BridgeRequest`` in the channel-agnostic ``BridgePayload`` (from
+``services.import_confirmation``) — the boundary keeps extractors free of
+service-layer types.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+
+from moneybin.extractors.pdf.fingerprint import compute_fingerprint
+from moneybin.extractors.pdf.ir import PdfDocument
+from moneybin.extractors.pdf.recipe import Recipe
+
+TRANSPARENCY_NOTICE = (
+    "Proceeding will surface this PDF's content to the agent you are "
+    "currently driving MoneyBin with. The document text and table headers "
+    "are sent verbatim — there is no redacted preview. An entry is written "
+    "to app.audit_log (action: smart_import_parse) recording the hand-off."
+)
+
+# How many leading rows per table to ship to the agent. Keeps the preview
+# compact (the executor only needs to see the pattern shape, not every row)
+# and bounds payload size on dense statements.
+_TABLE_PREVIEW_ROW_CAP = 5
+
+RequestKind = Literal["propose_recipe", "replay_failed_re_derive"]
+
+
+@dataclass(frozen=True)
+class BridgeRequest:
+    """Typed payload contents the bridge ships to the driving agent."""
+
+    transparency_notice: str
+    source_file: str
+    # text_lines joined with '\n'; agent can re-split as needed.
+    document_text: str
+    # One entry per table: {page, header, rows[:N]}.
+    tables_preview: list[dict[str, Any]]
+    fingerprint: dict[str, Any]
+    request_kind: RequestKind
+    # Populated only for 'replay_failed_re_derive' so the agent can see what
+    # the saved recipe was and what specifically failed. None for first-contact
+    # 'propose_recipe' requests.
+    saved_recipe_for_re_derive: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class BridgeResponse:
+    """The agent's vetted reply: a validated Recipe and extracted rows.
+
+    Recipe is the Pydantic-validated model (security bounds in
+    ``Recipe._bound_patterns`` already ran); rows are canonical-shape dicts
+    matching the recipe's field names so the apply path treats them
+    indistinguishably from deterministic-extracted rows.
+    """
+
+    recipe: Recipe
+    rows: list[dict[str, Any]]
+
+
+def build_bridge_request(
+    doc: PdfDocument,
+    *,
+    request_kind: RequestKind,
+    saved_recipe_for_re_derive: dict[str, Any] | None = None,
+) -> BridgeRequest:
+    """Build the typed bridge request envelope from a PDF IR + decision context.
+
+    The service layer wraps the resulting request in ``BridgePayload`` (from
+    ``import_confirmation``) before raising ``ImportConfirmationRequiredError``
+    — keeping the extractor-layer module free of service-layer types so the
+    architecture-layering test stays happy.
+    """
+    tables_preview = [
+        {
+            "page": t.page,
+            "header": list(t.header),
+            "rows": t.rows[:_TABLE_PREVIEW_ROW_CAP],
+        }
+        for t in doc.tables
+    ]
+    return BridgeRequest(
+        transparency_notice=TRANSPARENCY_NOTICE,
+        source_file=doc.source_file,
+        document_text="\n".join(doc.text_lines),
+        tables_preview=tables_preview,
+        fingerprint=compute_fingerprint(doc),
+        request_kind=request_kind,
+        saved_recipe_for_re_derive=saved_recipe_for_re_derive,
+    )
+
+
+def parse_bridge_response(payload: object) -> BridgeResponse:
+    """Validate an agent's response; raise ``ValueError`` on any bad shape.
+
+    Expected payload shape::
+
+        {"recipe": <Recipe-shaped dict>, "rows": [{...}, ...]}
+
+    ``Recipe.model_validate`` enforces the security bounds (Req 9b — pattern
+    length + nested-quantifier check) before the apply-side executor ever
+    runs against the agent's patterns, so a malicious bridge response cannot
+    bypass those guards by going through this seam.
+    """
+    if not isinstance(payload, dict):
+        raise ValueError("bridge response must be a dict")
+    if "recipe" not in payload:
+        raise ValueError("bridge response missing 'recipe' key")
+    if "rows" not in payload:
+        raise ValueError("bridge response missing 'rows' key")
+    raw_recipe = payload["recipe"]
+    if not isinstance(raw_recipe, dict):
+        raise ValueError("bridge response 'recipe' must be a dict")
+    raw_rows = payload["rows"]
+    if not isinstance(raw_rows, list):
+        raise ValueError("bridge response 'rows' must be a list")
+    # raw_recipe / raw_rows pass isinstance checks above; cast for pyright since
+    # the source dict (untrusted JSON) types its values as object.
+    typed_recipe = cast(dict[str, Any], raw_recipe)
+    typed_rows = cast(list[dict[str, Any]], raw_rows)
+    try:
+        recipe = Recipe.model_validate(typed_recipe)
+    except Exception as e:  # noqa: BLE001 — pydantic ValidationError + bound-validator ValueErrors
+        raise ValueError(f"bridge recipe invalid: {e}") from e
+    return BridgeResponse(recipe=recipe, rows=typed_rows)

--- a/src/moneybin/metrics/registry.py
+++ b/src/moneybin/metrics/registry.py
@@ -110,6 +110,18 @@ PDF_SEED_ROWS_TOTAL = Counter(
     ["alias"],
 )
 
+# Phase 2b — bridge egress events (Req 14). One increment per hand-off to the
+# driving agent. Outcomes: "proposed" (egress occurred, no response yet),
+# "applied" (agent returned a vetted recipe + rows that landed), "declined"
+# (agent or user rejected the proposal), "invalid" (response failed
+# parse_bridge_response / Recipe.model_validate). Labels stay bounded for stable
+# dashboards.
+PDF_BRIDGE_EGRESS_TOTAL = Counter(
+    "moneybin_pdf_bridge_egress_total",
+    "PDF bridge hand-offs to the driving agent by outcome.",
+    ["outcome"],  # values: "proposed", "applied", "declined", "invalid"
+)
+
 # ── Smart import confirmation ────────────────────────────────────────────────
 
 IMPORT_CONFIRMATIONS_TOTAL = Counter(

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -174,6 +174,45 @@ class BatchImportResult:
         return len(self.per_file)
 
 
+# Routing reasons where Phase 2b escalates `import_preview` to the bridge.
+# The deterministic rung produced *something* but couldn't finalize it — the
+# driving agent has a chance to crack the layout where the deterministic path
+# couldn't. ``no_transaction_table``, ``no_rows``, and ``unsupported_number_format``
+# are deliberately NOT in this set: the document isn't transaction-shaped (so
+# bridge would be off-target) or has no extractable content (so a text-bridge
+# has nothing to read).
+_BRIDGE_ELIGIBLE_REASONS: frozenset[str] = frozenset({
+    "low_confidence",
+    "replay_reconciliation_failed",
+    "reconciliation_failed",
+    "metadata_incomplete",
+})
+
+
+@dataclass(frozen=True)
+class PdfPreviewResult:
+    """Outcome of running ``pdf_preview`` against a native-text PDF.
+
+    Returned when the deterministic rung either succeeded or failed in a way
+    that the bridge can't improve on (e.g. ``no_transaction_table``). When the
+    deterministic outcome IS bridge-eligible, ``pdf_preview`` raises
+    ``ImportConfirmationRequiredError`` carrying a ``BridgePayload`` instead of
+    returning — the escalation is the result.
+    """
+
+    file_path: str
+    deterministic: bool
+    """True when the recipe ran cleanly and rows would route to transactions."""
+
+    decision_reason: str
+    """Routing reason (``passed`` on success; ``no_transaction_table`` /
+    ``no_rows`` / ``unsupported_number_format`` on non-escalating fallbacks)."""
+
+    confidence: float
+    row_count: int
+    fingerprint: dict[str, Any] | None = None
+
+
 @dataclass(frozen=True)
 class ResolvedMapping:
     """Final per-import mapping from the matched format or auto-detection.
@@ -1245,6 +1284,133 @@ class ImportService:
                 logger.debug("Could not auto-save format", exc_info=True)
 
         return result
+
+    def pdf_preview(self, file_path: Path) -> PdfPreviewResult:
+        """Run the Phase 2a routing state machine on a PDF without importing.
+
+        Three outcomes — same machinery as ``_import_pdf`` but no side effects
+        on raw tables and no ``raw.import_log`` row:
+
+        - Deterministic success (``decision.outcome == "transactions"``):
+          returns ``PdfPreviewResult(deterministic=True, ...)`` with the row
+          count and fingerprint. The caller can then call ``import_files``
+          to actually load.
+        - Bridge-eligible failure (``decision.outcome == "seed"`` with a
+          ``_BRIDGE_ELIGIBLE_REASONS`` reason): escalates by raising
+          ``ImportConfirmationRequiredError`` carrying a ``BridgePayload``
+          (a typed ``BridgeRequest`` wrapped in the channel-agnostic
+          envelope). Writes a ``smart_import_parse`` audit row (Req 14)
+          and increments ``PDF_BRIDGE_EGRESS_TOTAL{outcome="proposed"}``
+          before raising — the egress is the audited event regardless of
+          whether the agent ratifies.
+        - Non-bridge-eligible failure (``no_transaction_table`` / ``no_rows``
+          / ``unsupported_number_format``): returns
+          ``PdfPreviewResult(deterministic=False, ...)``. The bridge would
+          not help on these (the document isn't transaction-shaped, or has
+          no extractable content), so we surface the gap honestly rather
+          than ship an empty payload.
+
+        This is a read-mostly path: side effects are the audit row on
+        escalation (Req 14) and the metric bump. No ``raw.*`` rows land.
+        """
+        from moneybin.extractors.pdf.bridge import build_bridge_request
+        from moneybin.extractors.pdf.extractor import PDFExtractor
+        from moneybin.extractors.pdf.routing import route_pdf_import
+        from moneybin.metrics.registry import PDF_BRIDGE_EGRESS_TOTAL
+        from moneybin.services.import_confirmation import (
+            BridgePayload,
+            ConfirmationRequired,
+            ImportConfirmationRequiredError,
+        )
+
+        canonical = file_path.resolve()
+        doc = PDFExtractor().extract(canonical)
+        decision = route_pdf_import(doc, self._db)
+
+        if decision.outcome == "transactions":
+            return PdfPreviewResult(
+                file_path=str(canonical),
+                deterministic=True,
+                decision_reason=decision.reason,
+                confidence=decision.confidence,
+                row_count=len(decision.rows),
+                fingerprint=decision.fp,
+            )
+
+        if decision.reason in _BRIDGE_ELIGIBLE_REASONS:
+            # Bridge escalation. The driving agent gets the payload; whether
+            # it ratifies is a follow-up call to import_confirm. We audit the
+            # egress regardless (Req 14): the hand-off happened.
+            request_kind = (
+                "replay_failed_re_derive"
+                if decision.reason == "replay_reconciliation_failed"
+                else "propose_recipe"
+            )
+            saved_recipe = (
+                # The matched recipe is available on the decision when a saved
+                # format was the source of the failure; for first-contact
+                # paths it's None.
+                {"name": decision.matched_format_name}
+                if request_kind == "replay_failed_re_derive"
+                and decision.matched_format_name
+                else None
+            )
+            bridge_request = build_bridge_request(
+                doc,
+                request_kind=request_kind,
+                saved_recipe_for_re_derive=saved_recipe,
+            )
+            from dataclasses import asdict
+
+            payload = BridgePayload(payload=asdict(bridge_request))
+            self._audit.record_audit_event(
+                action="smart_import_parse",
+                target=("raw", "pdf_seeds", str(canonical)),
+                before=None,
+                after={
+                    "request_kind": request_kind,
+                    "fingerprint": bridge_request.fingerprint,
+                    "source_file": bridge_request.source_file,
+                    "decision_reason": decision.reason,
+                },
+                actor="system",
+                context={"confidence": decision.confidence},
+            )
+            PDF_BRIDGE_EGRESS_TOTAL.labels(outcome="proposed").inc()
+            from moneybin.config import get_settings as _get_settings
+            from moneybin.extractors.confidence import Confidence, tier_for
+
+            bands = _get_settings().import_.confidence
+            confidence_obj = Confidence(
+                score=decision.confidence,
+                tier=tier_for(
+                    decision.confidence, t_high=bands.t_high, t_med=bands.t_med
+                ),
+                flagged=(),
+                missing_required=(),
+            )
+            raise ImportConfirmationRequiredError(
+                ConfirmationRequired(
+                    channel="pdf",
+                    confidence=confidence_obj,
+                    proposed=payload,
+                    reason=(
+                        "validation_failure"
+                        if request_kind == "replay_failed_re_derive"
+                        else "unknown_layout"
+                    ),
+                )
+            )
+
+        # Non-bridge-eligible seed fallback — return the honest gap.
+        return PdfPreviewResult(
+            file_path=str(canonical),
+            deterministic=False,
+            decision_reason=decision.reason,
+            confidence=decision.confidence,
+            row_count=0,
+            fingerprint=decision.fp,
+        )
 
     def _import_pdf(
         self,

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -1313,6 +1313,8 @@ class ImportService:
         This is a read-mostly path: side effects are the audit row on
         escalation (Req 14) and the metric bump. No ``raw.*`` rows land.
         """
+        from moneybin.config import get_settings as _get_settings
+        from moneybin.extractors.confidence import Confidence, tier_for
         from moneybin.extractors.pdf.bridge import build_bridge_request
         from moneybin.extractors.pdf.extractor import PDFExtractor
         from moneybin.extractors.pdf.routing import route_pdf_import
@@ -1341,11 +1343,17 @@ class ImportService:
             # Bridge escalation. The driving agent gets the payload; whether
             # it ratifies is a follow-up call to import_confirm. We audit the
             # egress regardless (Req 14): the hand-off happened.
-            request_kind = (
-                "replay_failed_re_derive"
-                if decision.reason == "replay_reconciliation_failed"
-                else "propose_recipe"
+            #
+            # Routing guarantees matched_format_name is non-None for
+            # replay_reconciliation_failed, but its annotation allows None —
+            # falling back to propose_recipe when it's missing avoids ever
+            # emitting a replay envelope with no saved recipe to show, which
+            # would contradict the BridgeRequest contract.
+            is_replay = (
+                decision.reason == "replay_reconciliation_failed"
+                and decision.matched_format_name is not None
             )
+            request_kind = "replay_failed_re_derive" if is_replay else "propose_recipe"
             # For replay failures, surface both the saved format name AND the
             # actual recipe patterns the agent needs to inspect and propose a
             # refreshed version. Carrying only the name forces a first-contact
@@ -1357,8 +1365,7 @@ class ImportService:
                     if decision.recipe is not None
                     else None,
                 }
-                if request_kind == "replay_failed_re_derive"
-                and decision.matched_format_name
+                if is_replay
                 else None
             )
             bridge_request = build_bridge_request(
@@ -1378,12 +1385,15 @@ class ImportService:
                     "decision_reason": decision.reason,
                 },
                 actor="system",
-                context={"confidence": decision.confidence},
+                # Req 14: context carries routing reason + confidence so
+                # analytics can filter bridge egress by either dimension via
+                # json_extract on app.audit_log.context_json.
+                context={
+                    "decision_reason": decision.reason,
+                    "confidence": decision.confidence,
+                },
             )
             PDF_BRIDGE_EGRESS_TOTAL.labels(outcome="proposed").inc()
-            from moneybin.config import get_settings as _get_settings
-            from moneybin.extractors.confidence import Confidence, tier_for
-
             bands = _get_settings().import_.confidence
             confidence_obj = Confidence(
                 score=decision.confidence,

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -1346,11 +1346,17 @@ class ImportService:
                 if decision.reason == "replay_reconciliation_failed"
                 else "propose_recipe"
             )
+            # For replay failures, surface both the saved format name AND the
+            # actual recipe patterns the agent needs to inspect and propose a
+            # refreshed version. Carrying only the name forces a first-contact
+            # parse, defeating the point of the replay path.
             saved_recipe = (
-                # The matched recipe is available on the decision when a saved
-                # format was the source of the failure; for first-contact
-                # paths it's None.
-                {"name": decision.matched_format_name}
+                {
+                    "name": decision.matched_format_name,
+                    "recipe": decision.recipe.model_dump()
+                    if decision.recipe is not None
+                    else None,
+                }
                 if request_kind == "replay_failed_re_derive"
                 and decision.matched_format_name
                 else None
@@ -1360,9 +1366,7 @@ class ImportService:
                 request_kind=request_kind,
                 saved_recipe_for_re_derive=saved_recipe,
             )
-            from dataclasses import asdict
-
-            payload = BridgePayload(payload=asdict(bridge_request))
+            payload = BridgePayload(payload=dataclasses.asdict(bridge_request))
             self._audit.record_audit_event(
                 action="smart_import_parse",
                 target=("raw", "pdf_seeds", str(canonical)),

--- a/tests/moneybin/test_extractors/test_pdf/test_bridge.py
+++ b/tests/moneybin/test_extractors/test_pdf/test_bridge.py
@@ -1,0 +1,162 @@
+"""Tests for the Phase 2b bridge payload + response shapes.
+
+Covers ``build_bridge_request`` (export side) and ``parse_bridge_response``
+(apply side). The bridge module is the seam where MoneyBin hands a PDF to the
+driving agent and receives a vetted Recipe + rows back; both directions are
+data-shape contracts that must stay stable, so each shape gets explicit
+coverage.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from moneybin.extractors.pdf.bridge import (
+    TRANSPARENCY_NOTICE,
+    BridgeRequest,
+    BridgeResponse,
+    build_bridge_request,
+    parse_bridge_response,
+)
+from moneybin.extractors.pdf.ir import PdfDocument, PdfTable
+
+_VALID_RECIPE_DICT: dict[str, Any] = {
+    "row_region": {"start_anchor": "Date", "end_anchor": "Total:"},
+    "row_split": r"\s{2,}",
+    "fields": [
+        {
+            "name": "date",
+            "pattern": r"\d{2}/\d{2}",
+            "cast": "date",
+            "date_format": "%m/%d",
+        },
+        {"name": "amount", "pattern": r"-?\d+\.\d{2}", "cast": "decimal"},
+    ],
+    "sign_convention": "negative_is_expense",
+    "routing": "transactions",
+}
+
+
+def _doc() -> PdfDocument:
+    """Minimal native-text PDF with one table + a few text lines."""
+    return PdfDocument(
+        source_file="statement.pdf",
+        text_lines=[
+            "Chase Bank — Checking Statement",
+            "Date  Description  Amount",
+            "05/01  Coffee  -4.50",
+            "05/02  Refund  10.00",
+            "Total: 5.50",
+        ],
+        tables=[
+            PdfTable(
+                page=1,
+                header=["Date", "Description", "Amount"],
+                rows=[
+                    ["05/01", "Coffee", "-4.50"],
+                    ["05/02", "Refund", "10.00"],
+                    ["05/03", "Lunch", "-12.00"],
+                    ["05/04", "Bus", "-2.50"],
+                    ["05/05", "Coffee", "-4.50"],
+                    ["05/06", "Brunch", "-22.00"],
+                    ["05/07", "Lunch", "-15.00"],
+                ],
+            ),
+        ],
+    )
+
+
+def test_build_bridge_request_propose_recipe_returns_typed_request() -> None:
+    req = build_bridge_request(_doc(), request_kind="propose_recipe")
+    assert isinstance(req, BridgeRequest)
+    assert req.request_kind == "propose_recipe"
+    assert req.saved_recipe_for_re_derive is None
+
+
+def test_build_bridge_request_replay_failed_carries_saved_recipe() -> None:
+    saved = {"version": 1, "extraction_recipe": _VALID_RECIPE_DICT}
+    req = build_bridge_request(
+        _doc(),
+        request_kind="replay_failed_re_derive",
+        saved_recipe_for_re_derive=saved,
+    )
+    assert req.request_kind == "replay_failed_re_derive"
+    assert req.saved_recipe_for_re_derive == saved
+
+
+def test_bridge_request_includes_transparency_notice() -> None:
+    req = build_bridge_request(_doc(), request_kind="propose_recipe")
+    assert req.transparency_notice == TRANSPARENCY_NOTICE
+    assert "audit_log" in req.transparency_notice
+    assert "smart_import_parse" in req.transparency_notice
+
+
+def test_bridge_request_carries_fingerprint_with_required_keys() -> None:
+    req = build_bridge_request(_doc(), request_kind="propose_recipe")
+    assert set(req.fingerprint.keys()) >= {"issuer", "headers", "page_bucket"}
+    assert isinstance(req.fingerprint["headers"], list)
+
+
+def test_bridge_request_document_text_preserves_lines() -> None:
+    req = build_bridge_request(_doc(), request_kind="propose_recipe")
+    assert "Chase Bank" in req.document_text
+    assert "Total: 5.50" in req.document_text
+    # Newline-joined preserves separation
+    assert req.document_text.count("\n") >= 4
+
+
+def test_bridge_request_tables_preview_caps_rows_per_table() -> None:
+    req = build_bridge_request(_doc(), request_kind="propose_recipe")
+    assert len(req.tables_preview) == 1
+    preview = req.tables_preview[0]
+    assert preview["page"] == 1
+    assert preview["header"] == ["Date", "Description", "Amount"]
+    # The fixture has 7 rows; preview keeps at most 5.
+    assert len(preview["rows"]) == 5
+
+
+def test_parse_bridge_response_returns_typed_recipe_and_rows() -> None:
+    rows: list[dict[str, Any]] = [
+        {"date": "2026-05-01", "amount": "-4.50"},
+        {"date": "2026-05-02", "amount": "10.00"},
+    ]
+    payload: dict[str, Any] = {"recipe": _VALID_RECIPE_DICT, "rows": rows}
+    response = parse_bridge_response(payload)
+    assert isinstance(response, BridgeResponse)
+    assert response.recipe.routing == "transactions"
+    assert response.rows == rows
+
+
+def test_parse_bridge_response_rejects_non_dict_payload() -> None:
+    with pytest.raises(ValueError, match="must be a dict"):
+        parse_bridge_response("not-a-dict")  # type: ignore[arg-type]
+
+
+def test_parse_bridge_response_rejects_missing_recipe_key() -> None:
+    with pytest.raises(ValueError, match="recipe"):
+        parse_bridge_response({"rows": []})
+
+
+def test_parse_bridge_response_rejects_missing_rows_key() -> None:
+    with pytest.raises(ValueError, match="rows"):
+        parse_bridge_response({"recipe": _VALID_RECIPE_DICT})
+
+
+def test_parse_bridge_response_rejects_recipe_not_a_dict() -> None:
+    with pytest.raises(ValueError, match="must be a dict"):
+        parse_bridge_response({"recipe": "oops", "rows": []})
+
+
+def test_parse_bridge_response_rejects_rows_not_a_list() -> None:
+    with pytest.raises(ValueError, match="must be a list"):
+        parse_bridge_response({"recipe": _VALID_RECIPE_DICT, "rows": "oops"})
+
+
+def test_parse_bridge_response_rejects_invalid_recipe_shape() -> None:
+    # Recipe missing required `row_region` — pydantic ValidationError, wrapped
+    # as ValueError so callers have one exception type to catch.
+    bad: dict[str, Any] = {"oops": True}
+    with pytest.raises(ValueError, match="recipe invalid"):
+        parse_bridge_response({"recipe": bad, "rows": []})

--- a/tests/moneybin/test_services/test_pdf_preview.py
+++ b/tests/moneybin/test_services/test_pdf_preview.py
@@ -1,0 +1,270 @@
+"""Tests for ``ImportService.pdf_preview`` — the Phase 2b egress seam.
+
+The preview method runs the deterministic rung, then either returns a typed
+``PdfPreviewResult`` (when the deterministic outcome is final) or raises
+``ImportConfirmationRequiredError`` carrying a ``BridgePayload`` (when the
+agent can help — bridge-eligible failure modes). The escalation also writes
+a ``smart_import_parse`` audit row (Req 14) and bumps the egress metric.
+
+These tests stub ``route_pdf_import`` and ``PDFExtractor.extract`` because
+the unit under test is the dispatch logic in ``pdf_preview``, not the
+routing math (which has its own dedicated tests in ``test_routing.py``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from moneybin.database import Database
+from moneybin.extractors.pdf.ir import PdfDocument, PdfTable
+from moneybin.extractors.pdf.routing import RouteDecision
+from moneybin.metrics.registry import PDF_BRIDGE_EGRESS_TOTAL
+from moneybin.services.import_confirmation import (
+    BridgePayload,
+    ImportConfirmationRequiredError,
+)
+from moneybin.services.import_service import ImportService, PdfPreviewResult
+
+
+def _doc() -> PdfDocument:
+    return PdfDocument(
+        source_file="chase.pdf",
+        text_lines=[
+            "Chase Bank — Checking Statement",
+            "Date  Description  Amount",
+            "05/01  Coffee  -4.50",
+            "Total: -4.50",
+        ],
+        tables=[
+            PdfTable(
+                page=1,
+                header=["Date", "Description", "Amount"],
+                rows=[["05/01", "Coffee", "-4.50"]],
+            ),
+        ],
+    )
+
+
+def _decision(
+    *,
+    outcome: str = "seed",
+    reason: str = "low_confidence",
+    confidence: float = 0.55,
+    rows: list[dict[str, Any]] | None = None,
+    matched_format_name: str | None = None,
+) -> RouteDecision:
+    from moneybin.extractors.pdf.metadata import StatementMetadata
+
+    return RouteDecision(
+        outcome=outcome,  # type: ignore[arg-type]
+        recipe=None,
+        rows=rows or [],
+        metadata=StatementMetadata(
+            account_id=None,
+            period_start=None,
+            period_end=None,
+            opening_balance=None,
+            closing_balance=None,
+        ),
+        confidence=confidence,
+        reason=reason,  # type: ignore[arg-type]
+        matched_format_name=matched_format_name,
+        fp={
+            "issuer": "chase",
+            "headers": ["Date", "Description", "Amount"],
+            "page_bucket": "1",
+        },
+    )
+
+
+@pytest.fixture()
+def stub_pdf_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[list[RouteDecision], list[PdfDocument]]:
+    """Stub PDFExtractor + route_pdf_import. Caller appends decisions/docs."""
+    decisions: list[RouteDecision] = []
+    docs: list[PdfDocument] = []
+
+    class _StubExtractor:
+        def extract(self, _path: Path) -> PdfDocument:
+            return docs[0] if docs else _doc()
+
+    monkeypatch.setattr(
+        "moneybin.extractors.pdf.extractor.PDFExtractor", _StubExtractor
+    )
+
+    def _fake_route(_doc: PdfDocument, _db: Database) -> RouteDecision:
+        return decisions[0]
+
+    monkeypatch.setattr("moneybin.extractors.pdf.routing.route_pdf_import", _fake_route)
+    return decisions, docs
+
+
+def _make_pdf_path(tmp_path: Path) -> Path:
+    """Create a dummy file path with .pdf suffix (content irrelevant — stubbed)."""
+    path = tmp_path / "stub.pdf"
+    path.write_bytes(b"%PDF-1.4\n%dummy\n")
+    return path
+
+
+def test_pdf_preview_deterministic_returns_typed_result(
+    db: Database,
+    tmp_path: Path,
+    stub_pdf_pipeline: tuple[list[RouteDecision], list[PdfDocument]],
+) -> None:
+    decisions, docs = stub_pdf_pipeline
+    docs.append(_doc())
+    decisions.append(
+        _decision(
+            outcome="transactions",
+            reason="passed",
+            confidence=0.95,
+            rows=[{"date": "05/01", "amount": "-4.50"}],
+        )
+    )
+
+    result = ImportService(db).pdf_preview(_make_pdf_path(tmp_path))
+
+    assert isinstance(result, PdfPreviewResult)
+    assert result.deterministic is True
+    assert result.decision_reason == "passed"
+    assert result.row_count == 1
+    assert result.confidence == 0.95
+    assert result.fingerprint is not None
+
+
+def test_pdf_preview_low_confidence_raises_bridge_escalation(
+    db: Database,
+    tmp_path: Path,
+    stub_pdf_pipeline: tuple[list[RouteDecision], list[PdfDocument]],
+) -> None:
+    decisions, docs = stub_pdf_pipeline
+    docs.append(_doc())
+    decisions.append(_decision(reason="low_confidence", confidence=0.4))
+
+    with pytest.raises(ImportConfirmationRequiredError) as excinfo:
+        ImportService(db).pdf_preview(_make_pdf_path(tmp_path))
+
+    outcome = excinfo.value.outcome
+    assert outcome.channel == "pdf"
+    assert outcome.reason == "unknown_layout"
+    assert isinstance(outcome.proposed, BridgePayload)
+    payload = outcome.proposed.payload
+    assert payload["request_kind"] == "propose_recipe"
+    assert payload["saved_recipe_for_re_derive"] is None
+    assert "transparency_notice" in payload
+    # compute_fingerprint resolves issuer from the document — not the stub.fp.
+    assert set(payload["fingerprint"].keys()) >= {"issuer", "headers", "page_bucket"}
+
+
+def test_pdf_preview_replay_failed_uses_replay_request_kind(
+    db: Database,
+    tmp_path: Path,
+    stub_pdf_pipeline: tuple[list[RouteDecision], list[PdfDocument]],
+) -> None:
+    decisions, docs = stub_pdf_pipeline
+    docs.append(_doc())
+    decisions.append(
+        _decision(
+            reason="replay_reconciliation_failed",
+            confidence=0.9,
+            matched_format_name="chase_checking_pdf",
+        )
+    )
+
+    with pytest.raises(ImportConfirmationRequiredError) as excinfo:
+        ImportService(db).pdf_preview(_make_pdf_path(tmp_path))
+
+    outcome = excinfo.value.outcome
+    assert outcome.reason == "validation_failure"
+    assert isinstance(outcome.proposed, BridgePayload)
+    payload = outcome.proposed.payload
+    assert payload["request_kind"] == "replay_failed_re_derive"
+    assert payload["saved_recipe_for_re_derive"] == {"name": "chase_checking_pdf"}
+
+
+def test_pdf_preview_escalation_writes_smart_import_parse_audit_row(
+    db: Database,
+    tmp_path: Path,
+    stub_pdf_pipeline: tuple[list[RouteDecision], list[PdfDocument]],
+) -> None:
+    decisions, docs = stub_pdf_pipeline
+    docs.append(_doc())
+    decisions.append(_decision(reason="low_confidence", confidence=0.4))
+
+    with pytest.raises(ImportConfirmationRequiredError):
+        ImportService(db).pdf_preview(_make_pdf_path(tmp_path))
+
+    rows = db.conn.execute(
+        "SELECT actor, action, target_schema, target_table, after_value, context_json "
+        "FROM app.audit_log WHERE action = 'smart_import_parse'"
+    ).fetchall()
+    assert len(rows) == 1
+    actor, action, schema, table, after, context = rows[0]
+    assert actor == "system"
+    assert action == "smart_import_parse"
+    assert (schema, table) == ("raw", "pdf_seeds")
+    after_json = json.loads(after)
+    assert after_json["request_kind"] == "propose_recipe"
+    assert after_json["decision_reason"] == "low_confidence"
+    assert json.loads(context)["confidence"] == 0.4
+
+
+def test_pdf_preview_escalation_increments_egress_metric(
+    db: Database,
+    tmp_path: Path,
+    stub_pdf_pipeline: tuple[list[RouteDecision], list[PdfDocument]],
+) -> None:
+    decisions, docs = stub_pdf_pipeline
+    docs.append(_doc())
+    decisions.append(_decision(reason="low_confidence", confidence=0.4))
+
+    before = PDF_BRIDGE_EGRESS_TOTAL.labels(outcome="proposed")._value.get()  # type: ignore[reportPrivateUsage] — prometheus internals
+    with pytest.raises(ImportConfirmationRequiredError):
+        ImportService(db).pdf_preview(_make_pdf_path(tmp_path))
+    after = PDF_BRIDGE_EGRESS_TOTAL.labels(outcome="proposed")._value.get()  # type: ignore[reportPrivateUsage]
+    assert after == before + 1
+
+
+@pytest.mark.parametrize(
+    "reason",
+    ["no_transaction_table", "no_rows", "unsupported_number_format"],
+)
+def test_pdf_preview_non_bridge_reason_returns_non_deterministic(
+    db: Database,
+    tmp_path: Path,
+    reason: str,
+    stub_pdf_pipeline: tuple[list[RouteDecision], list[PdfDocument]],
+) -> None:
+    decisions, docs = stub_pdf_pipeline
+    docs.append(_doc())
+    decisions.append(_decision(reason=reason, confidence=0.0))
+
+    result = ImportService(db).pdf_preview(_make_pdf_path(tmp_path))
+
+    assert isinstance(result, PdfPreviewResult)
+    assert result.deterministic is False
+    assert result.decision_reason == reason
+    assert result.row_count == 0
+
+
+def test_pdf_preview_non_bridge_reason_does_not_write_audit_row(
+    db: Database,
+    tmp_path: Path,
+    stub_pdf_pipeline: tuple[list[RouteDecision], list[PdfDocument]],
+) -> None:
+    decisions, docs = stub_pdf_pipeline
+    docs.append(_doc())
+    decisions.append(_decision(reason="no_transaction_table", confidence=0.0))
+
+    ImportService(db).pdf_preview(_make_pdf_path(tmp_path))
+
+    rows = db.conn.execute(
+        "SELECT COUNT(*) FROM app.audit_log WHERE action = 'smart_import_parse'"
+    ).fetchone()
+    assert rows is not None
+    assert rows[0] == 0

--- a/tests/moneybin/test_services/test_pdf_preview.py
+++ b/tests/moneybin/test_services/test_pdf_preview.py
@@ -21,6 +21,7 @@ import pytest
 
 from moneybin.database import Database
 from moneybin.extractors.pdf.ir import PdfDocument, PdfTable
+from moneybin.extractors.pdf.recipe import Recipe
 from moneybin.extractors.pdf.routing import RouteDecision
 from moneybin.metrics.registry import PDF_BRIDGE_EGRESS_TOTAL
 from moneybin.services.import_confirmation import (
@@ -28,6 +29,26 @@ from moneybin.services.import_confirmation import (
     ImportConfirmationRequiredError,
 )
 from moneybin.services.import_service import ImportService, PdfPreviewResult
+
+
+def _make_recipe() -> Recipe:
+    """Build a minimal valid Recipe for replay-payload assertions."""
+    return Recipe.model_validate({
+        "metadata_anchors": [],
+        "row_region": {"start_anchor": "TRANSACTIONS", "end_anchor": "TOTAL"},
+        "row_split": r"\s{2,}",
+        "fields": [
+            {
+                "name": "date",
+                "pattern": r"\d{2}/\d{2}/\d{4}",
+                "cast": "date",
+                "date_format": "%m/%d/%Y",
+            },
+            {"name": "amount", "pattern": r"-?\d+\.\d{2}", "cast": "decimal"},
+        ],
+        "sign_convention": "negative_is_expense",
+        "routing": "transactions",
+    })
 
 
 def _doc() -> PdfDocument:
@@ -56,12 +77,13 @@ def _decision(
     confidence: float = 0.55,
     rows: list[dict[str, Any]] | None = None,
     matched_format_name: str | None = None,
+    recipe: Recipe | None = None,
 ) -> RouteDecision:
     from moneybin.extractors.pdf.metadata import StatementMetadata
 
     return RouteDecision(
         outcome=outcome,  # type: ignore[arg-type]
-        recipe=None,
+        recipe=recipe,
         rows=rows or [],
         metadata=StatementMetadata(
             account_id=None,
@@ -168,11 +190,13 @@ def test_pdf_preview_replay_failed_uses_replay_request_kind(
 ) -> None:
     decisions, docs = stub_pdf_pipeline
     docs.append(_doc())
+    recipe = _make_recipe()
     decisions.append(
         _decision(
             reason="replay_reconciliation_failed",
             confidence=0.9,
             matched_format_name="chase_checking_pdf",
+            recipe=recipe,
         )
     )
 
@@ -184,7 +208,54 @@ def test_pdf_preview_replay_failed_uses_replay_request_kind(
     assert isinstance(outcome.proposed, BridgePayload)
     payload = outcome.proposed.payload
     assert payload["request_kind"] == "replay_failed_re_derive"
-    assert payload["saved_recipe_for_re_derive"] == {"name": "chase_checking_pdf"}
+    # The replay payload carries both the saved format name AND the actual
+    # recipe patterns the agent needs to diagnose and refresh the failed match.
+    assert payload["saved_recipe_for_re_derive"] == {
+        "name": "chase_checking_pdf",
+        "recipe": recipe.model_dump(),
+    }
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "low_confidence",
+        "replay_reconciliation_failed",
+        "reconciliation_failed",
+        "metadata_incomplete",
+    ],
+)
+def test_pdf_preview_all_bridge_eligible_reasons_escalate(
+    db: Database,
+    tmp_path: Path,
+    reason: str,
+    stub_pdf_pipeline: tuple[list[RouteDecision], list[PdfDocument]],
+) -> None:
+    """Every entry in `_BRIDGE_ELIGIBLE_REASONS` must trigger bridge escalation.
+
+    Without parametrize coverage, `reconciliation_failed` and
+    `metadata_incomplete` would silently regress to the non-escalating
+    fallback if either were removed from the frozenset.
+    """
+    decisions, docs = stub_pdf_pipeline
+    docs.append(_doc())
+    decisions.append(
+        _decision(
+            reason=reason,
+            confidence=0.4,
+            matched_format_name=(
+                "chase_checking_pdf"
+                if reason == "replay_reconciliation_failed"
+                else None
+            ),
+            recipe=(
+                _make_recipe() if reason == "replay_reconciliation_failed" else None
+            ),
+        )
+    )
+
+    with pytest.raises(ImportConfirmationRequiredError):
+        ImportService(db).pdf_preview(_make_pdf_path(tmp_path))
 
 
 def test_pdf_preview_escalation_writes_smart_import_parse_audit_row(

--- a/tests/moneybin/test_services/test_pdf_preview.py
+++ b/tests/moneybin/test_services/test_pdf_preview.py
@@ -282,7 +282,9 @@ def test_pdf_preview_escalation_writes_smart_import_parse_audit_row(
     after_json = json.loads(after)
     assert after_json["request_kind"] == "propose_recipe"
     assert after_json["decision_reason"] == "low_confidence"
-    assert json.loads(context)["confidence"] == 0.4
+    context_json = json.loads(context)
+    assert context_json["confidence"] == 0.4
+    assert context_json["decision_reason"] == "low_confidence"
 
 
 def test_pdf_preview_escalation_increments_egress_metric(
@@ -337,5 +339,4 @@ def test_pdf_preview_non_bridge_reason_does_not_write_audit_row(
     rows = db.conn.execute(
         "SELECT COUNT(*) FROM app.audit_log WHERE action = 'smart_import_parse'"
     ).fetchone()
-    assert rows is not None
-    assert rows[0] == 0
+    assert rows[0] == 0  # type: ignore[index]  # COUNT(*) always returns a 1-tuple


### PR DESCRIPTION
## Summary

Phase 2a (PR #233) shipped the deterministic recipe ladder + replay + transactions routing. Phase 2b's bridge offers a recovery rung between deterministic success and seed fallback: when the deterministic rung produces a bridge-eligible failure, MoneyBin escalates by surfacing the document to the agent the user is *already* driving the host with (Reqs 8, 14).

**This PR ships the export side only** — the agent can see the payload and act on it. The apply side (vetting the agent's reply + persisting through `PdfFormatsRepo` + loading rows) follows in a separate PR so the egress contract can be reviewed independently of the apply machinery.

### What landed

- **`extractors/pdf/bridge.py`** (new) — `BridgeRequest` + `BridgeResponse` typed dataclasses + `build_bridge_request()` + `parse_bridge_response()`. The transparency notice (Req 14) is a typed field on `BridgeRequest`, not buried convention. `parse_bridge_response` runs `Recipe.model_validate` so the security bounds (Req 9b — pattern length + nested-quantifier check) hold for bridge-authored recipes too.
- **`ImportService.pdf_preview()`** (new) — runs the Phase 2a routing state machine without side effects on `raw.*` tables. Three outcomes:
  - Deterministic success → returns typed `PdfPreviewResult`.
  - Bridge-eligible failure (`low_confidence` / `replay_reconciliation_failed` / `reconciliation_failed` / `metadata_incomplete`) → writes a `smart_import_parse` audit row (Req 14), bumps `PDF_BRIDGE_EGRESS_TOTAL{outcome="proposed"}`, raises `ImportConfirmationRequiredError` carrying a `BridgePayload`.
  - Non-bridge-eligible failure (`no_transaction_table` / `no_rows` / `unsupported_number_format`) → returns `PdfPreviewResult(deterministic=False)`. The bridge cannot help on these; the gap is surfaced honestly.
- **`PDF_BRIDGE_EGRESS_TOTAL`** metric in `metrics/registry.py` — Counter with label set `{"proposed", "applied", "declined", "invalid"}`. Only `proposed` is used here; the apply-side PR wires the rest.
- **`docs/specs/privacy-and-ai-trust.md`** — replaces the Tier-3 "redacted preview" promise (which described the parsing flow earlier drafts placed in Tier 3) with the bridge-to-driving-agent model from `smart-import-pdf.md` Reqs 14-16. Names the trust shape, the local-first guarantee (deterministic-only sessions write no audit rows), and that there is no redacted-preview claim.

### Tests (22 added)

- `test_extractors/test_pdf/test_bridge.py` — 13 unit tests on `build_bridge_request` shape and `parse_bridge_response` rejection cases.
- `test_services/test_pdf_preview.py` — 9 integration tests against a real `Database` covering all three dispatch arms + audit-row write + metric increment.

### Out of scope (follow-up PRs)

- MCP wire-in (`import_preview` PDF branch + `import_confirm` bridge-response arm). The `pdf_preview` service method is callable but no public tool dispatches to it yet.
- Apply side (`parse_bridge_response` → reconciliation gate → `PdfFormatsRepo.save_new` → `raw.tabular_transactions` load).
- Auto-`bump_version` on replay-guard failure (Req 9a).
- `moneybin-mcp.md` + `moneybin-capabilities.md` updates (the public MCP surface is unchanged in this PR).

## Test plan

- [x] 22/22 new tests green
- [x] Full unit suite green: 3946 passed, 4 pre-existing skips
- [x] `make check` clean (format + lint + pyright 0 errors)
- [x] Bridge module has no upward import to services — architecture-layering test stays green