### PR TITLE
Fix security findings: bump pip to 26.1.2, harden test URL asserts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,8 +152,10 @@ dev = [
     "sqlparse>=0.5.3",
     # Security auditing
     "pip-audit>=2.10.0",
-    # Security: CVE-2026-6357 (pip 26.0.1) — fixed in 26.1 (transitive via pip-audit → pip-api)
-    "pip>=26.1",
+    # Security floor for pip (transitive via pip-audit → pip-api): bump as new
+    # CVEs land. CVE-2026-6357 (pip 26.0.1) fixed in 26.1; CVE-2026-8643 /
+    # PYSEC-2026-196 (entry points installed outside the install dir) fixed in 26.1.2.
+    "pip>=26.1.2",
     # Testing framework and tools
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",

--- a/tests/moneybin/test_mcp/test_mcp_sync.py
+++ b/tests/moneybin/test_mcp/test_mcp_sync.py
@@ -89,7 +89,7 @@ async def test_sync_link_returns_link_url_with_medium_sensitivity(
     # link_url is a one-time bearer credential → medium sensitivity per design
     assert envelope.summary.sensitivity == "medium"
     assert envelope.data.session_id == "sess_abc"
-    assert envelope.data.link_url.startswith("https://hosted.plaid.com")
+    assert envelope.data.link_url == "https://hosted.plaid.com/link/xyz"
     # Agent should know about expiration to decide when to give up polling
     assert envelope.data.expiration is not None
 
@@ -157,7 +157,7 @@ async def test_sync_connect_alias_warns_and_forwards(
     # returns the same typed SyncConnectPayload (link_url: DESCRIPTION → MEDIUM).
     assert envelope.summary.sensitivity == "medium"
     assert envelope.data.session_id == "sess_abc"
-    assert envelope.data.link_url.startswith("https://hosted.plaid.com")
+    assert envelope.data.link_url == "https://hosted.plaid.com/link/xyz"
     # Agent should know about expiration to decide when to give up polling.
     assert envelope.data.expiration is not None
     # Deprecation warning fires via module logger; assert against the patched

--- a/uv.lock
+++ b/uv.lock
@@ -1837,7 +1837,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pip", specifier = ">=26.1" },
+    { name = "pip", specifier = ">=26.1.2" },
     { name = "pip-audit", specifier = ">=2.10.0" },
     { name = "pre-commit", specifier = ">=4.4.0" },
     { name = "pyright", specifier = ">=1.1.408" },
@@ -2262,11 +2262,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Resolves all currently-open security findings surfaced by the `Security` workflow (the `Dependency Audit` job was failing; CodeQL had 2 open high-severity alerts):

- **`pip` CVE** — bumps the dev-dependency floor `pip>=26.1` → `pip>=26.1.2` for **CVE-2026-8643 / PYSEC-2026-196** (pip resolves `console_scripts`/`gui_scripts` entry points to absolute paths without sanitizing against the install directory, so entry points can be written outside it). Lockfile relocked to `pip 26.1.2`; `pip-audit` is now clean.
- **CodeQL `py/incomplete-url-substring-sanitization` (alerts #3, #4)** — replaces two `.startswith("https://hosted.plaid.com")` assertions in `test_mcp_sync.py` with exact-equality checks against the mock's full `link_url`. The value is fully controlled by the test mock, so exact match is both a stronger assertion and free of the flagged substring pattern. No suppressions added.

## Test plan

- [ ] `uv run pip-audit --skip-editable --ignore-vuln PYSEC-2026-161` → **No known vulnerabilities found** (the time-boxed starlette `PYSEC-2026-161` pin remains the only ignore)
- [ ] `make check` → ruff lint clean, pyright **0 errors**
- [ ] `make test` → full unit suite green (**3924 passed, 4 skipped** locally)
- [ ] After merge, the CodeQL re-scan should auto-close alerts **#3** and **#4**
