### PR TITLE
Account-identity follow-ups: strong-refs-on-mint, hardening, dedup

### DIFF
--- a/docs/specs/account-identity-resolution.md
+++ b/docs/specs/account-identity-resolution.md
@@ -345,8 +345,12 @@ signal reliability:
    `full_number`. Hit → **auto-adopt** that canonical id; record any new strong
    ref of this source as an accepted mapping. `decided_by='auto'`.
 2. **Candidate pass** (only if no strong hit). Mint a canonical account and write
-   its accepted `source_native` mapping (so it is in the dimension immediately),
-   then look for existing accounts sharing `institution + last4` (when institution
+   its accepted `source_native` mapping (so it is in the dimension immediately)
+   **plus an accepted strong ref for every scoped confirmer this source carries
+   (`persistent_token`, scoped `full_number`)** — safe because step 1 just proved
+   no existing account holds them, and it lets a later source bearing the same
+   token / scoped number auto-adopt via step 1 instead of minting a duplicate.
+   Then look for existing accounts sharing `institution + last4` (when institution
    is known), then fuzzy `account_name`, querying `core.dim_accounts`:
    - **0 candidates** → done: a new standalone account. Its `last_four` /
      institution / name (captured per Decision 7) become candidate signals for
@@ -361,7 +365,7 @@ signal reliability:
 |---|---|---|---|
 | Adopt (pinned) | explicit `account_id` | bind to the named canonical | accepted mapping (`decided_by=user`¹) |
 | Auto-adopt | remembered `source_native`, scoped full number, or persistent token | reuse existing canonical | accepted mapping (`auto`) |
-| Mint new | no candidate at all | new standalone canonical account | accepted mapping (`auto`) |
+| Mint new | no candidate at all | new standalone canonical account | accepted `source_native` + any scoped strong ref (`auto`) |
 | Propose / review | `institution+last4` or fuzzy name | new account + `pending` decision(s) | accepted mapping **plus** pending decision(s) |
 
 ¹ `decided_by` is `auto | user | system`; **agent ratification maps to `user`**

--- a/docs/specs/account-identity-resolution.md
+++ b/docs/specs/account-identity-resolution.md
@@ -261,7 +261,7 @@ state lives.
 decision_id            TEXT  PRIMARY KEY,  -- uuid4[:12]
 provisional_account_id TEXT  NOT NULL,     -- the just-minted source account under review
 candidate_account_id   TEXT  NOT NULL,     -- an existing canonical account proposed as the same
-confidence_score       DOUBLE,
+confidence_score       DECIMAL(5, 4),
 match_signals          TEXT,               -- JSON-encoded (per match_decisions convention):
                                            --   which weak signal matched + its value (institution_last4 / name)
 status                 TEXT  NOT NULL,     -- pending | accepted | rejected | reversed

--- a/docs/specs/account-identity-resolution.md
+++ b/docs/specs/account-identity-resolution.md
@@ -366,7 +366,7 @@ signal reliability:
 | Adopt (pinned) | explicit `account_id` | bind to the named canonical | accepted mapping (`decided_by=user`¹) |
 | Auto-adopt | remembered `source_native`, scoped full number, or persistent token | reuse existing canonical | accepted mapping (`auto`) |
 | Mint new | no candidate at all | new standalone canonical account | accepted `source_native` + any scoped strong ref (`auto`) |
-| Propose / review | `institution+last4` or fuzzy name | new account + `pending` decision(s) | accepted mapping **plus** pending decision(s) |
+| Propose / review | `institution+last4` or fuzzy name | new account + `pending` decision(s) | accepted `source_native` + any scoped strong ref **plus** pending decision(s) |
 
 ¹ `decided_by` is `auto | user | system`; **agent ratification maps to `user`**
 (consistent with `match_decisions_repo`) — `actor_kind` is a runtime distinction,

--- a/sqlmesh/models/core/dim_accounts.sql
+++ b/sqlmesh/models/core/dim_accounts.sql
@@ -68,8 +68,9 @@ WITH ofx_accounts AS (
      NULL collapsing into one bad row. Safety net: the durable path is re-import,
      not a migration — once all data is re-imported every account is linked, so
      the COALESCE always takes the canonical id and this fallback is inert.
-     source_rank: source strength for the golden-record merge (ofx > plaid >
-     tabular, lower rank wins). Mirrors MatchingSettings.source_priority. */
+     source_rank: bank-field authority ordering for the golden-record merge
+     (ofx > plaid > tabular, lower rank wins); manual/gsheet contribute no
+     structured bank fields. */
   SELECT
     *,
     COALESCE(account_id, source_account_key) AS grain_key,

--- a/sqlmesh/models/core/dim_accounts.sql
+++ b/sqlmesh/models/core/dim_accounts.sql
@@ -62,11 +62,12 @@ WITH ofx_accounts AS (
   FROM plaid_accounts
 ), ranked AS (
   /* grain_key: account_id is the CANONICAL opaque id when the account has an
-     accepted app.account_links row; it is NULL for accounts imported before the B7
-     backfill migration. COALESCE falls back to the source-native key so those
-     unlinked accounts stay DISTINCT instead of every NULL collapsing into one bad
-     row. Transient safety net: post-migration every account is linked, so the
-     COALESCE always takes the canonical id and this fallback is inert.
+     accepted app.account_links row; it is NULL for accounts not yet re-imported
+     through AccountResolver (pre-M1S.3 raw data). COALESCE falls back to the
+     source-native key so those unlinked accounts stay DISTINCT instead of every
+     NULL collapsing into one bad row. Safety net: the durable path is re-import,
+     not a migration — once all data is re-imported every account is linked, so
+     the COALESCE always takes the canonical id and this fallback is inert.
      source_rank: source strength for the golden-record merge (ofx > plaid >
      tabular, lower rank wins). Mirrors MatchingSettings.source_priority. */
   SELECT

--- a/src/moneybin/cli/commands/accounts/links.py
+++ b/src/moneybin/cli/commands/accounts/links.py
@@ -20,14 +20,10 @@ from moneybin.privacy.payloads.accounts import (
     AccountLinksHistoryPayload,
     AccountLinksPendingPayload,
     AccountLinksRunPayload,
-    LinkCandidateRow,
-    LinkHistoryRow,
-    LinkPendingGroup,
 )
 from moneybin.protocol.envelope import build_envelope
 from moneybin.services.account_links_service import (
     AccountLinksService,
-    signal_from_match_signals,
 )
 
 app = typer.Typer(
@@ -54,28 +50,7 @@ def links_pending(
             groups = svc.pending()
             n_pending = svc.count_pending()
 
-    payload = AccountLinksPendingPayload(
-        groups=[
-            LinkPendingGroup(
-                provisional_account_id=g.provisional_account_id,
-                provisional_display_name=g.provisional_display_name,
-                candidates=[
-                    LinkCandidateRow(
-                        decision_id=c.decision_id,
-                        candidate_account_id=c.candidate_account_id,
-                        candidate_display_name=c.candidate_display_name,
-                        confidence=float(c.confidence)
-                        if c.confidence is not None
-                        else None,
-                        signal=c.signal,
-                    )
-                    for c in g.candidates
-                ],
-            )
-            for g in groups
-        ],
-        n_pending=n_pending,
-    )
+    payload = AccountLinksPendingPayload.from_service(groups, n_pending)
 
     if output == OutputFormat.JSON:
         from moneybin.cli.output import render_or_json  # noqa: PLC0415 — defer import
@@ -174,25 +149,7 @@ def links_history(
         with get_database(read_only=True) as db:
             rows = AccountLinksService(db, actor="cli").history(limit=limit)
 
-    payload = AccountLinksHistoryPayload(
-        decisions=[
-            LinkHistoryRow(
-                decision_id=r["decision_id"],
-                provisional_account_id=r["provisional_account_id"],
-                candidate_account_id=r["candidate_account_id"],
-                status=r["status"],
-                decided_by=r["decided_by"],
-                decided_at=str(r["decided_at"]) if r.get("decided_at") else None,
-                confidence=(
-                    float(r["confidence_score"])
-                    if r.get("confidence_score") is not None
-                    else None
-                ),
-                signal=signal_from_match_signals(r.get("match_signals")),
-            )
-            for r in rows
-        ]
-    )
+    payload = AccountLinksHistoryPayload.from_rows(rows)
 
     if output == OutputFormat.JSON:
         from moneybin.cli.output import render_or_json  # noqa: PLC0415 — defer import

--- a/src/moneybin/cli/commands/accounts/links.py
+++ b/src/moneybin/cli/commands/accounts/links.py
@@ -140,7 +140,7 @@ def links_set(
 
 @app.command("history")
 def links_history(
-    limit: int = typer.Option(50, "--limit", "-n", help="Max records to show"),
+    limit: int = typer.Option(50, "--limit", "-n", min=0, help="Max records to show"),
     output: OutputFormat = output_option,
     quiet: bool = quiet_option,
 ) -> None:

--- a/src/moneybin/cli/commands/import_cmd.py
+++ b/src/moneybin/cli/commands/import_cmd.py
@@ -617,32 +617,18 @@ def _confirmation_envelope_data(outcome: ConfirmationRequired) -> dict[str, Any]
     """Build the ``confirmation_required`` envelope ``data`` dict from an outcome.
 
     Shared by ``import files`` and ``import confirm`` so the JSON shape cannot
-    drift between the two surfaces. The per-command ``actions[]`` hints differ
-    (files-level vs confirm-subcommand context) and stay in the callers.
+    drift between the two surfaces. Delegates to the canonical
+    ``confirmation_payload_dict`` — the single source MCP and the batch service
+    also use — so a new channel field (e.g. ``bridge_payload``) lands in one
+    place; this wrapper only prepends the CLI-envelope ``status`` field. The
+    per-command ``actions[]`` hints differ (files-level vs confirm-subcommand
+    context) and stay in the callers.
     """
-    from moneybin.services.import_confirmation import ProposedMapping  # noqa: PLC0415
+    from moneybin.services.import_confirmation import (  # noqa: PLC0415 — defer import to keep CLI cold-start light
+        confirmation_payload_dict,
+    )
 
-    proposed = outcome.proposed
-    if isinstance(proposed, ProposedMapping):
-        proposed_mapping: dict[str, str] = proposed.field_mapping
-        unmapped: list[str] = list(proposed.unmapped_columns)
-    else:
-        proposed_mapping = {}
-        unmapped = []
-    return {
-        "status": "confirmation_required",
-        "channel": outcome.channel,
-        "tier": outcome.confidence.tier,
-        "score": outcome.confidence.score,
-        "reason": outcome.reason,
-        "error_message": outcome.error_message,
-        "proposed_mapping": proposed_mapping,
-        "samples": outcome.samples,
-        "flagged": list(outcome.confidence.flagged),
-        "missing_required": list(outcome.confidence.missing_required),
-        "unmapped_columns": unmapped,
-        "account_proposals": list(outcome.account_proposals),
-    }
+    return {"status": "confirmation_required", **confirmation_payload_dict(outcome)}
 
 
 def _echo_account_proposals(outcome: ConfirmationRequired, *, err: bool) -> None:

--- a/src/moneybin/cli/commands/import_cmd.py
+++ b/src/moneybin/cli/commands/import_cmd.py
@@ -59,37 +59,34 @@ app.add_typer(import_labels.app, name="labels", help="Manage labels on imports")
 logger = logging.getLogger(__name__)
 
 
-def _parse_overrides(override: list[str] | None) -> dict[str, str] | None:
-    """Parse and validate --override field=column values."""
-    if not override:
+def _parse_kv(
+    values: list[str] | None, *, flag: str, fmt: str
+) -> dict[str, str] | None:
+    """Parse repeatable ``KEY=VALUE`` CLI options into a stripped dict.
+
+    ``flag`` and ``fmt`` shape only the error message (e.g. ``flag="--override"``,
+    ``fmt="field=column"``). Returns ``None`` for empty input.
+    """
+    if not values:
         return None
     result: dict[str, str] = {}
-    for raw in override:
+    for raw in values:
         if "=" not in raw:
-            logger.error(
-                f"❌ Invalid --override format (expected field=column): {raw!r}"
-            )
+            logger.error(f"❌ Invalid {flag} format (expected {fmt}): {raw!r}")
             raise typer.Exit(1)
-        field, _, col = raw.partition("=")
-        result[field.strip()] = col.strip()
+        key, _, value = raw.partition("=")
+        result[key.strip()] = value.strip()
     return result
+
+
+def _parse_overrides(override: list[str] | None) -> dict[str, str] | None:
+    """Parse and validate --override field=column values."""
+    return _parse_kv(override, flag="--override", fmt="field=column")
 
 
 def _parse_account_bindings(binding: list[str] | None) -> dict[str, str] | None:
     """Parse --account-binding source_key=ACCOUNT_ID|new values."""
-    if not binding:
-        return None
-    result: dict[str, str] = {}
-    for raw in binding:
-        if "=" not in raw:
-            logger.error(
-                "❌ Invalid --account-binding format "
-                f"(expected source_key=ACCOUNT_ID|new): {raw!r}"
-            )
-            raise typer.Exit(1)
-        key, _, target = raw.partition("=")
-        result[key.strip()] = target.strip()
-    return result
+    return _parse_kv(binding, flag="--account-binding", fmt="source_key=ACCOUNT_ID|new")
 
 
 def _parse_account_metadata(

--- a/src/moneybin/cli/commands/import_cmd.py
+++ b/src/moneybin/cli/commands/import_cmd.py
@@ -480,7 +480,6 @@ def import_files_command(
     except Exception as _exc:  # noqa: BLE001 — dispatch on type below
         from moneybin.services.import_confirmation import (  # noqa: PLC0415
             ImportConfirmationRequiredError,
-            ProposedMapping,
         )
 
         if isinstance(_exc, ImportConfirmationRequiredError):
@@ -493,30 +492,7 @@ def import_files_command(
             # to re-run with --confirm or --mapping instead.
             outcome = _exc.outcome
             file_path_str = str(file_paths[0]) if len(file_paths) == 1 else ""
-            proposed_mapping: dict[str, str] = (
-                outcome.proposed.field_mapping
-                if isinstance(outcome.proposed, ProposedMapping)
-                else {}
-            )
-            unmapped = (
-                list(outcome.proposed.unmapped_columns)
-                if isinstance(outcome.proposed, ProposedMapping)
-                else []
-            )
-            envelope_data: dict[str, Any] = {
-                "status": "confirmation_required",
-                "channel": outcome.channel,
-                "tier": outcome.confidence.tier,
-                "score": outcome.confidence.score,
-                "reason": outcome.reason,
-                "error_message": outcome.error_message,
-                "proposed_mapping": proposed_mapping,
-                "samples": outcome.samples,
-                "flagged": list(outcome.confidence.flagged),
-                "missing_required": list(outcome.confidence.missing_required),
-                "unmapped_columns": unmapped,
-                "account_proposals": list(outcome.account_proposals),
-            }
+            envelope_data = _confirmation_envelope_data(outcome)
             confirm_actions: list[str] = []
             if outcome.error_message:
                 confirm_actions.append(f"Validation failed: {outcome.error_message}")
@@ -635,6 +611,38 @@ def import_files_command(
     # Mirrors the fail-loud single-file path that raises on refresh() error.
     if data.get("transforms_error"):
         raise typer.Exit(1)
+
+
+def _confirmation_envelope_data(outcome: ConfirmationRequired) -> dict[str, Any]:
+    """Build the ``confirmation_required`` envelope ``data`` dict from an outcome.
+
+    Shared by ``import files`` and ``import confirm`` so the JSON shape cannot
+    drift between the two surfaces. The per-command ``actions[]`` hints differ
+    (files-level vs confirm-subcommand context) and stay in the callers.
+    """
+    from moneybin.services.import_confirmation import ProposedMapping  # noqa: PLC0415
+
+    proposed = outcome.proposed
+    if isinstance(proposed, ProposedMapping):
+        proposed_mapping: dict[str, str] = proposed.field_mapping
+        unmapped: list[str] = list(proposed.unmapped_columns)
+    else:
+        proposed_mapping = {}
+        unmapped = []
+    return {
+        "status": "confirmation_required",
+        "channel": outcome.channel,
+        "tier": outcome.confidence.tier,
+        "score": outcome.confidence.score,
+        "reason": outcome.reason,
+        "error_message": outcome.error_message,
+        "proposed_mapping": proposed_mapping,
+        "samples": outcome.samples,
+        "flagged": list(outcome.confidence.flagged),
+        "missing_required": list(outcome.confidence.missing_required),
+        "unmapped_columns": unmapped,
+        "account_proposals": list(outcome.account_proposals),
+    }
 
 
 def _echo_account_proposals(outcome: ConfirmationRequired, *, err: bool) -> None:
@@ -828,7 +836,6 @@ def import_confirm_command(
 
     from moneybin.services.import_confirmation import (
         ImportConfirmationRequiredError,
-        ProposedMapping,
     )
 
     try:
@@ -857,30 +864,7 @@ def import_confirm_command(
         # a structured payload instead of an unparseable stderr message.
         # Exit code stays 1: the confirm action did not succeed.
         outcome = e.outcome
-        proposed_mapping_dict = (
-            outcome.proposed.field_mapping
-            if isinstance(outcome.proposed, ProposedMapping)
-            else {}
-        )
-        unmapped = (
-            list(outcome.proposed.unmapped_columns)
-            if isinstance(outcome.proposed, ProposedMapping)
-            else []
-        )
-        envelope_data: dict[str, Any] = {
-            "status": "confirmation_required",
-            "channel": outcome.channel,
-            "tier": outcome.confidence.tier,
-            "score": outcome.confidence.score,
-            "reason": outcome.reason,
-            "error_message": outcome.error_message,
-            "proposed_mapping": proposed_mapping_dict,
-            "samples": outcome.samples,
-            "flagged": list(outcome.confidence.flagged),
-            "missing_required": list(outcome.confidence.missing_required),
-            "unmapped_columns": unmapped,
-            "account_proposals": list(outcome.account_proposals),
-        }
+        envelope_data = _confirmation_envelope_data(outcome)
         confirm_actions: list[str] = []
         if outcome.error_message:
             confirm_actions.append(f"Validation failed: {outcome.error_message}")

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -41,9 +41,6 @@ from moneybin.privacy.payloads.accounts import (
     AccountResolvePayload,
     AccountSettingsPayload,
     AccountSummaryStats,
-    LinkCandidateRow,
-    LinkHistoryRow,
-    LinkPendingGroup,
 )
 from moneybin.privacy.payloads.balances import (
     BalanceAssertionDeletePayload,
@@ -54,7 +51,6 @@ from moneybin.privacy.payloads.balances import (
 from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
 from moneybin.services.account_links_service import (
     AccountLinksService,
-    signal_from_match_signals,
 )
 from moneybin.services.account_service import CLEAR, AccountService
 from moneybin.services.balance_service import BalanceService
@@ -420,28 +416,7 @@ def accounts_links_pending() -> ResponseEnvelope[AccountLinksPendingPayload]:
         svc = AccountLinksService(db, actor="mcp")
         groups = svc.pending()
         n_pending = svc.count_pending()
-    payload = AccountLinksPendingPayload(
-        groups=[
-            LinkPendingGroup(
-                provisional_account_id=g.provisional_account_id,
-                provisional_display_name=g.provisional_display_name,
-                candidates=[
-                    LinkCandidateRow(
-                        decision_id=c.decision_id,
-                        candidate_account_id=c.candidate_account_id,
-                        candidate_display_name=c.candidate_display_name,
-                        confidence=float(c.confidence)
-                        if c.confidence is not None
-                        else None,
-                        signal=c.signal,
-                    )
-                    for c in g.candidates
-                ],
-            )
-            for g in groups
-        ],
-        n_pending=n_pending,
-    )
+    payload = AccountLinksPendingPayload.from_service(groups, n_pending)
     return build_envelope(
         data=payload,
         total_count=n_pending,
@@ -504,25 +479,7 @@ def accounts_links_history(
     """
     with get_database(read_only=True) as db:
         rows = AccountLinksService(db, actor="mcp").history(limit=limit)
-    payload = AccountLinksHistoryPayload(
-        decisions=[
-            LinkHistoryRow(
-                decision_id=r["decision_id"],
-                provisional_account_id=r["provisional_account_id"],
-                candidate_account_id=r["candidate_account_id"],
-                status=r["status"],
-                decided_by=r["decided_by"],
-                decided_at=str(r["decided_at"]) if r.get("decided_at") else None,
-                confidence=(
-                    float(r["confidence_score"])
-                    if r.get("confidence_score") is not None
-                    else None
-                ),
-                signal=signal_from_match_signals(r.get("match_signals")),
-            )
-            for r in rows
-        ]
-    )
+    payload = AccountLinksHistoryPayload.from_rows(rows)
     return build_envelope(
         data=payload,
         actions=["Use accounts_links_pending for the active review queue"],

--- a/src/moneybin/privacy/payloads/accounts.py
+++ b/src/moneybin/privacy/payloads/accounts.py
@@ -231,7 +231,9 @@ class LinkHistoryRow:
             candidate_account_id=r["candidate_account_id"],
             status=r["status"],
             decided_by=r["decided_by"],
-            decided_at=str(r["decided_at"]) if r.get("decided_at") else None,
+            decided_at=(
+                str(r["decided_at"]) if r.get("decided_at") is not None else None
+            ),
             confidence=(
                 float(r["confidence_score"])
                 if r.get("confidence_score") is not None

--- a/src/moneybin/privacy/payloads/accounts.py
+++ b/src/moneybin/privacy/payloads/accounts.py
@@ -18,6 +18,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Annotated, Any
 
 from moneybin.privacy.taxonomy import DataClass
+from moneybin.utils.parsing import signal_from_match_signals
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -224,10 +225,6 @@ class LinkHistoryRow:
     @classmethod
     def from_decision_row(cls, r: dict[str, Any]) -> LinkHistoryRow:
         """Map a decoded ``account_link_decisions`` row into the history payload."""
-        from moneybin.services.account_links_service import (  # noqa: PLC0415
-            signal_from_match_signals,
-        )
-
         return cls(
             decision_id=r["decision_id"],
             provisional_account_id=r["provisional_account_id"],

--- a/src/moneybin/privacy/payloads/accounts.py
+++ b/src/moneybin/privacy/payloads/accounts.py
@@ -15,9 +15,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from decimal import Decimal
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated, Any
 
 from moneybin.privacy.taxonomy import DataClass
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from moneybin.services.account_resolution_types import (
+        PendingLinkCandidate,
+        PendingLinkGroup,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -139,6 +147,17 @@ class LinkCandidateRow:
     confidence: Annotated[float | None, DataClass.AGGREGATE]
     signal: Annotated[str, DataClass.TXN_TYPE]  # "institution_last4" or "name"
 
+    @classmethod
+    def from_candidate(cls, c: PendingLinkCandidate) -> LinkCandidateRow:
+        """Map a service ``PendingLinkCandidate`` into the surfaced payload row."""
+        return cls(
+            decision_id=c.decision_id,
+            candidate_account_id=c.candidate_account_id,
+            candidate_display_name=c.candidate_display_name,
+            confidence=float(c.confidence) if c.confidence is not None else None,
+            signal=c.signal,
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class LinkPendingGroup:
@@ -149,6 +168,15 @@ class LinkPendingGroup:
     provisional_display_name: Annotated[str, DataClass.USER_NOTE]
     candidates: list[LinkCandidateRow]
 
+    @classmethod
+    def from_domain(cls, g: PendingLinkGroup) -> LinkPendingGroup:
+        """Map a service ``PendingLinkGroup`` into the surfaced payload group."""
+        return cls(
+            provisional_account_id=g.provisional_account_id,
+            provisional_display_name=g.provisional_display_name,
+            candidates=[LinkCandidateRow.from_candidate(c) for c in g.candidates],
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class AccountLinksPendingPayload:
@@ -156,6 +184,20 @@ class AccountLinksPendingPayload:
 
     groups: list[LinkPendingGroup]
     n_pending: Annotated[int, DataClass.AGGREGATE]
+
+    @classmethod
+    def from_service(
+        cls, groups: Iterable[PendingLinkGroup], n_pending: int
+    ) -> AccountLinksPendingPayload:
+        """Build the pending payload from ``AccountLinksService.pending()`` output.
+
+        Single mapper shared by the MCP tool and CLI command so the two surfaces
+        cannot drift in shape.
+        """
+        return cls(
+            groups=[LinkPendingGroup.from_domain(g) for g in groups],
+            n_pending=n_pending,
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -179,12 +221,39 @@ class LinkHistoryRow:
     confidence: Annotated[float | None, DataClass.AGGREGATE]
     signal: Annotated[str, DataClass.TXN_TYPE]
 
+    @classmethod
+    def from_decision_row(cls, r: dict[str, Any]) -> LinkHistoryRow:
+        """Map a decoded ``account_link_decisions`` row into the history payload."""
+        from moneybin.services.account_links_service import (  # noqa: PLC0415
+            signal_from_match_signals,
+        )
+
+        return cls(
+            decision_id=r["decision_id"],
+            provisional_account_id=r["provisional_account_id"],
+            candidate_account_id=r["candidate_account_id"],
+            status=r["status"],
+            decided_by=r["decided_by"],
+            decided_at=str(r["decided_at"]) if r.get("decided_at") else None,
+            confidence=(
+                float(r["confidence_score"])
+                if r.get("confidence_score") is not None
+                else None
+            ),
+            signal=signal_from_match_signals(r.get("match_signals")),
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class AccountLinksHistoryPayload:
     """Payload for accounts_links_history — decision log, newest first."""
 
     decisions: list[LinkHistoryRow]
+
+    @classmethod
+    def from_rows(cls, rows: Iterable[dict[str, Any]]) -> AccountLinksHistoryPayload:
+        """Build the history payload from ``AccountLinksService.history()`` rows."""
+        return cls(decisions=[LinkHistoryRow.from_decision_row(r) for r in rows])
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/moneybin/repositories/account_link_decisions_repo.py
+++ b/src/moneybin/repositories/account_link_decisions_repo.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import json
 from typing import Any
 
+import duckdb
+
 from moneybin.repositories.base import BaseRepo
 from moneybin.services.audit_service import AuditEvent
 from moneybin.tables import ACCOUNT_LINK_DECISIONS
@@ -69,6 +71,10 @@ class AccountLinkDecisionsRepo(BaseRepo):
             decision_id,
             decode=_decode_row,
         )
+
+    def fetch_by_id(self, decision_id: str) -> dict[str, Any] | None:
+        """Read one decoded decision row by id, or None when absent. Read-only."""
+        return self._fetch_row(decision_id)
 
     def insert(
         self,
@@ -211,4 +217,20 @@ class AccountLinkDecisionsRepo(BaseRepo):
             "WHERE status = 'pending' AND reversed_at IS NULL "
             "ORDER BY provisional_account_id, decision_id",
         ).fetchall()
+        return [_decode_row(r) for r in rows]
+
+    def history(self, *, limit: int = 50) -> list[dict[str, Any]]:
+        """All decisions (any status) newest-first by ``decided_at``. Read-only.
+
+        Returns an empty list when the table does not yet exist
+        (``CatalogException`` guard). No audit emitted.
+        """
+        try:
+            rows = self._db.execute(
+                f"SELECT {_COLS} FROM {ACCOUNT_LINK_DECISIONS.full_name} "  # noqa: S608  # constant column list + TableRef + parameterized limit
+                "ORDER BY decided_at DESC NULLS LAST LIMIT ?",
+                [limit],
+            ).fetchall()
+        except duckdb.CatalogException:
+            return []
         return [_decode_row(r) for r in rows]

--- a/src/moneybin/repositories/account_link_decisions_repo.py
+++ b/src/moneybin/repositories/account_link_decisions_repo.py
@@ -73,8 +73,16 @@ class AccountLinkDecisionsRepo(BaseRepo):
         )
 
     def fetch_by_id(self, decision_id: str) -> dict[str, Any] | None:
-        """Read one decoded decision row by id, or None when absent. Read-only."""
-        return self._fetch_row(decision_id)
+        """Read one decoded decision row by id, or None when absent. Read-only.
+
+        Returns None when the table does not yet exist (``CatalogException``
+        guard), matching ``count_pending``/``history`` so a fresh DB yields a
+        clean not-found rather than a raw catalog error.
+        """
+        try:
+            return self._fetch_row(decision_id)
+        except duckdb.CatalogException:
+            return None
 
     def insert(
         self,
@@ -210,21 +218,28 @@ class AccountLinkDecisionsRepo(BaseRepo):
         Returns ``status='pending'`` rows with ``reversed_at IS NULL``, decoded
         via ``_decode_row``, ordered ``provisional_account_id, decision_id`` so
         callers can group proposals by the provisional account under review.
+        Returns an empty list when the table does not yet exist
+        (``CatalogException`` guard), matching ``count_pending``/``history``.
         Read-only — no audit emitted.
         """
-        rows = self._db.execute(
-            f"SELECT {_COLS} FROM {ACCOUNT_LINK_DECISIONS.full_name} "  # noqa: S608  # constant column list + TableRef
-            "WHERE status = 'pending' AND reversed_at IS NULL "
-            "ORDER BY provisional_account_id, decision_id",
-        ).fetchall()
+        try:
+            rows = self._db.execute(
+                f"SELECT {_COLS} FROM {ACCOUNT_LINK_DECISIONS.full_name} "  # noqa: S608  # constant column list + TableRef
+                "WHERE status = 'pending' AND reversed_at IS NULL "
+                "ORDER BY provisional_account_id, decision_id",
+            ).fetchall()
+        except duckdb.CatalogException:
+            return []
         return [_decode_row(r) for r in rows]
 
     def history(self, *, limit: int = 50) -> list[dict[str, Any]]:
         """All decisions (any status) newest-first by ``decided_at``. Read-only.
 
         Returns an empty list when the table does not yet exist
-        (``CatalogException`` guard). No audit emitted.
+        (``CatalogException`` guard). A negative ``limit`` is clamped to 0 —
+        DuckDB rejects a negative LIMIT (``BinderException``). No audit emitted.
         """
+        limit = max(limit, 0)
         try:
             rows = self._db.execute(
                 f"SELECT {_COLS} FROM {ACCOUNT_LINK_DECISIONS.full_name} "  # noqa: S608  # constant column list + TableRef + parameterized limit

--- a/src/moneybin/services/account_links_service.py
+++ b/src/moneybin/services/account_links_service.py
@@ -27,31 +27,23 @@ from moneybin.services.account_resolution_types import (
     PendingLinkGroup,
 )
 from moneybin.tables import ACCOUNT_LINK_DECISIONS, ACCOUNT_LINKS, DIM_ACCOUNTS
+from moneybin.utils.parsing import signal_from_match_signals
 
 logger = logging.getLogger(__name__)
-
-
-def signal_from_match_signals(match_signals: Any) -> str:
-    """Extract the 'signal' key from an already-decoded match_signals dict.
-
-    ``list_pending()`` returns ``match_signals`` as a decoded ``dict``; the
-    ``Any`` annotation covers the raw DB read path too (used by ``history``).
-    Uses try/except to avoid pyright's ``dict[Unknown, Unknown]`` narrowing
-    issue after ``isinstance`` checks on ``Any``-typed inputs.
-    """
-    try:
-        return str(match_signals["signal"])
-    except (KeyError, TypeError):
-        return ""
 
 
 def _resolve_display_name(db: Database, account_id: str) -> str:
     """Return ``display_name`` from ``core.dim_accounts``; empty string when absent.
 
-    Thin alias over the shared ``fetch_display_name`` (imported function-locally
-    to match the module's existing account_resolver import pattern).
+    Thin alias that localizes the sole ``account_resolver`` seam to one place
+    rather than scattering the import across both call sites.
     """
-    from moneybin.services.account_resolver import fetch_display_name  # noqa: PLC0415
+    # Function-local for the same reason as run() below: a module-level import
+    # of account_resolver cycles (AccountResolver <- AccountLinkDecisionsRepo
+    # <- AccountLinksService).
+    from moneybin.services.account_resolver import (  # noqa: PLC0415 — circular-import avoidance
+        fetch_display_name,
+    )
 
     return fetch_display_name(db, account_id)
 

--- a/src/moneybin/services/account_links_service.py
+++ b/src/moneybin/services/account_links_service.py
@@ -11,7 +11,6 @@ column (``user``/``system``/``auto``). The caller supplies both.
 
 from __future__ import annotations
 
-import json
 import logging
 import uuid
 from typing import Any
@@ -31,22 +30,6 @@ from moneybin.tables import ACCOUNT_LINK_DECISIONS, ACCOUNT_LINKS, DIM_ACCOUNTS
 
 logger = logging.getLogger(__name__)
 
-# Column order matches app_account_link_decisions.sql (and the repo's constant).
-_DECISION_COLUMNS = (
-    "decision_id",
-    "provisional_account_id",
-    "candidate_account_id",
-    "confidence_score",
-    "match_signals",
-    "status",
-    "decided_by",
-    "match_reason",
-    "decided_at",
-    "reversed_at",
-    "reversed_by",
-)
-_DECISION_COLS = ", ".join(f'"{c}"' for c in _DECISION_COLUMNS)
-
 
 def signal_from_match_signals(match_signals: Any) -> str:
     """Extract the 'signal' key from an already-decoded match_signals dict.
@@ -62,31 +45,15 @@ def signal_from_match_signals(match_signals: Any) -> str:
         return ""
 
 
-def _decode_decision_row(row: tuple[Any, ...]) -> dict[str, Any]:
-    """Map a raw DB row to a dict, decoding the JSON ``match_signals`` column."""
-    out: dict[str, Any] = {}
-    for col, val in zip(_DECISION_COLUMNS, row, strict=True):
-        if col == "match_signals" and isinstance(val, str):
-            out[col] = json.loads(val)
-        else:
-            out[col] = val
-    return out
-
-
 def _resolve_display_name(db: Database, account_id: str) -> str:
     """Return ``display_name`` from ``core.dim_accounts``; empty string when absent.
 
-    Guards ``duckdb.CatalogException`` so callers work before the core layer is
-    materialized (e.g. during initial import before a SQLMesh run).
+    Thin alias over the shared ``fetch_display_name`` (imported function-locally
+    to match the module's existing account_resolver import pattern).
     """
-    try:
-        row = db.execute(
-            f"SELECT display_name FROM {DIM_ACCOUNTS.full_name} WHERE account_id = ?",  # noqa: S608  # TableRef constant + parameterized value
-            [account_id],
-        ).fetchone()
-        return (row[0] or "") if row else ""
-    except duckdb.CatalogException:
-        return ""
+    from moneybin.services.account_resolver import fetch_display_name  # noqa: PLC0415
+
+    return fetch_display_name(db, account_id)
 
 
 class AccountLinksService:
@@ -177,22 +144,10 @@ class AccountLinksService:
     def history(self, *, limit: int = 50) -> list[dict[str, Any]]:
         """All decisions (any status) newest-first by ``decided_at``. Read-only.
 
-        Mirrors ``MatchingService.get_log``. Returns an empty list when the
-        table does not yet exist (``CatalogException`` guard).
+        Mirrors ``MatchingService.get_log``. Delegates to the repo (raw SQL +
+        decode live in the repo layer); empty list when the table is absent.
         """
-        try:
-            rows = self._db.execute(
-                f"""
-                SELECT {_DECISION_COLS}
-                FROM {ACCOUNT_LINK_DECISIONS.full_name}
-                ORDER BY decided_at DESC NULLS LAST
-                LIMIT ?
-                """,  # noqa: S608  # constant column list + TableRef + parameterized limit
-                [limit],
-            ).fetchall()
-        except duckdb.CatalogException:
-            return []
-        return [_decode_decision_row(r) for r in rows]
+        return self._decisions.history(limit=limit)
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -200,11 +155,7 @@ class AccountLinksService:
 
     def _fetch_decision(self, decision_id: str) -> dict[str, Any] | None:
         """Read one decision row by id. Returns None when not found."""
-        row = self._db.execute(
-            f"SELECT {_DECISION_COLS} FROM {ACCOUNT_LINK_DECISIONS.full_name} WHERE decision_id = ?",  # noqa: S608  # constant columns + TableRef + parameterized pk
-            [decision_id],
-        ).fetchone()
-        return _decode_decision_row(row) if row else None
+        return self._decisions.fetch_by_id(decision_id)
 
     # ------------------------------------------------------------------
     # Mutations

--- a/src/moneybin/services/account_resolver.py
+++ b/src/moneybin/services/account_resolver.py
@@ -100,7 +100,25 @@ class AccountResolver:
 
         Ladder: explicit binding (step 0) -> strong confirmer / idempotency
         (step 1, A3) -> candidate pass / mint + propose (step 2, A4).
+
+        All writes for one account run in a single transaction (atomic per
+        account): a mid-resolve failure rolls back, so a later same-id import
+        cannot adopt a half-written account. resolve() owns the transaction —
+        it is always called outside one (the per-write repo transactions it
+        composes succeed today, proving no enclosing transaction), so the
+        composed writes pass in_outer_txn=True to join this one.
         """
+        self._db.begin()
+        try:
+            result = self._run_ladder(src)
+        except BaseException:
+            self._db.rollback()
+            raise
+        self._db.commit()
+        return result
+
+    def _run_ladder(self, src: SourceAccount) -> ResolvedAccount:
+        """Resolution-ladder body; runs inside ``resolve()``'s transaction."""
         # Step 0 - explicit binding: caller pinned identity, adopt above detection.
         if src.explicit_account_id:
             self._write_native_mapping(
@@ -160,6 +178,7 @@ class AccountResolver:
                 decided_by="auto",
                 actor=self._actor,
                 match_reason=cand.signal,
+                in_outer_txn=True,  # joins resolve()'s per-account transaction
             )
             ACCOUNT_LINK_CONFIDENCE.observe(cand.confidence)
             pending_ids.append(decision_id)
@@ -319,6 +338,7 @@ class AccountResolver:
             source_origin=src.source_origin,
             decided_by=decided_by,
             actor=self._actor,
+            in_outer_txn=True,  # joins resolve()'s per-account transaction
         )
 
     def _lookup_strong_ref(self, src: SourceAccount) -> tuple[str, str] | None:
@@ -407,6 +427,7 @@ class AccountResolver:
                 source_origin=src.source_origin,
                 decided_by=decided_by,
                 actor=self._actor,
+                in_outer_txn=True,  # joins resolve()'s per-account transaction
             )
 
     def _find_candidates(

--- a/src/moneybin/services/account_resolver.py
+++ b/src/moneybin/services/account_resolver.py
@@ -119,6 +119,10 @@ class AccountResolver:
         # Step 2 - candidate pass. Mint first (never orphaned), then propose.
         account_id = uuid.uuid4().hex[:12]
         self._write_native_mapping(src, account_id=account_id, decided_by="auto")
+        # Claim the mint's strong refs (persistent_token / scoped full_number) so
+        # a later source carrying the same id auto-adopts (step 1) instead of
+        # minting a duplicate. Safe: step 1 above already proved no conflict.
+        self._write_strong_ref(src, account_id=account_id, decided_by="auto")
 
         candidates = self._find_candidates(src, exclude_account_id=account_id)
         if not candidates:

--- a/src/moneybin/services/account_resolver.py
+++ b/src/moneybin/services/account_resolver.py
@@ -53,6 +53,24 @@ def refresh_account_link_pending_gauge(db: Database) -> None:
     ACCOUNT_LINK_REVIEW_PENDING.set(int(row[0]) if row else 0)
 
 
+def fetch_display_name(db: Database, account_id: str) -> str:
+    """Return ``display_name`` from ``core.dim_accounts``; empty string when absent.
+
+    Shared by the resolver's candidate decode and the account-link review queue.
+    Guards ``duckdb.CatalogException`` so callers work before the core layer is
+    materialized (e.g. during initial import before a SQLMesh run).
+    """
+    try:
+        row = db.execute(
+            f"SELECT display_name FROM {DIM_ACCOUNTS.full_name} "  # noqa: S608  # TableRef constant + parameterized value
+            "WHERE account_id = ? LIMIT 1",
+            [account_id],
+        ).fetchone()
+    except duckdb.CatalogException:
+        return ""
+    return str(row[0]) if row and row[0] is not None else ""
+
+
 @dataclass(frozen=True)
 class _Candidate:
     """A weak-signal candidate for a pending merge proposal.
@@ -265,17 +283,8 @@ class AccountResolver:
         )
 
     def _fetch_display_name(self, account_id: str) -> str:
-        """Return display_name from core.dim_accounts for a candidate account_id.
-
-        Returns empty string when the row is absent (defensive; if _find_candidates
-        returned a candidate, dim_accounts is materialized and the row should exist).
-        """
-        row = self._db.execute(
-            f"SELECT display_name FROM {DIM_ACCOUNTS.full_name} "  # noqa: S608  # TableRef + parameterized value
-            "WHERE account_id = ? LIMIT 1",
-            [account_id],
-        ).fetchone()
-        return str(row[0]) if row and row[0] is not None else ""
+        """Return display_name from core.dim_accounts for a candidate account_id."""
+        return fetch_display_name(self._db, account_id)
 
     def _write_native_mapping(
         self, src: SourceAccount, *, account_id: str, decided_by: str

--- a/src/moneybin/services/account_resolver.py
+++ b/src/moneybin/services/account_resolver.py
@@ -30,6 +30,7 @@ from moneybin.services.account_resolution_types import (
     SourceAccount,
 )
 from moneybin.tables import ACCOUNT_LINK_DECISIONS, ACCOUNT_LINKS, DIM_ACCOUNTS
+from moneybin.utils import slugify
 
 logger = logging.getLogger(__name__)
 
@@ -406,20 +407,26 @@ class AccountResolver:
         try:
             out: list[_Candidate] = []
             if src.last_four and src.institution:
+                # institution_name holds raw source text (OFX <ORG> "CHASE"),
+                # while src.institution may be a slug ("chase"). An exact SQL
+                # match never fires across that case/format gap, so fetch by the
+                # exact last_four and slugify-compare the institution in Python.
+                target_inst = slugify(src.institution)
                 rows = self._db.execute(
-                    f"SELECT account_id FROM {DIM_ACCOUNTS.full_name} "  # noqa: S608  # TableRef + parameterized values
-                    "WHERE last_four = ? AND institution_name = ? AND account_id != ?",
-                    [src.last_four, src.institution, exclude_account_id],
+                    f"SELECT account_id, institution_name FROM {DIM_ACCOUNTS.full_name} "  # noqa: S608  # TableRef + parameterized values
+                    "WHERE last_four = ? AND account_id != ?",
+                    [src.last_four, exclude_account_id],
                 ).fetchall()
                 # confidence is informational only — weak signals always go to review.
                 out.extend(
                     _Candidate(
                         account_id=str(r[0]),
                         signal="institution_last4",
-                        value=f"{src.institution}:{src.last_four}",
+                        value=f"{target_inst}:{src.last_four}",
                         confidence=0.5,
                     )
                     for r in rows
+                    if r[1] and slugify(str(r[1])) == target_inst
                 )
             if out:
                 return out

--- a/src/moneybin/services/account_resolver.py
+++ b/src/moneybin/services/account_resolver.py
@@ -419,12 +419,17 @@ class AccountResolver:
         """
         try:
             out: list[_Candidate] = []
-            if src.last_four and src.institution:
+            if (
+                src.last_four
+                and src.institution
+                and (target_inst := slugify(src.institution))
+            ):
                 # institution_name holds raw source text (OFX <ORG> "CHASE"),
                 # while src.institution may be a slug ("chase"). An exact SQL
                 # match never fires across that case/format gap, so fetch by the
                 # exact last_four and slugify-compare the institution in Python.
-                target_inst = slugify(src.institution)
+                # An empty slug (institution is all punctuation) is skipped — it
+                # would spuriously match other empty-slug rows sharing last_four.
                 rows = self._db.execute(
                     f"SELECT account_id, institution_name FROM {DIM_ACCOUNTS.full_name} "  # noqa: S608  # TableRef + parameterized values
                     "WHERE last_four = ? AND account_id != ?",

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -494,7 +494,10 @@ def _apply_account_bindings(
                     src, force_standalone=True, explicit_account_id=None
                 )
             )
-        elif not target:
+        elif not target.strip():
+            # Reject whitespace-only too: CLI input is not stripped (_parse_kv
+            # keeps the raw value) and MCP passes JSON as-is, so a bare-spaces
+            # value would otherwise be truthy and bind a bogus account_id.
             raise ValueError(
                 f"account_bindings for source key {src.source_account_key!r} "
                 'has an empty value; use an existing account_id or "new".'

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -476,6 +476,10 @@ def _apply_account_bindings(
     account, skip the merge-candidate pass); any other value is an existing
     canonical ``account_id`` to adopt (``explicit_account_id``). Unbound
     accounts pass through unchanged so the gate can still surface them.
+
+    Raises ``ValueError`` on an empty binding value — ``explicit_account_id=""``
+    is falsy and would silently fall through to a fresh mint as if no binding
+    were given, discarding the caller's intent ("magic stays visible").
     """
     if not bindings:
         return source_accounts
@@ -489,6 +493,11 @@ def _apply_account_bindings(
                 dataclasses.replace(
                     src, force_standalone=True, explicit_account_id=None
                 )
+            )
+        elif not target:
+            raise ValueError(
+                f"account_bindings for source key {src.source_account_key!r} "
+                'has an empty value; use an existing account_id or "new".'
             )
         else:
             bound.append(dataclasses.replace(src, explicit_account_id=target))

--- a/src/moneybin/utils/parsing.py
+++ b/src/moneybin/utils/parsing.py
@@ -57,3 +57,18 @@ def coerce_to_decimal(v: Any) -> Decimal | None:
                 return None
         return Decimal(str(v))
     raise ValueError(f"Cannot convert {type(v)} to Decimal")
+
+
+def signal_from_match_signals(match_signals: Any) -> str:
+    """Extract the ``'signal'`` key from an already-decoded match_signals dict.
+
+    ``account_link_decisions`` rows store ``match_signals`` as JSON; the repo's
+    ``_decode_row`` returns it as a ``dict``. The ``Any`` annotation also covers
+    the raw read path. Uses try/except to avoid pyright's
+    ``dict[Unknown, Unknown]`` narrowing issue after ``isinstance`` checks on
+    ``Any``-typed inputs. Returns ``""`` when the key/shape is absent.
+    """
+    try:
+        return str(match_signals["signal"])
+    except (KeyError, TypeError):
+        return ""

--- a/tests/moneybin/test_cli/test_import_commands.py
+++ b/tests/moneybin/test_cli/test_import_commands.py
@@ -1,4 +1,6 @@
 # ruff: noqa: S101,S106
+# TestConfirmationEnvelopeData tests the module-private _confirmation_envelope_data builder:
+# pyright: reportPrivateUsage=false
 """Tests for import CLI commands.
 
 Tests CLI-specific functionality: argument parsing, exit codes, error handling.
@@ -495,3 +497,46 @@ class TestImportStatusCommand:
         assert result.exit_code == 0
         assert "ofx_transactions" in result.output
         assert "2 rows" in result.output
+
+
+class TestConfirmationEnvelopeData:
+    """`_confirmation_envelope_data` is the single CLI confirmation_required builder.
+
+    It must produce the canonical `confirmation_payload_dict` shape (so the CLI
+    and MCP `confirmation_required` envelopes cannot drift) plus a leading
+    `status` field — including `bridge_payload` for the PDF bridge channel.
+    """
+
+    @staticmethod
+    def _bridge_outcome() -> Any:
+        from moneybin.extractors.confidence import Confidence
+        from moneybin.services.import_confirmation import (
+            BridgePayload,
+            ConfirmationRequired,
+        )
+
+        return ConfirmationRequired(
+            channel="pdf",
+            confidence=Confidence(
+                score=0.4, tier="low", flagged=(), missing_required=()
+            ),
+            proposed=BridgePayload(payload={"ir": "request"}),
+            reason="validation_failure",
+        )
+
+    def test_bridge_payload_is_carried(self) -> None:
+        from moneybin.cli.commands.import_cmd import _confirmation_envelope_data
+
+        data = _confirmation_envelope_data(self._bridge_outcome())
+        assert data["bridge_payload"] == {"ir": "request"}
+
+    def test_matches_canonical_helper_plus_status(self) -> None:
+        from moneybin.cli.commands.import_cmd import _confirmation_envelope_data
+        from moneybin.services.import_confirmation import confirmation_payload_dict
+
+        outcome = self._bridge_outcome()
+        data = _confirmation_envelope_data(outcome)
+        assert data == {
+            "status": "confirmation_required",
+            **confirmation_payload_dict(outcome),
+        }

--- a/tests/moneybin/test_repositories/test_account_link_decisions_repo.py
+++ b/tests/moneybin/test_repositories/test_account_link_decisions_repo.py
@@ -303,6 +303,29 @@ def test_history_respects_limit(db: Database) -> None:
     assert len(repo.history(limit=2)) == 2
 
 
+def test_history_orders_newest_first(db: Database) -> None:
+    """history() orders by decided_at DESC (newest decision first).
+
+    insert stamps decided_at (NOT NULL), so distinct timestamps are set
+    explicitly here to pin ordering deterministically rather than relying on
+    same-tick inserts.
+    """
+    repo = AccountLinkDecisionsRepo(db)
+    _insert(repo, decision_id="older", status="accepted")
+    _insert(repo, decision_id="newer", status="accepted")
+    db.conn.execute(
+        "UPDATE app.account_link_decisions SET decided_at = ? WHERE decision_id = ?",
+        ["2026-01-01 00:00:00", "older"],
+    )
+    db.conn.execute(
+        "UPDATE app.account_link_decisions SET decided_at = ? WHERE decision_id = ?",
+        ["2026-06-01 00:00:00", "newer"],
+    )
+
+    ids = [r["decision_id"] for r in repo.history()]
+    assert ids == ["newer", "older"]
+
+
 def test_history_clamps_negative_limit(db: Database) -> None:
     """A negative limit must not reach DuckDB (LIMIT/OFFSET cannot be negative)."""
     repo = AccountLinkDecisionsRepo(db)

--- a/tests/moneybin/test_repositories/test_account_link_decisions_repo.py
+++ b/tests/moneybin/test_repositories/test_account_link_decisions_repo.py
@@ -258,3 +258,46 @@ def test_list_pending_decodes_match_signals(db: Database) -> None:
     signals = result[0]["match_signals"]
     assert isinstance(signals, dict)
     assert signals["signal"] == "institution_last4"
+
+
+# -- fetch_by_id --
+
+
+def test_fetch_by_id_returns_decoded_row(db: Database) -> None:
+    repo = AccountLinkDecisionsRepo(db)
+    _insert(repo, decision_id="dec_fetch", status="pending")
+
+    row = repo.fetch_by_id("dec_fetch")
+    assert row is not None
+    assert row["decision_id"] == "dec_fetch"
+    assert row["provisional_account_id"] == "acct_prov_1"
+    assert row["candidate_account_id"] == "acct_cand_1"
+    # match_signals decodes to a nested object (not doubly-encoded).
+    assert row["match_signals"]["signal"] == "institution_last4"
+
+
+def test_fetch_by_id_returns_none_when_absent(db: Database) -> None:
+    repo = AccountLinkDecisionsRepo(db)
+    assert repo.fetch_by_id("nonexistent") is None
+
+
+# -- history --
+
+
+def test_history_includes_all_statuses(db: Database) -> None:
+    """history() spans every status — unlike list_pending, which is pending-only."""
+    repo = AccountLinkDecisionsRepo(db)
+    _insert(repo, decision_id="h_pending", status="pending")
+    _insert(repo, decision_id="h_accepted", status="accepted")
+    _insert(repo, decision_id="h_rejected", status="rejected")
+
+    ids = {r["decision_id"] for r in repo.history()}
+    assert ids == {"h_pending", "h_accepted", "h_rejected"}
+
+
+def test_history_respects_limit(db: Database) -> None:
+    repo = AccountLinkDecisionsRepo(db)
+    for i in range(3):
+        _insert(repo, decision_id=f"h_{i}", status="pending")
+
+    assert len(repo.history(limit=2)) == 2

--- a/tests/moneybin/test_repositories/test_account_link_decisions_repo.py
+++ b/tests/moneybin/test_repositories/test_account_link_decisions_repo.py
@@ -301,3 +301,31 @@ def test_history_respects_limit(db: Database) -> None:
         _insert(repo, decision_id=f"h_{i}", status="pending")
 
     assert len(repo.history(limit=2)) == 2
+
+
+def test_history_clamps_negative_limit(db: Database) -> None:
+    """A negative limit must not reach DuckDB (LIMIT/OFFSET cannot be negative)."""
+    repo = AccountLinkDecisionsRepo(db)
+    _insert(repo, decision_id="d1", status="pending")
+
+    # Must not raise duckdb.BinderException; clamps to an empty result.
+    assert repo.history(limit=-1) == []
+
+
+# -- missing-table resilience (CatalogException guard) --
+
+
+def test_list_pending_returns_empty_when_table_absent(db: Database) -> None:
+    """list_pending guards a missing table like count_pending/history do."""
+    db.conn.execute("DROP TABLE app.account_link_decisions")
+    repo = AccountLinkDecisionsRepo(db)
+
+    assert repo.list_pending() == []
+
+
+def test_fetch_by_id_returns_none_when_table_absent(db: Database) -> None:
+    """fetch_by_id returns None (clean not-found) rather than raising on a fresh DB."""
+    db.conn.execute("DROP TABLE app.account_link_decisions")
+    repo = AccountLinkDecisionsRepo(db)
+
+    assert repo.fetch_by_id("dec00000001") is None

--- a/tests/moneybin/test_services/test_account_resolver.py
+++ b/tests/moneybin/test_services/test_account_resolver.py
@@ -289,6 +289,29 @@ def test_institution_last4_matches_across_case(db: Database) -> None:
     assert dec == (first.account_id, "institution_last4")
 
 
+def test_institution_last4_skips_when_slug_is_empty(db: Database) -> None:
+    """A purely non-alphanumeric institution slugifies to '' and must not match.
+
+    '###' and '@@@' both slugify to '' (slugify strips non-alphanumerics), so an
+    empty slug would otherwise spuriously equal any stored institution that also
+    slugifies to '' sharing the last_four — a false merge proposal. The
+    institution+last4 rung is skipped when the slug is empty.
+    """
+    create_core_tables(db)
+    resolver = AccountResolver(db, actor="system")
+    first = resolver.resolve(_src(source_account_key="a", institution="@@@"))
+    _seed_dim_account(
+        db,
+        account_id=first.account_id,
+        last_four="4267",
+        institution_name="@@@",  # slugifies to ''
+    )
+    second = resolver.resolve(
+        _src(source_type="ofx", source_account_key="ofx-x", institution="###")
+    )
+    assert second.outcome == "minted_new"
+
+
 def test_mint_claims_full_number_strong_ref_for_later_adopt(db: Database) -> None:
     """A minted account claims its scoped full_number so a later source adopts it.
 

--- a/tests/moneybin/test_services/test_account_resolver.py
+++ b/tests/moneybin/test_services/test_account_resolver.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -582,3 +583,23 @@ def test_propose_existing_guards_catalog_exception(db: Database) -> None:
     # No create_core_tables call → dim_accounts absent → CatalogException guarded
     resolver = AccountResolver(db, actor="system")
     assert resolver.propose_existing("any_id") is None
+
+
+def test_resolve_rolls_back_partial_writes_on_failure(db: Database) -> None:
+    """resolve() is atomic per account: a mid-resolve failure rolls everything back.
+
+    _write_strong_ref runs after _write_native_mapping in every branch. Forcing
+    it to raise leaves the native mapping mid-flight; without a single enclosing
+    transaction the mapping would auto-commit and a later same-id import would
+    adopt a half-written account.
+    """
+    create_core_tables(db)
+    resolver = AccountResolver(db, actor="system")
+    with patch.object(
+        AccountResolver, "_write_strong_ref", side_effect=RuntimeError("boom")
+    ):
+        with pytest.raises(RuntimeError):
+            resolver.resolve(_src(account_number="121000248:1111"))
+
+    n = db.conn.execute("SELECT COUNT(*) FROM app.account_links").fetchone()
+    assert n is not None and n[0] == 0

--- a/tests/moneybin/test_services/test_account_resolver.py
+++ b/tests/moneybin/test_services/test_account_resolver.py
@@ -289,6 +289,45 @@ def test_institution_last4_matches_across_case(db: Database) -> None:
     assert dec == (first.account_id, "institution_last4")
 
 
+def test_mint_claims_full_number_strong_ref_for_later_adopt(db: Database) -> None:
+    """A minted account claims its scoped full_number so a later source adopts it.
+
+    Without claiming the strong ref on mint, a second source carrying the same
+    scoped full number mints a DUPLICATE instead of auto-adopting the same real
+    account (step 1 already proved no conflict, so the claim is safe).
+    """
+    create_core_tables(db)
+    resolver = AccountResolver(db, actor="system")
+    # First import mints (empty dim_accounts → no candidates) and must claim the
+    # scoped full_number strong ref.
+    first = resolver.resolve(
+        _src(
+            source_type="ofx",
+            source_origin="chase",
+            source_account_key="1111",
+            account_number="121000248:1111",
+            last_four=None,
+            institution=None,
+        )
+    )
+    assert first.is_new is True
+    assert first.outcome == "minted_new"
+    # A different source carrying the SAME scoped full_number auto-adopts.
+    second = resolver.resolve(
+        _src(
+            source_type="csv",
+            source_origin="chase-csv",
+            source_account_key="chk",
+            account_number="121000248:1111",
+            last_four=None,
+            institution=None,
+        )
+    )
+    assert second.account_id == first.account_id
+    assert second.is_new is False
+    assert second.outcome == "adopted_strong"
+
+
 def test_force_standalone_mints_despite_candidates(db: Database) -> None:
     """force_standalone declares a NEW account, skipping the merge-candidate pass."""
     create_core_tables(db)

--- a/tests/moneybin/test_services/test_account_resolver.py
+++ b/tests/moneybin/test_services/test_account_resolver.py
@@ -255,6 +255,40 @@ def test_institution_last4_writes_pending_never_merges(db: Database) -> None:
     assert dec == (second.account_id, first.account_id, "pending")
 
 
+def test_institution_last4_matches_across_case(db: Database) -> None:
+    """institution+last4 fires when the stored ORG differs in case from the slug.
+
+    OFX stores institution_name as raw ``<ORG>`` (e.g. ``CHASE``); a later import
+    carries the slug (``chase``). An exact text match would never fire — both
+    must slugify-compare equal for the cross-source signal to surface.
+    """
+    create_core_tables(db)
+    resolver = AccountResolver(db, actor="system")
+    first = resolver.resolve(_src(source_account_key="chase-a", institution="chase"))
+    _seed_dim_account(
+        db,
+        account_id=first.account_id,
+        last_four="4267",
+        institution_name="CHASE",  # raw OFX <ORG>, uppercase
+    )
+    second = resolver.resolve(
+        _src(
+            source_type="ofx",
+            source_account_key="ofx-4267",
+            last_four="4267",
+            institution="chase",
+        )
+    )
+    assert second.outcome == "pending_review"
+    assert len(second.pending_decision_ids) == 1
+    dec = db.conn.execute(
+        "SELECT candidate_account_id, match_reason "
+        "FROM app.account_link_decisions WHERE decision_id = ?",
+        [second.pending_decision_ids[0]],
+    ).fetchone()
+    assert dec == (first.account_id, "institution_last4")
+
+
 def test_force_standalone_mints_despite_candidates(db: Database) -> None:
     """force_standalone declares a NEW account, skipping the merge-candidate pass."""
     create_core_tables(db)

--- a/tests/moneybin/test_services/test_import_binding.py
+++ b/tests/moneybin/test_services/test_import_binding.py
@@ -289,6 +289,32 @@ def test_account_bindings_rejects_unknown_source_key(
         db.close()
 
 
+def test_account_bindings_rejects_empty_value(
+    mock_secret_store: MagicMock, tmp_path: Path
+) -> None:
+    """An empty binding value fails loud, not a silent fall-through to mint.
+
+    `explicit_account_id=""` is falsy, so without the guard the resolver would
+    skip the explicit-adopt path and mint fresh as if no binding was given.
+    """
+    db = _db(mock_secret_store, tmp_path)
+    try:
+        svc = ImportService(db)
+        with pytest.raises(ValueError, match="empty value"):
+            svc.import_file(
+                _STANDARD_CSV,
+                account_name="WF Checking",
+                refresh=False,
+                confirm=True,
+                actor_kind="human",
+                account_bindings={"wf-checking": ""},
+            )
+        n = db.execute("SELECT COUNT(*) FROM app.account_links").fetchone()
+        assert n is not None and n[0] == 0
+    finally:
+        db.close()
+
+
 def test_metadata_not_captured_for_pending_provisional(
     mock_secret_store: MagicMock, tmp_path: Path
 ) -> None:

--- a/tests/moneybin/test_services/test_import_binding.py
+++ b/tests/moneybin/test_services/test_import_binding.py
@@ -289,13 +289,16 @@ def test_account_bindings_rejects_unknown_source_key(
         db.close()
 
 
+@pytest.mark.parametrize("bad_value", ["", "   ", "\t"])
 def test_account_bindings_rejects_empty_value(
-    mock_secret_store: MagicMock, tmp_path: Path
+    mock_secret_store: MagicMock, tmp_path: Path, bad_value: str
 ) -> None:
-    """An empty binding value fails loud, not a silent fall-through to mint.
+    """An empty or whitespace-only binding value fails loud, not a silent mint.
 
-    `explicit_account_id=""` is falsy, so without the guard the resolver would
-    skip the explicit-adopt path and mint fresh as if no binding was given.
+    A falsy/whitespace `explicit_account_id` would otherwise skip the
+    explicit-adopt path and mint fresh as if no binding was given. CLI input is
+    not stripped (`_parse_kv` keeps the raw value) and MCP passes JSON as-is, so
+    the guard must reject whitespace-only too, not just the empty string.
     """
     db = _db(mock_secret_store, tmp_path)
     try:
@@ -307,7 +310,7 @@ def test_account_bindings_rejects_empty_value(
                 refresh=False,
                 confirm=True,
                 actor_kind="human",
-                account_bindings={"wf-checking": ""},
+                account_bindings={"wf-checking": bad_value},
             )
         n = db.execute("SELECT COUNT(*) FROM app.account_links").fetchone()
         assert n is not None and n[0] == 0

--- a/tests/moneybin/test_services/test_import_service_ofx.py
+++ b/tests/moneybin/test_services/test_import_service_ofx.py
@@ -111,11 +111,12 @@ class TestImportOFXAccountResolution:
         for new OFX imports. refresh=False skips the SQLMesh apply (no
         core.dim_accounts needed here).
 
-        Per account-identity-resolution.md Decision 3 step 2, the mint path writes
-        ONLY source_native; the scoped full_number is passed into the resolver (so
-        a later same-number import can adopt via step 1) but is NOT itself written
-        as an accepted strong ref on a fresh mint — asserted negatively below to
-        pin that contract. See the A7 report concern re: mint-time strong-ref write.
+        Per account-identity-resolution.md Decision 3 step 2, the mint path also
+        claims an accepted strong ref for every scoped confirmer the source carries
+        — here the OFX `full_number` (BANKID+ACCTID) — so a later source bearing the
+        same scoped number auto-adopts via step 1 instead of minting a duplicate.
+        Asserted positively below to pin that contract (resolves the A7 report
+        concern re: mint-time strong-ref write).
         """
         fixture = Path("tests/fixtures/ofx/sample_minimal.ofx")
         if not fixture.exists():
@@ -136,8 +137,8 @@ class TestImportOFXAccountResolution:
         assert len(native) == 1
         assert len(native[0][0]) == 12  # minted canonical uuid4[:12]
 
-        # Spec Decision 3 step 2: a fresh mint records source_native only; the
-        # scoped full_number is not yet an accepted strong ref.
+        # Spec Decision 3 step 2: a fresh mint also claims the scoped full_number
+        # strong ref so a later same-number source auto-adopts (no duplicate).
         full_number = db.execute(
             """
             SELECT COUNT(*) FROM app.account_links
@@ -145,4 +146,4 @@ class TestImportOFXAccountResolution:
               AND source_type = 'ofx'
             """,
         ).fetchone()
-        assert full_number is not None and full_number[0] == 0
+        assert full_number is not None and full_number[0] == 1


### PR DESCRIPTION
## Summary

Follow-up work on the M1S account-identity resolution feature: fixes a cross-source duplicate-account bug, hardens the account-link read/input surface, and dedups internals introduced across the M1S.4–.6 PRs. The headline behavioral fix is **strong-refs-on-mint** — a freshly minted account now claims its scoped strong references (`full_number` / `persistent_token`), so a later import of the same real account auto-adopts it instead of minting a duplicate.

## Background

The resolution ladder previously wrote only the `source_native` mapping when minting; the scoped `full_number` / `persistent_token` strong refs were claimed only on explicit-bind/adopt. That left a gap: an OFX-first (or Plaid-first) mint never *claimed* its strong ref, so a second source carrying the same scoped number minted a duplicate canonical account instead of auto-adopting. This was a deliberately-deferred decision in the original spec; the PR implements it (safe — the strong-confirmer pass already proved no conflict) and updates `account-identity-resolution.md` Decision 3 step 2 + the outcomes table to match.

`AccountResolver.resolve()` is now also **atomic per account**: the source-native mapping, strong refs, and candidate decisions commit in one transaction, so a mid-resolve failure can't leave a half-written account a later import would adopt.

## Changes

- **Resolution** (`account_resolver.py`): mint claims scoped strong refs (cross-source auto-adopt); `resolve()` wrapped in one per-account transaction; the institution+last4 candidate pass slugify-compares (fires across OFX `<ORG>` case differences) and skips empty slugs.
- **Account-link surface hardening:** repo `list_pending`/`fetch_by_id` guard the not-yet-created table (matching `count_pending`/`history`); `history` clamps a negative limit; empty/whitespace `account_bindings` values fail loud.
- **Dedup:** CLI confirmation envelope routes through the canonical `confirmation_payload_dict` (one builder for CLI + MCP, carrying `bridge_payload`); account-link payload builders extracted to shared `from_*` mappers; decision-row decode + display-name lookup consolidated; `signal_from_match_signals` moved to `utils.parsing` (removes a payload→service import).
- **Docs:** spec Decision 3 step 2 + outcomes table; `dim_accounts.sql` comment corrections.

## Test plan

- [ ] `make test` — full unit suite green (4335 passed, 4 skipped)
- [ ] `uv run pytest -m scenarios tests/scenarios/test_account_identity_cross_source.py tests/scenarios/test_dedup_cross_source.py` — cross-source collapse preserved
- [ ] New coverage: strong-ref-on-mint adopt path, empty-slug skip, per-account rollback on failure, CatalogException guards, negative-limit clamp, whitespace-binding rejection, `bridge_payload` parity
- [ ] `make check` — ruff + pyright clean on changed files

## Related

- Follows #254, #255 (M1S.4–.6 account-binding work)
