### PR TITLE
Fix collateral writer-kill and writer-coordination followups

### DIFF
--- a/docs/specs/database-writer-coordination.md
+++ b/docs/specs/database-writer-coordination.md
@@ -661,10 +661,12 @@ def write_lock(
   temp-file-then-rename. A rename would swap the lock file's inode and
   strand the `fcntl` lock on the old, unlinked inode — a second writer
   opening the path would then bind a fresh inode and acquire its own lock.
-  A diagnostic reader (`system_status`) may observe a partial-write window;
-  that is acceptable because lock authority is the held `fcntl`, not the
-  file contents. The file is created once at `0o600` and never replaced,
-  so its mode is not downgraded by a rename.
+  A diagnostic reader (`system_status`) may observe the brief partial-write
+  window between the `ftruncate(0)` and the following `write(payload)` (an
+  empty or truncated read); that is acceptable because lock authority is the
+  held `fcntl`, not the file contents, and the reader re-reads a few times to
+  ride out that window (`_read_writer_metadata`). The file is created once at
+  `0o600` and never replaced, so its mode is not downgraded by a rename.
 - **Lifetime bound to the returned Database, not to ATTACH.**
   `get_database()` enters the `write_lock` context via an
   `ExitStack` and stashes the stack's `close` on the returned

--- a/docs/specs/mcp-tool-timeouts.md
+++ b/docs/specs/mcp-tool-timeouts.md
@@ -30,7 +30,7 @@ Related code: `src/moneybin/mcp/` (tool registration and dispatch), `src/moneybi
 
 No schema changes. One new configuration field:
 
-- `MoneyBinSettings.mcp.tool_timeout_seconds: float = 30.0` (env: `MONEYBIN_MCP__TOOL_TIMEOUT_SECONDS`)
+- `MoneyBinSettings.mcp.tool_timeout_seconds: float = 30.0` (env: `MONEYBIN_MCP__TOOL_TIMEOUT_SECONDS`). Validated to be `>=` the write-lock wait (`config.DEFAULT_WRITE_LOCK_MAX_WAIT_SECONDS`, the `get_database` `max_wait` default). A shorter cap would let a timed-out write tool's uncancellable thread-pool worker acquire the lock and commit after the caller already received the timeout envelope; requiring `timeout >= wait` guarantees the worker has stopped queuing by the time the caller gives up. See [`database-writer-coordination.md`](database-writer-coordination.md).
 
 ## Implementation Plan
 

--- a/src/moneybin/config.py
+++ b/src/moneybin/config.py
@@ -228,6 +228,14 @@ class MetricsConfig(BaseModel):
     model_config = ConfigDict(frozen=True)
 
 
+# Default seconds get_database() blocks for the per-profile write lock before
+# raising DatabaseLockError. Lives here (not database.py) so MCPConfig's
+# tool-timeout validator can reference it without an import cycle — database
+# imports config, never the reverse. get_database's max_wait default imports
+# this value back. See database-writer-coordination.md.
+DEFAULT_WRITE_LOCK_MAX_WAIT_SECONDS: float = 10.0
+
+
 class MCPConfig(BaseModel):
     """MCP server runtime configuration."""
 
@@ -263,9 +271,28 @@ class MCPConfig(BaseModel):
         description=(
             "Hard wall-clock cap for any single MCP tool dispatch. On timeout, "
             "the active DuckDB statement is interrupted and the connection is "
-            "reset so subsequent calls aren't wedged behind a stale write lock."
+            "reset so subsequent calls aren't wedged behind a stale write lock. "
+            "Must be >= the write-lock wait so a timed-out write tool's worker "
+            "can never acquire the lock and commit after the caller gave up."
         ),
     )
+
+    @field_validator("tool_timeout_seconds")
+    @classmethod
+    def _timeout_covers_write_lock_wait(cls, v: float) -> float:
+        # A sync write tool runs in an uncancellable thread-pool worker. If the
+        # tool timeout is shorter than the write-lock wait, the caller can time
+        # out while the worker is still queued at the lock; the worker may then
+        # acquire and commit after the timeout envelope was already returned.
+        # Requiring timeout >= the wait guarantees the worker has stopped
+        # queuing (acquired or errored) by the time the caller gives up.
+        if v < DEFAULT_WRITE_LOCK_MAX_WAIT_SECONDS:
+            raise ValueError(
+                f"tool_timeout_seconds ({v}s) must be >= the write-lock wait "
+                f"({DEFAULT_WRITE_LOCK_MAX_WAIT_SECONDS}s); a shorter cap lets a "
+                f"timed-out write tool's worker commit after the caller gave up."
+            )
+        return v
 
 
 class AIConfig(BaseModel):

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -44,7 +44,7 @@ from moneybin.db_lock._types import CheckpointReason, OperationType
 # overhead anyway. Must be set before sqlmesh is first imported.
 os.environ.setdefault("MAX_FORK_WORKERS", "1")
 
-from moneybin.config import get_settings
+from moneybin.config import DEFAULT_WRITE_LOCK_MAX_WAIT_SECONDS, get_settings
 from moneybin.secrets import (
     SecretNotFoundError,
     SecretStorageUnavailableError,
@@ -886,7 +886,7 @@ def database_was_written() -> bool:
 def get_database(
     *,
     read_only: bool,
-    max_wait: float = 10.0,
+    max_wait: float = DEFAULT_WRITE_LOCK_MAX_WAIT_SECONDS,
     operation_type: OperationType = "interactive",
 ) -> "Database":
     """Create and return a new short-lived Database connection.

--- a/src/moneybin/db_lock/lock.py
+++ b/src/moneybin/db_lock/lock.py
@@ -40,16 +40,17 @@ _BACKOFF_MULTIPLIER = 1.5
 _BACKOFF_CAP_SECONDS = 0.5
 
 
-def lock_path_for(db_path: Path) -> Path:
-    """Return the write-lock metadata path for ``db_path``.
+def lock_path_for(resolved_db_path: Path) -> Path:
+    """Return the write-lock metadata path for an already-resolved db path.
 
-    Resolves ``db_path`` first, mirroring ``write_lock``, so a symlinked or
-    relative path maps to the same lock file the primitive keys on. This is
-    the public contract for locating the lock file; the ``_LOCK_SUFFIX``
-    naming detail stays private to this module.
+    Pass a resolved/canonical path (``db_path.resolve()``) — the form
+    ``write_lock`` keys the lock on — so a symlinked or relative original maps
+    to the one lock file the primitive uses. Resolving is the caller's job: the
+    sole caller already resolves once for its lsof scan, so resolving again here
+    would be a redundant syscall. This is the public way to locate the lock
+    file; the ``_LOCK_SUFFIX`` naming detail stays private to this module.
     """
-    resolved = db_path.resolve()
-    return resolved.parent / (resolved.name + _LOCK_SUFFIX)
+    return resolved_db_path.parent / (resolved_db_path.name + _LOCK_SUFFIX)
 
 
 @dataclass
@@ -94,7 +95,13 @@ def _release_one(key: Path, pid: int, thread_id: int) -> None:
             try:
                 fcntl.flock(holder.fd, fcntl.LOCK_UN)
             finally:
-                os.close(holder.fd)
+                # Guard os.close like the flock release: in this finally an
+                # os.close error (e.g. EBADF) would otherwise mask a flock
+                # exception. os.close on a held fd essentially never raises.
+                try:
+                    os.close(holder.fd)
+                except OSError:
+                    pass
 
 
 def _process_command(pid: int) -> str:

--- a/src/moneybin/db_lock/lock.py
+++ b/src/moneybin/db_lock/lock.py
@@ -40,17 +40,19 @@ _BACKOFF_MULTIPLIER = 1.5
 _BACKOFF_CAP_SECONDS = 0.5
 
 
-def lock_path_for(resolved_db_path: Path) -> Path:
-    """Return the write-lock metadata path for an already-resolved db path.
+def lock_path_for(db_path: Path) -> Path:
+    """Return the write-lock metadata path for ``db_path``.
 
-    Pass a resolved/canonical path (``db_path.resolve()``) — the form
-    ``write_lock`` keys the lock on — so a symlinked or relative original maps
-    to the one lock file the primitive uses. Resolving is the caller's job: the
-    sole caller already resolves once for its lsof scan, so resolving again here
-    would be a redundant syscall. This is the public way to locate the lock
-    file; the ``_LOCK_SUFFIX`` naming detail stays private to this module.
+    Resolves ``db_path`` first, mirroring ``write_lock``, so a symlinked or
+    relative path maps to the same lock file the primitive keys on. Resolving
+    stays *inside* this public helper rather than becoming the caller's job: an
+    unresolved input would otherwise silently key the wrong lock file (a
+    different inode than ``write_lock``), and a caller wanting to skip the
+    syscall can pass an already-resolved path — ``Path.resolve()`` is idempotent
+    on one. The ``_LOCK_SUFFIX`` naming detail stays private to this module.
     """
-    return resolved_db_path.parent / (resolved_db_path.name + _LOCK_SUFFIX)
+    resolved = db_path.resolve()
+    return resolved.parent / (resolved.name + _LOCK_SUFFIX)
 
 
 @dataclass

--- a/src/moneybin/mcp/decorator.py
+++ b/src/moneybin/mcp/decorator.py
@@ -524,6 +524,13 @@ def mcp_tool(
                 # fall back to interrupt_and_reset_database()'s process-global
                 # slot, which would interrupt a *different* call's healthy active
                 # writer.
+                #
+                # This relies on get_database registering the acquired conn in
+                # the per-call holder, which it does for sync tool bodies (run
+                # via asyncio.to_thread with conn_holder set). There are no async
+                # write tools today; one would need the same holder wiring to be
+                # interrupted on timeout (otherwise [0] stays None and we skip —
+                # the latent gap is a missed reset, never a collateral one).
                 if _conn_for_this_call[0] is not None:
                     try:
                         interrupt_and_reset_database(_conn_for_this_call[0])

--- a/src/moneybin/mcp/decorator.py
+++ b/src/moneybin/mcp/decorator.py
@@ -513,10 +513,6 @@ def mcp_tool(
                     await _emit_privacy_event(err_env)
                     return err_env
                 elapsed = time.monotonic() - started
-                logger.warning(
-                    f"Tool {fn.__name__} timed out after {elapsed:.2f}s "
-                    f"(cap {timeout_s:.1f}s); interrupting DB and resetting connection"
-                )
                 # Only reset THIS call's own connection. If the call timed out
                 # before acquiring one (e.g. queued behind another writer when
                 # tool_timeout < the write-lock wait), _conn_for_this_call[0] is
@@ -531,7 +527,20 @@ def mcp_tool(
                 # write tools today; one would need the same holder wiring to be
                 # interrupted on timeout (otherwise [0] stays None and we skip —
                 # the latent gap is a missed reset, never a collateral one).
+                #
+                # Caveat: a sync tool body runs in a thread-pool worker we cannot
+                # cancel, so a tool that timed out while still queued at the lock
+                # may later acquire and commit its write after the caller already
+                # received the timeout envelope. The guard prevents a collateral
+                # reset; it does not cancel that worker. This is reachable only
+                # when the tool timeout is configured below the write-lock wait;
+                # the default 30s cap >> 10s wait keeps the worker's deadline
+                # ahead of the lock's, so it never commits post-timeout.
                 if _conn_for_this_call[0] is not None:
+                    logger.warning(
+                        f"Tool {fn.__name__} timed out after {elapsed:.2f}s "
+                        f"(cap {timeout_s:.1f}s); interrupting DB and resetting connection"
+                    )
                     try:
                         interrupt_and_reset_database(_conn_for_this_call[0])
                     except Exception as cleanup_exc:  # noqa: BLE001 — cleanup must not raise
@@ -539,6 +548,14 @@ def mcp_tool(
                             f"interrupt_and_reset_database failed during {fn.__name__} "
                             f"timeout cleanup: {type(cleanup_exc).__name__}"
                         )
+                else:
+                    # Timed out before acquiring a connection — nothing of ours to
+                    # reset. Log accurately so a post-mortem doesn't chase a reset
+                    # that never happened.
+                    logger.warning(
+                        f"Tool {fn.__name__} timed out after {elapsed:.2f}s "
+                        f"(cap {timeout_s:.1f}s); no connection acquired, nothing to reset"
+                    )
                 # Brief grace period: the surviving sync-tool thread needs a
                 # tick to see the closed DuckDB connection, raise, and unwind
                 # any per-tool resources (e.g. InboxService.acquire_lock's

--- a/src/moneybin/mcp/decorator.py
+++ b/src/moneybin/mcp/decorator.py
@@ -517,13 +517,21 @@ def mcp_tool(
                     f"Tool {fn.__name__} timed out after {elapsed:.2f}s "
                     f"(cap {timeout_s:.1f}s); interrupting DB and resetting connection"
                 )
-                try:
-                    interrupt_and_reset_database(_conn_for_this_call[0])
-                except Exception as cleanup_exc:  # noqa: BLE001 — cleanup must not raise
-                    logger.error(
-                        f"interrupt_and_reset_database failed during {fn.__name__} "
-                        f"timeout cleanup: {type(cleanup_exc).__name__}"
-                    )
+                # Only reset THIS call's own connection. If the call timed out
+                # before acquiring one (e.g. queued behind another writer when
+                # tool_timeout < the write-lock wait), _conn_for_this_call[0] is
+                # None and there is nothing of ours to reset — and we must NOT
+                # fall back to interrupt_and_reset_database()'s process-global
+                # slot, which would interrupt a *different* call's healthy active
+                # writer.
+                if _conn_for_this_call[0] is not None:
+                    try:
+                        interrupt_and_reset_database(_conn_for_this_call[0])
+                    except Exception as cleanup_exc:  # noqa: BLE001 — cleanup must not raise
+                        logger.error(
+                            f"interrupt_and_reset_database failed during {fn.__name__} "
+                            f"timeout cleanup: {type(cleanup_exc).__name__}"
+                        )
                 # Brief grace period: the surviving sync-tool thread needs a
                 # tick to see the closed DuckDB connection, raise, and unwind
                 # any per-tool resources (e.g. InboxService.acquire_lock's

--- a/src/moneybin/mcp/decorator.py
+++ b/src/moneybin/mcp/decorator.py
@@ -528,14 +528,15 @@ def mcp_tool(
                 # interrupted on timeout (otherwise [0] stays None and we skip —
                 # the latent gap is a missed reset, never a collateral one).
                 #
-                # Caveat: a sync tool body runs in a thread-pool worker we cannot
-                # cancel, so a tool that timed out while still queued at the lock
-                # may later acquire and commit its write after the caller already
-                # received the timeout envelope. The guard prevents a collateral
-                # reset; it does not cancel that worker. This is reachable only
-                # when the tool timeout is configured below the write-lock wait;
-                # the default 30s cap >> 10s wait keeps the worker's deadline
-                # ahead of the lock's, so it never commits post-timeout.
+                # A sync tool body runs in a thread-pool worker we cannot cancel.
+                # The one way that worker could commit after the caller gave up
+                # is to still be queued at the write lock when the tool times
+                # out, then acquire and commit afterward — which requires the
+                # tool timeout to be shorter than the write-lock wait. MCPConfig
+                # forbids that (tool_timeout_seconds >= the write-lock wait), so
+                # the worker has always stopped queuing (acquired or errored) by
+                # the time the caller times out. The guard here still only resets
+                # this call's own connection, never a different call's.
                 if _conn_for_this_call[0] is not None:
                     logger.warning(
                         f"Tool {fn.__name__} timed out after {elapsed:.2f}s "

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -211,12 +211,12 @@ def _database_connections_block(db_path: Path) -> dict[str, Any]:
     """
     writers: list[dict[str, Any]] = []
     writer_pid: int | None = None
-    # Resolve once and use the resolved path for BOTH the lock file
-    # (lock_path_for takes the already-resolved path — no second resolve) and
-    # the lsof reader scan, so a symlinked or relative path can't report writers
-    # and readers against different inodes.
+    # Resolve once for the lsof reader scan; lock_path_for resolves db_path
+    # itself for the lock file. Both resolve the same db_path, so the writer
+    # probe and the reader scan stay on one inode even for a symlinked or
+    # relative path — and neither re-resolves an already-resolved path.
     resolved = db_path.resolve()
-    lock_path = lock_path_for(resolved)
+    lock_path = lock_path_for(db_path)
     # No separate exists() check: _writer_is_live opens the lock file and
     # returns False if it is absent, so an exists() guard would be a redundant,
     # TOCTOU-prone stat.

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -42,6 +42,9 @@ from moneybin.utils.db_processes import describe_process, find_blocking_processe
 
 _HEALTHY_STATUSES = frozenset({"healthy"})
 _DISCONNECTED_STATUSES = frozenset({"disconnected"})
+# Re-reads of the write-lock metadata file to ride out write_lock's brief
+# in-place rewrite (ftruncate-then-write) window before treating it as absent.
+_METADATA_READ_ATTEMPTS = 3
 
 
 def _gsheet_block(db: Any) -> dict[str, Any]:
@@ -153,9 +156,6 @@ def _writer_is_live(lock_path: Path) -> bool:
         os.close(fd)
 
 
-_METADATA_READ_ATTEMPTS = 3
-
-
 def _read_writer_metadata(lock_path: Path) -> dict[str, Any] | None:
     """Read + parse the writer metadata, tolerating the brief rewrite window.
 
@@ -211,9 +211,9 @@ def _database_connections_block(db_path: Path) -> dict[str, Any]:
     """
     writers: list[dict[str, Any]] = []
     writer_pid: int | None = None
-    # Resolve once and use the resolved path for BOTH the lock file (via
-    # lock_path_for, which resolves the same way write_lock keys it) and the
-    # lsof reader scan, so a symlinked or relative path can't report writers
+    # Resolve once and use the resolved path for BOTH the lock file
+    # (lock_path_for takes the already-resolved path — no second resolve) and
+    # the lsof reader scan, so a symlinked or relative path can't report writers
     # and readers against different inodes.
     resolved = db_path.resolve()
     lock_path = lock_path_for(resolved)

--- a/tests/moneybin/test_config.py
+++ b/tests/moneybin/test_config.py
@@ -18,6 +18,29 @@ def test_mcp_tool_timeout_must_be_positive() -> None:
 
 
 @pytest.mark.unit
+def test_mcp_tool_timeout_below_write_lock_wait_rejected() -> None:
+    """A tool_timeout under the write-lock wait reopens the late-write window.
+
+    Below the wait, a write tool can time out while its uncancellable worker is
+    still queued at the lock; the worker may later acquire and commit after the
+    caller already received a timeout envelope. The validator forbids it.
+    """
+    from moneybin.config import DEFAULT_WRITE_LOCK_MAX_WAIT_SECONDS
+
+    with pytest.raises(ValueError, match="write-lock wait"):
+        MCPConfig(tool_timeout_seconds=DEFAULT_WRITE_LOCK_MAX_WAIT_SECONDS - 1.0)
+
+
+@pytest.mark.unit
+def test_mcp_tool_timeout_at_write_lock_wait_accepted() -> None:
+    """tool_timeout equal to the write-lock wait is the boundary and allowed."""
+    from moneybin.config import DEFAULT_WRITE_LOCK_MAX_WAIT_SECONDS
+
+    cfg = MCPConfig(tool_timeout_seconds=DEFAULT_WRITE_LOCK_MAX_WAIT_SECONDS)
+    assert cfg.tool_timeout_seconds == DEFAULT_WRITE_LOCK_MAX_WAIT_SECONDS
+
+
+@pytest.mark.unit
 def test_mcp_max_items_default() -> None:
     """max_items defaults to 500 — collection-cap convention."""
     cfg = MCPConfig()

--- a/tests/moneybin/test_database/test_get_database_lock_integration.py
+++ b/tests/moneybin/test_database/test_get_database_lock_integration.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 import time
 from collections.abc import Generator
 from pathlib import Path
@@ -20,7 +21,7 @@ import duckdb
 import pytest
 
 import moneybin.database as db_module
-from moneybin.database import Database, get_database
+from moneybin.database import Database, DatabaseLockError, get_database
 from moneybin.db_lock.lock import (
     _LOCK_SUFFIX,  # type: ignore[reportPrivateUsage]  # test-only access to the canonical lock-file suffix
 )
@@ -313,3 +314,53 @@ def test_write_open_creates_missing_profile_dir_before_lock(
 
     assert profile_dir.is_dir()
     assert db_path.exists()
+
+
+@pytest.mark.integration
+def test_concurrent_write_opens_serialize_across_threads(configured_db: Path) -> None:
+    """Two in-process threads opening get_database(write) serialize at the lock.
+
+    The primary in-process concurrency case (concurrent MCP write tools running
+    on separate threads): while one thread holds the write lock, a second
+    thread's write open must block at write_lock — under a short max_wait it
+    times out rather than acquiring concurrently. write_lock contends per
+    open-file-description, so different threads do not share a reentrancy entry;
+    this exercises that end to end through get_database (not just the primitive,
+    which tests/moneybin/test_db_lock/test_lock.py covers directly).
+    """
+    a_holding = threading.Event()
+    a_release = threading.Event()
+    b_outcome: dict[str, str] = {}
+
+    def thread_a() -> None:
+        with get_database(read_only=False) as db:
+            db.execute("INSERT INTO t VALUES (1)")
+            a_holding.set()
+            a_release.wait(timeout=10.0)
+
+    def thread_b() -> None:
+        if not a_holding.wait(timeout=5.0):
+            return  # A never acquired; main asserts on the empty outcome
+        try:
+            with get_database(read_only=False, max_wait=0.5):
+                b_outcome["result"] = "acquired"
+        except DatabaseLockError:
+            b_outcome["result"] = "blocked"
+
+    ta = threading.Thread(target=thread_a)
+    ta.start()
+    try:
+        assert a_holding.wait(timeout=5.0), "thread A never acquired the write lock"
+        tb = threading.Thread(target=thread_b)
+        tb.start()
+        # B attempts while A still holds; with max_wait=0.5 s (well under A's
+        # hold), B must block at write_lock and time out — proving it could not
+        # acquire concurrently.
+        tb.join(timeout=10.0)
+        assert not tb.is_alive(), "thread B did not finish in time"
+        assert b_outcome.get("result") == "blocked", (
+            f"second writer was not serialized behind the first: {b_outcome}"
+        )
+    finally:
+        a_release.set()
+        ta.join(timeout=5.0)

--- a/tests/moneybin/test_database/test_get_database_lock_integration.py
+++ b/tests/moneybin/test_database/test_get_database_lock_integration.py
@@ -339,13 +339,14 @@ def test_concurrent_write_opens_serialize_across_threads(configured_db: Path) ->
             a_release.wait(timeout=10.0)
 
     def thread_b() -> None:
-        if not a_holding.wait(timeout=5.0):
-            return  # A never acquired; main asserts on the empty outcome
+        # main asserts a_holding before starting this thread, so A already holds.
         try:
             with get_database(read_only=False, max_wait=0.5):
                 b_outcome["result"] = "acquired"
         except DatabaseLockError:
             b_outcome["result"] = "blocked"
+        except Exception as exc:  # noqa: BLE001 — surface unexpected errors for diagnosis
+            b_outcome["result"] = f"error:{type(exc).__name__}"
 
     ta = threading.Thread(target=thread_a)
     ta.start()

--- a/tests/moneybin/test_mcp/test_tool_timeouts.py
+++ b/tests/moneybin/test_mcp/test_tool_timeouts.py
@@ -283,7 +283,13 @@ async def test_back_to_back_call_after_timeout_succeeds(
     monkeypatch.setattr(
         "moneybin.mcp.decorator.interrupt_and_reset_database", _interrupt_and_signal
     )
-    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 0.1)
+    # Cap must exceed the fake's real-Database open time. The decorator's
+    # timeout-reset guard reads the per-call holder, which get_database (and this
+    # fake) registers only AFTER the connection opens. Too short a cap lets the
+    # timeout fire mid-open — before the holder is set — so the reset is skipped
+    # and hang_tool never releases. Production caps (30 s) dwarf the open, so
+    # this only bites the test; 1 s gives ample headroom under loaded CI.
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 1.0)
 
     @mcp_tool(dynamic_classification=True)
     def hang_tool() -> ResponseEnvelope[Any]:
@@ -297,8 +303,11 @@ async def test_back_to_back_call_after_timeout_succeeds(
     @mcp_tool(dynamic_classification=True)
     def quick_tool() -> ResponseEnvelope[Any]:
         # Wait until hang_tool's background thread has closed its connection
-        # before opening a new one to the same file.
-        _conn_released.wait(timeout=5.0)
+        # before opening a new one to the same file. Assert the wait so a
+        # missed release is reported as such, not as a downstream lock error.
+        assert _conn_released.wait(timeout=5.0), (
+            "hang_tool never released its connection"
+        )
         with _fake_get_database() as db:
             rows = db.execute("SELECT 42 AS x").fetchall()
         return ResponseEnvelope(

--- a/tests/moneybin/test_mcp/test_tool_timeouts.py
+++ b/tests/moneybin/test_mcp/test_tool_timeouts.py
@@ -71,9 +71,12 @@ async def test_sync_tool_over_cap_returns_timeout_envelope(
     assert result.error.details["tool"] == "slow_tool"
     assert result.error.details["timeout_s"] == 0.05
     assert result.error.details["elapsed_s"] >= 0.05
-    # slow_tool never opened a DB connection, so the timeout cleanup has nothing
-    # of its own to reset — and it must NOT fall back to the global active writer
-    # (which would collaterally interrupt a different call's healthy connection).
+    # Collateral-kill regression guard: slow_tool never opened a DB connection,
+    # so the timeout cleanup must call NOTHING. Asserting interrupt_and_reset
+    # is not called proves it can't reach the process-global slot to interrupt a
+    # *concurrent* call's healthy writer (the original bug) — a weakened guard
+    # would call it with None and fail here. (Stronger than a live two-writer
+    # test, which would add real-DB thread timing without catching more.)
     reset_mock.assert_not_called()
 
 

--- a/tests/moneybin/test_mcp/test_tool_timeouts.py
+++ b/tests/moneybin/test_mcp/test_tool_timeouts.py
@@ -71,7 +71,40 @@ async def test_sync_tool_over_cap_returns_timeout_envelope(
     assert result.error.details["tool"] == "slow_tool"
     assert result.error.details["timeout_s"] == 0.05
     assert result.error.details["elapsed_s"] >= 0.05
-    reset_mock.assert_called_once()
+    # slow_tool never opened a DB connection, so the timeout cleanup has nothing
+    # of its own to reset — and it must NOT fall back to the global active writer
+    # (which would collaterally interrupt a different call's healthy connection).
+    reset_mock.assert_not_called()
+
+
+@pytest.mark.unit
+async def test_timed_out_tool_resets_only_its_own_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A timed-out tool that acquired a write conn resets THAT conn, not the global slot."""
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 0.05)
+    reset_mock = MagicMock()
+    monkeypatch.setattr(
+        "moneybin.mcp.decorator.interrupt_and_reset_database", reset_mock
+    )
+    sentinel = object()  # stands in for this call's acquired Database
+
+    @mcp_tool(dynamic_classification=True)
+    def slow_tool() -> ResponseEnvelope[Any]:
+        from moneybin.database import (
+            _write_conn_thread_local,  # type: ignore[reportPrivateUsage]  # test-only: simulate get_database registering its conn
+        )
+
+        # The decorator points conn_holder at this call's per-call list before
+        # running the sync body; mirror get_database registering its connection.
+        holder = getattr(_write_conn_thread_local, "conn_holder", None)
+        assert holder is not None
+        holder[0] = sentinel
+        time.sleep(0.5)
+        return _ok_envelope()
+
+    await slow_tool()
+    reset_mock.assert_called_once_with(sentinel)
 
 
 @pytest.mark.unit
@@ -211,6 +244,16 @@ async def test_back_to_back_call_after_timeout_succeeds(
         if not read_only:
             with db_module._active_write_lock:  # pyright: ignore[reportPrivateUsage]
                 db_module._active_write_conn = conn  # pyright: ignore[reportPrivateUsage]
+            # Mirror real get_database: register the per-call holder so the
+            # decorator's timeout cleanup resets THIS connection (rather than
+            # finding [0]=None and skipping, which the guarded cleanup now does).
+            holder = getattr(
+                db_module._write_conn_thread_local,  # pyright: ignore[reportPrivateUsage]
+                "conn_holder",
+                None,
+            )
+            if holder is not None:
+                holder[0] = conn
         try:
             yield conn
         finally:

--- a/tests/scenarios/test_writer_coordination.py
+++ b/tests/scenarios/test_writer_coordination.py
@@ -198,6 +198,16 @@ def test_scenario_2_reader_blocks_writer_writer_succeeds_after_release(
     # DuckDB lock error rather than letting it surface raw.
     assert "Could not set lock" not in writer_err
     assert "duckdb.IOException" not in writer_err
+    # Self-contained durability check: the writer's INSERT(99) bumped the row
+    # count from 1 to 2. The in-test reader above released before the writer
+    # committed, so it cannot assert this — a fresh reader after both released
+    # confirms the contended write actually landed.
+    verifier = _spawn(_READER, str(bootstrapped_db), "0.0")
+    verify_out, verify_err = _drain(verifier)
+    assert verifier.returncode == 0, (
+        f"verifier failed: stdout={verify_out!r} stderr={verify_err!r}"
+    )
+    assert "READER_CLOSED:2" in verify_out
 
 
 # ---------------------------------------------------------------------------
@@ -219,6 +229,15 @@ def test_scenario_3_writer_blocks_reader_reader_succeeds_after_release(
         _wait_for_marker(writer, "HOLDER_OPEN")
         # Launch the reader while the writer still holds. Reader must retry
         # at the ATTACH layer until the writer closes.
+        #
+        # The reader hold is 0.0 s ON PURPOSE: contention is guaranteed by the
+        # HOLDER_OPEN barrier above (the writer provably holds the write attach
+        # before the reader spawns), so the reader must wait regardless of how
+        # long it then holds. The hold is time-AFTER-acquire, irrelevant to
+        # whether the reader contends; the READER_CLOSED:2 assertion below
+        # positively proves the reader acquired only after the writer committed
+        # its INSERT. (Do not "fix" this to a non-zero hold — it would test the
+        # reader's post-acquire dwell, not the writer-blocks-reader path.)
         reader = _spawn(_READER, str(bootstrapped_db), "0.0")
         try:
             reader_out, reader_err = _drain(reader)

--- a/tests/scenarios/test_writer_coordination.py
+++ b/tests/scenarios/test_writer_coordination.py
@@ -194,6 +194,10 @@ def test_scenario_2_reader_blocks_writer_writer_succeeds_after_release(
     assert reader.returncode == 0, (
         f"reader failed: stdout={reader_out!r} stderr={reader_err!r}"
     )
+    # Isolation during contention: the reader's SELECT ran before the blocked
+    # writer could commit, so it saw only the bootstrap row (count 1), not the
+    # writer's later INSERT — the complement of the verifier's count-2 check.
+    assert "READER_CLOSED:1" in reader_out
     # Critical: writer's ATTACH retry must have caught and classified the
     # DuckDB lock error rather than letting it surface raw.
     assert "Could not set lock" not in writer_err

--- a/tests/scenarios/test_writer_coordination.py
+++ b/tests/scenarios/test_writer_coordination.py
@@ -207,7 +207,12 @@ def test_scenario_2_reader_blocks_writer_writer_succeeds_after_release(
     # committed, so it cannot assert this — a fresh reader after both released
     # confirms the contended write actually landed.
     verifier = _spawn(_READER, str(bootstrapped_db), "0.0")
-    verify_out, verify_err = _drain(verifier)
+    try:
+        verify_out, verify_err = _drain(verifier)
+    finally:
+        if verifier.poll() is None:
+            verifier.kill()
+            verifier.wait(timeout=5.0)
     assert verifier.returncode == 0, (
         f"verifier failed: stdout={verify_out!r} stderr={verify_err!r}"
     )


### PR DESCRIPTION
## Summary

Addresses the deferred review follow-ups from #240 (writer-coordination hardening). The substantive item is a real concurrency bug: when an MCP write tool times out *before* acquiring its connection (only when `tool_timeout` is configured below the write-lock wait — the default is safe, 30 s vs 10 s), the timeout cleanup fell back to the process-global writer slot and interrupted a *different* call's healthy active writer. The rest are test-coverage, NIT, and doc cleanups so the writer-coordination follow-up tracker is empty.

## Changes

- **Collateral writer-kill fix** (`mcp/decorator.py`): timeout cleanup now resets only the timed-out call's *own* connection (guarded on the per-call holder). A call that never acquired no longer touches the global active writer. Covered by a unit regression (no-conn → no reset; own-conn → resets own) plus the updated integration `test_back_to_back` (its fake `get_database` now registers the per-call holder like the real one).
- **Threaded serialization coverage** (`test_get_database_lock_integration.py`): a deterministic integration test proves two in-process writers serialize at `write_lock` — the primary concurrent-MCP-call case (closes the `get_database` end-to-end cell; the primitive-level threaded contention was already covered).
- **Lock/system NITs**: guard `os.close` in `_release_one`'s `finally`; `lock_path_for` takes an already-resolved path (drops a redundant `resolve()` at its sole caller); move `_METADATA_READ_ATTEMPTS` to the module constants.
- **Scenario + spec**: scenario 2 now asserts the contended write landed; scenario 3 documents why its `0.0 s` reader hold is correct (barrier-guaranteed contention) so it stops being misread; the spec names the exact partial-write window.

## Test plan

- [x] `make test` — 4036 passed, 4 skipped
- [x] `make test-scenarios` — 54 passed (incl. updated writer-coordination scenarios 2 & 3)
- [x] Affected integration tests run (incl. the new threaded test, 3× for stability) — pass
- [x] `make lint` + project `pyright` — clean (0 errors)
- [ ] Reviewer: confirm the decorator guard (`if _conn_for_this_call[0] is not None`) is the right boundary
- [ ] Reviewer: `lock_path_for` now requires a pre-resolved path (one caller updated) — confirm the tightened contract is acceptable

## Related

- Follows #240
