### PR TITLE
Account-link review queue (M1S.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,19 @@ M2 closing out and M3 underway. M2A curator state shipped (transaction notes, ta
 - **`system_status` `database_connections` section** identifies the active
   writer (via the lock file) and concurrent readers (via `lsof`). Powers the
   `DatabaseLockError` recovery action.
+- **`review` MCP tool and `moneybin review` CLI command** (M1S.5c) — domain-neutral
+  orientation sweep that aggregates all three review queues in one call:
+  `matches_pending`, `categorize_pending`, and `account_links_pending` (new).
+  One "what needs my attention?" call now covers transaction matches, uncategorized
+  transactions, and account-link decisions without a separate sweep per domain.
+
+### Deprecated
+- **`transactions_review` MCP tool** — use `review` instead. Registered as a
+  deprecated alias with description starting with "DEPRECATED: use `review`";
+  removed after one minor release.
+- **`moneybin transactions review`** — use `moneybin review` instead. Emits a
+  deprecation warning to stderr and delegates to the same implementation;
+  removed after one minor release.
 
 ### Changed
 - **`Database.__init__()` and `get_database()` now require `read_only` as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 M2 closing out and M3 underway. M2A curator state shipped (transaction notes, tags, splits, manual entry, audit log). M2B architecture reference shipped (`architecture-shared-primitives.md`; writer-coordination contract via short-lived per-call connections). M2C brand surface advancing: `moneybin system doctor` integrity command, `reports.*` recipe library (eight curated views), and the `transform_*` MCP toolset closing the agent ingest loop. M3A Plaid Transactions sync shipped (Phase 1). Doc surface tightened for the personas reachable today; MCP surface hardened with protocol-standard annotations, `accounts_resolve`, list-parameter cap, structured error envelopes, and shell completion. Categorization correctness pass: memo-aware matcher, exemplar accumulation, source-precedence enforcement, auto-fan-out after apply; seed merchant catalogs retired in favor of user-driven and LLM-assist-driven merchant creation.
 
 ### Added
+- **Account-link review queue (M1S.5).** New `accounts_links_pending` /
+  `accounts_links_set` / `accounts_links_history` / `accounts_links_run` MCP
+  tools and the `moneybin accounts links` CLI subgroup surface the cross-source
+  account-merge proposals the resolver raises (`institution+last4` / name) so a
+  weak account match is reviewed, never silently merged. Accepting a proposal
+  re-points the provisional account's native references onto the chosen
+  canonical account (auto-rejecting siblings); `--standalone` keeps it separate.
+  `accounts links run` backfills proposals over existing accounts. Account
+  numbers are never surfaced (proposals carry opaque ids + labels only).
 - **Smart-import-pdf Phase 2a — deterministic PDF routing to `raw.tabular_transactions`.**
   PDFs that auto-derive (or replay a saved) high-confidence recipe land
   rows in `raw.tabular_transactions` (`source_type='pdf'`) instead of the

--- a/docs/specs/moneybin-capabilities.md
+++ b/docs/specs/moneybin-capabilities.md
@@ -109,6 +109,9 @@ not-yet-built.
 | 46| Confirm a proposed import column mapping                          | `import_confirm` *(`file_path`, `accept=True`, `mapping={...}`)* | `import confirm <file> --accept` / `--mapping field=column` | —          | live                  |
 | 47| List available import formats (tabular + PDF) for selection / introspection | `import_formats` *(returns `formats` + `pdf_formats` arrays)* | `import formats list [--type tabular\|pdf\|all]` *(text or JSON; agent can also `import formats show <name>` for either kind)* | —          | live                  |
 | 48| Import a native-text PDF an agent must help extract (bridge round-trip) | `import_preview`/`import_files` *(return `confirmation_required` with a `bridge_payload` when the deterministic rung can't crack the layout)* → `import_confirm` *(`bridge_response={recipe, rows}`; re-runs the recipe, reconciles, persists, loads)* | *deferred — the CLI keeps the seed fallback until the agent-aware CLI escalation signal lands* | —          | live (MCP)            |
+| 49| List pending account-link decisions grouped by provisional account | `accounts_links_pending` | `accounts links pending` | — | live |
+| 50| Accept (merge) or standalone-reject one pending account-link decision | `accounts_links_set` *(`decision_id`, `target_account_id: str\|null` — no default; null = standalone-reject)* | `accounts links set <decision_id> --into <account_id>` (merge) / `--standalone` (reject) | — | live |
+| 51| Show recent account-link decisions (all statuses) | `accounts_links_history` *(`limit=50`)* | `accounts links history` *(`--limit`, `--output json`)* | — | live |
 
 *(Bootstrap rows only; full table populates incrementally as
 follow-up work closes the parity backlog. A prior row covering
@@ -149,7 +152,12 @@ agent (`import_preview`/`import_files` return a `bridge_payload`), and
 re-executed rows against the statement balances, persists the recipe, and loads
 the transactions. MCP-only for now — escalation is gated on the agent caller
 (`actor_kind="agent"`); the CLI keeps the Phase 2a seed fallback until its
-agent-aware escalation signal lands as follow-up work.)*
+agent-aware escalation signal lands as follow-up work.
+Rows 49–51 added 2026-06-15 with the account-binding review-surface PR (M1S.5a):
+`accounts_links_pending`, `accounts_links_set`, and `accounts_links_history` MCP tools
+registered; `accounts links {pending,set,history}` CLI commands wired. Sensitivity `low`
+throughout — opaque IDs + display names + signal/confidence only; `ref_value` never
+surfaced. `accounts_links_run` and undo deliberately not registered (run lands M1S.5b).)*
 
 ## Exemption categories
 

--- a/docs/specs/moneybin-capabilities.md
+++ b/docs/specs/moneybin-capabilities.md
@@ -113,6 +113,7 @@ not-yet-built.
 | 50| Accept (merge) or standalone-reject one pending account-link decision | `accounts_links_set` *(`decision_id`, `target_account_id: str\|null` — no default; null = standalone-reject)* | `accounts links set <decision_id> --into <account_id>` (merge) / `--standalone` (reject) | — | live |
 | 51| Show recent account-link decisions (all statuses) | `accounts_links_history` *(`limit=50`)* | `accounts links history` *(`--limit`, `--output json`)* | — | live |
 | 52| Backfill pending account-link proposals for existing accounts (cross-source twin discovery) | `accounts_links_run` *(returns `data.new_proposals`)* | `accounts links run` *(`--output json`)* | — | live |
+| 53| "What needs my attention?" — pending counts across all three review queues in one sweep | `review` *(returns `{matches_pending, categorize_pending, account_links_pending, total}`)* | `moneybin review --status` *(`--type`, `--output json`)* | — | live |
 
 *(Bootstrap rows only; full table populates incrementally as
 follow-up work closes the parity backlog. A prior row covering
@@ -162,7 +163,12 @@ surfaced.
 Row 52 added 2026-06-16 with the accounts-links-run backfill PR (M1S.5b):
 `accounts_links_run` (MCP) and `accounts links run` (CLI) registered. Backfills pending
 proposals for cross-source twins already in `core.dim_accounts`; skips pairs already
-proposed or decided in either direction. Undo deliberately deferred to M1L.)*
+proposed or decided in either direction. Undo deliberately deferred to M1L.
+Row 53 added 2026-06-16 with the review-promotion PR (M1S.5c):
+`review` (MCP) and `moneybin review` (CLI) replace `transactions_review` /
+`moneybin transactions review` as the domain-neutral orientation sweep. Payload gains
+`account_links_pending` so one call covers all three queues. Old names kept as
+deprecated aliases for one minor release; descriptions start with "DEPRECATED:".)*
 
 ## Exemption categories
 

--- a/docs/specs/moneybin-capabilities.md
+++ b/docs/specs/moneybin-capabilities.md
@@ -112,6 +112,7 @@ not-yet-built.
 | 49| List pending account-link decisions grouped by provisional account | `accounts_links_pending` | `accounts links pending` | — | live |
 | 50| Accept (merge) or standalone-reject one pending account-link decision | `accounts_links_set` *(`decision_id`, `target_account_id: str\|null` — no default; null = standalone-reject)* | `accounts links set <decision_id> --into <account_id>` (merge) / `--standalone` (reject) | — | live |
 | 51| Show recent account-link decisions (all statuses) | `accounts_links_history` *(`limit=50`)* | `accounts links history` *(`--limit`, `--output json`)* | — | live |
+| 52| Backfill pending account-link proposals for existing accounts (cross-source twin discovery) | `accounts_links_run` *(returns `data.new_proposals`)* | `accounts links run` *(`--output json`)* | — | live |
 
 *(Bootstrap rows only; full table populates incrementally as
 follow-up work closes the parity backlog. A prior row covering
@@ -157,7 +158,11 @@ Rows 49–51 added 2026-06-15 with the account-binding review-surface PR (M1S.5a
 `accounts_links_pending`, `accounts_links_set`, and `accounts_links_history` MCP tools
 registered; `accounts links {pending,set,history}` CLI commands wired. Sensitivity `low`
 throughout — opaque IDs + display names + signal/confidence only; `ref_value` never
-surfaced. `accounts_links_run` and undo deliberately not registered (run lands M1S.5b).)*
+surfaced.
+Row 52 added 2026-06-16 with the accounts-links-run backfill PR (M1S.5b):
+`accounts_links_run` (MCP) and `accounts links run` (CLI) registered. Backfills pending
+proposals for cross-source twins already in `core.dim_accounts`; skips pairs already
+proposed or decided in either direction. Undo deliberately deferred to M1L.)*
 
 ## Exemption categories
 

--- a/docs/specs/moneybin-cli.md
+++ b/docs/specs/moneybin-cli.md
@@ -179,6 +179,18 @@ moneybin [--profile NAME] [--verbose] <command> [--output text|json] [--quiet] [
 |                                    standalone `transform_apply` MCP tool.
 |         [--output json] [-q]
 |
++-- review                         -- What needs my attention? Pending counts across all review queues.
+|     [--type matches|categorize|all]   Default all; walks matches first then categorize
+|     [--status]                        Counts only, no interactive loop
+|     [--confirm <id>]                  Non-interactive: confirm one match by ID
+|     [--reject <id>]                   Non-interactive: reject one match by ID
+|     [--confirm-all]                   Non-interactive: confirm all items in scope
+|     [--limit N]                       Cap items per session
+|     [--output text|json] [-q]
+|   Aggregates matches_pending + categorize_pending + account_links_pending in one sweep.
+|   Use `--status` for counts only; drill into `accounts links pending`,
+|   `transactions matches list`, or `transactions categorize pending` for queue contents.
+|
 +-- accounts
 |   +-- list                       -- List accounts [--include-archived] [--type TYPE]
 |   +-- get <account_id>           -- Show one account's full settings + dim record
@@ -233,7 +245,8 @@ moneybin [--profile NAME] [--verbose] <command> [--output text|json] [--quiet] [
 |   +-- list                       -- List transactions [--account ID] [--from] [--to]
 |   +-- create                     -- Create a manual transaction
 |   +-- audit                      -- Audit one transaction's curation history (notes, tags, splits)
-|   +-- review                     -- Unified review queue (matches + categorize)
+|   +-- review                     -- DEPRECATED: use `moneybin review` (removed after one minor release)
+|   |                                  Unified review queue (matches + categorize + account-links)
 |   |     [--type matches|categorize|all]   Default all; walks matches first then categorize
 |   |     [--status]                        Counts only, no interactive loop
 |   |     [--confirm <id>]                  Non-interactive: confirm one match or categorize item by ID

--- a/docs/specs/moneybin-cli.md
+++ b/docs/specs/moneybin-cli.md
@@ -180,7 +180,7 @@ moneybin [--profile NAME] [--verbose] <command> [--output text|json] [--quiet] [
 |         [--output json] [-q]
 |
 +-- review                         -- What needs my attention? Pending counts across all review queues.
-|     [--type matches|categorize|all]   Default all; walks matches first then categorize
+|     [--type all|matches|categorize|account-links]   Default all; walks matches first then categorize
 |     [--status]                        Counts only, no interactive loop
 |     [--confirm <id>]                  Non-interactive: confirm one match by ID
 |     [--reject <id>]                   Non-interactive: reject one match by ID
@@ -247,7 +247,7 @@ moneybin [--profile NAME] [--verbose] <command> [--output text|json] [--quiet] [
 |   +-- audit                      -- Audit one transaction's curation history (notes, tags, splits)
 |   +-- review                     -- DEPRECATED: use `moneybin review` (removed after one minor release)
 |   |                                  Unified review queue (matches + categorize + account-links)
-|   |     [--type matches|categorize|all]   Default all; walks matches first then categorize
+|   |     [--type all|matches|categorize|account-links]   Default all; walks matches first then categorize
 |   |     [--status]                        Counts only, no interactive loop
 |   |     [--confirm <id>]                  Non-interactive: confirm one match or categorize item by ID
 |   |     [--reject <id>]                   Non-interactive: reject one match by ID

--- a/docs/specs/moneybin-cli.md
+++ b/docs/specs/moneybin-cli.md
@@ -205,9 +205,13 @@ moneybin [--profile NAME] [--verbose] <command> [--output text|json] [--quiet] [
 |       |         Merge the provisional into the candidate (--into) or keep as standalone
 |       |         (--standalone). The two flags are mutually exclusive; omitting both exits 2.
 |       +-- history [--limit N] [--output json] [--quiet]
-|                 Recent decisions (all statuses), newest first.
-|   Note: `accounts links run` and `accounts links undo` are deliberately NOT YET registered
-|         (run lands in M1S.5b; undo deferred to M1L audit-undo consumer).
+|       |         Recent decisions (all statuses), newest first.
+|       +-- run [--output json]
+|                 Backfill pending link proposals for all existing accounts.
+|                 Finds cross-source twins (same institution+last4 or fuzzy name match)
+|                 that have no pending proposal yet and writes pending decisions.
+|                 Prints count of new proposals written; hints user toward `accounts links pending`.
+|   Note: `accounts links undo` is deliberately NOT YET registered (deferred to M1L audit-undo consumer).
 |
 +-- assets                         -- (future spec) Physical assets (real estate, vehicles, valuables)
 |                                     Workflows defined in asset-tracking.md.

--- a/docs/specs/moneybin-cli.md
+++ b/docs/specs/moneybin-cli.md
@@ -197,6 +197,17 @@ moneybin [--profile NAME] [--verbose] <command> [--output text|json] [--quiet] [
 |   |   +-- assertion-delete <account_id> <date> [--yes]
 |   |   +-- reconcile [--account ID] [--threshold AMOUNT]
 |   |   +-- history --account ID [--from DATE] [--to DATE]
+|   +-- links                      -- Review and manage account-link binding decisions
+|       +-- pending [--output json] [--quiet]
+|       |         List provisional accounts + candidate merge proposals; each candidate
+|       |         shows decision_id, candidate_account_id, display name, confidence, signal.
+|       +-- set <decision_id> --into <account_id> | --standalone [--quiet]
+|       |         Merge the provisional into the candidate (--into) or keep as standalone
+|       |         (--standalone). The two flags are mutually exclusive; omitting both exits 2.
+|       +-- history [--limit N] [--output json] [--quiet]
+|                 Recent decisions (all statuses), newest first.
+|   Note: `accounts links run` and `accounts links undo` are deliberately NOT YET registered
+|         (run lands in M1S.5b; undo deferred to M1L audit-undo consumer).
 |
 +-- assets                         -- (future spec) Physical assets (real estate, vehicles, valuables)
 |                                     Workflows defined in asset-tracking.md.

--- a/docs/specs/moneybin-mcp.md
+++ b/docs/specs/moneybin-mcp.md
@@ -133,7 +133,7 @@ Required content:
 - One-line product description (local-first, on-device DuckDB)
 - Top-level group enumeration with brief domain hint (entity groups, reference data, reports, system, pipeline, privacy)
 - Naming convention reminder (path-prefix-verb-suffix, with 2–3 examples)
-- Orientation pointers — which tool to call to "get oriented" (`system_status` for data status; `transactions_review` for review queues; `reports_networth` + `reports_spending` for a quick financial pulse)
+- Orientation pointers — which tool to call to "get oriented" (`system_status` for data status; `review` for pending review counts across all queues; `reports_networth` + `reports_spending` for a quick financial pulse)
 - Response envelope shape (`{summary, data, actions}`) and pagination convention
 - Batch-tool preference
 - Sensitivity tiers and degraded-response behavior
@@ -594,15 +594,21 @@ Primary transaction read tool. Returns full transaction records with curation me
 - **CLI:** `moneybin transactions list`
 - **read_only:** true
 
-### `transactions_review`
+### `review`
 
-Orientation tool: pending counts across the review queues.
+Orientation tool: pending counts across **all three** review queues (matches + categorize + account-links).
 
 - **Sensitivity:** `low` — counts only.
 - **Unique parameters:** None.
-- **Behavior:** Returns `{matches_pending: int, categorize_pending: int, total: int}` so the agent can answer "anything to review?" in one call. The agent drills into `transactions_categorize_pending` for categorization items and into `transactions_matches_pending` for match proposals. Use `transactions_matches_set` to accept or reject individual match proposals; use `transactions_categorize_commit` to persist categorization decisions.
-- **Service:** `TransactionService.review_counts() -> ReviewCounts`
-- **CLI:** `moneybin transactions review`
+- **Behavior:** Returns `{matches_pending: int, categorize_pending: int, account_links_pending: int, total: int}` so the agent can answer "what needs my attention?" in one sweep. Drill into `transactions_categorize_pending` for categorization items, `transactions_matches_pending` for match proposals, and `accounts_links_pending` for account-link decisions.
+- **Service:** `ReviewService(MatchingService, CategorizationService, AccountLinksService).status()`
+- **CLI:** `moneybin review`
+
+### `transactions_review` *(deprecated — removed after one minor release)*
+
+**DEPRECATED alias for `review`.** Registered with a description starting with `"DEPRECATED: use review — removed after one minor release."` Identical behavior; prefer `review` in all new agent code.
+
+- **CLI:** `moneybin transactions review` *(deprecated — use `moneybin review`)*
 
 ### Curation tools (`transactions_create`, notes / tags / splits, `import_labels_set`, `system_audit`)
 

--- a/docs/specs/moneybin-mcp.md
+++ b/docs/specs/moneybin-mcp.md
@@ -532,6 +532,38 @@ Partial-update entry point for an account's settings.
 - **Service:** `AccountService.settings_update() -> AccountSettings`
 - **CLI:** `moneybin accounts set <account_id> [--display-name TEXT] [--include/--exclude] [--archive/--unarchive] [--subtype TYPE] [--holder-category CAT] [--currency CODE] [--credit-limit N] [--last-four DIGITS] [--official-name TEXT] [--clear-display-name] [--clear-currency] [--yes]`
 
+### `accounts_links_pending`
+
+List pending account-link decisions grouped by provisional account.
+
+- **Sensitivity:** `low` — opaque IDs, display names (entity labels, not user-authored text), signal strings, and confidence scores only. Never surfaces `ref_value` (which can be a full account number).
+- **Unique parameters:** None.
+- **Behavior:** Returns all provisional accounts that have pending merge candidates, each grouped with their candidate list. Each candidate carries `decision_id`, `candidate_account_id`, `candidate_display_name`, `confidence`, and `signal`. Use `accounts_links_set` with the candidate's `account_id` as `target_account_id` to merge, or `null` to standalone-reject.
+- **Service:** `AccountLinksService.pending()` + `AccountLinksService.count_pending()`
+- **CLI:** `moneybin accounts links pending`
+
+### `accounts_links_set`
+
+Accept (merge) or standalone-reject one pending account-link decision.
+
+- **Sensitivity:** `low`
+- **Unique parameters:** `decision_id: str` (required); `target_account_id: str | None` (required — no Python default; pass the candidate's `account_id` to merge, `null` to standalone-reject). The absence of a default prevents accidental rejection when the argument is omitted.
+- **Mutation surface:** writes `app.account_links` and `app.account_link_decisions`. Revert via `system_audit_undo`.
+- **Service:** `AccountLinksService.set()`
+- **CLI:** `moneybin accounts links set <decision_id> --into <account_id>` (merge) or `--standalone` (standalone-reject)
+
+### `accounts_links_history`
+
+Show recent account-link decisions (all statuses), newest first.
+
+- **Sensitivity:** `low`
+- **Unique parameters:** `limit: int = 50`
+- **Behavior:** Returns decisions across all statuses (pending, accepted, rejected). Useful for auditing what has already been decided.
+- **Service:** `AccountLinksService.history()`
+- **CLI:** `moneybin accounts links history`
+
+> **Not yet registered:** `accounts_links_run` (lands in M1S.5b) and an undo variant are deliberately out of scope for this increment.
+
 ---
 
 ## 6. `transactions.*` — Transaction-level operations (matches and categorize workflows nested)

--- a/docs/specs/moneybin-mcp.md
+++ b/docs/specs/moneybin-mcp.md
@@ -562,7 +562,19 @@ Show recent account-link decisions (all statuses), newest first.
 - **Service:** `AccountLinksService.history()`
 - **CLI:** `moneybin accounts links history`
 
-> **Not yet registered:** `accounts_links_run` (lands in M1S.5b) and an undo variant are deliberately out of scope for this increment.
+### `accounts_links_run`
+
+Backfill account-link proposals for accounts already in `core.dim_accounts` that have no pending proposal yet.
+
+- **Sensitivity:** `low` — count only.
+- **Unique parameters:** None.
+- **Behavior:** Iterates all accounts in `core.dim_accounts`, calls the resolver candidate pass (institution+last4 or name fuzzy-match) excluding each account itself, and writes `pending` `app.account_link_decisions` rows for any new unordered pair not already proposed or decided. Skips pairs that already have a decision in either direction (any status). Returns `data.new_proposals` — count of new pending decisions written.
+- **Mutation surface:** writes `app.account_link_decisions`; revert via `app.audit_log` (no undo tool; deferred to M1L).
+- **Service:** `AccountLinksService.run()`
+- **CLI:** `moneybin accounts links run`
+- **read_only:** false
+
+> **Note:** An undo variant (`accounts_links_undo`) remains deliberately out of scope, deferred to the M1L audit-undo consumer.
 
 ---
 

--- a/docs/specs/moneybin-mcp.md
+++ b/docs/specs/moneybin-mcp.md
@@ -536,7 +536,7 @@ Partial-update entry point for an account's settings.
 
 List pending account-link decisions grouped by provisional account.
 
-- **Sensitivity:** `low` — opaque IDs, display names (entity labels, not user-authored text), signal strings, and confidence scores only. Never surfaces `ref_value` (which can be a full account number).
+- **Sensitivity:** `medium` — surfaces account `display_name` (classified `USER_NOTE`, matching `accounts_summary`/`accounts_get`), so the proposal labels sit behind the same consent bar; opaque IDs, signal strings, and confidence scores otherwise. Never surfaces `ref_value` (which can be a full account number). Without consent the response degrades to counts.
 - **Unique parameters:** None.
 - **Behavior:** Returns all provisional accounts that have pending merge candidates, each grouped with their candidate list. Each candidate carries `decision_id`, `candidate_account_id`, `candidate_display_name`, `confidence`, and `signal`. Use `accounts_links_set` with the candidate's `account_id` as `target_account_id` to merge, or `null` to standalone-reject.
 - **Service:** `AccountLinksService.pending()` + `AccountLinksService.count_pending()`

--- a/src/moneybin/cli/commands/accounts/__init__.py
+++ b/src/moneybin/cli/commands/accounts/__init__.py
@@ -44,7 +44,7 @@ from moneybin.services.balance_service import (
     BalanceService,  # noqa: F401 — re-exported for patch targets in tests  # type: ignore[reportUnusedImport]
 )
 
-from . import balance, investments
+from . import balance, investments, links
 
 logger = logging.getLogger(__name__)
 
@@ -337,3 +337,4 @@ def accounts_resolve(
 
 app.add_typer(balance.app, name="balance")
 app.add_typer(investments.app, name="investments")
+app.add_typer(links.app, name="links")

--- a/src/moneybin/cli/commands/accounts/links.py
+++ b/src/moneybin/cli/commands/accounts/links.py
@@ -25,21 +25,16 @@ from moneybin.privacy.payloads.accounts import (
     LinkPendingGroup,
 )
 from moneybin.protocol.envelope import build_envelope
-from moneybin.services.account_links_service import AccountLinksService
+from moneybin.services.account_links_service import (
+    AccountLinksService,
+    signal_from_match_signals,
+)
 
 app = typer.Typer(
     help="Review and manage account-link binding decisions",
     no_args_is_help=True,
 )
 logger = logging.getLogger(__name__)
-
-
-def _link_signal(match_signals: object) -> str:
-    """Extract 'signal' from a decoded match_signals dict."""
-    try:
-        return str(match_signals["signal"])  # type: ignore[index]  # Any-typed dict
-    except (KeyError, TypeError):
-        return ""
 
 
 @app.command("pending")
@@ -193,7 +188,7 @@ def links_history(
                     if r.get("confidence_score") is not None
                     else None
                 ),
-                signal=_link_signal(r.get("match_signals")),
+                signal=signal_from_match_signals(r.get("match_signals")),
             )
             for r in rows
         ]

--- a/src/moneybin/cli/commands/accounts/links.py
+++ b/src/moneybin/cli/commands/accounts/links.py
@@ -1,0 +1,233 @@
+"""accounts links — review-queue commands for account identity binding.
+
+Subcommands: pending, set, history.
+Mirrors `transactions matches` — thin wrappers over AccountLinksService.
+
+accounts_links_run and `accounts links undo` are deliberately NOT YET
+registered: run lands in M1S.5b; undo is deferred to the M1L audit-undo
+consumer.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import typer
+
+from moneybin.cli.output import OutputFormat, output_option, quiet_option
+from moneybin.cli.utils import handle_cli_errors
+from moneybin.database import get_database
+from moneybin.privacy.payloads.accounts import (
+    AccountLinksHistoryPayload,
+    AccountLinksPendingPayload,
+    LinkCandidateRow,
+    LinkHistoryRow,
+    LinkPendingGroup,
+)
+from moneybin.protocol.envelope import build_envelope
+from moneybin.services.account_links_service import AccountLinksService
+
+app = typer.Typer(
+    help="Review and manage account-link binding decisions",
+    no_args_is_help=True,
+)
+logger = logging.getLogger(__name__)
+
+
+def _link_signal(match_signals: object) -> str:
+    """Extract 'signal' from a decoded match_signals dict."""
+    try:
+        return str(match_signals["signal"])  # type: ignore[index]  # Any-typed dict
+    except (KeyError, TypeError):
+        return ""
+
+
+@app.command("pending")
+def links_pending(
+    output: OutputFormat = output_option,
+    quiet: bool = quiet_option,
+) -> None:
+    """List pending account-link decisions, grouped by provisional account.
+
+    Shows provisional accounts with candidate merge proposals. Each group
+    lists the candidate decision_id, account_id, display name, confidence,
+    and match signal. Use `accounts links set` to decide each group.
+    """
+    with handle_cli_errors():
+        with get_database(read_only=True) as db:
+            svc = AccountLinksService(db, actor="cli")
+            groups = svc.pending()
+            n_pending = svc.count_pending()
+
+    payload = AccountLinksPendingPayload(
+        groups=[
+            LinkPendingGroup(
+                provisional_account_id=g.provisional_account_id,
+                provisional_display_name=g.provisional_display_name,
+                candidates=[
+                    LinkCandidateRow(
+                        decision_id=c.decision_id,
+                        candidate_account_id=c.candidate_account_id,
+                        candidate_display_name=c.candidate_display_name,
+                        confidence=float(c.confidence)
+                        if c.confidence is not None
+                        else None,
+                        signal=c.signal,
+                    )
+                    for c in g.candidates
+                ],
+            )
+            for g in groups
+        ],
+        n_pending=n_pending,
+    )
+
+    if output == OutputFormat.JSON:
+        from moneybin.cli.output import render_or_json  # noqa: PLC0415 — defer import
+
+        render_or_json(
+            build_envelope(data=payload),
+            output,
+            cli_actor="accounts_links_pending",
+        )
+        return
+
+    if not groups:
+        if not quiet:
+            logger.info("No pending account-link decisions")
+        return
+
+    for group in groups:
+        typer.echo(
+            f"\n── provisional {group.provisional_account_id} "
+            f"({group.provisional_display_name or '-'}) "
+            f"— {len(group.candidates)} candidate(s) ──"
+        )
+        typer.echo(
+            f"  {'Decision ID':<14} {'Candidate ID':<14} {'Signal':<18} "
+            f"{'Conf':>5}  {'Display Name'}"
+        )
+        for c in group.candidates:
+            conf_str = f"{c.confidence:.2f}" if c.confidence is not None else "  -  "
+            typer.echo(
+                f"  {c.decision_id[:12]:<14} "
+                f"{c.candidate_account_id[:12]:<14} "
+                f"{c.signal:<18} "
+                f"{conf_str:>5}  "
+                f"{c.candidate_display_name or '-'}"
+            )
+    typer.echo()
+
+
+@app.command("set")
+def links_set(
+    decision_id: str = typer.Argument(
+        ..., help="Decision ID to act on (from `accounts links pending`)"
+    ),
+    into: str | None = typer.Option(
+        None,
+        "--into",
+        help="Merge: the candidate account_id to adopt (from the pending group)",
+    ),
+    standalone: bool = typer.Option(
+        False,
+        "--standalone",
+        help="Standalone-reject: keep the provisional account as its own canonical entity",
+    ),
+) -> None:
+    """Accept (merge) or standalone-reject a pending account-link decision.
+
+    Pass exactly one of:
+      --into <candidate_account_id>   merge the provisional into the candidate
+      --standalone                    reject all candidates; provisional stays standalone
+
+    Examples:
+      accounts links set dec001 --into ACC002
+      accounts links set dec001 --standalone
+    """
+    if into is not None and standalone:
+        logger.error("❌ --into and --standalone are mutually exclusive")
+        raise typer.Exit(2)
+    if into is None and not standalone:
+        logger.error("❌ Specify either --into <account_id> or --standalone")
+        raise typer.Exit(2)
+
+    target_account_id: str | None = into if not standalone else None
+
+    with handle_cli_errors():
+        with get_database(read_only=False) as db:
+            AccountLinksService(db, actor="cli").set(
+                decision_id, target_account_id=target_account_id, decided_by="user"
+            )
+
+    action = (
+        f"merged into {target_account_id}"
+        if target_account_id
+        else "standalone (rejected)"
+    )
+    logger.info(f"✅ Decision {decision_id[:12]}... → {action}")
+
+
+@app.command("history")
+def links_history(
+    limit: int = typer.Option(50, "--limit", "-n", help="Max records to show"),
+    output: OutputFormat = output_option,
+    quiet: bool = quiet_option,
+) -> None:
+    """Show recent account-link decisions (all statuses), newest first."""
+    with handle_cli_errors():
+        with get_database(read_only=True) as db:
+            rows = AccountLinksService(db, actor="cli").history(limit=limit)
+
+    payload = AccountLinksHistoryPayload(
+        decisions=[
+            LinkHistoryRow(
+                decision_id=r["decision_id"],
+                provisional_account_id=r["provisional_account_id"],
+                candidate_account_id=r["candidate_account_id"],
+                status=r["status"],
+                decided_by=r["decided_by"],
+                decided_at=str(r["decided_at"]) if r.get("decided_at") else None,
+                confidence=(
+                    float(r["confidence_score"])
+                    if r.get("confidence_score") is not None
+                    else None
+                ),
+                signal=_link_signal(r.get("match_signals")),
+            )
+            for r in rows
+        ]
+    )
+
+    if output == OutputFormat.JSON:
+        from moneybin.cli.output import render_or_json  # noqa: PLC0415 — defer import
+
+        render_or_json(
+            build_envelope(data=payload),
+            output,
+            cli_actor="accounts_links_history",
+        )
+        return
+
+    if not rows:
+        if not quiet:
+            logger.info("No account-link decisions found")
+        return
+
+    typer.echo(
+        f"\n{'Decision ID':<14} {'Provisional':<14} {'Candidate':<14} "
+        f"{'Status':<10} {'Decided By':<10} {'Signal':<18} {'Conf':>5}"
+    )
+    typer.echo("-" * 90)
+    for d in payload.decisions:
+        conf_str = f"{d.confidence:.2f}" if d.confidence is not None else "  -  "
+        typer.echo(
+            f"{d.decision_id[:12]:<14} "
+            f"{d.provisional_account_id[:12]:<14} "
+            f"{d.candidate_account_id[:12]:<14} "
+            f"{d.status:<10} "
+            f"{d.decided_by:<10} "
+            f"{d.signal:<18} "
+            f"{conf_str:>5}"
+        )
+    typer.echo()

--- a/src/moneybin/cli/commands/accounts/links.py
+++ b/src/moneybin/cli/commands/accounts/links.py
@@ -1,11 +1,10 @@
 """accounts links — review-queue commands for account identity binding.
 
-Subcommands: pending, set, history.
+Subcommands: pending, set, history, run.
 Mirrors `transactions matches` — thin wrappers over AccountLinksService.
 
-accounts_links_run and `accounts links undo` are deliberately NOT YET
-registered: run lands in M1S.5b; undo is deferred to the M1L audit-undo
-consumer.
+`accounts links undo` is deliberately NOT YET registered:
+deferred to the M1L audit-undo consumer.
 """
 
 from __future__ import annotations
@@ -20,6 +19,7 @@ from moneybin.database import get_database
 from moneybin.privacy.payloads.accounts import (
     AccountLinksHistoryPayload,
     AccountLinksPendingPayload,
+    AccountLinksRunPayload,
     LinkCandidateRow,
     LinkHistoryRow,
     LinkPendingGroup,
@@ -231,3 +231,38 @@ def links_history(
             f"{conf_str:>5}"
         )
     typer.echo()
+
+
+@app.command("run")
+def links_run(
+    output: OutputFormat = output_option,
+) -> None:
+    """Backfill pending account-link proposals for existing accounts.
+
+    Finds weak-signal candidate pairs for every account in core.dim_accounts
+    that has no pending proposal yet and writes pending decisions for review.
+
+    Run this after importing accounts from multiple sources to surface
+    cross-source twins for review.
+    """
+    with handle_cli_errors():
+        with get_database(read_only=False) as db:
+            new_proposals = AccountLinksService(db, actor="cli").run()
+
+    payload = AccountLinksRunPayload(new_proposals=new_proposals)
+
+    if output == OutputFormat.JSON:
+        from moneybin.cli.output import render_or_json  # noqa: PLC0415 — defer import
+
+        render_or_json(
+            build_envelope(data=payload),
+            output,
+            cli_actor="accounts_links_run",
+        )
+        return
+
+    if new_proposals == 0:
+        typer.echo("No new account-link proposals written.")
+    else:
+        typer.echo(f"✅ Wrote {new_proposals} new pending account-link proposal(s).")
+    typer.echo("Run `accounts links pending` to review.")

--- a/src/moneybin/cli/commands/review.py
+++ b/src/moneybin/cli/commands/review.py
@@ -1,0 +1,60 @@
+"""Top-level `moneybin review` command — domain-neutral orientation sweep.
+
+Aggregates pending counts from all three review queues:
+  - Matches (transaction dedup / transfer pairs)
+  - Uncategorized transactions
+  - Account-link decisions
+
+Use `moneybin review --status` to see counts; interactive walk is
+stubbed pending the v2 review-loop UX.
+
+See also: `moneybin transactions review` (deprecated alias — removed after
+one minor release; points here).
+"""
+
+from __future__ import annotations
+
+import typer
+
+from moneybin.cli.output import (
+    OutputFormat,
+    output_option,
+    quiet_option,
+)
+
+from .transactions.review import review_impl
+
+
+def review_command(
+    type_: str = typer.Option("all", "--type", help="all | matches | categorize"),
+    status: bool = typer.Option(
+        False, "--status", help="Show queue counts only, no interactive loop"
+    ),
+    confirm_id: str | None = typer.Option(
+        None, "--confirm", help="Non-interactive: confirm one match by ID"
+    ),
+    reject_id: str | None = typer.Option(
+        None, "--reject", help="Non-interactive: reject one match by ID"
+    ),
+    confirm_all: bool = typer.Option(
+        False, "--confirm-all", help="Non-interactive: confirm all items in scope"
+    ),
+    limit: int = typer.Option(50, "--limit", help="Cap items per session"),  # noqa: ARG001 — placeholder; interactive loop pending
+    output: OutputFormat = output_option,
+    quiet: bool = quiet_option,
+) -> None:
+    """Walk all pending review queues: matches, uncategorized, and account-links.
+
+    One sweep answers "what needs my attention?" across all review domains.
+    Use --status for counts only; --type to filter to a specific queue.
+    """
+    review_impl(
+        type_=type_,
+        status=status,
+        confirm_id=confirm_id,
+        reject_id=reject_id,
+        confirm_all=confirm_all,
+        limit=limit,
+        output=output,
+        quiet=quiet,
+    )

--- a/src/moneybin/cli/commands/review.py
+++ b/src/moneybin/cli/commands/review.py
@@ -26,7 +26,9 @@ from .transactions.review import review_impl
 
 
 def review_command(
-    type_: str = typer.Option("all", "--type", help="all | matches | categorize"),
+    type_: str = typer.Option(
+        "all", "--type", help="all | matches | categorize | account-links"
+    ),
     status: bool = typer.Option(
         False, "--status", help="Show queue counts only, no interactive loop"
     ),

--- a/src/moneybin/cli/commands/transactions/review.py
+++ b/src/moneybin/cli/commands/transactions/review.py
@@ -31,7 +31,7 @@ from ..stubs import _not_implemented
 
 logger = logging.getLogger(__name__)
 
-_VALID_TYPES = {"all", "matches", "categorize"}
+_VALID_TYPES = {"all", "matches", "categorize", "account-links"}
 
 
 def review_impl(
@@ -74,7 +74,9 @@ def review_impl(
 
 
 def transactions_review(
-    type_: str = typer.Option("all", "--type", help="all | matches | categorize"),
+    type_: str = typer.Option(
+        "all", "--type", help="all | matches | categorize | account-links"
+    ),
     status: bool = typer.Option(
         False, "--status", help="Show queue counts only, no interactive loop"
     ),
@@ -181,8 +183,10 @@ def _print_status(type_: str, output: OutputFormat) -> None:
             )
         elif type_ == "matches":
             data = {"matches_pending": s.matches_pending}
-        else:  # type_ == "categorize"
+        elif type_ == "categorize":
             data = {"categorize_pending": s.categorize_pending}
+        else:  # type_ == "account-links"
+            data = {"account_links_pending": s.account_links_pending}
         render_or_json(
             build_envelope(data=data, sensitivity="low"),
             output,
@@ -194,6 +198,8 @@ def _print_status(type_: str, output: OutputFormat) -> None:
         typer.echo(f"Matches pending: {s.matches_pending}")
     elif type_ == "categorize":
         typer.echo(f"Uncategorized transactions: {s.categorize_pending}")
+    elif type_ == "account-links":
+        typer.echo(f"Account-link decisions pending: {s.account_links_pending}")
     else:
         typer.echo(f"Matches pending: {s.matches_pending}")
         typer.echo(f"Uncategorized transactions: {s.categorize_pending}")

--- a/src/moneybin/cli/commands/transactions/review.py
+++ b/src/moneybin/cli/commands/transactions/review.py
@@ -1,11 +1,15 @@
-"""Unified review queue: walks pending matches + uncategorized transactions.
+"""Unified review queue: walks pending matches + uncategorized transactions + account-links.
 
 CLI-only collapse (per moneybin-cli.md v2). MCP keeps separate
 ``transactions_matches_pending`` and ``transactions_categorize_pending``
 tools because their result shapes differ; the orientation tool
-``transactions_review`` returns the counts.
+``review`` returns the counts.
 
 Interactive loop UX is stubbed for v2; --status works end-to-end.
+
+``transactions_review`` is a **deprecated alias** for the top-level
+``review_command`` (``moneybin review``). It emits a deprecation warning
+then delegates to ``review_impl``.
 """
 
 from __future__ import annotations
@@ -30,25 +34,21 @@ logger = logging.getLogger(__name__)
 _VALID_TYPES = {"all", "matches", "categorize"}
 
 
-def transactions_review(
-    type_: str = typer.Option("all", "--type", help="all | matches | categorize"),
-    status: bool = typer.Option(
-        False, "--status", help="Show queue counts only, no interactive loop"
-    ),
-    confirm_id: str | None = typer.Option(
-        None, "--confirm", help="Non-interactive: confirm one item by ID"
-    ),
-    reject_id: str | None = typer.Option(
-        None, "--reject", help="Non-interactive: reject one item by ID"
-    ),
-    confirm_all: bool = typer.Option(
-        False, "--confirm-all", help="Non-interactive: confirm all items in scope"
-    ),
-    limit: int = typer.Option(50, "--limit", help="Cap items per session"),  # noqa: ARG001 — placeholder; interactive loop pending
-    output: OutputFormat = output_option,
-    quiet: bool = quiet_option,  # noqa: ARG001 — --status emits data only; nothing to suppress
+def review_impl(
+    type_: str,
+    status: bool,
+    confirm_id: str | None,
+    reject_id: str | None,
+    confirm_all: bool,
+    limit: int,
+    output: OutputFormat,
+    quiet: bool,  # noqa: ARG001 — --status emits data only; nothing to suppress
 ) -> None:
-    """Walk pending matches first, then uncategorized transactions."""
+    """Shared implementation for `moneybin review` and `moneybin transactions review`.
+
+    Extracted so both the top-level leaf and the deprecated alias can call it
+    without duplicating logic.
+    """
     if type_ not in _VALID_TYPES:
         raise typer.BadParameter(
             f"--type must be one of {sorted(_VALID_TYPES)}, got {type_!r}"
@@ -71,6 +71,45 @@ def transactions_review(
         return
 
     _not_implemented("moneybin-cli.md (review collapse — interactive loop pending)")
+
+
+def transactions_review(
+    type_: str = typer.Option("all", "--type", help="all | matches | categorize"),
+    status: bool = typer.Option(
+        False, "--status", help="Show queue counts only, no interactive loop"
+    ),
+    confirm_id: str | None = typer.Option(
+        None, "--confirm", help="Non-interactive: confirm one item by ID"
+    ),
+    reject_id: str | None = typer.Option(
+        None, "--reject", help="Non-interactive: reject one item by ID"
+    ),
+    confirm_all: bool = typer.Option(
+        False, "--confirm-all", help="Non-interactive: confirm all items in scope"
+    ),
+    limit: int = typer.Option(50, "--limit", help="Cap items per session"),
+    output: OutputFormat = output_option,
+    quiet: bool = quiet_option,
+) -> None:
+    """Walk pending matches first, then uncategorized transactions.
+
+    DEPRECATED: use `moneybin review` instead. Removed after one minor release.
+    """
+    typer.echo(
+        "⚠️  `moneybin transactions review` is deprecated. "
+        "Use `moneybin review` instead. Removed after one minor release.",
+        err=True,
+    )
+    review_impl(
+        type_=type_,
+        status=status,
+        confirm_id=confirm_id,
+        reject_id=reject_id,
+        confirm_all=confirm_all,
+        limit=limit,
+        output=output,
+        quiet=quiet,
+    )
 
 
 def _review_matches_noninteractive(
@@ -114,6 +153,7 @@ def _review_matches_noninteractive(
 def _print_status(type_: str, output: OutputFormat) -> None:
     from moneybin.cli.utils import handle_cli_errors
     from moneybin.config import get_settings
+    from moneybin.services.account_links_service import AccountLinksService
     from moneybin.services.categorization import CategorizationService
     from moneybin.services.matching_service import MatchingService
     from moneybin.services.review_service import ReviewService
@@ -123,6 +163,7 @@ def _print_status(type_: str, output: OutputFormat) -> None:
             review_svc = ReviewService(
                 match_service=MatchingService(db, get_settings().matching),
                 categorize_service=CategorizationService(db),
+                account_links_service=AccountLinksService(db),
             )
             s = review_svc.status()
 
@@ -135,6 +176,7 @@ def _print_status(type_: str, output: OutputFormat) -> None:
             data: object = ReviewStatusPayload(
                 matches_pending=s.matches_pending,
                 categorize_pending=s.categorize_pending,
+                account_links_pending=s.account_links_pending,
                 total=s.total,
             )
         elif type_ == "matches":
@@ -144,7 +186,7 @@ def _print_status(type_: str, output: OutputFormat) -> None:
         render_or_json(
             build_envelope(data=data, sensitivity="low"),
             output,
-            cli_actor="transactions_review",
+            cli_actor="review",
         )
         return
 
@@ -155,4 +197,5 @@ def _print_status(type_: str, output: OutputFormat) -> None:
     else:
         typer.echo(f"Matches pending: {s.matches_pending}")
         typer.echo(f"Uncategorized transactions: {s.categorize_pending}")
+        typer.echo(f"Account-link decisions pending: {s.account_links_pending}")
         typer.echo(f"Total: {s.total}")

--- a/src/moneybin/cli/main.py
+++ b/src/moneybin/cli/main.py
@@ -32,6 +32,7 @@ from .commands import (
     profile,
     refresh,
     reports,
+    review,
     sql,
     stats,
     sync,
@@ -144,6 +145,10 @@ app.add_typer(
     name="reports",
     help="Cross-domain analytical reports",
 )
+app.command(
+    name="review",
+    help="Pending counts across all review queues (matches, categorize, account-links)",
+)(review.review_command)
 app.add_typer(transactions.app, name="transactions")
 app.add_typer(assets.app, name="assets")
 app.add_typer(categories.app, name="categories")

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -12,12 +12,11 @@ Read tools (balance):      accounts_balances, accounts_balance_history,
                            accounts_balance_reconcile, accounts_balance_assertions
 Write tools (balance):     accounts_balance_assert, accounts_balance_assertion_delete
 Read tools (links):        accounts_links_pending, accounts_links_history
-Write tools (links):       accounts_links_set
+Write tools (links):       accounts_links_set, accounts_links_run
 
 All tools delegate to AccountService / BalanceService / AccountLinksService — no
-business logic here. accounts_links_run and accounts links undo are deliberately
-NOT YET registered: run lands in M1S.5b; undo is deferred to the M1L audit-undo
-consumer.
+business logic here. accounts links undo is deliberately NOT YET registered:
+deferred to the M1L audit-undo consumer.
 """
 
 from __future__ import annotations
@@ -36,6 +35,7 @@ from moneybin.privacy.payloads.accounts import (
     AccountDetail,
     AccountLinksHistoryPayload,
     AccountLinksPendingPayload,
+    AccountLinksRunPayload,
     AccountLinksSetPayload,
     AccountListPayload,
     AccountResolvePayload,
@@ -534,6 +534,34 @@ def accounts_links_history(
     )
 
 
+@mcp_tool(domain="links", read_only=False)
+def accounts_links_run() -> ResponseEnvelope[AccountLinksRunPayload]:
+    """Backfill account-link proposals for existing accounts in core.dim_accounts.
+
+    Surfaces weak-candidate merge proposals for accounts that already exist but
+    have no pending proposal yet (e.g. accounts imported before the resolver
+    candidate-pass existed, or cross-source twins minted separately). Writes
+    ``pending`` ``app.account_link_decisions`` rows — the same shape the
+    import-time resolver writes.
+
+    Skips pairs that already have a decision in either direction (any status)
+    and avoids double-proposing the same unordered pair within one run.
+
+    Mutation surface: writes ``app.account_link_decisions``. Revert is via the
+    audit log in ``app.audit_log`` (no undo tool yet; deferred to M1L).
+    Review new proposals with ``accounts_links_pending``.
+
+    Returns:
+        Envelope with ``data.new_proposals`` — count of new pending decisions written.
+    """
+    with get_database(read_only=False) as db:
+        new_proposals = AccountLinksService(db, actor="mcp").run()
+    return build_envelope(
+        data=AccountLinksRunPayload(new_proposals=new_proposals),
+        actions=["Use accounts_links_pending to review the proposed merges"],
+    )
+
+
 # ─── Registration ──────────────────────────────────────────────────────────
 
 
@@ -644,8 +672,19 @@ def register_accounts_tools(mcp: FastMCP) -> None:
         "score, and the match signal (institution_last4 or name). ref_value "
         "(raw native reference, which can be a full account number) is never "
         "included. Use accounts_links_set to accept or standalone-reject each group. "
-        "accounts_links_run (backfill) and undo are not yet registered — deferred "
-        "to M1S.5b and M1L respectively.",
+        "Run accounts_links_run first to backfill proposals for pre-existing accounts.",
+    )
+    register(
+        mcp,
+        accounts_links_run,
+        "accounts_links_run",
+        "Backfill account-link proposals for accounts already in core.dim_accounts "
+        "that have no pending proposal yet (e.g. cross-source twins imported separately). "
+        "Writes pending app.account_link_decisions rows; skips pairs already proposed "
+        "or decided in either direction. Returns data.new_proposals (count of new pending "
+        "decisions written). Mutation surface: writes app.account_link_decisions; "
+        "revert via app.audit_log (no undo tool yet). "
+        "Review results with accounts_links_pending.",
     )
     register(
         mcp,

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -11,8 +11,13 @@ Write tools (entity):      accounts_set
 Read tools (balance):      accounts_balances, accounts_balance_history,
                            accounts_balance_reconcile, accounts_balance_assertions
 Write tools (balance):     accounts_balance_assert, accounts_balance_assertion_delete
+Read tools (links):        accounts_links_pending, accounts_links_history
+Write tools (links):       accounts_links_set
 
-All tools delegate to AccountService / BalanceService — no business logic here.
+All tools delegate to AccountService / BalanceService / AccountLinksService — no
+business logic here. accounts_links_run and accounts links undo are deliberately
+NOT YET registered: run lands in M1S.5b; undo is deferred to the M1L audit-undo
+consumer.
 """
 
 from __future__ import annotations
@@ -29,10 +34,16 @@ from moneybin.mcp._registration import register
 from moneybin.mcp.decorator import mcp_tool
 from moneybin.privacy.payloads.accounts import (
     AccountDetail,
+    AccountLinksHistoryPayload,
+    AccountLinksPendingPayload,
+    AccountLinksSetPayload,
     AccountListPayload,
     AccountResolvePayload,
     AccountSettingsPayload,
     AccountSummaryStats,
+    LinkCandidateRow,
+    LinkHistoryRow,
+    LinkPendingGroup,
 )
 from moneybin.privacy.payloads.balances import (
     BalanceAssertionDeletePayload,
@@ -41,6 +52,7 @@ from moneybin.privacy.payloads.balances import (
     BalanceObservationListPayload,
 )
 from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
+from moneybin.services.account_links_service import AccountLinksService
 from moneybin.services.account_service import CLEAR, AccountService
 from moneybin.services.balance_service import BalanceService
 
@@ -380,6 +392,148 @@ def accounts_resolve(
     return build_envelope(data=payload, actions=actions)
 
 
+# ─── Review tools (links) ──────────────────────────────────────────────────
+
+
+def _link_signal(match_signals: object) -> str:
+    """Extract 'signal' from an already-decoded match_signals dict."""
+    try:
+        return str(match_signals["signal"])  # type: ignore[index]  # Any-typed dict
+    except (KeyError, TypeError):
+        return ""
+
+
+@mcp_tool(domain="links")
+def accounts_links_pending() -> ResponseEnvelope[AccountLinksPendingPayload]:
+    """List pending account-link decisions, grouped by provisional account.
+
+    Returns the review queue of provisional accounts with candidate merge
+    proposals. Each group represents one provisional account (recently
+    imported but not yet confirmed as a canonical entity) and its candidate
+    existing accounts that may represent the same real-world account.
+
+    For each candidate: decision_id, candidate_account_id, display name,
+    confidence score, and the matching signal that fired (institution_last4
+    or name). ref_value (the raw native reference, which can be a full
+    account number) is never included.
+
+    Decide each group via accounts_links_set. accounts_links_run (backfill
+    discovery) and accounts links undo are not yet registered — deferred to
+    follow-up units M1S.5b and M1L respectively.
+    """
+    with get_database(read_only=True) as db:
+        svc = AccountLinksService(db, actor="mcp")
+        groups = svc.pending()
+        n_pending = svc.count_pending()
+    payload = AccountLinksPendingPayload(
+        groups=[
+            LinkPendingGroup(
+                provisional_account_id=g.provisional_account_id,
+                provisional_display_name=g.provisional_display_name,
+                candidates=[
+                    LinkCandidateRow(
+                        decision_id=c.decision_id,
+                        candidate_account_id=c.candidate_account_id,
+                        candidate_display_name=c.candidate_display_name,
+                        confidence=float(c.confidence)
+                        if c.confidence is not None
+                        else None,
+                        signal=c.signal,
+                    )
+                    for c in g.candidates
+                ],
+            )
+            for g in groups
+        ],
+        n_pending=n_pending,
+    )
+    return build_envelope(
+        data=payload,
+        total_count=n_pending,
+        actions=[
+            "Use accounts_links_set to merge (pass candidate_account_id as "
+            "target_account_id) or standalone-reject (pass null) each decision",
+        ],
+    )
+
+
+@mcp_tool(domain="links", read_only=False)
+def accounts_links_set(
+    decision_id: str,
+    target_account_id: str | None,
+) -> ResponseEnvelope[AccountLinksSetPayload]:
+    """Accept (merge) or standalone-reject one pending account-link decision.
+
+    Mutates app.account_link_decisions (sets status) and, on accept,
+    re-points app.account_links source_native entries from the provisional
+    account onto target_account_id. On standalone-reject (target_account_id
+    = null), rejects every pending decision for the provisional account —
+    it remains its own canonical account.
+
+    target_account_id MUST be passed explicitly — there is no default:
+    - Pass the candidate_account_id from accounts_links_pending to MERGE.
+    - Pass null to STANDALONE-REJECT (keep the provisional as its own entity).
+    Omitting it would default the merge, which may cause unintended binding.
+
+    Mutation surface: writes app.account_link_decisions + app.account_links.
+    Revert is via the audit log in app.audit_log (no undo tool yet; undo
+    is deferred to the M1L audit-undo consumer). Find pending decisions
+    with accounts_links_pending.
+
+    Args:
+        decision_id: The decision id to act on (from accounts_links_pending).
+        target_account_id: The candidate account_id to merge into, or null
+            to standalone-reject (keep provisional as its own canonical account).
+    """
+    with get_database(read_only=False) as db:
+        AccountLinksService(db, actor="mcp").set(
+            decision_id, target_account_id=target_account_id, decided_by="user"
+        )
+    status = "accepted" if target_account_id is not None else "rejected"
+    return build_envelope(
+        data=AccountLinksSetPayload(decision_id=decision_id, status=status),
+        actions=[
+            "Use accounts_links_pending to review remaining pending decisions",
+        ],
+    )
+
+
+@mcp_tool(domain="links")
+def accounts_links_history(
+    limit: int = 50,
+) -> ResponseEnvelope[AccountLinksHistoryPayload]:
+    """Recent account-link decisions (all statuses), newest first.
+
+    Args:
+        limit: Maximum rows (default 50).
+    """
+    with get_database(read_only=True) as db:
+        rows = AccountLinksService(db, actor="mcp").history(limit=limit)
+    payload = AccountLinksHistoryPayload(
+        decisions=[
+            LinkHistoryRow(
+                decision_id=r["decision_id"],
+                provisional_account_id=r["provisional_account_id"],
+                candidate_account_id=r["candidate_account_id"],
+                status=r["status"],
+                decided_by=r["decided_by"],
+                decided_at=str(r["decided_at"]) if r.get("decided_at") else None,
+                confidence=(
+                    float(r["confidence_score"])
+                    if r.get("confidence_score") is not None
+                    else None
+                ),
+                signal=_link_signal(r.get("match_signals")),
+            )
+            for r in rows
+        ]
+    )
+    return build_envelope(
+        data=payload,
+        actions=["Use accounts_links_pending for the active review queue"],
+    )
+
+
 # ─── Registration ──────────────────────────────────────────────────────────
 
 
@@ -478,4 +632,39 @@ def register_accounts_tools(mcp: FastMCP) -> None:
         "'checking') to an account_id. Returns ranked candidates with "
         "confidence scores. Use this before tools that require an account_id "
         "when you only have a natural-language reference.",
+    )
+    register(
+        mcp,
+        accounts_links_pending,
+        "accounts_links_pending",
+        "List pending account-link decisions grouped by provisional account. "
+        "Returns the review queue of provisional accounts (recently imported, "
+        "not yet confirmed canonical) with candidate merge proposals. Each "
+        "candidate carries decision_id, account_id, display name, confidence "
+        "score, and the match signal (institution_last4 or name). ref_value "
+        "(raw native reference, which can be a full account number) is never "
+        "included. Use accounts_links_set to accept or standalone-reject each group. "
+        "accounts_links_run (backfill) and undo are not yet registered — deferred "
+        "to M1S.5b and M1L respectively.",
+    )
+    register(
+        mcp,
+        accounts_links_set,
+        "accounts_links_set",
+        "Accept (merge) or standalone-reject one pending account-link decision. "
+        "Pass target_account_id = candidate_account_id to MERGE the provisional "
+        "account into the candidate. Pass null to STANDALONE-REJECT — the "
+        "provisional stays its own canonical account. target_account_id has no "
+        "default: pass it explicitly to avoid accidental standalone rejection. "
+        "Writes app.account_link_decisions + app.account_links; revert via "
+        "app.audit_log (no undo tool yet). Discover pending decisions with "
+        "accounts_links_pending.",
+    )
+    register(
+        mcp,
+        accounts_links_history,
+        "accounts_links_history",
+        "Recent account-link decisions (all statuses), newest first. "
+        "Read-only. Filter by limit. Use accounts_links_pending for the "
+        "active review queue.",
     )

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -52,7 +52,10 @@ from moneybin.privacy.payloads.balances import (
     BalanceObservationListPayload,
 )
 from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
-from moneybin.services.account_links_service import AccountLinksService
+from moneybin.services.account_links_service import (
+    AccountLinksService,
+    signal_from_match_signals,
+)
 from moneybin.services.account_service import CLEAR, AccountService
 from moneybin.services.balance_service import BalanceService
 
@@ -395,14 +398,6 @@ def accounts_resolve(
 # ─── Review tools (links) ──────────────────────────────────────────────────
 
 
-def _link_signal(match_signals: object) -> str:
-    """Extract 'signal' from an already-decoded match_signals dict."""
-    try:
-        return str(match_signals["signal"])  # type: ignore[index]  # Any-typed dict
-    except (KeyError, TypeError):
-        return ""
-
-
 @mcp_tool(domain="links")
 def accounts_links_pending() -> ResponseEnvelope[AccountLinksPendingPayload]:
     """List pending account-link decisions, grouped by provisional account.
@@ -523,7 +518,7 @@ def accounts_links_history(
                     if r.get("confidence_score") is not None
                     else None
                 ),
-                signal=_link_signal(r.get("match_signals")),
+                signal=signal_from_match_signals(r.get("match_signals")),
             )
             for r in rows
         ]

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -24,6 +24,7 @@ from moneybin.privacy.payloads.system import (
     SystemAuditHistoryPayload,
     SystemAuditUndoPayload,
     SystemDoctorPayload,
+    SystemStatusAccountLinksInfo,
     SystemStatusAccountsInfo,
     SystemStatusCategorizationInfo,
     SystemStatusDatabaseConnectionsInfo,
@@ -263,6 +264,7 @@ def _locked_status_envelope(
                 count=0, date_range=[None, None], last_import_at=None
             ),
             matches=SystemStatusMatchesInfo(pending_review=0),
+            account_links=SystemStatusAccountLinksInfo(pending_review=0),
             categorization=SystemStatusCategorizationInfo(uncategorized=0),
             transforms=SystemStatusTransformsInfo(pending=False, last_apply_at=None),
             schema_drift=None,
@@ -364,6 +366,9 @@ def system_status() -> ResponseEnvelope[SystemStatusPayload]:
                 ),
             ),
             matches=SystemStatusMatchesInfo(pending_review=status.matches_pending),
+            account_links=SystemStatusAccountLinksInfo(
+                pending_review=status.account_links_pending
+            ),
             categorization=SystemStatusCategorizationInfo(
                 uncategorized=status.categorize_pending
             ),

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -326,7 +326,7 @@ def system_status() -> ResponseEnvelope[SystemStatusPayload]:
 
     schema_drift_payload: SystemStatusSchemaDrift | None = None
     actions = [
-        "Use transactions_review for per-queue review counts",
+        "Use `review` for per-queue review counts (matches + categorize + account-links)",
         "Use reports_spending for a monthly spending trend snapshot",
     ]
     if status.schema_drift:

--- a/src/moneybin/mcp/tools/transactions.py
+++ b/src/moneybin/mcp/tools/transactions.py
@@ -2,8 +2,9 @@
 """Transactions namespace tools.
 
 Tools:
+    - review — Pending counts across all review queues (low); top-level orientation
     - transactions_get — Fetch transactions with filters (medium sensitivity)
-    - transactions_review — Pending counts across queues (low)
+    - transactions_review — DEPRECATED alias for `review`; removed after one minor release
     - transactions_matches_pending — List pending match decisions (low)
     - transactions_matches_set — Accept or reject one pending match (low)
     - transactions_matches_history — Recent match decisions, newest first (low)
@@ -114,15 +115,13 @@ def transactions_get(
     )
 
 
-@mcp_tool()
-def transactions_review() -> ResponseEnvelope[ReviewStatusPayload]:
-    """Return counts of pending reviews across both queues.
+def _build_review_envelope() -> ResponseEnvelope[ReviewStatusPayload]:
+    """Shared impl for the `review` tool and the deprecated `transactions_review` alias.
 
-    Orientation tool: call this to decide which queue to drain first.
-    For categorize, fetch items via ``transactions_categorize_pending``.
-    For matches, fetch the queue via ``transactions_matches_pending`` and
-    decide each pair with ``transactions_matches_set``.
+    Opens a short-lived read-only DB connection, calls ReviewService.status()
+    (which queries all three review queues), and returns the envelope.
     """
+    from moneybin.services.account_links_service import AccountLinksService
     from moneybin.services.categorization import CategorizationService
     from moneybin.services.review_service import ReviewService
 
@@ -130,19 +129,49 @@ def transactions_review() -> ResponseEnvelope[ReviewStatusPayload]:
         status = ReviewService(
             match_service=MatchingService(db=db),
             categorize_service=CategorizationService(db=db),
+            account_links_service=AccountLinksService(db=db),
         ).status()
 
     return build_envelope(
         data=ReviewStatusPayload(
             matches_pending=status.matches_pending,
             categorize_pending=status.categorize_pending,
+            account_links_pending=status.account_links_pending,
             total=status.total,
         ),
         actions=[
             "Use transactions_categorize_pending to fetch the categorize queue",
             "Use transactions_matches_pending to fetch the matches queue",
+            "Use accounts_links_pending to fetch the account-links queue",
         ],
     )
+
+
+@mcp_tool()
+def review() -> ResponseEnvelope[ReviewStatusPayload]:
+    """Return counts of pending reviews across all three queues.
+
+    Orientation tool: call this to answer "what needs my attention?" in one call.
+    Surfaces matches_pending, categorize_pending, and account_links_pending
+    so the agent can decide which queue to drain first.
+    For categorize, fetch items via ``transactions_categorize_pending``.
+    For matches, fetch the queue via ``transactions_matches_pending`` and
+    decide each pair with ``transactions_matches_set``.
+    For account links, fetch the queue via ``accounts_links_pending`` and
+    decide each group with ``accounts_links_set``.
+    """
+    return _build_review_envelope()
+
+
+@mcp_tool()
+def transactions_review() -> ResponseEnvelope[ReviewStatusPayload]:
+    """DEPRECATED: use `review` — removed after one minor release.
+
+    Return counts of pending reviews across all three queues.
+    Orientation tool: call this to decide which queue to drain first.
+    Prefer the top-level ``review`` tool going forward.
+    """
+    return _build_review_envelope()
 
 
 @mcp_tool(domain="matches", read_only=False)
@@ -301,9 +330,20 @@ def register_transactions_tools(mcp: FastMCP) -> None:
     )
     register(
         mcp,
+        review,
+        "review",
+        "Return pending counts across all three review queues (matches, categorize, account-links). "
+        "Call this to answer 'what needs my attention?' in one sweep. "
+        "Drill into `transactions_matches_pending` for match proposals, "
+        "`transactions_categorize_pending` for uncategorized transactions, "
+        "and `accounts_links_pending` for account-link decisions.",
+    )
+    register(
+        mcp,
         transactions_review,
         "transactions_review",
-        "Return pending counts for matches and categorize queues. "
+        "DEPRECATED: use `review` — removed after one minor release. "
+        "Return pending counts for matches, categorize, and account-links queues. "
         "Call this to orient before fetching specific queue contents.",
     )
     register(

--- a/src/moneybin/privacy/payloads/accounts.py
+++ b/src/moneybin/privacy/payloads/accounts.py
@@ -115,3 +115,71 @@ class AccountSettingsPayload:
     archived: Annotated[bool, DataClass.TXN_TYPE]
     warnings: Annotated[list[str], DataClass.DESCRIPTION] = field(default_factory=list)
     cascaded_include_in_net_worth: Annotated[bool | None, DataClass.TXN_TYPE] = None
+
+
+# ---------------------------------------------------------------------------
+# accounts_links_pending / accounts_links_set / accounts_links_history
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class LinkCandidateRow:
+    """One candidate merge proposal in an account-links pending review group.
+
+    Carries only opaque ids + account labels + match signal/confidence.
+    ref_value (which can be a full account number) is never surfaced here.
+    """
+
+    decision_id: Annotated[str, DataClass.RECORD_ID]
+    candidate_account_id: Annotated[str, DataClass.RECORD_ID]
+    # INSTITUTION (LOW) — account display label, not sensitive free text.
+    candidate_display_name: Annotated[str, DataClass.INSTITUTION]
+    confidence: Annotated[float | None, DataClass.AGGREGATE]
+    signal: Annotated[str, DataClass.TXN_TYPE]  # "institution_last4" or "name"
+
+
+@dataclass(frozen=True, slots=True)
+class LinkPendingGroup:
+    """One provisional account with its candidate merge proposals."""
+
+    provisional_account_id: Annotated[str, DataClass.RECORD_ID]
+    # INSTITUTION (LOW) — account display label, not sensitive free text.
+    provisional_display_name: Annotated[str, DataClass.INSTITUTION]
+    candidates: list[LinkCandidateRow]
+
+
+@dataclass(frozen=True, slots=True)
+class AccountLinksPendingPayload:
+    """Payload for accounts_links_pending — pending review queue grouped by provisional account."""
+
+    groups: list[LinkPendingGroup]
+    n_pending: Annotated[int, DataClass.AGGREGATE]
+
+
+@dataclass(frozen=True, slots=True)
+class AccountLinksSetPayload:
+    """Payload for accounts_links_set — confirmation of the decision applied."""
+
+    decision_id: Annotated[str, DataClass.RECORD_ID]
+    status: Annotated[str, DataClass.TXN_TYPE]  # "accepted" or "rejected"
+
+
+@dataclass(frozen=True, slots=True)
+class LinkHistoryRow:
+    """One past account-link decision (accounts_links_history result)."""
+
+    decision_id: Annotated[str, DataClass.RECORD_ID]
+    provisional_account_id: Annotated[str, DataClass.RECORD_ID]
+    candidate_account_id: Annotated[str, DataClass.RECORD_ID]
+    status: Annotated[str, DataClass.TXN_TYPE]
+    decided_by: Annotated[str, DataClass.TXN_TYPE]
+    decided_at: Annotated[str | None, DataClass.TIMESTAMP_OBSERVABILITY]
+    confidence: Annotated[float | None, DataClass.AGGREGATE]
+    signal: Annotated[str, DataClass.TXN_TYPE]
+
+
+@dataclass(frozen=True, slots=True)
+class AccountLinksHistoryPayload:
+    """Payload for accounts_links_history — decision log, newest first."""
+
+    decisions: list[LinkHistoryRow]

--- a/src/moneybin/privacy/payloads/accounts.py
+++ b/src/moneybin/privacy/payloads/accounts.py
@@ -132,8 +132,10 @@ class LinkCandidateRow:
 
     decision_id: Annotated[str, DataClass.RECORD_ID]
     candidate_account_id: Annotated[str, DataClass.RECORD_ID]
-    # INSTITUTION (LOW) — account display label, not sensitive free text.
-    candidate_display_name: Annotated[str, DataClass.INSTITUTION]
+    # USER_NOTE (MEDIUM) — matches the canonical display_name class everywhere
+    # else (taxonomy.py / AccountSummary / AccountDetail); a user/auto label can
+    # embed identifying text, so it must not be under-classified to LOW here.
+    candidate_display_name: Annotated[str, DataClass.USER_NOTE]
     confidence: Annotated[float | None, DataClass.AGGREGATE]
     signal: Annotated[str, DataClass.TXN_TYPE]  # "institution_last4" or "name"
 
@@ -143,8 +145,8 @@ class LinkPendingGroup:
     """One provisional account with its candidate merge proposals."""
 
     provisional_account_id: Annotated[str, DataClass.RECORD_ID]
-    # INSTITUTION (LOW) — account display label, not sensitive free text.
-    provisional_display_name: Annotated[str, DataClass.INSTITUTION]
+    # USER_NOTE (MEDIUM) — see LinkCandidateRow.candidate_display_name.
+    provisional_display_name: Annotated[str, DataClass.USER_NOTE]
     candidates: list[LinkCandidateRow]
 
 

--- a/src/moneybin/privacy/payloads/accounts.py
+++ b/src/moneybin/privacy/payloads/accounts.py
@@ -183,3 +183,10 @@ class AccountLinksHistoryPayload:
     """Payload for accounts_links_history — decision log, newest first."""
 
     decisions: list[LinkHistoryRow]
+
+
+@dataclass(frozen=True, slots=True)
+class AccountLinksRunPayload:
+    """Payload for accounts_links_run — count of new pending proposals written."""
+
+    new_proposals: Annotated[int, DataClass.AGGREGATE]

--- a/src/moneybin/privacy/payloads/system.py
+++ b/src/moneybin/privacy/payloads/system.py
@@ -149,6 +149,13 @@ class SystemStatusMatchesInfo:
 
 
 @dataclass(frozen=True, slots=True)
+class SystemStatusAccountLinksInfo:
+    """Account-link review queue sub-object inside SystemStatusPayload."""
+
+    pending_review: Annotated[int, DataClass.AGGREGATE]
+
+
+@dataclass(frozen=True, slots=True)
 class SystemStatusCategorizationInfo:
     """Categorization queue sub-object inside SystemStatusPayload."""
 
@@ -247,6 +254,7 @@ class SystemStatusPayload:
     accounts: SystemStatusAccountsInfo
     transactions: SystemStatusTransactionsInfo
     matches: SystemStatusMatchesInfo
+    account_links: SystemStatusAccountLinksInfo
     categorization: SystemStatusCategorizationInfo
     transforms: SystemStatusTransformsInfo
     schema_drift: SystemStatusSchemaDrift | None

--- a/src/moneybin/privacy/payloads/transactions.py
+++ b/src/moneybin/privacy/payloads/transactions.py
@@ -71,10 +71,11 @@ class TransactionGetPayload:
 
 @dataclass(frozen=True, slots=True)
 class ReviewStatusPayload:
-    """Payload for transactions_review — aggregate queue counts only."""
+    """Payload for `review` / `transactions_review` — aggregate queue counts only."""
 
     matches_pending: Annotated[int, DataClass.AGGREGATE]
     categorize_pending: Annotated[int, DataClass.AGGREGATE]
+    account_links_pending: Annotated[int, DataClass.AGGREGATE]
     total: Annotated[int, DataClass.AGGREGATE]
 
 

--- a/src/moneybin/repositories/account_link_decisions_repo.py
+++ b/src/moneybin/repositories/account_link_decisions_repo.py
@@ -38,6 +38,9 @@ _ACCOUNT_LINK_DECISIONS_COLUMNS = (
 # (AuditService json.dumps the whole payload). Writes json.dumps once.
 _JSON_COLUMNS = frozenset({"match_signals"})
 
+# Pre-quoted column list for multi-row SELECT (security.md: identifiers quoted).
+_COLS = ", ".join(f'"{c}"' for c in _ACCOUNT_LINK_DECISIONS_COLUMNS)
+
 
 def _decode_row(row: tuple[Any, ...]) -> dict[str, Any]:
     """Map a fetched row to a column → value dict, decoding JSON columns."""
@@ -116,3 +119,96 @@ class AccountLinkDecisionsRepo(BaseRepo):
                 actor=actor,
                 parent_audit_id=parent_audit_id,
             )
+
+    def update_status(
+        self,
+        decision_id: str,
+        *,
+        status: str,
+        decided_by: str,
+        actor: str,
+        parent_audit_id: str | None = None,
+        in_outer_txn: bool = False,
+    ) -> AuditEvent:
+        """Transition a decision's status (e.g. pending → accepted/rejected).
+
+        Re-stamps ``decided_at``/``decided_by``; captures full before/after.
+        Raises ``ValueError`` when no decision with this id exists.
+        """
+        with self._transaction(in_outer_txn=in_outer_txn):
+            before = self._require(
+                self._fetch_row(decision_id), "decision_id", decision_id
+            )
+            self._db.execute(
+                f"""
+                UPDATE {ACCOUNT_LINK_DECISIONS.full_name}
+                SET status = ?, decided_by = ?, decided_at = CURRENT_TIMESTAMP
+                WHERE decision_id = ?
+                """,  # noqa: S608  # TableRef + parameterized values
+                [status, decided_by, decision_id],
+            )
+            after = self._fetch_row(decision_id)
+            return self._emit_audit(
+                action="account_link_decision.update_status",
+                target=(*self._audit_target, decision_id),
+                before=self._serialize_for_audit(before),
+                after=self._serialize_for_audit(after),
+                actor=actor,
+                parent_audit_id=parent_audit_id,
+            )
+
+    def reverse(
+        self,
+        decision_id: str,
+        *,
+        reversed_by: str,
+        actor: str,
+        parent_audit_id: str | None = None,
+        in_outer_txn: bool = False,
+    ) -> AuditEvent:
+        """Reverse a decision (sets ``reversed_at``/``reversed_by``, status reversed).
+
+        Captures the full prior row in ``before``. Raises ``ValueError`` when no
+        decision with this id exists, or when it is already reversed — re-reversing
+        would overwrite the original reversal's audit trail
+        (``reversed_at``/``reversed_by``), so a second reverse is rejected.
+        """
+        with self._transaction(in_outer_txn=in_outer_txn):
+            before = self._require(
+                self._fetch_row(decision_id), "decision_id", decision_id
+            )
+            if before["reversed_at"] is not None:
+                raise ValueError(f"Decision already reversed: {decision_id}")
+            self._db.execute(
+                f"""
+                UPDATE {ACCOUNT_LINK_DECISIONS.full_name}
+                SET reversed_at = CURRENT_TIMESTAMP, reversed_by = ?,
+                    status = 'reversed'
+                WHERE decision_id = ?
+                """,  # noqa: S608  # TableRef + parameterized values
+                [reversed_by, decision_id],
+            )
+            after = self._fetch_row(decision_id)
+            return self._emit_audit(
+                action="account_link_decision.reverse",
+                target=(*self._audit_target, decision_id),
+                before=self._serialize_for_audit(before),
+                after=self._serialize_for_audit(after),
+                actor=actor,
+                parent_audit_id=parent_audit_id,
+            )
+
+    def list_pending(self) -> list[dict[str, Any]]:
+        """Return all pending, non-reversed decisions ordered for review grouping.
+
+        Returns ``status='pending'`` rows with ``reversed_at IS NULL``, decoded
+        via ``_decode_row``, ordered ``provisional_account_id, decision_id`` so
+        callers can group proposals by the provisional account under review.
+        Read-only — no audit emitted.
+        """
+        rows = self._db.execute(
+            f"SELECT {_COLS} FROM {ACCOUNT_LINK_DECISIONS.full_name} "  # noqa: S608  # constant column list + TableRef
+            "WHERE status = 'pending' AND reversed_at IS NULL "
+            "ORDER BY provisional_account_id, decision_id",
+        ).fetchall()
+        return [_decode_row(r) for r in rows]

--- a/src/moneybin/repositories/account_links_repo.py
+++ b/src/moneybin/repositories/account_links_repo.py
@@ -14,6 +14,7 @@ caller supplies both.
 
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
 from moneybin.repositories.base import BaseRepo
@@ -158,6 +159,80 @@ class AccountLinksRepo(BaseRepo):
                 target=(*self._audit_target, link_id),
                 before=None,
                 after=self._serialize_for_audit(after),
+                actor=actor,
+                parent_audit_id=parent_audit_id,
+            )
+
+    def repoint(
+        self,
+        *,
+        link_id: str,
+        new_account_id: str,
+        decided_by: str,
+        actor: str,
+        parent_audit_id: str | None = None,
+        in_outer_txn: bool = False,
+    ) -> AuditEvent:
+        """Re-point an accepted link onto a different canonical account_id (merge primitive).
+
+        Within one transaction:
+        1. Reverses the existing row (status='reversed') so ``_guard_uniqueness``
+           no longer sees it as accepted.
+        2. Inserts a new accepted row for ``new_account_id`` with the same ref
+           coordinates — the guard now passes because the old row is reversed.
+        3. Emits a paired audit for the OLD row's reversal (action
+           ``"account_link.repoint"``). The nested ``insert`` emits its own audit
+           for the new row (Invariant 10 — each mutation audited independently).
+
+        Raises ``ValueError`` when ``link_id`` is not found, already points to
+        ``new_account_id`` (caller bug), or is not in ``accepted`` status.
+        """
+        with self._transaction(in_outer_txn=in_outer_txn):
+            before = self._require(self._fetch_row(link_id), "link_id", link_id)
+            if before["account_id"] == new_account_id:
+                raise ValueError(
+                    f"account_links repoint: link {link_id!r} already points to "
+                    f"account_id={new_account_id!r}"
+                )
+            if before["status"] != "accepted":
+                raise ValueError(
+                    f"account_links repoint: link {link_id!r} has status="
+                    f"{before['status']!r}; can only re-point an accepted link"
+                )
+            # Reverse the old row first so _guard_uniqueness won't block the insert.
+            self._db.execute(
+                f"""
+                UPDATE {ACCOUNT_LINKS.full_name}
+                SET reversed_at = CURRENT_TIMESTAMP, reversed_by = ?,
+                    status = 'reversed'
+                WHERE link_id = ?
+                """,  # noqa: S608  # TableRef + parameterized values
+                [decided_by, link_id],
+            )
+            after_reversal = self._fetch_row(link_id)
+            # Insert a new accepted row for new_account_id (same ref coordinates).
+            # Uses in_outer_txn=True to join the enclosing transaction; the insert
+            # emits its own audit row (Invariant 10).
+            new_link_id = uuid.uuid4().hex[:12]
+            self.insert(
+                link_id=new_link_id,
+                account_id=new_account_id,
+                ref_kind=before["ref_kind"],
+                ref_value=before["ref_value"],
+                source_type=before["source_type"],
+                source_origin=before["source_origin"],
+                decided_by=decided_by,
+                actor=actor,
+                status="accepted",
+                parent_audit_id=parent_audit_id,
+                in_outer_txn=True,
+            )
+            # Audit the OLD row's reversal as the repoint action.
+            return self._emit_audit(
+                action="account_link.repoint",
+                target=(*self._audit_target, link_id),
+                before=self._serialize_for_audit(before),
+                after=self._serialize_for_audit(after_reversal),
                 actor=actor,
                 parent_audit_id=parent_audit_id,
             )

--- a/src/moneybin/services/account_links_service.py
+++ b/src/moneybin/services/account_links_service.py
@@ -1,0 +1,337 @@
+"""AccountLinksService — review-queue facade for ``app.account_link_decisions``.
+
+Mirrors :mod:`moneybin.services.matching_service`: a thin service that composes
+two Invariant-10 repos (``AccountLinksRepo`` and ``AccountLinkDecisionsRepo``)
+and coordinates multi-write atomic operations using the same
+``db.begin() / db.commit() / db.rollback()`` pattern.
+
+``actor`` is the audit surface (``cli``/``mcp``); ``decided_by`` is the domain
+column (``user``/``system``/``auto``). The caller supplies both.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import duckdb
+
+from moneybin import error_codes
+from moneybin.database import Database
+from moneybin.errors import UserError
+from moneybin.repositories.account_link_decisions_repo import AccountLinkDecisionsRepo
+from moneybin.repositories.account_links_repo import AccountLinksRepo
+from moneybin.services.account_resolution_types import (
+    PendingLinkCandidate,
+    PendingLinkGroup,
+)
+from moneybin.tables import ACCOUNT_LINK_DECISIONS, ACCOUNT_LINKS, DIM_ACCOUNTS
+
+logger = logging.getLogger(__name__)
+
+# Column order matches app_account_link_decisions.sql (and the repo's constant).
+_DECISION_COLUMNS = (
+    "decision_id",
+    "provisional_account_id",
+    "candidate_account_id",
+    "confidence_score",
+    "match_signals",
+    "status",
+    "decided_by",
+    "match_reason",
+    "decided_at",
+    "reversed_at",
+    "reversed_by",
+)
+_DECISION_COLS = ", ".join(f'"{c}"' for c in _DECISION_COLUMNS)
+
+
+def _signal_from_decoded(match_signals: Any) -> str:
+    """Extract the 'signal' key from an already-decoded match_signals dict.
+
+    ``list_pending()`` returns ``match_signals`` as a decoded ``dict``; the
+    ``Any`` annotation covers the raw DB read path too (used by ``history``).
+    Uses try/except to avoid pyright's ``dict[Unknown, Unknown]`` narrowing
+    issue after ``isinstance`` checks on ``Any``-typed inputs.
+    """
+    try:
+        return str(match_signals["signal"])
+    except (KeyError, TypeError):
+        return ""
+
+
+def _decode_decision_row(row: tuple[Any, ...]) -> dict[str, Any]:
+    """Map a raw DB row to a dict, decoding the JSON ``match_signals`` column."""
+    out: dict[str, Any] = {}
+    for col, val in zip(_DECISION_COLUMNS, row, strict=True):
+        if col == "match_signals" and isinstance(val, str):
+            out[col] = json.loads(val)
+        else:
+            out[col] = val
+    return out
+
+
+def _resolve_display_name(db: Database, account_id: str) -> str:
+    """Return ``display_name`` from ``core.dim_accounts``; empty string when absent.
+
+    Guards ``duckdb.CatalogException`` so callers work before the core layer is
+    materialized (e.g. during initial import before a SQLMesh run).
+    """
+    try:
+        row = db.execute(
+            f"SELECT display_name FROM {DIM_ACCOUNTS.full_name} WHERE account_id = ?",  # noqa: S608  # TableRef constant + parameterized value
+            [account_id],
+        ).fetchone()
+        return (row[0] or "") if row else ""
+    except duckdb.CatalogException:
+        return ""
+
+
+class AccountLinksService:
+    """Review-queue facade over ``app.account_link_decisions`` + ``app.account_links``.
+
+    Composes ``AccountLinkDecisionsRepo`` and ``AccountLinksRepo`` for all
+    mutations (Invariant 10). Multi-step atomic operations use
+    ``db.begin()`` / ``db.commit()`` / ``db.rollback()`` with each repo method
+    called via ``in_outer_txn=True`` — the same pattern as
+    :class:`~moneybin.services.matching_service.MatchingService.set_status`.
+    """
+
+    def __init__(self, db: Database, *, actor: str = "cli") -> None:
+        """Initialize with a Database and the audit surface actor."""
+        self._db = db
+        self._actor = actor
+        self._links = AccountLinksRepo(db)
+        self._decisions = AccountLinkDecisionsRepo(db)
+
+    # ------------------------------------------------------------------
+    # Read-only methods
+    # ------------------------------------------------------------------
+
+    def count_pending(self) -> int:
+        """Number of DISTINCT provisional accounts with pending, non-reversed decisions.
+
+        The review *unit* is the provisional account, not the raw decision row —
+        one provisional with two candidate proposals counts as one item, not two.
+        Returns 0 when the table does not yet exist.
+        """
+        try:
+            row = self._db.execute(
+                f"""
+                SELECT COUNT(DISTINCT provisional_account_id)
+                FROM {ACCOUNT_LINK_DECISIONS.full_name}
+                WHERE status = 'pending' AND reversed_at IS NULL
+                """,  # noqa: S608  # TableRef constant, no user values
+            ).fetchone()
+            return int(row[0]) if row else 0
+        except duckdb.CatalogException:
+            return 0
+
+    def pending(self) -> list[PendingLinkGroup]:
+        """Return pending decisions grouped by provisional account.
+
+        Reads ``AccountLinkDecisionsRepo.list_pending()`` (already ordered
+        ``provisional_account_id, decision_id``) and groups into
+        ``PendingLinkGroup`` structs. Display names are resolved from
+        ``core.dim_accounts``; empty string when the row is absent or the
+        table is not yet materialized (``CatalogException`` guard).
+        Read-only — no audit emitted.
+        """
+        rows = self._decisions.list_pending()
+        if not rows:
+            return []
+
+        # list_pending() orders by provisional_account_id, decision_id — group in order.
+        groups: dict[str, list[dict[str, Any]]] = {}
+        for row in rows:
+            pid = row["provisional_account_id"]
+            groups.setdefault(pid, []).append(row)
+
+        result: list[PendingLinkGroup] = []
+        for provisional_id, decisions in groups.items():
+            prov_display = _resolve_display_name(self._db, provisional_id)
+            candidates = tuple(
+                PendingLinkCandidate(
+                    decision_id=d["decision_id"],
+                    candidate_account_id=d["candidate_account_id"],
+                    candidate_display_name=_resolve_display_name(
+                        self._db, d["candidate_account_id"]
+                    ),
+                    confidence=d["confidence_score"],
+                    # match_signals is already decoded by list_pending(); cast for pyright.
+                    signal=_signal_from_decoded(d["match_signals"]),
+                )
+                for d in decisions
+            )
+            result.append(
+                PendingLinkGroup(
+                    provisional_account_id=provisional_id,
+                    provisional_display_name=prov_display,
+                    candidates=candidates,
+                )
+            )
+        return result
+
+    def history(self, *, limit: int = 50) -> list[dict[str, Any]]:
+        """All decisions (any status) newest-first by ``decided_at``. Read-only.
+
+        Mirrors ``MatchingService.get_log``. Returns an empty list when the
+        table does not yet exist (``CatalogException`` guard).
+        """
+        try:
+            rows = self._db.execute(
+                f"""
+                SELECT {_DECISION_COLS}
+                FROM {ACCOUNT_LINK_DECISIONS.full_name}
+                ORDER BY decided_at DESC NULLS LAST
+                LIMIT ?
+                """,  # noqa: S608  # constant column list + TableRef + parameterized limit
+                [limit],
+            ).fetchall()
+        except duckdb.CatalogException:
+            return []
+        return [_decode_decision_row(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _fetch_decision(self, decision_id: str) -> dict[str, Any] | None:
+        """Read one decision row by id. Returns None when not found."""
+        row = self._db.execute(
+            f"SELECT {_DECISION_COLS} FROM {ACCOUNT_LINK_DECISIONS.full_name} WHERE decision_id = ?",  # noqa: S608  # constant columns + TableRef + parameterized pk
+            [decision_id],
+        ).fetchone()
+        return _decode_decision_row(row) if row else None
+
+    # ------------------------------------------------------------------
+    # Mutations
+    # ------------------------------------------------------------------
+
+    def set(  # noqa: A003  # mirrors the existing set_status verb shape; "set" is the surface verb
+        self,
+        decision_id: str,
+        *,
+        target_account_id: str | None,
+        decided_by: str = "user",
+    ) -> None:
+        """Accept (merge) or standalone-reject a pending link decision atomically.
+
+        ``target_account_id`` is not None (accept → merge):
+          1. Validates the arg matches the decision's own ``candidate_account_id``.
+          2. Re-points every accepted ``source_native`` link for the provisional
+             account onto ``target_account_id`` via ``AccountLinksRepo.repoint``.
+          3. Marks the named decision ``accepted``.
+          4. Auto-rejects every other pending, non-reversed decision for the
+             same provisional account.
+
+        ``target_account_id`` is None (standalone):
+          Rejects every pending, non-reversed decision for the provisional
+          account. No repoint — the provisional stays its own canonical account.
+
+        All writes run inside one ``db.begin()`` / ``db.commit()`` transaction
+        (matching :meth:`MatchingService.set_status`). Each repo method is
+        called with ``in_outer_txn=True`` so it joins the enclosing transaction
+        instead of opening a nested one.
+
+        Raises ``UserError`` when:
+        - ``decision_id`` is not found (MUTATION_NOT_FOUND).
+        - The decision is not in ``pending`` status (MUTATION_CONSTRAINT_VIOLATION).
+        - ``target_account_id`` does not match the decision's ``candidate_account_id``
+          (MUTATION_INVALID_INPUT).
+        """
+        self._db.begin()
+        try:
+            decision = self._fetch_decision(decision_id)
+            if decision is None:
+                raise UserError(
+                    f"No account-link decision found for id {decision_id!r}.",
+                    code=error_codes.MUTATION_NOT_FOUND,
+                )
+            if decision["status"] != "pending":
+                raise UserError(
+                    f"Decision {decision_id!r} is {decision['status']!r}, not pending.",
+                    code=error_codes.MUTATION_CONSTRAINT_VIOLATION,
+                )
+
+            provisional_id = decision["provisional_account_id"]
+
+            if target_account_id is not None:
+                # Accept path: validate confirming arg then repoint + accept + auto-reject.
+                if target_account_id != decision["candidate_account_id"]:
+                    raise UserError(
+                        "target_account_id does not match the candidate named in "
+                        f"decision {decision_id!r}; pass the decision's own "
+                        "candidate_account_id as a confirming safety check.",
+                        code=error_codes.MUTATION_INVALID_INPUT,
+                    )
+                # Re-point all accepted source_native links for the provisional.
+                links = self._db.execute(
+                    f"""
+                    SELECT link_id FROM {ACCOUNT_LINKS.full_name}
+                    WHERE account_id = ?
+                      AND ref_kind = 'source_native'
+                      AND status = 'accepted'
+                    """,  # noqa: S608  # TableRef constant + parameterized values
+                    [provisional_id],
+                ).fetchall()
+                for (link_id,) in links:
+                    self._links.repoint(
+                        link_id=link_id,
+                        new_account_id=target_account_id,
+                        decided_by=decided_by,
+                        actor=self._actor,
+                        in_outer_txn=True,
+                    )
+                # Accept the named decision.
+                self._decisions.update_status(
+                    decision_id,
+                    status="accepted",
+                    decided_by=decided_by,
+                    actor=self._actor,
+                    in_outer_txn=True,
+                )
+                # Auto-reject sibling pending decisions on the same provisional.
+                sibling_rows = self._db.execute(
+                    f"""
+                    SELECT decision_id FROM {ACCOUNT_LINK_DECISIONS.full_name}
+                    WHERE provisional_account_id = ?
+                      AND decision_id != ?
+                      AND status = 'pending'
+                      AND reversed_at IS NULL
+                    """,  # noqa: S608  # TableRef constant + parameterized values
+                    [provisional_id, decision_id],
+                ).fetchall()
+                for (sid,) in sibling_rows:
+                    self._decisions.update_status(
+                        sid,
+                        status="rejected",
+                        decided_by=decided_by,
+                        actor=self._actor,
+                        in_outer_txn=True,
+                    )
+            else:
+                # Standalone path: reject every pending decision for this provisional.
+                pending_rows = self._db.execute(
+                    f"""
+                    SELECT decision_id FROM {ACCOUNT_LINK_DECISIONS.full_name}
+                    WHERE provisional_account_id = ?
+                      AND status = 'pending'
+                      AND reversed_at IS NULL
+                    """,  # noqa: S608  # TableRef constant + parameterized values
+                    [provisional_id],
+                ).fetchall()
+                for (did,) in pending_rows:
+                    self._decisions.update_status(
+                        did,
+                        status="rejected",
+                        decided_by=decided_by,
+                        actor=self._actor,
+                        in_outer_txn=True,
+                    )
+
+            self._db.commit()
+        except BaseException:
+            self._db.rollback()
+            raise

--- a/src/moneybin/services/account_links_service.py
+++ b/src/moneybin/services/account_links_service.py
@@ -48,7 +48,7 @@ _DECISION_COLUMNS = (
 _DECISION_COLS = ", ".join(f'"{c}"' for c in _DECISION_COLUMNS)
 
 
-def _signal_from_decoded(match_signals: Any) -> str:
+def signal_from_match_signals(match_signals: Any) -> str:
     """Extract the 'signal' key from an already-decoded match_signals dict.
 
     ``list_pending()`` returns ``match_signals`` as a decoded ``dict``; the
@@ -161,7 +161,7 @@ class AccountLinksService:
                     ),
                     confidence=d["confidence_score"],
                     # match_signals is already decoded by list_pending(); cast for pyright.
-                    signal=_signal_from_decoded(d["match_signals"]),
+                    signal=signal_from_match_signals(d["match_signals"]),
                 )
                 for d in decisions
             )
@@ -241,6 +241,18 @@ class AccountLinksService:
             logger.debug("core.dim_accounts unavailable in run(); returning 0")
             return 0
 
+        # Only a provisional with an accepted source_native link can be merged
+        # (set() re-points that link; without it the merge can't collapse data
+        # and set() refuses it). Don't write backfill proposals that would
+        # dead-end at the merge step — they'd only be resolvable as standalone.
+        mergeable = {
+            str(r[0])
+            for r in self._db.execute(
+                f"SELECT DISTINCT account_id FROM {ACCOUNT_LINKS.full_name} "  # noqa: S608  # TableRef constant
+                "WHERE ref_kind = 'source_native' AND status = 'accepted'",
+            ).fetchall()
+        }
+
         new_count = 0
         # Track unordered pairs written this run to avoid A→B + B→A double-writes.
         seen_pairs: set[frozenset[str]] = set()
@@ -248,6 +260,8 @@ class AccountLinksService:
         self._db.begin()
         try:
             for account_id in account_ids:
+                if account_id not in mergeable:
+                    continue
                 proposal = resolver.propose_existing(account_id)
                 if proposal is None:
                     continue
@@ -357,17 +371,20 @@ class AccountLinksService:
                         "candidate_account_id as a confirming safety check.",
                         code=error_codes.MUTATION_INVALID_INPUT,
                     )
-                # Re-point all accepted source_native links for the provisional.
+                # Re-point ALL accepted links for the provisional onto the
+                # candidate — not only source_native (the staging-JOIN key) but
+                # also strong refs (persistent_token / full_number, used for
+                # adoption lookups). Leaving a strong ref on the merged-away
+                # provisional would later mis-adopt a source carrying the same
+                # token/number onto the dead id instead of the candidate.
                 links = self._db.execute(
                     f"""
-                    SELECT link_id FROM {ACCOUNT_LINKS.full_name}
-                    WHERE account_id = ?
-                      AND ref_kind = 'source_native'
-                      AND status = 'accepted'
+                    SELECT link_id, ref_kind FROM {ACCOUNT_LINKS.full_name}
+                    WHERE account_id = ? AND status = 'accepted'
                     """,  # noqa: S608  # TableRef constant + parameterized values
                     [provisional_id],
                 ).fetchall()
-                if not links:
+                if not any(ref_kind == "source_native" for _, ref_kind in links):
                     # No source_native mapping to re-point means the merge can't
                     # take effect: the staging JOIN translates raw rows via
                     # source_native links, so accepting here would record a
@@ -379,7 +396,7 @@ class AccountLinksService:
                         "re-point onto the candidate.",
                         code=error_codes.MUTATION_CONSTRAINT_VIOLATION,
                     )
-                for (link_id,) in links:
+                for link_id, _ref_kind in links:
                     self._links.repoint(
                         link_id=link_id,
                         new_account_id=target_account_id,

--- a/src/moneybin/services/account_links_service.py
+++ b/src/moneybin/services/account_links_service.py
@@ -367,6 +367,18 @@ class AccountLinksService:
                     """,  # noqa: S608  # TableRef constant + parameterized values
                     [provisional_id],
                 ).fetchall()
+                if not links:
+                    # No source_native mapping to re-point means the merge can't
+                    # take effect: the staging JOIN translates raw rows via
+                    # source_native links, so accepting here would record a
+                    # "paper merge" that never collapses the data. Refuse (rolls
+                    # back) rather than silently mark the decision accepted.
+                    raise UserError(
+                        f"Cannot apply merge for decision {decision_id!r}: the "
+                        "provisional account has no source_native mapping to "
+                        "re-point onto the candidate.",
+                        code=error_codes.MUTATION_CONSTRAINT_VIOLATION,
+                    )
                 for (link_id,) in links:
                     self._links.repoint(
                         link_id=link_id,

--- a/src/moneybin/services/account_links_service.py
+++ b/src/moneybin/services/account_links_service.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import logging
+import uuid
 from typing import Any
 
 import duckdb
@@ -208,6 +209,96 @@ class AccountLinksService:
     # ------------------------------------------------------------------
     # Mutations
     # ------------------------------------------------------------------
+
+    def run(self, *, decided_by: str = "auto") -> int:
+        """Backfill pending link proposals for all accounts in core.dim_accounts.
+
+        For each account in core.dim_accounts, calls
+        ``AccountResolver.propose_existing`` to find weak-signal candidates
+        (institution+last4 or name fuzzy-match), then writes a ``pending``
+        ``app.account_link_decisions`` row for each new unordered pair.
+
+        Dedup rules (skips a candidate if either holds):
+        - A decision already exists for that pair in either direction (any status).
+        - The same unordered pair was already written in this run.
+
+        Returns the count of new ``pending`` decisions written. Returns 0 when
+        ``core.dim_accounts`` is not yet materialized.
+        """
+        # Import here to avoid a circular-import at module level
+        # (AccountResolver ← AccountLinkDecisionsRepo ← AccountLinksService would cycle).
+        from moneybin.services.account_resolver import AccountResolver  # noqa: PLC0415
+
+        resolver = AccountResolver(self._db, actor=self._actor)
+        try:
+            account_ids = [
+                str(r[0])
+                for r in self._db.execute(
+                    f"SELECT account_id FROM {DIM_ACCOUNTS.full_name}",  # noqa: S608  # TableRef constant
+                ).fetchall()
+            ]
+        except duckdb.CatalogException:
+            logger.debug("core.dim_accounts unavailable in run(); returning 0")
+            return 0
+
+        new_count = 0
+        # Track unordered pairs written this run to avoid A→B + B→A double-writes.
+        seen_pairs: set[frozenset[str]] = set()
+
+        self._db.begin()
+        try:
+            for account_id in account_ids:
+                proposal = resolver.propose_existing(account_id)
+                if proposal is None:
+                    continue
+                for candidate in proposal.candidates:
+                    pair: frozenset[str] = frozenset({account_id, candidate.account_id})
+                    if pair in seen_pairs:
+                        continue
+                    # Skip if any decision (any status, either direction) already covers this pair.
+                    existing = self._db.execute(
+                        f"""
+                        SELECT 1 FROM {ACCOUNT_LINK_DECISIONS.full_name}
+                        WHERE (provisional_account_id = ? AND candidate_account_id = ?)
+                           OR (provisional_account_id = ? AND candidate_account_id = ?)
+                        LIMIT 1
+                        """,  # noqa: S608  # TableRef constant + parameterized values
+                        [
+                            account_id,
+                            candidate.account_id,
+                            candidate.account_id,
+                            account_id,
+                        ],
+                    ).fetchone()
+                    seen_pairs.add(pair)
+                    if existing is not None:
+                        continue
+                    decision_id = uuid.uuid4().hex[:12]
+                    self._decisions.insert(
+                        decision_id=decision_id,
+                        provisional_account_id=account_id,
+                        candidate_account_id=candidate.account_id,
+                        confidence_score=candidate.confidence,
+                        # value = matched candidate's display_name (schema intent:
+                        # "which weak signal fired + its value"), mirroring import-time.
+                        # Internal field; the queue surfaces signal/display_name, not this.
+                        match_signals={
+                            "signal": candidate.signal,
+                            "value": candidate.display_name,
+                        },
+                        decided_by=decided_by,
+                        actor=self._actor,
+                        status="pending",
+                        in_outer_txn=True,
+                    )
+                    new_count += 1
+            self._db.commit()
+        except BaseException:
+            self._db.rollback()
+            raise
+
+        logger.info(f"accounts_links_run: wrote {new_count} new pending decisions")
+        return new_count
 
     def set(  # noqa: A003  # mirrors the existing set_status verb shape; "set" is the surface verb
         self,

--- a/src/moneybin/services/account_links_service.py
+++ b/src/moneybin/services/account_links_service.py
@@ -412,16 +412,21 @@ class AccountLinksService:
                     actor=self._actor,
                     in_outer_txn=True,
                 )
-                # Auto-reject sibling pending decisions on the same provisional.
+                # Auto-reject every other pending decision that touches the
+                # provisional — both where it is the provisional (other
+                # candidates for it) AND where it is the *candidate* (some other
+                # Q→P proposal). The provisional is merged away, so a later
+                # accept of Q→P would re-point Q onto a dead account; a fresh
+                # run() re-proposes Q→C if Q really is the same account.
                 sibling_rows = self._db.execute(
                     f"""
                     SELECT decision_id FROM {ACCOUNT_LINK_DECISIONS.full_name}
-                    WHERE provisional_account_id = ?
+                    WHERE (provisional_account_id = ? OR candidate_account_id = ?)
                       AND decision_id != ?
                       AND status = 'pending'
                       AND reversed_at IS NULL
                     """,  # noqa: S608  # TableRef constant + parameterized values
-                    [provisional_id, decision_id],
+                    [provisional_id, provisional_id, decision_id],
                 ).fetchall()
                 for (sid,) in sibling_rows:
                     self._decisions.update_status(

--- a/src/moneybin/services/account_resolution_types.py
+++ b/src/moneybin/services/account_resolution_types.py
@@ -6,6 +6,64 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
+class AccountCandidate:
+    """One weak-signal merge candidate surfaced for confirmation."""
+
+    account_id: str
+    display_name: str
+    confidence: float
+    signal: str  # "institution_last4" | "name"
+
+
+@dataclass(frozen=True)
+class AccountProposal:
+    """The resolver verdict for one detected source account, surfaced to confirm.
+
+    ``requires_confirm`` encodes the surfacing rule structurally: a proposal with
+    weak candidates ALWAYS surfaces; a strong-confirmer adoption (``adopted_via``
+    set, no candidates) never does. A brand-new standalone account (is_new, no
+    adoption, no candidates) also surfaces — minting a new account is a visible
+    moment (spec Decision 7).
+    """
+
+    source_account_key: str
+    proposed_account_id: str
+    is_new: bool
+    candidates: tuple[AccountCandidate, ...] = ()
+    adopted_via: str | None = (
+        None  # "source_native"|"persistent_token"|"full_number"|"explicit"
+    )
+
+    @property
+    def requires_confirm(self) -> bool:
+        """True when the proposal must be shown to the user before import proceeds."""
+        return bool(self.candidates) or (self.is_new and self.adopted_via is None)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialise to a plain dict for surface display.
+
+        Includes opaque ids, display_name, confidence, and signal.
+        Never exposes ref_value or other PII-bearing fields.
+        """
+        return {
+            "source_account_key": self.source_account_key,
+            "proposed_account_id": self.proposed_account_id,
+            "is_new": self.is_new,
+            "adopted_via": self.adopted_via,
+            "requires_confirm": self.requires_confirm,
+            "candidates": [
+                {
+                    "account_id": c.account_id,
+                    "display_name": c.display_name,
+                    "confidence": c.confidence,
+                    "signal": c.signal,
+                }
+                for c in self.candidates
+            ],
+        }
+
+
+@dataclass(frozen=True)
 class SourceAccount:
     """One source account presented to the resolver.
 

--- a/src/moneybin/services/account_resolution_types.py
+++ b/src/moneybin/services/account_resolution_types.py
@@ -98,3 +98,23 @@ class ResolvedAccount:
 
     outcome: str = "minted_new"
     """One of the ACCOUNT_LINK_OUTCOMES_TOTAL result labels."""
+
+
+@dataclass(frozen=True)
+class PendingLinkCandidate:
+    """One candidate merge proposal within a pending-review group."""
+
+    decision_id: str
+    candidate_account_id: str
+    candidate_display_name: str
+    confidence: float | None
+    signal: str  # e.g. "institution_last4" | "name"
+
+
+@dataclass(frozen=True)
+class PendingLinkGroup:
+    """One provisional account awaiting review + its candidate proposals."""
+
+    provisional_account_id: str
+    provisional_display_name: str
+    candidates: tuple[PendingLinkCandidate, ...]

--- a/src/moneybin/services/account_resolver.py
+++ b/src/moneybin/services/account_resolver.py
@@ -164,6 +164,57 @@ class AccountResolver:
             adopted_via=None,
         )
 
+    def propose_existing(self, account_id: str) -> AccountProposal | None:
+        """Backfill verdict for an account already in core.dim_accounts.
+
+        Looks up the account's institution_name, last_four, and display_name,
+        builds a synthetic SourceAccount (source_type/source_origin="backfill";
+        the candidate pass only uses last_four, institution, account_name), then
+        delegates to _find_candidates excluding the account itself.
+
+        Returns None when the account is absent from dim_accounts, when
+        core.dim_accounts is not yet materialized, or when no candidates are
+        found. Read-only — writes nothing.
+        """
+        try:
+            row = self._db.execute(
+                f"SELECT institution_name, last_four, display_name "  # noqa: S608  # TableRef + parameterized value
+                f"FROM {DIM_ACCOUNTS.full_name} WHERE account_id = ? LIMIT 1",
+                [account_id],
+            ).fetchone()
+        except duckdb.CatalogException:
+            logger.debug("core.dim_accounts unavailable in propose_existing")
+            return None
+        if row is None:
+            return None
+        institution_name, last_four, display_name = row
+        src = SourceAccount(
+            source_type="backfill",
+            source_origin="backfill",
+            source_account_key="",
+            account_name=str(display_name or ""),
+            last_four=str(last_four) if last_four is not None else None,
+            institution=str(institution_name) if institution_name is not None else None,
+        )
+        raw_candidates = self._find_candidates(src, exclude_account_id=account_id)
+        if not raw_candidates:
+            return None
+        candidates = tuple(
+            AccountCandidate(
+                account_id=c.account_id,
+                display_name=self._fetch_display_name(c.account_id),
+                confidence=c.confidence,
+                signal=c.signal,
+            )
+            for c in raw_candidates
+        )
+        return AccountProposal(
+            source_account_key="",
+            proposed_account_id=account_id,
+            is_new=False,
+            candidates=candidates,
+        )
+
     def _fetch_display_name(self, account_id: str) -> str:
         """Return display_name from core.dim_accounts for a candidate account_id.
 

--- a/src/moneybin/services/account_resolver.py
+++ b/src/moneybin/services/account_resolver.py
@@ -19,7 +19,12 @@ from moneybin.database import Database
 from moneybin.extractors.tabular.account_matching import match_account
 from moneybin.repositories.account_link_decisions_repo import AccountLinkDecisionsRepo
 from moneybin.repositories.account_links_repo import AccountLinksRepo
-from moneybin.services.account_resolution_types import ResolvedAccount, SourceAccount
+from moneybin.services.account_resolution_types import (
+    AccountCandidate,
+    AccountProposal,
+    ResolvedAccount,
+    SourceAccount,
+)
 from moneybin.tables import ACCOUNT_LINKS, DIM_ACCOUNTS
 
 logger = logging.getLogger(__name__)
@@ -70,8 +75,9 @@ class AccountResolver:
             )
         # Step 1 - strong confirmer / idempotency: source_native, then
         # persistent_token, then scoped full_number. Hit -> auto-adopt.
-        adopted = self._lookup_strong_ref(src)
-        if adopted is not None:
+        strong = self._lookup_strong_ref(src)
+        if strong is not None:
+            adopted, _kind = strong
             self._write_native_mapping(src, account_id=adopted, decided_by="auto")
             self._write_strong_ref(src, account_id=adopted)
             return ResolvedAccount(
@@ -108,6 +114,69 @@ class AccountResolver:
             outcome="pending_review",
         )
 
+    def propose(self, src: SourceAccount) -> AccountProposal:
+        """Compute the resolver verdict without writing anything (read-only preview).
+
+        Mirrors the resolve() ladder exactly — explicit binding, strong ref,
+        candidate pass — but performs no writes: no mint is persisted, no
+        account_links row is inserted, no account_link_decisions row is created.
+        Safe to call at any point in the import flow, including before confirm.
+
+        The proposed_account_id in the mint path (is_new=True) is a preview id
+        (uuid4[:12]) that is NOT written anywhere; resolve() will produce a
+        different real id when the import is actually committed.
+        """
+        # Step 0 - explicit binding.
+        if src.explicit_account_id:
+            return AccountProposal(
+                source_account_key=src.source_account_key,
+                proposed_account_id=src.explicit_account_id,
+                is_new=False,
+                adopted_via="explicit",
+            )
+        # Step 1 - strong ref.
+        strong = self._lookup_strong_ref(src)
+        if strong is not None:
+            adopted, kind = strong
+            return AccountProposal(
+                source_account_key=src.source_account_key,
+                proposed_account_id=adopted,
+                is_new=False,
+                adopted_via=kind,
+            )
+        # Step 2 - candidate pass. Mint a preview id (NOT written anywhere).
+        preview_id = uuid.uuid4().hex[:12]
+        raw_candidates = self._find_candidates(src, exclude_account_id=preview_id)
+        candidates = tuple(
+            AccountCandidate(
+                account_id=c.account_id,
+                display_name=self._fetch_display_name(c.account_id),
+                confidence=c.confidence,
+                signal=c.signal,
+            )
+            for c in raw_candidates
+        )
+        return AccountProposal(
+            source_account_key=src.source_account_key,
+            proposed_account_id=preview_id,
+            is_new=True,
+            candidates=candidates,
+            adopted_via=None,
+        )
+
+    def _fetch_display_name(self, account_id: str) -> str:
+        """Return display_name from core.dim_accounts for a candidate account_id.
+
+        Returns empty string when the row is absent (defensive; if _find_candidates
+        returned a candidate, dim_accounts is materialized and the row should exist).
+        """
+        row = self._db.execute(
+            f"SELECT display_name FROM {DIM_ACCOUNTS.full_name} "  # noqa: S608  # TableRef + parameterized value
+            "WHERE account_id = ? LIMIT 1",
+            [account_id],
+        ).fetchone()
+        return str(row[0]) if row and row[0] is not None else ""
+
     def _write_native_mapping(
         self, src: SourceAccount, *, account_id: str, decided_by: str
     ) -> None:
@@ -143,11 +212,12 @@ class AccountResolver:
             actor=self._actor,
         )
 
-    def _lookup_strong_ref(self, src: SourceAccount) -> str | None:
-        """Return an existing canonical id if any accepted strong ref matches.
+    def _lookup_strong_ref(self, src: SourceAccount) -> tuple[str, str] | None:
+        """Return (account_id, ref_kind) if any accepted strong ref matches, else None.
 
         Checks source_native first (same-source re-import), then persistent_token
         (cross-connection identity), then scoped full_number (cross-source format).
+        The ref_kind is surfaced so propose() can populate adopted_via accurately.
         """
         row = self._db.execute(
             f"SELECT account_id FROM {ACCOUNT_LINKS.full_name} "  # noqa: S608  # TableRef + parameterized values
@@ -156,7 +226,7 @@ class AccountResolver:
             [src.source_type, src.source_origin, src.source_account_key],
         ).fetchone()
         if row is not None:
-            return str(row[0])
+            return str(row[0]), "source_native"
         if src.persistent_token:
             row = self._db.execute(
                 f"SELECT account_id FROM {ACCOUNT_LINKS.full_name} "  # noqa: S608  # TableRef + parameterized values
@@ -165,7 +235,7 @@ class AccountResolver:
                 [src.persistent_token],
             ).fetchone()
             if row is not None:
-                return str(row[0])
+                return str(row[0]), "persistent_token"
         scoped = self._scoped_full_number(src)
         if scoped is not None:
             row = self._db.execute(
@@ -175,7 +245,7 @@ class AccountResolver:
                 [scoped],
             ).fetchone()
             if row is not None:
-                return str(row[0])
+                return str(row[0]), "full_number"
         return None
 
     @staticmethod

--- a/src/moneybin/services/review_service.py
+++ b/src/moneybin/services/review_service.py
@@ -1,39 +1,48 @@
-"""Service composing match + categorize review queue counts."""
+"""Service composing match + categorize + account-links review queue counts."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 
+from moneybin.services.account_links_service import AccountLinksService
 from moneybin.services.categorization import CategorizationService
 from moneybin.services.matching_service import MatchingService
 
 
 @dataclass(frozen=True)
 class ReviewStatus:
-    """Counts for both review queues at a point in time."""
+    """Counts for all three review queues at a point in time."""
 
     matches_pending: int
     categorize_pending: int
+    account_links_pending: int
 
     @property
     def total(self) -> int:
-        """Sum of both queues."""
-        return self.matches_pending + self.categorize_pending
+        """Sum of all three queues."""
+        return (
+            self.matches_pending + self.categorize_pending + self.account_links_pending
+        )
 
 
 class ReviewService:
-    """Composes MatchingService + CategorizationService for unified review queue counts."""
+    """Composes MatchingService + CategorizationService + AccountLinksService for unified review queue counts."""
 
     def __init__(
-        self, match_service: MatchingService, categorize_service: CategorizationService
+        self,
+        match_service: MatchingService,
+        categorize_service: CategorizationService,
+        account_links_service: AccountLinksService,
     ) -> None:
-        """Bind to an existing MatchingService and CategorizationService."""
+        """Bind to existing services."""
         self._match_service = match_service
         self._categorize_service = categorize_service
+        self._account_links_service = account_links_service
 
     def status(self) -> ReviewStatus:
-        """Return current queue counts for both review queues."""
+        """Return current queue counts for all three review queues."""
         return ReviewStatus(
             matches_pending=self._match_service.count_pending(),
             categorize_pending=self._categorize_service.count_uncategorized(),
+            account_links_pending=self._account_links_service.count_pending(),
         )

--- a/src/moneybin/services/system_service.py
+++ b/src/moneybin/services/system_service.py
@@ -55,8 +55,12 @@ class SystemService:
         accounts_count = self._count_accounts()
         transactions_count, min_date, max_date = self._query_transactions()
         last_import_at = self._last_import_at()
+        from moneybin.services.account_links_service import AccountLinksService
+
         review = ReviewService(
-            MatchingService(self._db), CategorizationService(self._db)
+            MatchingService(self._db),
+            CategorizationService(self._db),
+            AccountLinksService(self._db),
         ).status()
         freshness = TransformService(self._db).freshness()
         schema_drift = check_core_schema_drift(self._db)

--- a/src/moneybin/services/system_service.py
+++ b/src/moneybin/services/system_service.py
@@ -25,6 +25,7 @@ class SystemStatus:
     transactions_date_range: tuple[date | None, date | None]
     last_import_at: date | None
     matches_pending: int
+    account_links_pending: int
     categorize_pending: int
     transforms_pending: bool
     transforms_last_apply_at: datetime | None
@@ -76,6 +77,7 @@ class SystemService:
             transactions_date_range=(min_date, max_date),
             last_import_at=last_import_at,
             matches_pending=review.matches_pending,
+            account_links_pending=review.account_links_pending,
             categorize_pending=review.categorize_pending,
             transforms_pending=freshness.pending,
             transforms_last_apply_at=freshness.last_apply_at,

--- a/tests/e2e/test_e2e_help.py
+++ b/tests/e2e/test_e2e_help.py
@@ -131,6 +131,14 @@ _HELP_COMMANDS: list[list[str]] = [
     ["sql"],
     ["sql", "query"],
     ["export"],
+    # top-level review leaf
+    ["review"],
+    # accounts links subgroup + leaves
+    ["accounts", "links"],
+    ["accounts", "links", "pending"],
+    ["accounts", "links", "set"],
+    ["accounts", "links", "history"],
+    ["accounts", "links", "run"],
 ]
 
 _runner = CliRunner()

--- a/tests/e2e/test_e2e_mutating.py
+++ b/tests/e2e/test_e2e_mutating.py
@@ -1342,6 +1342,85 @@ class TestCategorizeRulesDeleteCLI:
         assert "Rule does-not-exist not found" in result.stderr
 
 
+class TestAccountLinksMutating:
+    """E2E smoke tests for `accounts links run` and `accounts links set`."""
+
+    def test_accounts_links_run(
+        self, _mutating_profile_template: Path, tmp_path: Path
+    ) -> None:
+        """`accounts links run` exits 0; 0 proposals on empty data is success."""
+        env = make_workflow_env_fast(tmp_path, "links-run", _mutating_profile_template)
+        result = run_cli("accounts", "links", "run", env=env)
+        result.assert_success()
+
+    def test_accounts_links_run_json(
+        self, _mutating_profile_template: Path, tmp_path: Path
+    ) -> None:
+        """`accounts links run --output json` returns an envelope with new_proposals."""
+        env = make_workflow_env_fast(
+            tmp_path, "links-run-json", _mutating_profile_template
+        )
+        result = run_cli("accounts", "links", "run", "--output", "json", env=env)
+        result.assert_success()
+        payload = json.loads(result.stdout)
+        assert "data" in payload
+        assert "new_proposals" in payload["data"]
+        assert isinstance(payload["data"]["new_proposals"], int)
+
+    def test_accounts_links_set_not_found(
+        self, _mutating_profile_template: Path, tmp_path: Path
+    ) -> None:
+        """`accounts links set <nonexistent_id> --standalone` fails with not-found, no traceback.
+
+        No pending link decisions exist on a fresh profile — the service raises
+        UserError(MUTATION_NOT_FOUND) which handle_cli_errors converts to exit 1.
+        """
+        env = make_workflow_env_fast(
+            tmp_path, "links-set-nf", _mutating_profile_template
+        )
+        result = run_cli(
+            "accounts",
+            "links",
+            "set",
+            "nonexistent-decision-id",
+            "--standalone",
+            env=env,
+        )
+        assert result.exit_code != 0
+        assert "Traceback (most recent call last)" not in result.stderr
+
+    def test_accounts_links_set_missing_flag_is_usage_error(
+        self, _mutating_profile_template: Path, tmp_path: Path
+    ) -> None:
+        """`accounts links set <id>` without --into or --standalone exits 2 (usage error)."""
+        env = make_workflow_env_fast(
+            tmp_path, "links-set-usage", _mutating_profile_template
+        )
+        result = run_cli("accounts", "links", "set", "any-id", env=env)
+        assert result.exit_code == 2
+        assert "Traceback (most recent call last)" not in result.stderr
+
+    def test_accounts_links_set_mutual_exclusion_error(
+        self, _mutating_profile_template: Path, tmp_path: Path
+    ) -> None:
+        """`accounts links set <id> --into X --standalone` exits 2 (mutually exclusive)."""
+        env = make_workflow_env_fast(
+            tmp_path, "links-set-mutex", _mutating_profile_template
+        )
+        result = run_cli(
+            "accounts",
+            "links",
+            "set",
+            "any-id",
+            "--into",
+            "CAND001",
+            "--standalone",
+            env=env,
+        )
+        assert result.exit_code == 2
+        assert "Traceback (most recent call last)" not in result.stderr
+
+
 class TestPrivacyConsent:
     """Consent ledger CLI commands (grant / revoke / revoke-all)."""
 

--- a/tests/e2e/test_e2e_readonly.py
+++ b/tests/e2e/test_e2e_readonly.py
@@ -365,6 +365,86 @@ class TestDBReadOnlyCommands:
         assert result.exit_code == 0, result.output
         assert "--from" in result.output
 
+    # ── review ──────────────────────────────────────────────────────────
+
+    def test_review_status(self, e2e_profile: dict[str, str]) -> None:
+        """`moneybin review --status` prints three queue counts and exits 0."""
+        result = run_cli("review", "--status", env=e2e_profile)
+        result.assert_success()
+        out = result.stdout.lower()
+        # All three queues appear in text output
+        assert "match" in out
+        assert "categori" in out
+        assert "account" in out or "link" in out
+
+    def test_review_status_json(self, e2e_profile: dict[str, str]) -> None:
+        """`moneybin review --status --output json` returns a three-field envelope."""
+        import json
+
+        result = run_cli("review", "--status", "--output", "json", env=e2e_profile)
+        result.assert_success()
+        envelope = json.loads(result.stdout)
+        payload = envelope["data"]
+        assert "matches_pending" in payload
+        assert "categorize_pending" in payload
+        assert "account_links_pending" in payload
+        assert "total" in payload
+        assert payload["total"] == (
+            payload["matches_pending"]
+            + payload["categorize_pending"]
+            + payload["account_links_pending"]
+        )
+
+    def test_review_type_account_links_status(
+        self, e2e_profile: dict[str, str]
+    ) -> None:
+        """`moneybin review --type account-links --status` exits 0 and shows account-link count."""
+        result = run_cli(
+            "review", "--type", "account-links", "--status", env=e2e_profile
+        )
+        result.assert_success()
+        out = result.stdout.lower()
+        assert "account" in out or "link" in out or "decision" in out
+
+    # ── accounts links (read-only) ───────────────────────────────────────
+
+    def test_accounts_links_pending(self, e2e_profile: dict[str, str]) -> None:
+        """`moneybin accounts links pending` exits 0 on an empty queue."""
+        result = run_cli("accounts", "links", "pending", env=e2e_profile)
+        result.assert_success()
+
+    def test_accounts_links_pending_json(self, e2e_profile: dict[str, str]) -> None:
+        """`moneybin accounts links pending --output json` returns an envelope with groups[] and n_pending."""
+        import json
+
+        result = run_cli(
+            "accounts", "links", "pending", "--output", "json", env=e2e_profile
+        )
+        result.assert_success()
+        envelope = json.loads(result.stdout)
+        assert "data" in envelope
+        assert "groups" in envelope["data"]
+        assert isinstance(envelope["data"]["groups"], list)
+        assert "n_pending" in envelope["data"]
+
+    def test_accounts_links_history(self, e2e_profile: dict[str, str]) -> None:
+        """`moneybin accounts links history` exits 0 on a fresh profile."""
+        result = run_cli("accounts", "links", "history", env=e2e_profile)
+        result.assert_success()
+
+    def test_accounts_links_history_json(self, e2e_profile: dict[str, str]) -> None:
+        """`moneybin accounts links history --output json` returns an envelope with decisions[]."""
+        import json
+
+        result = run_cli(
+            "accounts", "links", "history", "--output", "json", env=e2e_profile
+        )
+        result.assert_success()
+        envelope = json.loads(result.stdout)
+        assert "data" in envelope
+        assert "decisions" in envelope["data"]
+        assert isinstance(envelope["data"]["decisions"], list)
+
     # ── stats ───────────────────────────────────────────────────────────
 
     def test_stats_show(self, e2e_profile: dict[str, str]) -> None:

--- a/tests/moneybin/test_cli/test_accounts_links.py
+++ b/tests/moneybin/test_cli/test_accounts_links.py
@@ -1,0 +1,262 @@
+"""Tests for `accounts links` CLI commands.
+
+Mirrors test_matches.py for the transactions surface. CLI tests mock the
+service layer and test argument parsing, exit codes, and output shape.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from moneybin.cli.commands.accounts.links import app
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pending_group(
+    *,
+    provisional_id: str = "PROV1",
+    provisional_name: str = "Provisional Account",
+    decision_id: str = "dec001",
+    candidate_id: str = "CAND001",
+    candidate_name: str = "Candidate Account",
+    confidence: float = 0.85,
+    signal: str = "institution_last4",
+) -> MagicMock:
+    """Build a mock PendingLinkGroup with sensible defaults."""
+    candidate = MagicMock()
+    candidate.decision_id = decision_id
+    candidate.candidate_account_id = candidate_id
+    candidate.candidate_display_name = candidate_name
+    candidate.confidence = confidence
+    candidate.signal = signal
+
+    group = MagicMock()
+    group.provisional_account_id = provisional_id
+    group.provisional_display_name = provisional_name
+    group.candidates = [candidate]
+    return group
+
+
+# ---------------------------------------------------------------------------
+# links pending
+# ---------------------------------------------------------------------------
+
+
+class TestLinksPending:
+    """Tests for `accounts links pending`."""
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.pending")
+    @patch("moneybin.services.account_links_service.AccountLinksService.count_pending")
+    def test_pending_empty(
+        self,
+        mock_count: MagicMock,
+        mock_pending: MagicMock,
+        mock_get_db: MagicMock,
+    ) -> None:
+        """Empty queue exits 0 with no output."""
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_pending.return_value = []
+        mock_count.return_value = 0
+
+        result = runner.invoke(app, ["pending"])
+        assert result.exit_code == 0
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.pending")
+    @patch("moneybin.services.account_links_service.AccountLinksService.count_pending")
+    def test_pending_shows_provisional_and_candidates(
+        self,
+        mock_count: MagicMock,
+        mock_pending: MagicMock,
+        mock_get_db: MagicMock,
+    ) -> None:
+        """Text output includes provisional account id and candidate decision ids."""
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        group = _make_pending_group(
+            provisional_id="PROV1",
+            decision_id="dec001",
+            candidate_id="CAND001",
+        )
+        mock_pending.return_value = [group]
+        mock_count.return_value = 1
+
+        result = runner.invoke(app, ["pending"])
+        assert result.exit_code == 0
+        assert "PROV1" in result.output
+        assert "dec001" in result.output
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.pending")
+    @patch("moneybin.services.account_links_service.AccountLinksService.count_pending")
+    def test_pending_json_output_shape(
+        self,
+        mock_count: MagicMock,
+        mock_pending: MagicMock,
+        mock_get_db: MagicMock,
+    ) -> None:
+        """--output json emits groups[] with candidates[] and n_pending."""
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        group = _make_pending_group(
+            provisional_id="PROV_J",
+            decision_id="dec_j",
+            candidate_id="CAND_J",
+        )
+        mock_pending.return_value = [group]
+        mock_count.return_value = 1
+
+        result = runner.invoke(app, ["pending", "--output", "json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        # Same envelope as MCP: summary + data + actions
+        assert "data" in parsed
+        assert "groups" in parsed["data"]
+        groups = parsed["data"]["groups"]
+        assert len(groups) == 1
+        assert groups[0]["provisional_account_id"] == "PROV_J"
+        assert len(groups[0]["candidates"]) == 1
+        assert groups[0]["candidates"][0]["decision_id"] == "dec_j"
+        assert "n_pending" in parsed["data"]
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.pending")
+    @patch("moneybin.services.account_links_service.AccountLinksService.count_pending")
+    def test_pending_json_no_ref_value(
+        self,
+        mock_count: MagicMock,
+        mock_pending: MagicMock,
+        mock_get_db: MagicMock,
+    ) -> None:
+        """JSON output never includes ref_value."""
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_pending.return_value = [_make_pending_group()]
+        mock_count.return_value = 1
+
+        result = runner.invoke(app, ["pending", "--output", "json"])
+        assert result.exit_code == 0
+        assert "ref_value" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# links set
+# ---------------------------------------------------------------------------
+
+
+class TestLinksSet:
+    """Tests for `accounts links set`."""
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.set")
+    def test_set_into_calls_service_with_target(
+        self,
+        mock_set: MagicMock,
+        mock_get_db: MagicMock,
+    ) -> None:
+        """--into <account_id> passes target_account_id to service."""
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+
+        result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"])
+        assert result.exit_code == 0
+        mock_set.assert_called_once_with(
+            "dec001", target_account_id="CAND001", decided_by="user"
+        )
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.set")
+    def test_set_standalone_calls_service_with_none(
+        self,
+        mock_set: MagicMock,
+        mock_get_db: MagicMock,
+    ) -> None:
+        """--standalone passes target_account_id=None to service."""
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+
+        result = runner.invoke(app, ["set", "dec001", "--standalone"])
+        assert result.exit_code == 0
+        mock_set.assert_called_once_with(
+            "dec001", target_account_id=None, decided_by="user"
+        )
+
+    def test_set_requires_into_or_standalone(self) -> None:
+        """Invoking set without --into or --standalone exits 2."""
+        result = runner.invoke(app, ["set", "dec001"])
+        assert result.exit_code == 2
+
+    def test_set_rejects_both_flags(self) -> None:
+        """--into and --standalone are mutually exclusive → exit 2."""
+        result = runner.invoke(
+            app, ["set", "dec001", "--into", "CAND001", "--standalone"]
+        )
+        assert result.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# links history
+# ---------------------------------------------------------------------------
+
+
+class TestLinksHistory:
+    """Tests for `accounts links history`."""
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.history")
+    def test_history_empty(
+        self, mock_history: MagicMock, mock_get_db: MagicMock
+    ) -> None:
+        """Empty history exits 0."""
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_history.return_value = []
+
+        result = runner.invoke(app, ["history"])
+        assert result.exit_code == 0
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.history")
+    def test_history_json_output(
+        self, mock_history: MagicMock, mock_get_db: MagicMock
+    ) -> None:
+        """--output json returns an envelope with decisions[]."""
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_history.return_value = [
+            {
+                "decision_id": "dh001",
+                "provisional_account_id": "PROV_H",
+                "candidate_account_id": "CAND_H",
+                "status": "accepted",
+                "decided_by": "user",
+                "decided_at": "2025-06-01T10:00:00",
+                "confidence_score": 0.85,
+                "match_signals": {"signal": "name"},
+            }
+        ]
+
+        result = runner.invoke(app, ["history", "--output", "json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert "data" in parsed
+        assert "decisions" in parsed["data"]
+        decisions = parsed["data"]["decisions"]
+        assert len(decisions) == 1
+        assert decisions[0]["decision_id"] == "dh001"
+        assert decisions[0]["signal"] == "name"
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.history")
+    def test_history_limit_option(
+        self, mock_history: MagicMock, mock_get_db: MagicMock
+    ) -> None:
+        """--limit is forwarded to the service."""
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_history.return_value = []
+
+        runner.invoke(app, ["history", "--limit", "10"])
+        mock_history.assert_called_once_with(limit=10)

--- a/tests/moneybin/test_cli/test_accounts_links.py
+++ b/tests/moneybin/test_cli/test_accounts_links.py
@@ -204,6 +204,61 @@ class TestLinksSet:
 # ---------------------------------------------------------------------------
 
 
+class TestLinksRun:
+    """Tests for `accounts links run`."""
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.run")
+    def test_run_exits_0(self, mock_run: MagicMock, mock_get_db: MagicMock) -> None:
+        """Run exits 0 and prints the new-proposal count."""
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_run.return_value = 3
+
+        result = runner.invoke(app, ["run"])
+        assert result.exit_code == 0
+        assert "3" in result.output
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.run")
+    def test_run_mentions_pending_command(
+        self, mock_run: MagicMock, mock_get_db: MagicMock
+    ) -> None:
+        """Run output hints the user toward `accounts links pending`."""
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_run.return_value = 2
+
+        result = runner.invoke(app, ["run"])
+        assert result.exit_code == 0
+        assert "pending" in result.output.lower()
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.run")
+    def test_run_zero_proposals_exits_0(
+        self, mock_run: MagicMock, mock_get_db: MagicMock
+    ) -> None:
+        """Run with 0 new proposals still exits 0."""
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_run.return_value = 0
+
+        result = runner.invoke(app, ["run"])
+        assert result.exit_code == 0
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.run")
+    def test_run_json_output_shape(
+        self, mock_run: MagicMock, mock_get_db: MagicMock
+    ) -> None:
+        """--output json returns an envelope with new_proposals in data."""
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_run.return_value = 7
+
+        result = runner.invoke(app, ["run", "--output", "json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert "data" in parsed
+        assert parsed["data"]["new_proposals"] == 7
+
+
 class TestLinksHistory:
     """Tests for `accounts links history`."""
 

--- a/tests/moneybin/test_cli/test_review.py
+++ b/tests/moneybin/test_cli/test_review.py
@@ -1,0 +1,98 @@
+"""Tests for the top-level `moneybin review` command and deprecated `transactions review` alias."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from moneybin.cli.main import app
+
+runner = CliRunner()
+
+
+@patch("moneybin.cli.commands.transactions.review.get_database")
+@patch("moneybin.config.get_settings")
+def test_review_status_flag(
+    mock_get_settings: MagicMock, mock_get_db: MagicMock
+) -> None:
+    """`moneybin review --status` returns counts including account_links_pending."""
+    mock_db = MagicMock()
+    mock_get_db.return_value.__enter__.return_value = mock_db
+    mock_get_settings.return_value = MagicMock()
+    mock_db.execute.return_value.fetchone.return_value = (0,)
+
+    result = runner.invoke(app, ["review", "--status"])
+    assert result.exit_code == 0
+    out = result.output.lower()
+    # All three queues should appear in text output
+    assert "match" in out or "matches" in out
+    assert "categori" in out
+    assert "account" in out or "link" in out
+
+
+@patch("moneybin.cli.commands.transactions.review.get_database")
+@patch("moneybin.config.get_settings")
+def test_review_json_output(
+    mock_get_settings: MagicMock, mock_get_db: MagicMock
+) -> None:
+    """`moneybin review --status --output json` emits a three-way envelope."""
+    mock_db = MagicMock()
+    mock_get_db.return_value.__enter__.return_value = mock_db
+    mock_get_settings.return_value = MagicMock()
+    mock_db.execute.return_value.fetchone.return_value = (0,)
+
+    result = runner.invoke(app, ["review", "--status", "--output", "json"])
+    assert result.exit_code == 0
+    envelope = json.loads(result.stdout)
+    payload = envelope["data"]
+    assert "matches_pending" in payload
+    assert "categorize_pending" in payload
+    assert "account_links_pending" in payload
+    assert "total" in payload
+    assert payload["total"] == (
+        payload["matches_pending"]
+        + payload["categorize_pending"]
+        + payload["account_links_pending"]
+    )
+
+
+def test_review_help_includes_standard_flags() -> None:
+    """`moneybin review --help` shows the same flags as `transactions review`."""
+    result = runner.invoke(app, ["review", "--help"])
+    assert result.exit_code == 0
+    out = result.output
+    assert "--status" in out
+    assert "--type" in out
+
+
+@patch("moneybin.cli.commands.transactions.review.get_database")
+@patch("moneybin.config.get_settings")
+def test_transactions_review_alias_warns_deprecated(
+    mock_get_settings: MagicMock, mock_get_db: MagicMock
+) -> None:
+    """`moneybin transactions review --status` emits a deprecation warning to stderr."""
+    mock_db = MagicMock()
+    mock_get_db.return_value.__enter__.return_value = mock_db
+    mock_get_settings.return_value = MagicMock()
+    mock_db.execute.return_value.fetchone.return_value = (0,)
+
+    # CliRunner mixes stdout + stderr into result.output
+    result = runner.invoke(app, ["transactions", "review", "--status"])
+    assert result.exit_code == 0
+    combined = result.output.lower()
+    assert "deprecated" in combined or "moneybin review" in combined
+
+
+@patch("moneybin.cli.commands.transactions.review.get_database")
+@patch("moneybin.config.get_settings")
+def test_transactions_review_alias_still_works(
+    mock_get_settings: MagicMock, mock_get_db: MagicMock
+) -> None:
+    """`moneybin transactions review --status` still runs and exits 0 (backward compat)."""
+    mock_db = MagicMock()
+    mock_get_db.return_value.__enter__.return_value = mock_db
+    mock_get_settings.return_value = MagicMock()
+    mock_db.execute.return_value.fetchone.return_value = (0,)
+
+    result = runner.invoke(app, ["transactions", "review", "--status"])
+    assert result.exit_code == 0

--- a/tests/moneybin/test_cli/test_review.py
+++ b/tests/moneybin/test_cli/test_review.py
@@ -96,3 +96,47 @@ def test_transactions_review_alias_still_works(
 
     result = runner.invoke(app, ["transactions", "review", "--status"])
     assert result.exit_code == 0
+
+
+@patch("moneybin.cli.commands.transactions.review.get_database")
+@patch("moneybin.config.get_settings")
+def test_review_type_account_links_status_text(
+    mock_get_settings: MagicMock, mock_get_db: MagicMock
+) -> None:
+    """`moneybin review --type account-links --status` shows only the account-link count (text)."""
+    mock_db = MagicMock()
+    mock_get_db.return_value.__enter__.return_value = mock_db
+    mock_get_settings.return_value = MagicMock()
+    mock_db.execute.return_value.fetchone.return_value = (0,)
+
+    result = runner.invoke(app, ["review", "--type", "account-links", "--status"])
+    assert result.exit_code == 0
+    out = result.output.lower()
+    # Only the account-links queue appears in text output for --type account-links
+    assert "account" in out or "link" in out or "decision" in out
+    # The other queues must NOT appear when --type filters to account-links
+    assert "match" not in out
+    assert "categori" not in out
+
+
+@patch("moneybin.cli.commands.transactions.review.get_database")
+@patch("moneybin.config.get_settings")
+def test_review_type_account_links_status_json(
+    mock_get_settings: MagicMock, mock_get_db: MagicMock
+) -> None:
+    """`moneybin review --type account-links --status --output json` returns only account_links_pending."""
+    mock_db = MagicMock()
+    mock_get_db.return_value.__enter__.return_value = mock_db
+    mock_get_settings.return_value = MagicMock()
+    mock_db.execute.return_value.fetchone.return_value = (0,)
+
+    result = runner.invoke(
+        app, ["review", "--type", "account-links", "--status", "--output", "json"]
+    )
+    assert result.exit_code == 0
+    envelope = json.loads(result.stdout)
+    payload = envelope["data"]
+    assert "account_links_pending" in payload
+    # Per-type JSON must NOT include the other queue fields
+    assert "matches_pending" not in payload
+    assert "categorize_pending" not in payload

--- a/tests/moneybin/test_cli/test_transactions_review.py
+++ b/tests/moneybin/test_cli/test_transactions_review.py
@@ -106,6 +106,7 @@ def test_review_status_json_output(
     assert payload == {
         "matches_pending": 0,
         "categorize_pending": 0,
+        "account_links_pending": 0,
         "total": 0,
     }
 

--- a/tests/moneybin/test_mcp/test_accounts_links.py
+++ b/tests/moneybin/test_mcp/test_accounts_links.py
@@ -80,10 +80,14 @@ class TestAccountsLinksPending:
         assert "data" in parsed
         assert "actions" in parsed
 
-    async def test_sensitivity_is_low(self) -> None:
-        """accounts_links_pending is sensitivity low (no amounts/descriptions)."""
+    async def test_sensitivity_is_medium(self) -> None:
+        """accounts_links_pending is medium (it surfaces account display_name).
+
+        display_name is USER_NOTE — matching accounts_summary/accounts_get — so
+        the proposal labels sit behind the same consent bar.
+        """
         parsed = (await accounts_links_pending()).to_dict()
-        assert parsed["summary"]["sensitivity"] == "low"
+        assert parsed["summary"]["sensitivity"] == "medium"
 
     async def test_empty_queue(self) -> None:
         """Empty queue returns groups=[], n_pending=0."""

--- a/tests/moneybin/test_mcp/test_accounts_links.py
+++ b/tests/moneybin/test_mcp/test_accounts_links.py
@@ -1,0 +1,389 @@
+"""Tests for accounts_links_* MCP tools.
+
+Mirrors test_transactions_tools.py for the matches surface. All tests use the
+mcp_db fixture (session-template DB + monkeypatch for get_settings/SecretStore).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from moneybin.database import get_database
+from moneybin.mcp.tools.accounts import (
+    accounts_links_history,
+    accounts_links_pending,
+    accounts_links_set,
+    register_accounts_tools,
+)
+
+pytestmark = pytest.mark.usefixtures("mcp_db")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = datetime.now(tz=UTC).isoformat()
+
+
+def _insert_decision(
+    *,
+    decision_id: str,
+    provisional_account_id: str,
+    candidate_account_id: str,
+    status: str = "pending",
+    confidence: float = 0.85,
+    signal: str = "institution_last4",
+    decided_by: str = "auto",
+) -> None:
+    """Insert one row into app.account_link_decisions via a write connection."""
+    with get_database(read_only=False) as db:
+        db.execute(
+            """
+            INSERT INTO app.account_link_decisions (
+                decision_id, provisional_account_id, candidate_account_id,
+                confidence_score, match_signals, status, decided_by,
+                match_reason, decided_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,  # noqa: S608  # test input, not executing SQL
+            [
+                decision_id,
+                provisional_account_id,
+                candidate_account_id,
+                confidence,
+                json.dumps({"signal": signal}),
+                status,
+                decided_by,
+                None,
+                _NOW,
+            ],
+        )
+
+
+# ---------------------------------------------------------------------------
+# accounts_links_pending
+# ---------------------------------------------------------------------------
+
+
+class TestAccountsLinksPending:
+    """Tests for accounts_links_pending."""
+
+    async def test_returns_envelope(self) -> None:
+        """accounts_links_pending returns a valid ResponseEnvelope."""
+        parsed = (await accounts_links_pending()).to_dict()
+        assert "summary" in parsed
+        assert "data" in parsed
+        assert "actions" in parsed
+
+    async def test_sensitivity_is_low(self) -> None:
+        """accounts_links_pending is sensitivity low (no amounts/descriptions)."""
+        parsed = (await accounts_links_pending()).to_dict()
+        assert parsed["summary"]["sensitivity"] == "low"
+
+    async def test_empty_queue(self) -> None:
+        """Empty queue returns groups=[], n_pending=0."""
+        data = (await accounts_links_pending()).to_dict()["data"]
+        assert data["groups"] == []
+        assert data["n_pending"] == 0
+
+    async def test_pending_grouped_by_provisional(self, mcp_db: object) -> None:
+        """Pending decisions are grouped by provisional_account_id."""
+        _insert_decision(
+            decision_id="d001",
+            provisional_account_id="PROV1",
+            candidate_account_id="ACC001",
+        )
+        _insert_decision(
+            decision_id="d002",
+            provisional_account_id="PROV1",
+            candidate_account_id="ACC002",
+        )
+        _insert_decision(
+            decision_id="d003",
+            provisional_account_id="PROV2",
+            candidate_account_id="ACC001",
+        )
+
+        data = (await accounts_links_pending()).to_dict()["data"]
+        groups = data["groups"]
+        assert len(groups) == 2  # PROV1 and PROV2
+
+        prov1 = next(g for g in groups if g["provisional_account_id"] == "PROV1")
+        assert len(prov1["candidates"]) == 2
+
+        prov2 = next(g for g in groups if g["provisional_account_id"] == "PROV2")
+        assert len(prov2["candidates"]) == 1
+
+    async def test_candidate_fields_present(self, mcp_db: object) -> None:
+        """Each candidate carries decision_id, account_id, confidence, signal."""
+        _insert_decision(
+            decision_id="d010",
+            provisional_account_id="PROV_A",
+            candidate_account_id="ACC001",
+            confidence=0.9,
+            signal="institution_last4",
+        )
+
+        data = (await accounts_links_pending()).to_dict()["data"]
+        groups = data["groups"]
+        assert len(groups) == 1
+        cand = groups[0]["candidates"][0]
+        assert cand["decision_id"] == "d010"
+        assert cand["candidate_account_id"] == "ACC001"
+        assert "confidence" in cand
+        assert cand["signal"] == "institution_last4"
+
+    async def test_no_ref_value_in_payload(self, mcp_db: object) -> None:
+        """ref_value (account number) is never present in the payload."""
+        _insert_decision(
+            decision_id="d020",
+            provisional_account_id="PROV_B",
+            candidate_account_id="ACC001",
+        )
+
+        data = (await accounts_links_pending()).to_dict()["data"]
+        raw = json.dumps(data)
+        assert "ref_value" not in raw
+
+    async def test_n_pending_counts_provisional_accounts(self, mcp_db: object) -> None:
+        """n_pending counts distinct provisional accounts, not decision rows."""
+        _insert_decision(
+            decision_id="d030",
+            provisional_account_id="PROV_C",
+            candidate_account_id="ACC001",
+        )
+        _insert_decision(
+            decision_id="d031",
+            provisional_account_id="PROV_C",
+            candidate_account_id="ACC002",
+        )
+
+        data = (await accounts_links_pending()).to_dict()["data"]
+        # Two rows but one provisional account → n_pending = 1
+        assert data["n_pending"] == 1
+
+    async def test_actions_point_to_set(self) -> None:
+        """actions[] hint points the agent at accounts_links_set."""
+        result = (await accounts_links_pending()).to_dict()
+        actions_text = " ".join(result["actions"])
+        assert "accounts_links_set" in actions_text
+
+
+# ---------------------------------------------------------------------------
+# accounts_links_set
+# ---------------------------------------------------------------------------
+
+
+class TestAccountsLinksSet:
+    """Tests for accounts_links_set."""
+
+    async def test_accept_returns_envelope(self, mcp_db: object) -> None:
+        """accounts_links_set (accept) returns a valid ResponseEnvelope."""
+        _insert_decision(
+            decision_id="ds001",
+            provisional_account_id="PROV_S1",
+            candidate_account_id="ACC001",
+        )
+        parsed = (
+            await accounts_links_set(decision_id="ds001", target_account_id="ACC001")
+        ).to_dict()
+        assert "summary" in parsed
+        assert "data" in parsed
+
+    async def test_accept_payload_status_accepted(self, mcp_db: object) -> None:
+        """Accepting a decision returns status='accepted' in payload."""
+        _insert_decision(
+            decision_id="ds010",
+            provisional_account_id="PROV_S2",
+            candidate_account_id="ACC001",
+        )
+        # Also need an account_links row so the repoint doesn't error
+        with get_database(read_only=False) as db:
+            db.execute(
+                """
+                INSERT INTO app.account_links
+                    (link_id, account_id, ref_kind, ref_value,
+                     source_type, source_origin, status, decided_by, decided_at)
+                VALUES ('lnk001', 'PROV_S2', 'source_native', 'key_s2',
+                        'csv', 'bank_a', 'accepted', 'auto', ?)
+                """,  # noqa: S608  # test input, not executing SQL
+                [_NOW],
+            )
+
+        data = (
+            await accounts_links_set(decision_id="ds010", target_account_id="ACC001")
+        ).to_dict()["data"]
+        assert data["decision_id"] == "ds010"
+        assert data["status"] == "accepted"
+
+    async def test_standalone_null_returns_rejected(self, mcp_db: object) -> None:
+        """Passing target_account_id=None returns status='rejected'."""
+        _insert_decision(
+            decision_id="ds020",
+            provisional_account_id="PROV_S3",
+            candidate_account_id="ACC001",
+        )
+
+        data = (
+            await accounts_links_set(decision_id="ds020", target_account_id=None)
+        ).to_dict()["data"]
+        assert data["status"] == "rejected"
+
+    async def test_set_sensitivity_is_low(self, mcp_db: object) -> None:
+        """accounts_links_set response carries low sensitivity."""
+        _insert_decision(
+            decision_id="ds030",
+            provisional_account_id="PROV_S4",
+            candidate_account_id="ACC001",
+        )
+        parsed = (
+            await accounts_links_set(decision_id="ds030", target_account_id=None)
+        ).to_dict()
+        assert parsed["summary"]["sensitivity"] == "low"
+
+    async def test_set_actions_point_back_to_pending(self, mcp_db: object) -> None:
+        """actions[] after set points back at accounts_links_pending."""
+        _insert_decision(
+            decision_id="ds040",
+            provisional_account_id="PROV_S5",
+            candidate_account_id="ACC001",
+        )
+        result = (
+            await accounts_links_set(decision_id="ds040", target_account_id=None)
+        ).to_dict()
+        actions_text = " ".join(result["actions"])
+        assert "accounts_links_pending" in actions_text
+
+
+# ---------------------------------------------------------------------------
+# accounts_links_history
+# ---------------------------------------------------------------------------
+
+
+class TestAccountsLinksHistory:
+    """Tests for accounts_links_history."""
+
+    async def test_empty_history(self) -> None:
+        """Empty history returns decisions=[]."""
+        data = (await accounts_links_history()).to_dict()["data"]
+        assert data["decisions"] == []
+
+    async def test_returns_envelope(self) -> None:
+        """accounts_links_history returns a valid ResponseEnvelope."""
+        parsed = (await accounts_links_history()).to_dict()
+        assert "summary" in parsed
+        assert "data" in parsed
+
+    async def test_sensitivity_is_low(self) -> None:
+        """accounts_links_history has low sensitivity."""
+        parsed = (await accounts_links_history()).to_dict()
+        assert parsed["summary"]["sensitivity"] == "low"
+
+    async def test_history_row_fields(self, mcp_db: object) -> None:
+        """History rows carry decision_id, account ids, status, decided_by, confidence, signal."""
+        _insert_decision(
+            decision_id="dh001",
+            provisional_account_id="PROV_H1",
+            candidate_account_id="ACC001",
+            status="accepted",
+            confidence=0.75,
+            signal="name",
+            decided_by="user",
+        )
+
+        data = (await accounts_links_history()).to_dict()["data"]
+        assert len(data["decisions"]) == 1
+        row = data["decisions"][0]
+        assert row["decision_id"] == "dh001"
+        assert row["provisional_account_id"] == "PROV_H1"
+        assert row["candidate_account_id"] == "ACC001"
+        assert row["status"] == "accepted"
+        assert row["decided_by"] == "user"
+        assert "confidence" in row
+        assert row["signal"] == "name"
+
+    async def test_history_newest_first(self, mcp_db: object) -> None:
+        """History is ordered newest-first by decided_at."""
+        with get_database(read_only=False) as db:
+            db.execute(
+                """
+                INSERT INTO app.account_link_decisions (
+                    decision_id, provisional_account_id, candidate_account_id,
+                    confidence_score, match_signals, status, decided_by,
+                    match_reason, decided_at
+                ) VALUES
+                ('dh_old', 'PROV_HA', 'ACC001', 0.8, '{"signal":"name"}',
+                 'accepted', 'user', NULL, '2025-01-01T10:00:00'),
+                ('dh_new', 'PROV_HB', 'ACC002', 0.9, '{"signal":"institution_last4"}',
+                 'rejected', 'user', NULL, '2025-06-01T10:00:00')
+                """,  # noqa: S608  # test input, not executing SQL
+            )
+
+        data = (await accounts_links_history()).to_dict()["data"]
+        ids = [r["decision_id"] for r in data["decisions"]]
+        assert ids.index("dh_new") < ids.index("dh_old")
+
+    async def test_history_limit(self, mcp_db: object) -> None:
+        """Limit parameter is respected."""
+        for i in range(5):
+            _insert_decision(
+                decision_id=f"dlim{i:03d}",
+                provisional_account_id=f"PROV_LIM{i}",
+                candidate_account_id="ACC001",
+                status="accepted",
+            )
+
+        data = (await accounts_links_history(limit=2)).to_dict()["data"]
+        assert len(data["decisions"]) <= 2
+
+    async def test_history_actions_point_to_pending(self) -> None:
+        """History actions[] hint points back at accounts_links_pending."""
+        result = (await accounts_links_history()).to_dict()
+        actions_text = " ".join(result["actions"])
+        assert "accounts_links_pending" in actions_text
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestAccountsLinksRegistration:
+    """Verify accounts_links_* tools are registered with the FastMCP server."""
+
+    async def test_tools_registered(self) -> None:
+        """register_accounts_tools includes all three accounts_links_* tools."""
+        srv = FastMCP("test")
+        register_accounts_tools(srv)
+        names = {t.name for t in await srv._list_tools()}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        assert "accounts_links_pending" in names
+        assert "accounts_links_set" in names
+        assert "accounts_links_history" in names
+
+
+# ---------------------------------------------------------------------------
+# Actor threading
+# ---------------------------------------------------------------------------
+
+
+class TestAccountsLinksActor:
+    """Verify the MCP actor is passed through to the service."""
+
+    @patch("moneybin.mcp.tools.accounts.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.set")
+    async def test_set_uses_mcp_actor(
+        self, mock_set: MagicMock, mock_get_db: MagicMock
+    ) -> None:
+        """accounts_links_set calls AccountLinksService with actor='mcp'."""
+        mock_db = MagicMock()
+        mock_get_db.return_value.__enter__.return_value = mock_db
+
+        await accounts_links_set(decision_id="d_actor", target_account_id=None)
+
+        mock_set.assert_called_once_with(
+            "d_actor", target_account_id=None, decided_by="user"
+        )

--- a/tests/moneybin/test_mcp/test_accounts_links.py
+++ b/tests/moneybin/test_mcp/test_accounts_links.py
@@ -17,6 +17,7 @@ from moneybin.database import get_database
 from moneybin.mcp.tools.accounts import (
     accounts_links_history,
     accounts_links_pending,
+    accounts_links_run,
     accounts_links_set,
     register_accounts_tools,
 )
@@ -348,6 +349,70 @@ class TestAccountsLinksHistory:
 
 
 # ---------------------------------------------------------------------------
+# accounts_links_run
+# ---------------------------------------------------------------------------
+
+
+class TestAccountsLinksRun:
+    """Tests for accounts_links_run."""
+
+    @patch("moneybin.mcp.tools.accounts.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.run")
+    async def test_run_returns_envelope(
+        self, mock_run: MagicMock, mock_get_db: MagicMock
+    ) -> None:
+        """accounts_links_run returns a valid ResponseEnvelope."""
+        mock_db = MagicMock()
+        mock_get_db.return_value.__enter__.return_value = mock_db
+        mock_run.return_value = 3
+
+        parsed = (await accounts_links_run()).to_dict()
+        assert "summary" in parsed
+        assert "data" in parsed
+        assert "actions" in parsed
+
+    @patch("moneybin.mcp.tools.accounts.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.run")
+    async def test_run_payload_contains_count(
+        self, mock_run: MagicMock, mock_get_db: MagicMock
+    ) -> None:
+        """data.new_proposals reflects the count returned by service.run()."""
+        mock_db = MagicMock()
+        mock_get_db.return_value.__enter__.return_value = mock_db
+        mock_run.return_value = 5
+
+        data = (await accounts_links_run()).to_dict()["data"]
+        assert data["new_proposals"] == 5
+
+    @patch("moneybin.mcp.tools.accounts.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.run")
+    async def test_run_sensitivity_is_low(
+        self, mock_run: MagicMock, mock_get_db: MagicMock
+    ) -> None:
+        """accounts_links_run has low sensitivity (counts only)."""
+        mock_db = MagicMock()
+        mock_get_db.return_value.__enter__.return_value = mock_db
+        mock_run.return_value = 0
+
+        parsed = (await accounts_links_run()).to_dict()
+        assert parsed["summary"]["sensitivity"] == "low"
+
+    @patch("moneybin.mcp.tools.accounts.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.run")
+    async def test_run_actions_point_to_pending(
+        self, mock_run: MagicMock, mock_get_db: MagicMock
+    ) -> None:
+        """actions[] after run points at accounts_links_pending."""
+        mock_db = MagicMock()
+        mock_get_db.return_value.__enter__.return_value = mock_db
+        mock_run.return_value = 2
+
+        result = (await accounts_links_run()).to_dict()
+        actions_text = " ".join(result["actions"])
+        assert "accounts_links_pending" in actions_text
+
+
+# ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
 
@@ -356,13 +421,14 @@ class TestAccountsLinksRegistration:
     """Verify accounts_links_* tools are registered with the FastMCP server."""
 
     async def test_tools_registered(self) -> None:
-        """register_accounts_tools includes all three accounts_links_* tools."""
+        """register_accounts_tools includes all four accounts_links_* tools."""
         srv = FastMCP("test")
         register_accounts_tools(srv)
         names = {t.name for t in await srv._list_tools()}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
         assert "accounts_links_pending" in names
         assert "accounts_links_set" in names
         assert "accounts_links_history" in names
+        assert "accounts_links_run" in names
 
 
 # ---------------------------------------------------------------------------

--- a/tests/moneybin/test_mcp/test_review.py
+++ b/tests/moneybin/test_mcp/test_review.py
@@ -1,0 +1,82 @@
+"""Tests for the top-level `review` MCP tool and deprecated `transactions_review` alias."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import FastMCP
+
+from moneybin.mcp.tools.transactions import (
+    register_transactions_tools,
+    review,
+    transactions_review,
+)
+
+pytestmark = pytest.mark.usefixtures("mcp_db")
+
+
+@pytest.mark.unit
+async def test_review_returns_envelope(mcp_db: object) -> None:
+    """`review` returns a valid ResponseEnvelope."""
+    parsed = (await review()).to_dict()
+    assert "summary" in parsed
+    assert "data" in parsed
+    assert "actions" in parsed
+    assert parsed["summary"]["sensitivity"] == "low"
+
+
+@pytest.mark.unit
+async def test_review_data_shape(mcp_db: object) -> None:
+    """Data carries matches_pending, categorize_pending, account_links_pending, and total."""
+    data = (await review()).to_dict()["data"]
+    assert "matches_pending" in data
+    assert "categorize_pending" in data
+    assert "account_links_pending" in data
+    assert "total" in data
+    assert isinstance(data["account_links_pending"], int)
+    assert data["total"] == (
+        data["matches_pending"]
+        + data["categorize_pending"]
+        + data["account_links_pending"]
+    )
+
+
+@pytest.mark.unit
+async def test_review_actions_mention_all_three_queues(mcp_db: object) -> None:
+    """actions[] guides the agent to all three queues."""
+    parsed = (await review()).to_dict()
+    actions_text = " ".join(parsed["actions"])
+    assert "transactions_matches_pending" in actions_text
+    assert "transactions_categorize_pending" in actions_text
+    assert "accounts_links_pending" in actions_text
+
+
+@pytest.mark.unit
+async def test_transactions_review_alias_returns_same_shape(mcp_db: object) -> None:
+    """`transactions_review` is a deprecated alias with the same data shape."""
+    data = (await transactions_review()).to_dict()["data"]
+    assert "matches_pending" in data
+    assert "categorize_pending" in data
+    assert "account_links_pending" in data
+    assert "total" in data
+
+
+@pytest.mark.unit
+async def test_register_includes_review_and_alias() -> None:
+    """register_transactions_tools registers both `review` and `transactions_review`."""
+    srv = FastMCP("test")
+    register_transactions_tools(srv)
+    names = {t.name for t in await srv._list_tools()}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    assert "review" in names
+    assert "transactions_review" in names
+
+
+@pytest.mark.unit
+async def test_transactions_review_description_starts_with_deprecated() -> None:
+    """`transactions_review` description must start with 'DEPRECATED:'."""
+    srv = FastMCP("test")
+    register_transactions_tools(srv)
+    tools = {t.name: t for t in await srv._list_tools()}  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    desc = tools["transactions_review"].description or ""
+    assert desc.startswith("DEPRECATED:"), (
+        f"transactions_review description must start with 'DEPRECATED:' but got: {desc[:80]!r}"
+    )

--- a/tests/moneybin/test_mcp/test_transactions_tools.py
+++ b/tests/moneybin/test_mcp/test_transactions_tools.py
@@ -30,14 +30,20 @@ async def test_review_status_returns_envelope(mcp_db: object) -> None:
 
 @pytest.mark.unit
 async def test_review_status_data_shape(mcp_db: object) -> None:
-    """Data dict carries matches_pending, categorize_pending, and total."""
+    """Data dict carries matches_pending, categorize_pending, account_links_pending, and total."""
     data = (await transactions_review()).to_dict()["data"]
     assert "matches_pending" in data
     assert "categorize_pending" in data
+    assert "account_links_pending" in data
     assert "total" in data
     assert isinstance(data["matches_pending"], int)
     assert isinstance(data["categorize_pending"], int)
-    assert data["total"] == data["matches_pending"] + data["categorize_pending"]
+    assert isinstance(data["account_links_pending"], int)
+    assert data["total"] == (
+        data["matches_pending"]
+        + data["categorize_pending"]
+        + data["account_links_pending"]
+    )
 
 
 @pytest.mark.unit

--- a/tests/moneybin/test_repositories/test_account_link_decisions_repo.py
+++ b/tests/moneybin/test_repositories/test_account_link_decisions_repo.py
@@ -124,3 +124,137 @@ def test_insert_rolls_back_when_audit_raises(db: Database) -> None:
         ["ghost_decision"],
     ).fetchall()
     assert rows == []
+
+
+# -- update_status --
+
+
+def test_update_status_captures_before_and_after(db: Database) -> None:
+    repo = AccountLinkDecisionsRepo(db)
+    _insert(repo, status="pending")
+
+    event = repo.update_status(
+        "dec00000001", status="accepted", decided_by="user", actor="cli"
+    )
+    assert event.target_id == "dec00000001"
+
+    row = db.conn.execute(
+        "SELECT status, decided_by FROM app.account_link_decisions WHERE decision_id = ?",
+        ["dec00000001"],
+    ).fetchone()
+    assert row == ("accepted", "user")
+
+    upd = next(
+        r
+        for r in _audit_rows_for(db, "dec00000001")
+        if r[0] == "account_link_decision.update_status"
+    )
+    assert json.loads(upd[4])["status"] == "pending"
+    assert json.loads(upd[5])["status"] == "accepted"
+    assert upd[6] == "cli"
+
+
+def test_update_status_raises_for_missing_decision(db: Database) -> None:
+    repo = AccountLinkDecisionsRepo(db)
+    with pytest.raises(ValueError, match="not found"):
+        repo.update_status("nope", status="accepted", decided_by="user", actor="cli")
+
+
+# -- reverse --
+
+
+def test_reverse_sets_reversed_fields_and_captures_before(db: Database) -> None:
+    repo = AccountLinkDecisionsRepo(db)
+    _insert(repo, status="accepted")
+
+    event = repo.reverse("dec00000001", reversed_by="user", actor="cli")
+    assert event.target_id == "dec00000001"
+
+    row = db.conn.execute(
+        "SELECT status, reversed_by, reversed_at IS NOT NULL "
+        "FROM app.account_link_decisions WHERE decision_id = ?",
+        ["dec00000001"],
+    ).fetchone()
+    assert row == ("reversed", "user", True)
+
+    rev = next(
+        r
+        for r in _audit_rows_for(db, "dec00000001")
+        if r[0] == "account_link_decision.reverse"
+    )
+    assert json.loads(rev[4])["status"] == "accepted"
+    assert json.loads(rev[5])["status"] == "reversed"
+
+
+def test_reverse_raises_for_missing_decision(db: Database) -> None:
+    repo = AccountLinkDecisionsRepo(db)
+    with pytest.raises(ValueError, match="not found"):
+        repo.reverse("nope", reversed_by="user", actor="cli")
+
+
+def test_reverse_raises_when_already_reversed(db: Database) -> None:
+    """Re-reversing an already-reversed decision is rejected (audit integrity)."""
+    repo = AccountLinkDecisionsRepo(db)
+    _insert(repo, status="accepted")
+    repo.reverse("dec00000001", reversed_by="user", actor="cli")
+    with pytest.raises(ValueError, match="already reversed"):
+        repo.reverse("dec00000001", reversed_by="user", actor="cli")
+
+
+# -- list_pending --
+
+
+def test_list_pending_returns_only_active_pending(db: Database) -> None:
+    repo = AccountLinkDecisionsRepo(db)
+    _insert(repo, decision_id="d_pending", status="pending")
+    _insert(repo, decision_id="d_accepted", status="accepted")
+    _insert(repo, decision_id="d_rejected", status="rejected")
+    # Reverse a pending decision — it drops from the queue (reversed_at set, status=reversed)
+    repo.reverse("d_pending", reversed_by="user", actor="cli")
+    # A fresh pending decision should appear
+    _insert(repo, decision_id="d_pending2", status="pending")
+
+    result = repo.list_pending()
+    ids = [r["decision_id"] for r in result]
+    assert "d_pending2" in ids
+    assert "d_pending" not in ids  # reversed
+    assert "d_accepted" not in ids
+    assert "d_rejected" not in ids
+
+
+def test_list_pending_orders_by_provisional_then_decision_id(db: Database) -> None:
+    repo = AccountLinkDecisionsRepo(db)
+    _insert(
+        repo,
+        decision_id="dec_B1",
+        provisional_account_id="acct_prov_B",
+        status="pending",
+    )
+    _insert(
+        repo,
+        decision_id="dec_A2",
+        provisional_account_id="acct_prov_A",
+        status="pending",
+    )
+    _insert(
+        repo,
+        decision_id="dec_A1",
+        provisional_account_id="acct_prov_A",
+        status="pending",
+    )
+
+    result = repo.list_pending()
+    ids = [r["decision_id"] for r in result]
+    assert ids == ["dec_A1", "dec_A2", "dec_B1"]
+
+
+def test_list_pending_decodes_match_signals(db: Database) -> None:
+    """list_pending decodes JSON match_signals to nested objects (not doubly-encoded)."""
+    repo = AccountLinkDecisionsRepo(db)
+    _insert(repo, decision_id="dec_json", status="pending")
+
+    result = repo.list_pending()
+    assert len(result) == 1
+    signals = result[0]["match_signals"]
+    assert isinstance(signals, dict)
+    assert signals["signal"] == "institution_last4"

--- a/tests/moneybin/test_repositories/test_account_links_repo.py
+++ b/tests/moneybin/test_repositories/test_account_links_repo.py
@@ -203,3 +203,94 @@ def test_allows_strong_ref_same_value_different_kind(db: Database) -> None:
     )
     n = db.conn.execute("SELECT COUNT(*) FROM app.account_links").fetchone()
     assert n is not None and n[0] == 2
+
+
+# -- repoint --
+
+
+def test_repoint_net_effect(db: Database) -> None:
+    """After repoint: old row is reversed.
+
+    Exactly one accepted row for the same ref coordinates now points to
+    new_account_id.
+    """
+    repo = AccountLinksRepo(db)
+    _insert(repo, link_id="lnk00000001", account_id="acct_canonical_1")
+
+    repo.repoint(
+        link_id="lnk00000001",
+        new_account_id="acct_canonical_2",
+        decided_by="user",
+        actor="cli",
+    )
+
+    old_row = db.conn.execute(
+        "SELECT status, account_id FROM app.account_links WHERE link_id = ?",
+        ["lnk00000001"],
+    ).fetchone()
+    assert old_row == ("reversed", "acct_canonical_1")
+
+    accepted = db.conn.execute(
+        "SELECT account_id FROM app.account_links "
+        "WHERE status = 'accepted' AND ref_kind = ? AND ref_value = ? "
+        "AND source_type = ? AND source_origin = ?",
+        ["source_native", "checking", "ofx", "wells_fargo"],
+    ).fetchall()
+    assert len(accepted) == 1
+    assert accepted[0][0] == "acct_canonical_2"
+
+
+def test_repoint_raises_for_same_account(db: Database) -> None:
+    """Re-pointing a link onto its current account_id is a caller bug."""
+    repo = AccountLinksRepo(db)
+    _insert(repo, link_id="lnk00000001", account_id="acct_canonical_1")
+    with pytest.raises(ValueError, match="already points"):
+        repo.repoint(
+            link_id="lnk00000001",
+            new_account_id="acct_canonical_1",
+            decided_by="user",
+            actor="cli",
+        )
+
+
+def test_repoint_raises_for_non_accepted_link(db: Database) -> None:
+    """Can only re-point an accepted link; a reversed link raises."""
+    repo = AccountLinksRepo(db)
+    _insert(repo, link_id="lnk00000001", account_id="acct_canonical_1")
+    db.conn.execute(  # noqa: S608  # test input, not executing user SQL
+        "UPDATE app.account_links SET status = 'reversed' WHERE link_id = 'lnk00000001'"
+    )
+    with pytest.raises(ValueError, match="can only re-point"):
+        repo.repoint(
+            link_id="lnk00000001",
+            new_account_id="acct_canonical_2",
+            decided_by="user",
+            actor="cli",
+        )
+
+
+def test_repoint_emits_both_audit_rows(db: Database) -> None:
+    """Repoint emits one audit for the old-row reversal AND one for the new insert."""
+    repo = AccountLinksRepo(db)
+    _insert(repo, link_id="lnk00000001", account_id="acct_canonical_1")
+
+    repo.repoint(
+        link_id="lnk00000001",
+        new_account_id="acct_canonical_2",
+        decided_by="user",
+        actor="cli",
+    )
+
+    # Old row's repoint audit — before=accepted, after=reversed
+    old_audits = _audit_rows_for(db, "lnk00000001")
+    repoint_audit = next(r for r in old_audits if r[0] == "account_link.repoint")
+    assert json.loads(repoint_audit[4])["account_id"] == "acct_canonical_1"
+    assert json.loads(repoint_audit[5])["status"] == "reversed"
+
+    # New row's insert audit — keyed on the freshly minted link_id
+    new_link_id = db.conn.execute(
+        "SELECT link_id FROM app.account_links WHERE account_id = 'acct_canonical_2'"
+    ).fetchone()
+    assert new_link_id is not None
+    new_audits = _audit_rows_for(db, new_link_id[0])
+    assert any(r[0] == "account_link.insert" for r in new_audits)

--- a/tests/moneybin/test_services/test_account_links_service.py
+++ b/tests/moneybin/test_services/test_account_links_service.py
@@ -369,6 +369,29 @@ def test_set_wrong_target_raises_user_error(seeded: AccountLinksService) -> None
         seeded.set(_DEC1, target_account_id=_CAND_B)  # dec1 names cand_a, not cand_b
 
 
+def test_set_accept_with_no_source_native_link_raises(
+    svc: AccountLinksService, db: Database
+) -> None:
+    """Accepting a merge whose provisional has no source_native link is refused.
+
+    The staging JOIN translates raw rows via source_native links; with none to
+    re-point, accepting would record a 'paper merge' that never collapses the
+    data — so set() raises and rolls back rather than marking it accepted.
+    """
+    _insert_dim_account(db, "prov_nolink01", "Prov NoLink")
+    _insert_dim_account(db, _CAND_A, "Cand A")
+    _insert_decision(
+        db,
+        decision_id="dec_nolink001",
+        provisional_account_id="prov_nolink01",
+        candidate_account_id=_CAND_A,
+    )
+    with pytest.raises(UserError, match="no source_native mapping"):
+        svc.set("dec_nolink001", target_account_id=_CAND_A)
+    # Rolled back: the decision stays pending.
+    assert _decision_status(db, "dec_nolink001") == "pending"
+
+
 def test_set_missing_decision_raises_user_error(svc: AccountLinksService) -> None:
     """Unknown decision_id → UserError with MUTATION_NOT_FOUND code."""
     with pytest.raises(UserError) as exc_info:

--- a/tests/moneybin/test_services/test_account_links_service.py
+++ b/tests/moneybin/test_services/test_account_links_service.py
@@ -484,6 +484,24 @@ def _seed_twin_accounts(db: Database) -> None:
         "VALUES (?, ?, ?, ?, ?)",  # noqa: S608  # test fixture insert
         [_TWIN_B, "7777", "first_bank", "First Bank Checking B", "ofx"],
     )
+    # Each twin carries an accepted source_native link (as resolver-imported
+    # accounts do) so run() treats them as mergeable provisionals.
+    _insert_link(
+        db,
+        link_id="link_twin_a0",
+        account_id=_TWIN_A,
+        ref_value="twin_a_native",
+        source_type="csv",
+        source_origin="first_bank_csv",
+    )
+    _insert_link(
+        db,
+        link_id="link_twin_b0",
+        account_id=_TWIN_B,
+        ref_value="twin_b_native",
+        source_type="ofx",
+        source_origin="first_bank_ofx",
+    )
 
 
 def test_run_writes_pending_for_cross_source_twins(
@@ -542,7 +560,59 @@ def test_run_skips_pair_with_existing_decision_any_status(
 
     count = svc.run()
 
+    # The pair is already covered (accepted) — 0 new decisions
     assert count == 0
+
+
+def test_run_skips_provisionals_without_source_native_link(
+    svc: AccountLinksService, db: Database
+) -> None:
+    """run() does not propose merges for accounts lacking a source_native link.
+
+    set() refuses to merge such a provisional (nothing to re-point), so proposing
+    one would be a dead-end. Two twins share institution+last4 but neither has a
+    source_native link → zero proposals.
+    """
+    db.execute(
+        "INSERT INTO core.dim_accounts (account_id, last_four, institution_name, display_name, source_type) "
+        "VALUES (?, ?, ?, ?, ?)",  # noqa: S608  # test fixture insert
+        ["nolink_a0001", "5555", "second_bank", "No-Link A", "csv"],
+    )
+    db.execute(
+        "INSERT INTO core.dim_accounts (account_id, last_four, institution_name, display_name, source_type) "
+        "VALUES (?, ?, ?, ?, ?)",  # noqa: S608  # test fixture insert
+        ["nolink_b0001", "5555", "second_bank", "No-Link B", "ofx"],
+    )
+    assert svc.run() == 0
+    n = db.execute("SELECT count(*) FROM app.account_link_decisions").fetchone()
+    assert n is not None and n[0] == 0
+
+
+def test_set_accept_repoints_strong_ref_links_too(
+    seeded: AccountLinksService, db: Database
+) -> None:
+    """Accept re-points strong-ref links too, not just source_native.
+
+    Otherwise a later source carrying the same persistent_token / full_number
+    would mis-adopt onto the merged-away provisional.
+    """
+    AccountLinksRepo(db).insert(
+        link_id="link_prov1_pt0",
+        account_id=_PROV1,
+        ref_kind="persistent_token",
+        ref_value="prov1-token-xyz",
+        source_type="plaid",
+        source_origin="plaid_first_bank",
+        decided_by="auto",
+        actor="system",
+    )
+    seeded.set(_DEC1, target_account_id=_CAND_A)
+    # The persistent_token strong ref now points at the candidate (old reversed).
+    accepted_tokens = _link_rows(db, ref_kind="persistent_token", status="accepted")
+    assert len(accepted_tokens) == 1
+    assert accepted_tokens[0][1] == _CAND_A  # account_id column
+    # The provisional retains no accepted links — all re-pointed onto the candidate.
+    assert _link_rows(db, account_id=_PROV1, status="accepted") == []
 
 
 def test_run_skips_reverse_direction_pair(

--- a/tests/moneybin/test_services/test_account_links_service.py
+++ b/tests/moneybin/test_services/test_account_links_service.py
@@ -1,0 +1,438 @@
+"""Tests for AccountLinksService (M1S.5a review-queue service).
+
+Fixture layout:
+- ``prov1`` / ``prov2``: provisional (source-minted) accounts.
+- ``cand_a`` / ``cand_b``: candidate canonical accounts for merging.
+- Each provisional has one accepted ``source_native`` link in ``app.account_links``.
+- Decisions are inserted through ``AccountLinkDecisionsRepo`` to exercise the
+  full Invariant-10 audited path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from moneybin.database import Database
+from moneybin.errors import UserError
+from moneybin.repositories.account_link_decisions_repo import AccountLinkDecisionsRepo
+from moneybin.repositories.account_links_repo import AccountLinksRepo
+from moneybin.services.account_links_service import AccountLinksService
+from tests.moneybin.db_helpers import create_core_tables
+
+# ---------------------------------------------------------------------------
+# Test-data constants — opaque IDs (no account numbers or PII)
+# ---------------------------------------------------------------------------
+
+_PROV1 = "prov1_acct000"
+_PROV2 = "prov2_acct000"
+_CAND_A = "cand_a_acct00"
+_CAND_B = "cand_b_acct00"
+
+_DEC1 = "dec1_id000001"  # prov1 → cand_a
+_DEC2 = "dec1_id000002"  # prov1 → cand_b  (sibling)
+_DEC3 = "dec2_id000001"  # prov2 → cand_a
+
+_LINK_PROV1 = "link_prov1_00"
+_LINK_PROV2 = "link_prov2_00"
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_dim_account(db: Database, account_id: str, display_name: str) -> None:
+    db.execute(
+        "INSERT INTO core.dim_accounts (account_id, display_name, source_type) "
+        "VALUES (?, ?, ?)",
+        [account_id, display_name, "csv"],
+    )
+
+
+def _insert_link(
+    db: Database,
+    *,
+    link_id: str,
+    account_id: str,
+    ref_value: str,
+    source_type: str = "csv",
+    source_origin: str = "bank_a",
+) -> None:
+    AccountLinksRepo(db).insert(
+        link_id=link_id,
+        account_id=account_id,
+        ref_kind="source_native",
+        ref_value=ref_value,
+        source_type=source_type,
+        source_origin=source_origin,
+        decided_by="auto",
+        actor="system",
+        status="accepted",
+    )
+
+
+def _insert_decision(
+    db: Database,
+    *,
+    decision_id: str,
+    provisional_account_id: str,
+    candidate_account_id: str,
+    signal: str = "institution_last4",
+    confidence: float = 0.9,
+) -> None:
+    AccountLinkDecisionsRepo(db).insert(
+        decision_id=decision_id,
+        provisional_account_id=provisional_account_id,
+        candidate_account_id=candidate_account_id,
+        confidence_score=confidence,
+        match_signals={"signal": signal, "value": "***"},
+        decided_by="auto",
+        actor="system",
+        status="pending",
+    )
+
+
+def _decision_status(db: Database, decision_id: str) -> str | None:
+    row = db.execute(
+        "SELECT status FROM app.account_link_decisions WHERE decision_id = ?",
+        [decision_id],
+    ).fetchone()
+    return row[0] if row else None
+
+
+def _link_rows(db: Database, **kw: Any) -> list[tuple[Any, ...]]:
+    """Fetch (link_id, account_id, ref_kind, ref_value, status) with WHERE filters."""
+    clauses: list[str] = []
+    params: list[Any] = []
+    for col, val in kw.items():
+        clauses.append(f"{col} = ?")
+        params.append(val)
+    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+    return db.execute(
+        f"SELECT link_id, account_id, ref_kind, ref_value, status FROM app.account_links{where}",  # noqa: S608  # test helper, static pattern
+        params,
+    ).fetchall()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def svc(db: Database) -> AccountLinksService:
+    """Service instance over a fresh test DB."""
+    create_core_tables(db)  # materializes core.dim_accounts
+    return AccountLinksService(db, actor="cli")
+
+
+@pytest.fixture()
+def seeded(svc: AccountLinksService, db: Database) -> AccountLinksService:
+    """Service with a full set of seeded accounts + decisions.
+
+    Seeded state:
+    - 4 dim_accounts rows: prov1, prov2, cand_a, cand_b
+    - 2 account_links rows: one accepted source_native link per provisional
+    - 3 decisions: prov1→cand_a (dec1), prov1→cand_b (dec2), prov2→cand_a (dec3)
+    """
+    # Dim accounts
+    _insert_dim_account(db, _PROV1, "Provisional One")
+    _insert_dim_account(db, _PROV2, "Provisional Two")
+    _insert_dim_account(db, _CAND_A, "Candidate Alpha")
+    _insert_dim_account(db, _CAND_B, "Candidate Beta")
+    # Source-native links
+    _insert_link(db, link_id=_LINK_PROV1, account_id=_PROV1, ref_value="native-ref-1")
+    _insert_link(db, link_id=_LINK_PROV2, account_id=_PROV2, ref_value="native-ref-2")
+    # Decisions
+    _insert_decision(
+        db,
+        decision_id=_DEC1,
+        provisional_account_id=_PROV1,
+        candidate_account_id=_CAND_A,
+        signal="institution_last4",
+    )
+    _insert_decision(
+        db,
+        decision_id=_DEC2,
+        provisional_account_id=_PROV1,
+        candidate_account_id=_CAND_B,
+        signal="name",
+    )
+    _insert_decision(
+        db,
+        decision_id=_DEC3,
+        provisional_account_id=_PROV2,
+        candidate_account_id=_CAND_A,
+        signal="institution_last4",
+    )
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# count_pending
+# ---------------------------------------------------------------------------
+
+
+def test_count_pending_empty(svc: AccountLinksService) -> None:
+    """Zero pending when no decisions exist."""
+    assert svc.count_pending() == 0
+
+
+def test_count_pending_two_decisions_one_provisional(
+    svc: AccountLinksService, db: Database
+) -> None:
+    """Two decisions on the same provisional count as 1 (review unit = provisional)."""
+    _insert_decision(
+        db,
+        decision_id=_DEC1,
+        provisional_account_id=_PROV1,
+        candidate_account_id=_CAND_A,
+    )
+    _insert_decision(
+        db,
+        decision_id=_DEC2,
+        provisional_account_id=_PROV1,
+        candidate_account_id=_CAND_B,
+    )
+    assert svc.count_pending() == 1
+
+
+def test_count_pending_two_provisionals(svc: AccountLinksService, db: Database) -> None:
+    """Decisions on two distinct provisionals count as 2."""
+    _insert_decision(
+        db,
+        decision_id=_DEC1,
+        provisional_account_id=_PROV1,
+        candidate_account_id=_CAND_A,
+    )
+    _insert_decision(
+        db,
+        decision_id=_DEC3,
+        provisional_account_id=_PROV2,
+        candidate_account_id=_CAND_A,
+    )
+    assert svc.count_pending() == 2
+
+
+# ---------------------------------------------------------------------------
+# pending
+# ---------------------------------------------------------------------------
+
+
+def test_pending_empty(svc: AccountLinksService) -> None:
+    """Empty list when no pending decisions exist."""
+    assert svc.pending() == []
+
+
+def test_pending_groups_by_provisional(seeded: AccountLinksService) -> None:
+    """Decisions are grouped under their provisional; 2 groups expected."""
+    groups = seeded.pending()
+    assert len(groups) == 2  # prov1 and prov2
+
+    prov_ids = {g.provisional_account_id for g in groups}
+    assert prov_ids == {_PROV1, _PROV2}
+
+
+def test_pending_display_names_resolved(seeded: AccountLinksService) -> None:
+    """Display names for provisionals and candidates are pulled from dim_accounts."""
+    groups = seeded.pending()
+    by_prov = {g.provisional_account_id: g for g in groups}
+
+    g1 = by_prov[_PROV1]
+    assert g1.provisional_display_name == "Provisional One"
+    cand_names = {
+        c.candidate_account_id: c.candidate_display_name for c in g1.candidates
+    }
+    assert cand_names[_CAND_A] == "Candidate Alpha"
+    assert cand_names[_CAND_B] == "Candidate Beta"
+
+
+def test_pending_candidates_have_correct_signal(seeded: AccountLinksService) -> None:
+    """PendingLinkCandidate.signal is decoded from match_signals['signal']."""
+    groups = seeded.pending()
+    by_prov = {g.provisional_account_id: g for g in groups}
+    g1 = by_prov[_PROV1]
+    cand_by_id = {c.decision_id: c for c in g1.candidates}
+    assert cand_by_id[_DEC1].signal == "institution_last4"
+    assert cand_by_id[_DEC2].signal == "name"
+
+
+def test_pending_display_name_absent_dim_is_empty_string(
+    svc: AccountLinksService, db: Database
+) -> None:
+    """When dim_accounts has no row for an id, display_name resolves to ''."""
+    # Insert decision without inserting dim_accounts rows
+    _insert_decision(
+        db,
+        decision_id=_DEC1,
+        provisional_account_id=_PROV1,
+        candidate_account_id=_CAND_A,
+    )
+    groups = svc.pending()
+    assert len(groups) == 1
+    g = groups[0]
+    assert g.provisional_display_name == ""
+    assert g.candidates[0].candidate_display_name == ""
+
+
+# ---------------------------------------------------------------------------
+# set — accept (target_account_id = candidate)
+# ---------------------------------------------------------------------------
+
+
+def test_set_accept_repoints_provisional_link(
+    seeded: AccountLinksService, db: Database
+) -> None:
+    """Accepting a decision repoints the provisional's source_native link to the candidate."""
+    seeded.set(_DEC1, target_account_id=_CAND_A)
+
+    # Old link (prov1 → native-ref-1) must be reversed
+    old = _link_rows(db, link_id=_LINK_PROV1)
+    assert len(old) == 1
+    assert old[0][4] == "reversed"  # status column
+
+    # New link (cand_a → native-ref-1) must be accepted
+    new = _link_rows(
+        db, account_id=_CAND_A, ref_kind="source_native", status="accepted"
+    )
+    assert len(new) == 1
+    assert new[0][3] == "native-ref-1"  # ref_value
+
+
+def test_set_accept_marks_decision_accepted(
+    seeded: AccountLinksService, db: Database
+) -> None:
+    """The named decision transitions to 'accepted'."""
+    seeded.set(_DEC1, target_account_id=_CAND_A)
+    assert _decision_status(db, _DEC1) == "accepted"
+
+
+def test_set_accept_auto_rejects_sibling(
+    seeded: AccountLinksService, db: Database
+) -> None:
+    """Sibling pending decision on the same provisional is auto-rejected."""
+    seeded.set(_DEC1, target_account_id=_CAND_A)
+    assert _decision_status(db, _DEC2) == "rejected"
+
+
+def test_set_accept_does_not_affect_other_provisional(
+    seeded: AccountLinksService, db: Database
+) -> None:
+    """Decision on a different provisional is unaffected."""
+    seeded.set(_DEC1, target_account_id=_CAND_A)
+    assert _decision_status(db, _DEC3) == "pending"
+
+
+# ---------------------------------------------------------------------------
+# set — standalone (target_account_id = None)
+# ---------------------------------------------------------------------------
+
+
+def test_set_standalone_rejects_all_pending_decisions(
+    seeded: AccountLinksService, db: Database
+) -> None:
+    """Standalone set rejects every pending decision for the provisional."""
+    seeded.set(_DEC1, target_account_id=None)
+    assert _decision_status(db, _DEC1) == "rejected"
+    assert _decision_status(db, _DEC2) == "rejected"
+
+
+def test_set_standalone_does_not_repoint_link(
+    seeded: AccountLinksService, db: Database
+) -> None:
+    """Standalone set leaves the provisional's source_native link intact."""
+    seeded.set(_DEC1, target_account_id=None)
+    rows = _link_rows(db, link_id=_LINK_PROV1)
+    assert len(rows) == 1
+    assert rows[0][1] == _PROV1  # account_id unchanged
+    assert rows[0][4] == "accepted"  # status unchanged
+
+
+def test_set_standalone_does_not_affect_other_provisional(
+    seeded: AccountLinksService, db: Database
+) -> None:
+    """A standalone on prov1 does not touch prov2's decisions."""
+    seeded.set(_DEC1, target_account_id=None)
+    assert _decision_status(db, _DEC3) == "pending"
+
+
+# ---------------------------------------------------------------------------
+# set — error cases
+# ---------------------------------------------------------------------------
+
+
+def test_set_wrong_target_raises_user_error(seeded: AccountLinksService) -> None:
+    """target_account_id != decision's candidate_account_id → UserError."""
+    with pytest.raises(UserError, match="does not match"):
+        seeded.set(_DEC1, target_account_id=_CAND_B)  # dec1 names cand_a, not cand_b
+
+
+def test_set_missing_decision_raises_user_error(svc: AccountLinksService) -> None:
+    """Unknown decision_id → UserError with MUTATION_NOT_FOUND code."""
+    with pytest.raises(UserError) as exc_info:
+        svc.set("no-such-id-xxx", target_account_id=None)
+    assert exc_info.value.code == "mutation_not_found"
+
+
+def test_set_on_already_accepted_raises_user_error(
+    seeded: AccountLinksService, db: Database
+) -> None:
+    """Calling set on an already-accepted decision → UserError."""
+    seeded.set(_DEC1, target_account_id=_CAND_A)
+    with pytest.raises(UserError) as exc_info:
+        seeded.set(_DEC1, target_account_id=_CAND_A)
+    assert exc_info.value.code == "mutation_constraint_violation"
+
+
+def test_set_on_rejected_decision_raises_user_error(
+    seeded: AccountLinksService, db: Database
+) -> None:
+    """Calling set on a rejected decision → UserError."""
+    seeded.set(_DEC1, target_account_id=None)  # rejects dec1
+    with pytest.raises(UserError):
+        seeded.set(_DEC1, target_account_id=None)
+
+
+# ---------------------------------------------------------------------------
+# history
+# ---------------------------------------------------------------------------
+
+
+def test_history_empty(svc: AccountLinksService) -> None:
+    """Empty list when no decisions exist."""
+    assert svc.history() == []
+
+
+def test_history_returns_all_statuses(
+    seeded: AccountLinksService, db: Database
+) -> None:
+    """history() includes accepted, rejected, and pending rows."""
+    seeded.set(_DEC1, target_account_id=_CAND_A)  # accepts dec1, rejects dec2
+    rows = seeded.history(limit=10)
+    statuses = {r["status"] for r in rows}
+    assert "accepted" in statuses
+    assert "rejected" in statuses
+    assert "pending" in statuses  # dec3 is still pending
+
+
+def test_history_newest_first(seeded: AccountLinksService, db: Database) -> None:
+    """Rows are ordered descending by decided_at (most-recently-decided first)."""
+    seeded.set(_DEC1, target_account_id=_CAND_A)  # mutates decided_at on dec1 and dec2
+    rows = seeded.history(limit=10)
+    dates = [r["decided_at"] for r in rows if r["decided_at"] is not None]
+    assert dates == sorted(dates, reverse=True)
+
+
+def test_history_limit_respected(seeded: AccountLinksService) -> None:
+    """Limit parameter caps the returned count."""
+    rows = seeded.history(limit=2)
+    assert len(rows) <= 2
+
+
+def test_history_match_signals_decoded(seeded: AccountLinksService) -> None:
+    """match_signals is returned as a dict, not a raw JSON string."""
+    rows = seeded.history(limit=5)
+    for row in rows:
+        assert isinstance(row["match_signals"], dict)

--- a/tests/moneybin/test_services/test_account_links_service.py
+++ b/tests/moneybin/test_services/test_account_links_service.py
@@ -436,3 +436,107 @@ def test_history_match_signals_decoded(seeded: AccountLinksService) -> None:
     rows = seeded.history(limit=5)
     for row in rows:
         assert isinstance(row["match_signals"], dict)
+
+
+# ---------------------------------------------------------------------------
+# run — backfill pending proposals
+# ---------------------------------------------------------------------------
+
+# Two accounts sharing institution+last4 in dim_accounts (cross-source twins).
+_TWIN_A = "twin_a_acct00"
+_TWIN_B = "twin_b_acct00"
+_TWIN_LINK_A = "twin_link_a_00"
+_TWIN_LINK_B = "twin_link_b_00"
+
+
+def _seed_twin_accounts(db: Database) -> None:
+    """Insert two dim_accounts rows sharing institution+last4 (triggers institution_last4 signal)."""
+    db.execute(
+        "INSERT INTO core.dim_accounts (account_id, last_four, institution_name, display_name, source_type) "
+        "VALUES (?, ?, ?, ?, ?)",  # noqa: S608  # test fixture insert
+        [_TWIN_A, "7777", "first_bank", "First Bank Checking A", "csv"],
+    )
+    db.execute(
+        "INSERT INTO core.dim_accounts (account_id, last_four, institution_name, display_name, source_type) "
+        "VALUES (?, ?, ?, ?, ?)",  # noqa: S608  # test fixture insert
+        [_TWIN_B, "7777", "first_bank", "First Bank Checking B", "ofx"],
+    )
+
+
+def test_run_writes_pending_for_cross_source_twins(
+    svc: AccountLinksService, db: Database
+) -> None:
+    """run() writes one pending decision for a twin pair sharing institution+last4."""
+    _seed_twin_accounts(db)
+
+    count = svc.run()
+
+    assert count == 1
+    row = db.execute(
+        "SELECT provisional_account_id, candidate_account_id, status "
+        "FROM app.account_link_decisions LIMIT 1"
+    ).fetchone()
+    assert row is not None
+    provisional, candidate, status = row
+    # Either direction is valid — the pair is unordered
+    pair = {provisional, candidate}
+    assert pair == {_TWIN_A, _TWIN_B}
+    assert status == "pending"
+
+
+def test_run_is_idempotent(svc: AccountLinksService, db: Database) -> None:
+    """A second run() writes 0 new decisions — the pair is already proposed."""
+    _seed_twin_accounts(db)
+
+    first = svc.run()
+    second = svc.run()
+
+    assert first == 1
+    assert second == 0
+    # Still exactly one decision row
+    n = db.execute("SELECT COUNT(*) FROM app.account_link_decisions").fetchone()
+    assert n is not None and n[0] == 1
+
+
+def test_run_skips_pair_with_existing_decision_any_status(
+    svc: AccountLinksService, db: Database
+) -> None:
+    """run() does not re-propose a pair that already has a decision (accepted or rejected)."""
+    _seed_twin_accounts(db)
+    # Seed a pre-existing accepted decision for the twin pair
+    _insert_decision(
+        db,
+        decision_id="pre_dec_00001",
+        provisional_account_id=_TWIN_A,
+        candidate_account_id=_TWIN_B,
+        signal="institution_last4",
+    )
+    # Mark it accepted
+    db.execute(
+        "UPDATE app.account_link_decisions SET status = 'accepted' WHERE decision_id = ?",
+        ["pre_dec_00001"],
+    )
+
+    count = svc.run()
+
+    assert count == 0
+
+
+def test_run_skips_reverse_direction_pair(
+    svc: AccountLinksService, db: Database
+) -> None:
+    """run() skips the pair B→A when A→B was already proposed in prior run."""
+    _seed_twin_accounts(db)
+    # Seed a pre-existing decision in the reverse direction
+    _insert_decision(
+        db,
+        decision_id="rev_dec_00001",
+        provisional_account_id=_TWIN_B,
+        candidate_account_id=_TWIN_A,
+        signal="institution_last4",
+    )
+
+    count = svc.run()
+
+    # The pair is already covered (in reverse) — 0 new decisions
+    assert count == 0

--- a/tests/moneybin/test_services/test_account_links_service.py
+++ b/tests/moneybin/test_services/test_account_links_service.py
@@ -633,3 +633,25 @@ def test_run_skips_reverse_direction_pair(
 
     # The pair is already covered (in reverse) — 0 new decisions
     assert count == 0
+
+
+def test_set_accept_rejects_proposals_where_provisional_is_candidate(
+    seeded: AccountLinksService, db: Database
+) -> None:
+    """Accepting P→C also rejects pending Q→P proposals.
+
+    P is merged away, so a later accept of Q→P would re-point Q onto a dead
+    provisional. Unrelated proposals (neither side is P) stay pending.
+    """
+    # A proposal to merge prov2 INTO prov1 — prov1 is the *candidate* here.
+    _insert_decision(
+        db,
+        decision_id="qp_dec000001",
+        provisional_account_id=_PROV2,
+        candidate_account_id=_PROV1,
+        signal="institution_last4",
+    )
+    seeded.set(_DEC1, target_account_id=_CAND_A)  # merge prov1 into cand_a
+    assert _decision_status(db, "qp_dec000001") == "rejected"
+    # The unrelated prov2→cand_a proposal (neither side is prov1) stays pending.
+    assert _decision_status(db, _DEC3) == "pending"

--- a/tests/moneybin/test_services/test_account_resolution_types.py
+++ b/tests/moneybin/test_services/test_account_resolution_types.py
@@ -1,0 +1,53 @@
+"""Tests for AccountCandidate + AccountProposal (M1S.4 surfaced proposal types)."""
+
+from __future__ import annotations
+
+from moneybin.services.account_resolution_types import AccountCandidate, AccountProposal
+
+
+def test_account_proposal_round_trips_to_dict() -> None:
+    """A proposal with a weak candidate serialises cleanly and requires confirmation."""
+    candidate = AccountCandidate(
+        account_id="abc123",
+        display_name="WF Checking",
+        confidence=0.5,
+        signal="institution_last4",
+    )
+    proposal = AccountProposal(
+        source_account_key="wf-checking",
+        proposed_account_id="def456",
+        is_new=True,
+        candidates=(candidate,),
+        adopted_via=None,
+    )
+    assert proposal.requires_confirm is True
+    d = proposal.to_dict()
+    assert d["proposed_account_id"] == "def456"
+    assert isinstance(d["candidates"], list)
+    assert d["candidates"][0]["signal"] == "institution_last4"
+    # to_dict must not expose ref_value / raw PII
+    assert "ref_value" not in d["candidates"][0]
+
+
+def test_strong_adoption_does_not_require_confirm() -> None:
+    """A source_native-adopted account never surfaces for confirmation."""
+    proposal = AccountProposal(
+        source_account_key="plaid-tok-1",
+        proposed_account_id="abc123",
+        is_new=False,
+        candidates=(),
+        adopted_via="source_native",
+    )
+    assert proposal.requires_confirm is False
+
+
+def test_new_standalone_requires_confirm() -> None:
+    """A brand-new account (no adoption, no candidates) surfaces for confirmation."""
+    proposal = AccountProposal(
+        source_account_key="new-account",
+        proposed_account_id="xyz789",
+        is_new=True,
+        candidates=(),
+        adopted_via=None,
+    )
+    assert proposal.requires_confirm is True

--- a/tests/moneybin/test_services/test_account_resolver.py
+++ b/tests/moneybin/test_services/test_account_resolver.py
@@ -1,4 +1,4 @@
-"""Tests for AccountResolver (M1S.2 resolution ladder)."""
+"""Tests for AccountResolver (M1S.2 resolution ladder + M1S.4 propose())."""
 
 from __future__ import annotations
 
@@ -7,7 +7,8 @@ from typing import Any
 import pytest
 
 from moneybin.database import Database
-from moneybin.services.account_resolution_types import SourceAccount
+from moneybin.repositories.account_links_repo import AccountLinksRepo
+from moneybin.services.account_resolution_types import AccountProposal, SourceAccount
 from moneybin.services.account_resolver import AccountResolver
 from tests.moneybin.db_helpers import create_core_tables
 
@@ -274,3 +275,66 @@ def test_missing_dim_accounts_mints_standalone(db: Database) -> None:
     resolved = resolver.resolve(_src())
     assert resolved.is_new is True
     assert resolved.outcome == "minted_new"
+
+
+# ---------------------------------------------------------------------------
+# M1S.4 — propose() read-only preview
+# ---------------------------------------------------------------------------
+
+
+def test_propose_surfaces_weak_candidate_without_writing(db: Database) -> None:
+    """propose() returns a weak-signal candidate but writes nothing to app tables."""
+    create_core_tables(db)
+    _seed_dim_account(
+        db,
+        account_id="wf_existing_01",
+        last_four="4267",
+        institution_name="wells_fargo",
+        display_name="WF Checking",
+    )
+    resolver = AccountResolver(db, actor="system")
+    src = _src()  # last_four="4267", institution="wells_fargo"
+    proposal = resolver.propose(src)
+
+    assert isinstance(proposal, AccountProposal)
+    assert proposal.requires_confirm is True
+    assert len(proposal.candidates) == 1
+    assert proposal.candidates[0].signal == "institution_last4"
+    assert proposal.candidates[0].display_name == "WF Checking"
+    # Zero side effects — no rows written
+    n_links = db.conn.execute("SELECT count(*) FROM app.account_links").fetchone()
+    assert n_links is not None and n_links[0] == 0
+    n_decisions = db.conn.execute(
+        "SELECT count(*) FROM app.account_link_decisions"
+    ).fetchone()
+    assert n_decisions is not None and n_decisions[0] == 0
+
+
+def test_propose_strong_ref_adopts_without_writing(db: Database) -> None:
+    """propose() on a known source_native key returns adopted verdict with no new writes."""
+    resolver = AccountResolver(db, actor="system")
+    # Pre-insert one accepted source_native link directly via repo
+    AccountLinksRepo(db).insert(
+        link_id="link_pre",
+        account_id="acct_existing",
+        ref_kind="source_native",
+        ref_value="wf-checking",
+        source_type="csv",
+        source_origin="wells_fargo",
+        decided_by="auto",
+        actor="system",
+    )
+    src = _src()  # source_native key = "wf-checking"
+    proposal = resolver.propose(src)
+
+    assert proposal.is_new is False
+    assert proposal.adopted_via == "source_native"
+    assert proposal.candidates == ()
+    assert proposal.requires_confirm is False
+    # propose() must not write new rows — only the pre-inserted link is present
+    n_links = db.conn.execute("SELECT count(*) FROM app.account_links").fetchone()
+    assert n_links is not None and n_links[0] == 1
+    n_decisions = db.conn.execute(
+        "SELECT count(*) FROM app.account_link_decisions"
+    ).fetchone()
+    assert n_decisions is not None and n_decisions[0] == 0

--- a/tests/moneybin/test_services/test_account_resolver.py
+++ b/tests/moneybin/test_services/test_account_resolver.py
@@ -338,3 +338,95 @@ def test_propose_strong_ref_adopts_without_writing(db: Database) -> None:
         "SELECT count(*) FROM app.account_link_decisions"
     ).fetchone()
     assert n_decisions is not None and n_decisions[0] == 0
+
+
+# ---------------------------------------------------------------------------
+# M1S.5b — propose_existing() backfill read-only preview
+# ---------------------------------------------------------------------------
+
+
+def test_propose_existing_finds_candidates_excluding_self(db: Database) -> None:
+    """propose_existing(A) finds B (same institution+last4) but not A itself."""
+    create_core_tables(db)
+    _seed_dim_account(
+        db,
+        account_id="twin_a",
+        last_four="9999",
+        institution_name="chase",
+        display_name="Chase Checking A",
+    )
+    _seed_dim_account(
+        db,
+        account_id="twin_b",
+        last_four="9999",
+        institution_name="chase",
+        display_name="Chase Checking B",
+    )
+    resolver = AccountResolver(db, actor="system")
+    proposal = resolver.propose_existing("twin_a")
+
+    assert proposal is not None
+    assert proposal.proposed_account_id == "twin_a"
+    assert proposal.is_new is False
+    assert len(proposal.candidates) == 1
+    assert proposal.candidates[0].account_id == "twin_b"
+    assert proposal.candidates[0].signal == "institution_last4"
+    # twin_a must not appear as its own candidate
+    assert all(c.account_id != "twin_a" for c in proposal.candidates)
+
+
+def test_propose_existing_returns_none_for_absent_account(db: Database) -> None:
+    """propose_existing on an account not in dim_accounts returns None."""
+    create_core_tables(db)
+    resolver = AccountResolver(db, actor="system")
+    assert resolver.propose_existing("nonexistent_id") is None
+
+
+def test_propose_existing_returns_none_when_no_candidates(db: Database) -> None:
+    """propose_existing with no matching twins returns None (no candidates)."""
+    create_core_tables(db)
+    _seed_dim_account(
+        db,
+        account_id="solo_acct",
+        last_four="1111",
+        institution_name="wells_fargo",
+        display_name="Solo Account",
+    )
+    resolver = AccountResolver(db, actor="system")
+    assert resolver.propose_existing("solo_acct") is None
+
+
+def test_propose_existing_is_read_only(db: Database) -> None:
+    """propose_existing writes nothing to app.account_links or account_link_decisions."""
+    create_core_tables(db)
+    _seed_dim_account(
+        db,
+        account_id="ro_acct_a",
+        last_four="5555",
+        institution_name="bank_x",
+        display_name="RO Account A",
+    )
+    _seed_dim_account(
+        db,
+        account_id="ro_acct_b",
+        last_four="5555",
+        institution_name="bank_x",
+        display_name="RO Account B",
+    )
+    resolver = AccountResolver(db, actor="system")
+    proposal = resolver.propose_existing("ro_acct_a")
+    assert proposal is not None  # candidate found, but nothing written
+
+    n_links = db.conn.execute("SELECT COUNT(*) FROM app.account_links").fetchone()
+    assert n_links is not None and n_links[0] == 0
+    n_decisions = db.conn.execute(
+        "SELECT COUNT(*) FROM app.account_link_decisions"
+    ).fetchone()
+    assert n_decisions is not None and n_decisions[0] == 0
+
+
+def test_propose_existing_guards_catalog_exception(db: Database) -> None:
+    """propose_existing returns None when core.dim_accounts does not exist."""
+    # No create_core_tables call → dim_accounts absent → CatalogException guarded
+    resolver = AccountResolver(db, actor="system")
+    assert resolver.propose_existing("any_id") is None

--- a/tests/moneybin/test_services/test_review_service.py
+++ b/tests/moneybin/test_services/test_review_service.py
@@ -10,13 +10,20 @@ def test_review_status_counts_both_queues() -> None:
     match_service.count_pending.return_value = 3
     cat_service = MagicMock()
     cat_service.count_uncategorized.return_value = 12
+    links_service = MagicMock()
+    links_service.count_pending.return_value = 0
 
-    svc = ReviewService(match_service=match_service, categorize_service=cat_service)
+    svc = ReviewService(
+        match_service=match_service,
+        categorize_service=cat_service,
+        account_links_service=links_service,
+    )
     status = svc.status()
 
     assert isinstance(status, ReviewStatus)
     assert status.matches_pending == 3
     assert status.categorize_pending == 12
+    assert status.account_links_pending == 0
     assert status.total == 15
 
 
@@ -25,13 +32,20 @@ def test_review_status_zero_queues() -> None:
     match_service.count_pending.return_value = 0
     cat_service = MagicMock()
     cat_service.count_uncategorized.return_value = 0
+    links_service = MagicMock()
+    links_service.count_pending.return_value = 0
 
-    svc = ReviewService(match_service=match_service, categorize_service=cat_service)
+    svc = ReviewService(
+        match_service=match_service,
+        categorize_service=cat_service,
+        account_links_service=links_service,
+    )
     status = svc.status()
 
     assert status.total == 0
     assert status.matches_pending == 0
     assert status.categorize_pending == 0
+    assert status.account_links_pending == 0
 
 
 def test_review_status_delegates_to_services() -> None:
@@ -40,9 +54,55 @@ def test_review_status_delegates_to_services() -> None:
     match_service.count_pending.return_value = 5
     cat_service = MagicMock()
     cat_service.count_uncategorized.return_value = 7
+    links_service = MagicMock()
+    links_service.count_pending.return_value = 2
 
-    svc = ReviewService(match_service=match_service, categorize_service=cat_service)
+    svc = ReviewService(
+        match_service=match_service,
+        categorize_service=cat_service,
+        account_links_service=links_service,
+    )
     svc.status()
 
     match_service.count_pending.assert_called_once()
     cat_service.count_uncategorized.assert_called_once()
+    links_service.count_pending.assert_called_once()
+
+
+def test_review_status_includes_account_links_pending() -> None:
+    """account_links_pending is counted and included in total."""
+    match_service = MagicMock()
+    match_service.count_pending.return_value = 0
+    cat_service = MagicMock()
+    cat_service.count_uncategorized.return_value = 0
+    links_service = MagicMock()
+    links_service.count_pending.return_value = 4
+
+    svc = ReviewService(
+        match_service=match_service,
+        categorize_service=cat_service,
+        account_links_service=links_service,
+    )
+    status = svc.status()
+
+    assert status.account_links_pending == 4
+    assert status.total == 4
+
+
+def test_review_status_total_sums_all_three_queues() -> None:
+    """Total = matches_pending + categorize_pending + account_links_pending."""
+    match_service = MagicMock()
+    match_service.count_pending.return_value = 2
+    cat_service = MagicMock()
+    cat_service.count_uncategorized.return_value = 3
+    links_service = MagicMock()
+    links_service.count_pending.return_value = 5
+
+    svc = ReviewService(
+        match_service=match_service,
+        categorize_service=cat_service,
+        account_links_service=links_service,
+    )
+    status = svc.status()
+
+    assert status.total == 10  # 2 + 3 + 5

--- a/tests/moneybin/test_services/test_system_service.py
+++ b/tests/moneybin/test_services/test_system_service.py
@@ -162,13 +162,17 @@ def test_status_last_import_at_populated(system_db: Database) -> None:
 
 @pytest.mark.unit
 def test_status_queue_counts_integer_types(system_db: Database) -> None:
-    """matches_pending and categorize_pending are integers."""
+    """matches_pending, account_links_pending, and categorize_pending are integers."""
     svc = SystemService(db=system_db)
     result = svc.status()
     assert isinstance(result.matches_pending, int)
+    assert isinstance(result.account_links_pending, int)
     assert isinstance(result.categorize_pending, int)
     # matches_pending is 0 because match_decisions table is empty
     assert result.matches_pending == 0
+    # account_links_pending is 0 because account_link_decisions is empty —
+    # the count is surfaced (no longer computed-then-dropped), not stuck at 0.
+    assert result.account_links_pending == 0
     # categorize_pending reflects the 2 uncategorized transactions in the fixture
     assert result.categorize_pending == 2
 


### PR DESCRIPTION
Surfaces the cross-source account-merge proposals the `AccountResolver` already raises (`institution+last4` / name), so a weak account match is **reviewed, never silently merged**. This is the M1S.5 increment of the account-identity work; the import-time binding gate (M1S.4) and the cross-source scenario (M1S.6) follow in their own PRs.

## What's in it

- **Queue data layer** — `AccountLinkDecisionsRepo` gains `list_pending` / `update_status` / `reverse`; `AccountLinksRepo` gains `repoint` — the atomic reverse-then-insert primitive that re-points a provisional account's native references onto a chosen canonical account (navigating the `source_native` uniqueness guard). **This re-point is the mechanism that collapses cross-source duplicate accounts.**
- **`AccountLinksService`** — `pending` (proposals grouped by provisional account), `set` (accept → repoint onto the candidate + auto-reject siblings, or `--standalone` → keep separate), `history`, `run` (backfill proposals over existing accounts). `set` is atomic (`db.begin()/commit()`), mirroring `MatchingService`.
- **Surface** — `accounts_links_pending` / `_set` / `_history` / `_run` MCP tools + `moneybin accounts links …` CLI, mirroring `transactions_matches_*`. Low sensitivity: proposals carry opaque ids + labels only — account numbers are never surfaced.
- **Unified review** — `transactions_review` promoted to a domain-neutral top-level `review` (MCP) / `moneybin review` (CLI) that aggregates matches + categorize + **account-links** pending counts, so a single "what needs my attention?" sweep can't miss the backlog. `transactions_review` / `transactions review` kept as deprecated aliases for one minor release.

## Notably *not* in this PR

- The import-time binding gate (`account_bindings` on `import_confirm`, new-account capture, the `ACCOUNT_LINK_*` metric emission) — that's M1S.4.
- `accounts links undo` of an *accepted* merge — deferred to the M1L audit-undo consumer (reversing the decision alone can't unwind the `repoint`; correct undo needs to invert the repoint's audit events in order). The queue's `set` re-merge is the interim recovery path.

## Tests

Unit coverage across the repos, service, and both surfaces (pending/accept/standalone/repoint/auto-reject/dedup/alias). `make check` clean (ruff + pyright 0 errors). Full suite green apart from two pre-existing `test_system_freshness` macOS-keychain sandbox failures (unrelated; pass in CI).