### PR TITLE
Reconcile public docs with shipped import and confirmation state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-<!-- Last reviewed: 2026-05-17 -->
+<!-- Last reviewed: 2026-06-10 -->
 # Contributing to MoneyBin
 
 Thanks for helping out. This file gets you to a landed change without a reading
@@ -172,7 +172,7 @@ tier signals what gates merge vs what's worth doing vs what's polish:
   one, file a followup and call out the override in the PR description.
 - 🟡 **CONSIDER** — substantive quality: design, refactoring, potential
   bugs, missing edge cases. Your call per finding: fix in this PR (when
-  bounded) or defer to `private/followups.md` (when fixing would
+  bounded) or defer as a follow-up noted in the PR (when fixing would
   meaningfully expand scope). Either resolution closes the PR cleanly.
 - 🔵 **NIT** — small consistency issues: docstring formatting, naming
   drift, minor style. Worth fixing on early iterations to keep the

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- Last reviewed: 2026-05-24 -->
+<!-- Last reviewed: 2026-06-10 -->
 <!-- markdownlint-disable MD033 MD041 -->
 <div align="center">
   <img src="docs/assets/moneybin-icon.png" alt="MoneyBin" width="300">
@@ -32,7 +32,7 @@ As easy as Mint was. As powerful as the tools data engineers actually use. Ask y
 
 - **You own it, end to end.** Local-first by default — one encrypted DuckDB file per profile under `~/.moneybin/`, AES-256-GCM at rest. No vendor account required, no data resale, no lock-in. The same code powers an optional hosted tier; switching deployments is moving one file. → [Architecture](docs/architecture.md) · [Threat model](docs/guides/threat-model.md)
 
-- **Your history comes with you.** Import from bank files (CSV/OFX/QFX/QBO/Excel/Parquet), sync from Plaid, or connect a live Google Sheet — your categories migrate with you and auto-rules learn from them. Cross-source dedup means re-importing overlapping months never double-counts. → [Data import](docs/guides/data-import.md)
+- **Your history comes with you.** Import from bank files (CSV/OFX/QFX/QBO/Excel/Parquet/PDF), sync from Plaid, or connect a live Google Sheet — your categories migrate with you and auto-rules learn from them. Cross-source dedup means re-importing overlapping months never double-counts. → [Data import](docs/guides/data-import.md)
 
 ## How it works
 
@@ -94,9 +94,9 @@ moneybin sql query "SELECT category, SUM(amount) FROM core.fct_transactions GROU
 
 **MoneyBin is pre-v1.** It's in daily use by the author, and the foundation is built to last rather than built to demo.
 
-**Working today:** the CLI and MCP server (≈70 tools across nine AI clients), encrypted multi-profile storage, file imports (CSV/OFX/QFX/QBO/Excel/Parquet) and a watched-folder inbox, Plaid sync (cash + credit cards), live Google Sheets sync, cross-source dedup and transfer detection, rule-based categorization with an opt-in LLM-assist step, eight curated reports, privacy-safe ad-hoc SQL, reversible edits with a full audit trail, and `moneybin system doctor` integrity checks.
+**Working today:** the CLI and MCP server (≈70 tools across nine AI clients), encrypted multi-profile storage, file imports (CSV/OFX/QFX/QBO/Excel/Parquet), native-text PDF statement import with saved replayable per-format recipes, a watched-folder inbox, Plaid sync (cash + credit cards), live Google Sheets sync, cross-source dedup and transfer detection, rule-based categorization with an opt-in LLM-assist step, eight curated reports, privacy-safe ad-hoc SQL, reversible edits with a full audit trail, and `moneybin system doctor` integrity checks.
 
-**In flight:** a `brew install` path and first-run onboarding, drop-any-PDF import (AI-assisted extraction), an extensible report framework, Plaid production approval, and the contributor extension contract.
+**In flight:** a `brew install` path and first-run onboarding, AI-assisted import for scanned and other hard-to-parse PDFs, an extensible report framework, Plaid production approval, and the contributor extension contract.
 
 **Planned:** investment & cost-basis tracking, multi-currency, budgets, a web UI dashboard, and an opt-in hosted tier — same code you can self-host.
 

--- a/docs/audience.md
+++ b/docs/audience.md
@@ -1,4 +1,4 @@
-<!-- Last reviewed: 2026-05-24 -->
+<!-- Last reviewed: 2026-06-10 -->
 # Who MoneyBin Is For
 
 MoneyBin is built for a specific set of people. This page tells you whether you're one of them — honestly, including who you should use instead if you're not.
@@ -90,7 +90,7 @@ These are the people MoneyBin is being built for but doesn't fully serve yet. No
 
 **Partner sharing:** MoneyBin is single-user. There's no household-shared budget on the v1 roadmap — if joint finances with a partner are a hard requirement, Monarch or Tiller is the right answer.
 
-**What's still rough:** No production web UI yet. A narrow review-queue prototype exists for the AI-categorization workflow, but it isn't a tracker dashboard. **Stay on Monarch or Copilot until the web UI ships.**
+**What's still rough:** No production web UI yet. A CLI/MCP review queue exists for the AI-categorization workflow; there is no web surface yet. **Stay on Monarch or Copilot until the web UI ships.**
 
 ### The FIRE / wealth-builder
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,4 +1,4 @@
-<!-- Last reviewed: 2026-05-24 -->
+<!-- Last reviewed: 2026-06-10 -->
 # What Works Today
 
 What MoneyBin can do today. Each capability links to its guide; the [roadmap](roadmap.md) covers what's planned and the [CHANGELOG](../CHANGELOG.md) carries the dated record.
@@ -46,7 +46,7 @@ What MoneyBin can do today. Each capability links to its guide; the [roadmap](ro
 
 - **Notes** — Free-text notes on transactions.
 - **Tags** — Multi-tag table with rename semantics.
-- **Splits via annotation** — Annotation-based splits today; first-class split rows planned (see [roadmap](roadmap.md)).
+- **Splits via annotation** — Annotation-based splits today; first-class split rows are parked (see [roadmap](roadmap.md)).
 - **Import-batch labels** — Group imported rows under a human label.
 - **Edit-history audit log** — Per-row history of every curation edit.
 - **Reversible edits** — Every protected `app.*` mutation (notes, tags, splits, categories, rules, account settings) is audit-paired and undoable as a unit keyed on `operation_id`. `moneybin system audit undo|history|get` (and `system_audit_undo` / `system_audit_history` / `system_audit_get` on MCP) reverse a change from its full before/after image; the undo is itself audited and undoable. Undo refuses (rather than silently cascading) when a later operation touched the same rows. -> [CLI reference](guides/cli-reference.md)
@@ -119,7 +119,7 @@ MoneyBin is built on the assumption that you'll want to track your money your wa
 These are visible gaps a migrant or agent author will notice. See [Roadmap](roadmap.md) for the full milestone view.
 
 - **Plaintext export** — `moneybin export` (CSV / Excel / Sheets) for data exit. Planned, not shipped.
-- **Budgeting** — Envelopes, rollovers, period-over-period burn. Planned.
+- **Budgeting** — Monthly budgets, target-vs-actual, rollovers. Planned.
 - **Investment tracking** — Holdings, FIFO lots, cost basis, 1099-B reconciliation. Planned (core, not a package).
 - **Multi-currency** — FX gain/loss and non-USD accounts. Planned.
 - **Web UI dashboard** — Local web UI plus Streamable HTTP MCP transport (so remote clients like ChatGPT web can reach MoneyBin). Planned.
@@ -129,9 +129,9 @@ These are visible gaps a migrant or agent author will notice. See [Roadmap](road
 - **Extension contract** — The contributor-facing surface for reports, analysis packages, and providers (see [Extensibility](#extensibility)). In flight; ships at v1 with two reference packages at Platinum quality.
 - **Reference package: `assets`** — Real estate, vehicles, and valuables. First reference package; demonstrates the package contract.
 - **Reference package: `us_tax`** — Locale-specific tax reporting helpers (realized gain/loss summaries, cost-basis snapshots). Built on top of investment tracking; not Schedule D generation.
-- **First-class split rows** — Today splits are annotations on the parent row; first-class split lines arrive with the curation polish work. Planned.
+- **First-class split rows** — Splits ship as annotations on the parent row; that's the intended shape. First-class split lines are parked, revisited only if budgeting needs or real-data feedback force them.
 - **Subscription-cancellation workflow** — `reports.recurring_subscriptions` surfaces the candidates; a "mark cancelled / paused" tracking surface is planned.
 - **Native mobile apps** — Not on the roadmap.
 - **Household / shared budgets** — Multi-user accounts within one profile. Not on the roadmap.
 
-Post-launch candidates (PDF data extraction, ML-powered categorization, mobile read-only viewer, expanded privacy tiers) live on the same page.
+Post-launch candidates (AI-assisted parsing of non-PDF file types, ML-powered categorization, mobile read-only viewer, expanded privacy tiers) live on the same page.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,4 +1,4 @@
-<!-- Last reviewed: 2026-05-30 -->
+<!-- Last reviewed: 2026-06-10 -->
 # Roadmap
 
 Pre-v1 roadmap. Each milestone is a coherent slice of work, not a calendar date — we don't commit dates pre-v1. Statuses below reflect what's merged to `main` today; the dated record of individual changes lives in [`CHANGELOG.md`](../CHANGELOG.md). For "is this for me?" see [`audience.md`](audience.md); for where MoneyBin fits and who to use instead, [`comparison.md`](comparison.md); for shipped capability detail, [`features.md`](features.md).
@@ -68,8 +68,8 @@ Every planned way your money gets in lands cleanly — with the *ergonomics* (co
 | **M1E** | Transaction curation: notes, tags, splits, manual entry, audit log | ✅ | [`transaction-curation.md`](specs/transaction-curation.md). |
 | **M1F** | Google Sheets connect (live tabular source via direct OAuth) | ✅ | Airtable/Smartsheet siblings planned. [`connect-gsheet.md`](specs/connect-gsheet.md). |
 | **M1G** | Plaid sync | 🚧 | Phase 1 (cash + credit) ✅. Remaining: Production approval, real-user round-trip; SimpleFIN + Plaid-Investments planned. [`sync-plaid.md`](specs/sync-plaid.md). |
-| **M1H** | Confirm-the-columns confidence layer | 📐 | One `import_preview`→`import_confirm` flow across tabular/gsheet/PDF; saved layouts reuse silently. [`smart-import-confirmation.md`](specs/smart-import-confirmation.md). |
-| **M1I** | Native PDF import | 🚧 | Phase 1 seed path ✅ (PR #228). Phase 2a deterministic recipe ladder + replay + transactions routing ✅ (PR #233): auto-derived recipes persist to `app.pdf_formats` keyed by layout fingerprint and replay for free on the next statement; reconciliation gate (±1¢) routes transaction-shaped PDFs to `raw.tabular_transactions`. Phase 2b bridge + LLM rung + auto-`bump_version` on replay-guard failure 📐. [`smart-import-pdf.md`](specs/smart-import-pdf.md). |
+| **M1H** | Confirm-the-columns confidence layer | 🚧 | Confirmation & confidence contract + cross-channel `import_preview`→`import_confirm` implementation ✅ (PR #227); saved layouts reuse silently. Remaining channels wire in as M1I/M1Q land. [`smart-import-confirmation.md`](specs/smart-import-confirmation.md). |
+| **M1I** | Native PDF import | 🚧 | Phase 1 seed path ✅ (PR #228). Phase 2a deterministic recipe ladder + replay + transactions routing ✅ (PR #233): auto-derived recipes persist to `app.pdf_formats` keyed by layout fingerprint and replay for free on the next statement; reconciliation gate (±1¢) routes transaction-shaped PDFs to `raw.tabular_transactions`. Phase 2b 🚧 — bridge egress shipped (PR #237); apply round-trip, LLM rung + auto-`bump_version` remaining. [`smart-import-pdf.md`](specs/smart-import-pdf.md). |
 | **M1J** | Investments core | 📐 | Securities, ledger, lots, realized gain/loss, holdings; Decimal precision. **🔒 closes only when cost basis ties to a real broker 1099-B for a full tax year.** [`investments-data-model.md`](specs/investments-data-model.md). |
 | **M1K** | Multi-currency schema wave | 🗓️ | Currency at every grain; auditable FX rate provenance; realized FX gain/loss. |
 | **M1L** | Engine integrity & recovery completion | 🚧 | Paired audit writes + doctor coverage + undo consumer. [`app-integrity-invariant.md`](specs/app-integrity-invariant.md), [`data-recovery-contract.md`](specs/data-recovery-contract.md). |
@@ -141,7 +141,7 @@ Designed or noted, but not gating launch. Listed without commitment.
 
 - **Privacy tiers + consent model** deepening. Framework spec at [`privacy-and-ai-trust.md`](specs/privacy-and-ai-trust.md).
 - **Connect: more live sources** — Airtable, Smartsheet, and Notion connectors under the same connection-lifecycle pattern as Google Sheets (M1F).
-- **AI-assisted parsing of non-PDF file types** — the smart-import bridge (shipped first for PDF in M1I) applied to other formats.
+- **AI-assisted parsing of non-PDF file types** — the smart-import bridge (ships first for PDF in M1I) applied to other formats.
 - **ML-powered categorization + merchant entity resolution.** Needs accumulated labeled data from real users.
 - **FIRE / retirement projection** (Monte Carlo, Roth conversions, RMDs). A wealth analysis package on top of M1J — built only after the investment ledger is correct, never as a shallow dashboard.
 - **Multi-account-holder sharing / household ownership.** Single-user is the v1 posture; if adopted, modeled as core ownership bridges, not app-only filters.


### PR DESCRIPTION
## Summary

Public docs drifted behind the last shipping wave. This reconciles five docs with what's actually merged:

- **docs/roadmap.md** — M1H 📐→🚧 (confirmation & confidence contract + cross-channel implementation shipped in #227); M1I Phase 2b 📐→🚧 (bridge egress shipped in #237; apply round-trip, LLM rung, and auto-`bump_version` remaining); the post-launch bullet no longer counts the bridge as fully shipped.
- **docs/features.md** — Budgeting bullet matches roadmap scope (envelopes are explicitly out of scope); first-class split rows marked parked (both occurrences); post-launch candidates drop already-shipped PDF extraction in favor of the non-PDF phrasing the roadmap uses.
- **docs/audience.md** — Replaces the claim that a web review-queue prototype exists (it doesn't) with the accurate CLI/MCP review-queue statement.
- **README.md** — Import-formats line gains PDF; "Where it stands" separates shipped native-text PDF import (with saved replayable recipes) from the in-flight AI-assisted bridge for hard-to-parse PDFs.
- **CONTRIBUTING.md** — Removes a reference to a gitignored path that outside contributors can't see.

All five files get fresh `<\!-- Last reviewed: 2026-06-10 -->` stamps.

## Verification

- Docs-only diff (17 insertions, 17 deletions); pre-commit hooks pass.
- Status changes cross-checked against merged PRs #227/#228/#233/#237 and `docs/specs/INDEX.md`.
