### PR TITLE
Account identity: bind-first + exporter/institution split, with de-shortcut scenario (M1S.8/.9)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -194,3 +194,49 @@ When authoring or modifying a scenario:
 5. **Negative expectations are required where applicable.** If a scenario asserts "these N records should match," it must also include cases that should *not* match. Otherwise the test only catches under-matching, not over-matching.
 
 This rule applies to YAML scenario expectations, pytest assertions in `tests/scenarios/`, and any future bug-report-driven scenario. See [`docs/specs/testing-scenario-comprehensive.md`](../../docs/specs/testing-scenario-comprehensive.md) for the full taxonomy and contributor recipe.
+
+## No Shortcuts: Exercise the Real Mechanism
+
+A test or scenario must reach its asserted state through the **same mechanism a
+real user or agent would use**. Never pre-wire the end state to make an
+assertion pass when the mechanism that produces that state is the thing under
+test. A green test that bypasses the mechanism proves nothing about the
+mechanism — it hides bugs.
+
+**The canonical failure this rule exists to prevent:** cross-source account
+linking was silently broken in the wild through ~6 days of development because
+the only cross-source scenario *forced* the CSV→OFX account link — via
+`account_bindings` (the import path) and a shared `account:` label on the
+fixture pair (the `load_fixtures` path) — instead of letting the account matcher
+fire. The scenario stayed green the entire time while automatic matching never
+once worked. See `account-identity-resolution.md` (Decision 8).
+
+**When the mechanism IS what the scenario validates, never substitute for it:**
+
+- **Account identity / matching:** don't force the link with `account_bindings`,
+  a shared `account:` fixture label, a pinned `account_id`/`explicit_account_id`,
+  `force_standalone`, or a direct `INSERT INTO app.account_links`. Import the raw
+  twins and let `AccountResolver` produce the proposal.
+- **Derived `core.*` / pipeline-owned `app.*` state:** don't `INSERT` rows the
+  pipeline is supposed to derive (`dim_*` rows, match decisions, categorizations,
+  gold records) and then assert on them. Run `transform` / `match` / `categorize`
+  and assert what the pipeline produced.
+- **Propose→review→confirm flows:** don't skip the gate and write the accepted
+  state directly when the gating behavior is under test. Drive the real verb
+  (`import_confirm`, the link-review accept) the way the user/agent would.
+
+**The dividing line — explicit vs automatic are BOTH real, and each needs its
+own scenario.** Explicit binding/seeding *is* a legitimate user mechanism; use it
+only in a scenario whose point is that explicit path ("user binds a CSV to a
+known account"). A capability reachable two ways (explicit binding **and**
+automatic matching) needs a scenario for **each**, and the automatic one must
+drive the automatic path end-to-end — import raw → run the matcher/resolver →
+accept the proposal as a user would → assert the derived result. The automatic
+scenario must not borrow the explicit scenario's shortcut. Isolating a
+downstream mechanism (e.g. transaction dedup) behind a forced upstream link
+(account assignment) is acceptable **only when** a separate scenario proves that
+upstream link forms through its real mechanism — otherwise the chain is untested.
+
+If making a test pass tempts you to set up the answer directly, stop: either the
+mechanism is broken (fix it) or the test belongs at a layer where that state is a
+real input, not a shortcut.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,15 @@ M2 closing out and M3 underway. M2A curator state shipped (transaction notes, ta
   accounts rendered as `Institution Type` with the last-4 fragment dropped
   because `last_four` was NULL; `core.dim_accounts.display_name` now shows the
   derived last 4 (`Institution Type …NNNN`). (#257)
+- **Multi-account (Tiller-style) imports record each account's own institution
+  (M1S.9).** For a multi-account exporter format with a per-row Institution
+  column, every account now gets its own institution (which the cross-source
+  bridge can use) instead of a single shared exporter/tool name stamped on all of
+  them. (#258)
+- **Saved tabular formats no longer store an account label as their institution
+  (M1S.8).** An auto-saved format records its resolved (filename/format)
+  institution or `unknown`, never the per-account `--account-name` — a format
+  describes a column layout, not an account. (#258)
 
 ### Added
 - **PDF import (seed path).** Native-text PDFs import via `moneybin import <file.pdf>` and the inbox; their tables land as a queryable JSON seed (`raw.pdf_seeds`) with an auto-generated typed view (`raw.pdf_<alias>`), reversible like any import. Mapping PDFs to transactions/core is a later phase.

--- a/src/moneybin/services/account_resolver.py
+++ b/src/moneybin/services/account_resolver.py
@@ -348,6 +348,14 @@ class AccountResolver:
         (cross-connection identity), then scoped full_number (cross-source format).
         The ref_kind is surfaced so propose() can populate adopted_via accurately.
         """
+        # A source_native ref is the EXACT source_account_key (a slug). For a
+        # mutable-label source (CSV / aggregator export) that slug derives from
+        # the account label, so a RENAMED account yields a DIFFERENT slug and
+        # misses here by design — it then falls through to the candidate pass,
+        # which re-associates it onto the original account via institution+last4
+        # as a review PROPOSAL (never a silent merge). Decision 8
+        # (account-identity-resolution.md): a mutable label is a Tier-B
+        # suggestion, not a hard auto-adopt key.
         row = self._db.execute(
             f"SELECT account_id FROM {ACCOUNT_LINKS.full_name} "  # noqa: S608  # TableRef + parameterized values
             "WHERE status = 'accepted' AND ref_kind = 'source_native' "

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -1409,8 +1409,9 @@ class ImportService:
                     if l4 := _last4_from_account_number(value):
                         number_last4_by_key[aid] = l4
             # Per-account institution from a mapped Institution column (Tiller-style):
-            # first non-null value per account key. The institution embedded in a
-            # Monarch-style account LABEL is not parsed here (future increment).
+            # first non-null value per account key. An institution embedded only in a
+            # Monarch-style account LABEL is not parsed here — label→institution
+            # parsing is not implemented.
             inst_col = resolved.field_mapping.get("institution_name")
             if inst_col and inst_col in df.columns:
                 for nm, inst_val in zip(raw_names, df[inst_col].to_list(), strict=True):

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -1546,12 +1546,20 @@ class ImportService:
         # the multi-account branch actually ran (no explicit --account-name/
         # --account-id); an explicit account on a multi-account-detected format
         # keeps the shared format/file institution (Decision 8). Single-account
-        # uses the shared institution for its one row (unchanged).
+        # uses the shared institution for its one row.
+        #
+        # Fall back to resolved_institution (the filename/format value captured at
+        # Stage 1) because Stage 5 above clobbers `institution` to None for an
+        # unregistered import (no matched_format). Without it the account's dim row
+        # stores institution_name=NULL, and a later cross-source twin can't match it
+        # on (institution, last4) — breaking the CSV-first matching direction.
         per_account_inst = (
             resolved.is_multi_account and not account_id and not account_name
         )
         account_institutions = [
-            multi_acct_inst.get(aid) if per_account_inst else institution
+            multi_acct_inst.get(aid)
+            if per_account_inst
+            else (institution or resolved_institution)
             for aid in unique_ids
         ]
         account_df = pl.DataFrame({

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -1592,7 +1592,11 @@ class ImportService:
             try:
                 detected_fmt = TabularFormat(
                     name=source_origin,
-                    institution_name=account_name or source_origin,
+                    # Institution is best-effort metadata; the per-account label
+                    # (account_name) must NEVER land here — a format describes a
+                    # column layout, not an account (bug #5). "unknown" when no
+                    # institution resolved; the exporter/format identity is `name`.
+                    institution_name=institution or "unknown",
                     file_type=format_info.file_type,
                     delimiter=format_info.delimiter,
                     encoding=format_info.encoding,

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -1295,6 +1295,10 @@ class ImportService:
         # source_origin scopes the source_native key; compute before resolution so
         # raw.* and app.account_links.source_origin stay identical (a later staging
         # JOIN keys on it). Do NOT change how source_origin is derived.
+        # This is the EXPORTER / format identity (Monarch / Tiller / bank export,
+        # or the account slug for an unregistered single file) — orthogonal to the
+        # per-account institution, which is resolved separately and, for
+        # multi-account exporters, comes from row data (Decision 8).
         source_origin = (
             matched_format.name
             if matched_format

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -1325,6 +1325,11 @@ class ImportService:
         # when a label carries none (e.g. "Checking" alongside an "Account Number"
         # column). Keyed by native account key.
         number_last4_by_key: dict[str, str | None] = {}
+        # Per-account institution for multi-account exporter formats, from a mapped
+        # Institution column (Tiller-style); else None. NEVER the exporter/tool name
+        # (Decision 8 exporter/institution split). Single-account keeps the
+        # format/file institution unchanged.
+        multi_acct_inst: dict[str, str | None] = {}
 
         # Phase 1 — enumerate the source accounts this file presents (one per
         # native key) WITHOUT resolving, so the account-binding gate can run
@@ -1395,13 +1400,22 @@ class ImportService:
                         continue
                     if l4 := _last4_from_account_number(value):
                         number_last4_by_key[aid] = l4
+            # Per-account institution from a mapped Institution column (Tiller-style):
+            # first non-null value per account key. The institution embedded in a
+            # Monarch-style account LABEL is not parsed here (future increment).
+            inst_col = resolved.field_mapping.get("institution_name")
+            if inst_col and inst_col in df.columns:
+                for nm, inst_val in zip(raw_names, df[inst_col].to_list(), strict=True):
+                    key = slugify(nm)
+                    if key not in multi_acct_inst and inst_val:
+                        multi_acct_inst[key] = str(inst_val)
             source_accounts.extend(
                 SourceAccount(
                     source_type=source_type,
                     source_origin=source_origin,
                     source_account_key=native_key,
                     account_name=label_parsed_by_key[native_key][0],
-                    institution=institution,
+                    institution=multi_acct_inst.get(native_key),
                     last_four=(
                         label_parsed_by_key[native_key][1]
                         or number_last4_by_key.get(native_key)
@@ -1519,13 +1533,20 @@ class ImportService:
         for aid in acct_id_to_name:
             l4 = label_parsed_by_key[aid][1] or number_last4_by_key.get(aid)
             acct_id_to_last4[aid] = f"****{l4}" if l4 else None
+        # institution_name per account: multi-account exporters carry per-account
+        # institution from row data (Decision 8); single-account uses the
+        # format/file institution for its one row (unchanged).
+        account_institutions = [
+            multi_acct_inst.get(aid) if resolved.is_multi_account else institution
+            for aid in unique_ids
+        ]
         account_df = pl.DataFrame({
             "account_id": unique_ids,
             "account_name": [acct_id_to_name[aid] for aid in unique_ids],
             "account_number": [None] * len(unique_ids),
             "account_number_masked": [acct_id_to_last4[aid] for aid in unique_ids],
             "account_type": [None] * len(unique_ids),
-            "institution_name": [institution] * len(unique_ids),
+            "institution_name": account_institutions,
             "currency": [None] * len(unique_ids),
             "source_file": [str(file_path)] * len(unique_ids),
             "source_type": [source_type] * len(unique_ids),

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -1313,6 +1313,10 @@ class ImportService:
             ),
             cli_override=None,  # no --institution flag on tabular yet
         )
+        # Stage 5 reassigns `institution` for the account_df flow; keep the
+        # resolved (format / filename) value for the auto-save block below so a
+        # saved format records its real institution rather than always "unknown".
+        resolved_institution = institution
         resolver = AccountResolver(self._db, actor="system")
         bindings = account_bindings or {}
 
@@ -1537,11 +1541,16 @@ class ImportService:
         for aid in acct_id_to_name:
             l4 = label_parsed_by_key[aid][1] or number_last4_by_key.get(aid)
             acct_id_to_last4[aid] = f"****{l4}" if l4 else None
-        # institution_name per account: multi-account exporters carry per-account
-        # institution from row data (Decision 8); single-account uses the
-        # format/file institution for its one row (unchanged).
+        # institution_name per account: per-account institution applies only when
+        # the multi-account branch actually ran (no explicit --account-name/
+        # --account-id); an explicit account on a multi-account-detected format
+        # keeps the shared format/file institution (Decision 8). Single-account
+        # uses the shared institution for its one row (unchanged).
+        per_account_inst = (
+            resolved.is_multi_account and not account_id and not account_name
+        )
         account_institutions = [
-            multi_acct_inst.get(aid) if resolved.is_multi_account else institution
+            multi_acct_inst.get(aid) if per_account_inst else institution
             for aid in unique_ids
         ]
         account_df = pl.DataFrame({
@@ -1621,7 +1630,7 @@ class ImportService:
                     # (account_name) must NEVER land here — a format describes a
                     # column layout, not an account (bug #5). "unknown" when no
                     # institution resolved; the exporter/format identity is `name`.
-                    institution_name=institution or "unknown",
+                    institution_name=resolved_institution or "unknown",
                     file_type=format_info.file_type,
                     delimiter=format_info.delimiter,
                     encoding=format_info.encoding,

--- a/src/moneybin/sql/schema/app_tabular_formats.sql
+++ b/src/moneybin/sql/schema/app_tabular_formats.sql
@@ -4,7 +4,7 @@
    --save-format. User formats override built-ins of the same name. */
 CREATE TABLE IF NOT EXISTS app.tabular_formats (
     name VARCHAR PRIMARY KEY,                   -- Machine identifier for this format (e.g. "chase_credit", "tiller", "mint")
-    institution_name VARCHAR NOT NULL,          -- Human-readable institution or tool name (e.g. "Chase", "Tiller", "Mint")
+    institution_name VARCHAR NOT NULL,          -- Institution for single-institution formats; for multi_account exporter formats (Tiller/Mint/Monarch) this is the tool/exporter name, NOT a per-account institution (those come from row data, Decision 8)
     file_type VARCHAR NOT NULL DEFAULT 'auto',  -- Expected file type: csv, tsv, xlsx, parquet, feather, pipe, or "auto" for any type
     delimiter VARCHAR,                          -- Explicit delimiter character for text formats; NULL means auto-detected at import time
     encoding VARCHAR NOT NULL DEFAULT 'utf-8',  -- Character encoding for text formats (e.g. utf-8, latin-1, windows-1252)

--- a/tests/moneybin/test_services/test_account_resolver.py
+++ b/tests/moneybin/test_services/test_account_resolver.py
@@ -290,6 +290,55 @@ def test_institution_last4_matches_across_case(db: Database) -> None:
     assert dec == (first.account_id, "institution_last4")
 
 
+def test_renamed_csv_label_reassociates_via_last4_not_duplicate(db: Database) -> None:
+    """Renamed Monarch account re-associates via last4, never mints a duplicate.
+
+    A Monarch account renamed Daily Expense (...1789) -> Fun Money (...1789)
+    re-associates onto the original via a PENDING institution_last4 decision —
+    not a duplicate mint that silently merges (Decision 8 mutable-label
+    behavior). The renamed import has a different source_account_key (slug) so
+    the strong-ref lookup misses; the unchanged last4 drives the candidate pass.
+    """
+    create_core_tables(db)
+    resolver = AccountResolver(db, actor="system")
+    first = resolver.resolve(
+        _src(
+            source_origin="monarch",
+            source_account_key="daily-expense-1789",
+            account_name="Daily Expense (...1789)",
+            last_four="1789",
+            institution="wells_fargo",
+        )
+    )
+    # Simulate the transform landing first's derived last4 + institution in dim.
+    _seed_dim_account(
+        db,
+        account_id=first.account_id,
+        last_four="1789",
+        institution_name="wells_fargo",
+        display_name="Daily Expense",
+    )
+    renamed = resolver.resolve(
+        _src(
+            source_origin="monarch",
+            source_account_key="fun-money-1789",
+            account_name="Fun Money (...1789)",
+            last_four="1789",
+            institution="wells_fargo",
+        )
+    )
+    # Not silently merged: the renamed import minted its own provisional account.
+    assert renamed.account_id != first.account_id
+    # ...but a pending institution_last4 proposal points back at the original.
+    pend = db.execute(
+        "SELECT candidate_account_id, match_reason FROM app.account_link_decisions "
+        "WHERE status = 'pending'"
+    ).fetchall()
+    assert any(
+        c == first.account_id and reason == "institution_last4" for c, reason in pend
+    ), pend
+
+
 def test_institution_last4_skips_when_slug_is_empty(db: Database) -> None:
     """A purely non-alphanumeric institution slugifies to '' and must not match.
 

--- a/tests/moneybin/test_services/test_import_exporter_institution.py
+++ b/tests/moneybin/test_services/test_import_exporter_institution.py
@@ -1,0 +1,44 @@
+"""Multi-account exporter formats carry per-account institution, not the tool name."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from moneybin.database import Database
+
+
+def test_multi_account_institution_is_per_account_not_tool_name(
+    mock_secret_store: MagicMock, tmp_path: Path
+) -> None:
+    """Per-row Institution column lands each account's institution, not the tool name.
+
+    A multi-account CSV (Tiller-style) with a per-row Institution column must land
+    each account's own institution in raw.tabular_accounts, never a single shared
+    tool/format name (Decision 8 exporter/institution split).
+    """
+    from moneybin.services.import_service import ImportService
+
+    csv = tmp_path / "multi.csv"
+    csv.write_text(
+        "Date,Description,Amount,Account,Institution\n"
+        "2026-01-15,Coffee,-12.50,Checking,Wells Fargo\n"
+        "2026-01-16,Dinner,-40.00,Credit Card,Amex\n"
+    )
+    db = Database(
+        tmp_path / "multi.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
+    )
+    try:
+        svc = ImportService(db)
+        svc.import_file(csv, confirm=True, actor_kind="human", refresh=False)
+        rows = db.execute(
+            "SELECT account_name, institution_name FROM raw.tabular_accounts"
+        ).fetchall()
+        inst_by_name = dict(rows)
+        assert inst_by_name.get("Checking") == "Wells Fargo", inst_by_name
+        assert inst_by_name.get("Credit Card") == "Amex", inst_by_name
+    finally:
+        db.close()

--- a/tests/moneybin/test_services/test_import_format_save.py
+++ b/tests/moneybin/test_services/test_import_format_save.py
@@ -39,3 +39,55 @@ def test_autosaved_format_does_not_store_account_name_as_institution(
         )
     finally:
         db.close()
+
+
+def test_explicit_account_name_overrides_saved_format_binding(
+    mock_secret_store: MagicMock, tmp_path: Path
+) -> None:
+    """Two structurally-identical CSVs imported with DIFFERENT explicit account names.
+
+    They land on DISTINCT accounts, even though the second matches the saved
+    format. A saved format carries columns only, never an account binding (#5).
+    """
+    from moneybin.services.import_service import ImportService
+
+    db = Database(
+        tmp_path / "override.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
+    )
+    try:
+        svc = ImportService(db)
+        a = tmp_path / "a.csv"
+        a.write_text("Date,Description,Amount\n2026-01-01,X,-1.00\n")
+        b = tmp_path / "b.csv"
+        b.write_text("Date,Description,Amount\n2026-02-01,Y,-2.00\n")
+        # First import saves the format (header signature = these columns).
+        svc.import_file(
+            a,
+            account_name="WF Checking",
+            confirm=True,
+            actor_kind="human",
+            save_format=True,
+            refresh=False,
+        )
+        # Second import is structurally identical -> matches the saved format,
+        # but carries a DIFFERENT explicit account name.
+        svc.import_file(
+            b,
+            account_name="WF Savings",
+            confirm=True,
+            actor_kind="human",
+            refresh=False,
+        )
+        keys = {
+            r[0]
+            for r in db.execute(
+                "SELECT ref_value FROM app.account_links WHERE ref_kind = 'source_native' "
+                "AND source_type IN ('csv', 'tsv', 'excel')"
+            ).fetchall()
+        }
+        assert keys == {"wf-checking", "wf-savings"}, keys
+    finally:
+        db.close()

--- a/tests/moneybin/test_services/test_import_format_save.py
+++ b/tests/moneybin/test_services/test_import_format_save.py
@@ -1,0 +1,41 @@
+"""Auto-saved tabular formats must carry columns only, never an account binding."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from moneybin.database import Database
+
+
+def test_autosaved_format_does_not_store_account_name_as_institution(
+    mock_secret_store: MagicMock, tmp_path: Path
+) -> None:
+    """Auto-saved format.institution_name must never contain the per-account label (bug #5)."""
+    from moneybin.services.import_service import ImportService
+
+    csv = tmp_path / "txns.csv"
+    csv.write_text("Date,Description,Amount\n2026-01-15,Coffee,-12.50\n")
+    db = Database(
+        tmp_path / "fmt.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
+    )
+    try:
+        svc = ImportService(db)
+        svc.import_file(
+            csv,
+            account_name="WF Checking (...4267)",
+            confirm=True,
+            actor_kind="human",
+            save_format=True,
+            refresh=False,
+        )
+        row = db.execute("SELECT institution_name FROM app.tabular_formats").fetchone()
+        assert row is not None, "expected an auto-saved format row"
+        assert "4267" not in row[0] and "WF Checking" not in row[0], (
+            f"account label leaked into format.institution_name: {row[0]!r}"
+        )
+    finally:
+        db.close()

--- a/tests/moneybin/test_services/test_import_format_save.py
+++ b/tests/moneybin/test_services/test_import_format_save.py
@@ -91,3 +91,38 @@ def test_explicit_account_name_overrides_saved_format_binding(
         assert keys == {"wf-checking", "wf-savings"}, keys
     finally:
         db.close()
+
+
+def test_autosaved_format_records_resolved_institution(
+    mock_secret_store: MagicMock, tmp_path: Path
+) -> None:
+    """An auto-saved format records the filename-resolved institution, not "unknown".
+
+    A future import matching the format then inherits a real institution hint for
+    the cross-source bridge. The account-label leak stays fixed; only a
+    genuinely-resolved institution lands here.
+    """
+    from moneybin.services.import_service import ImportService
+
+    csv = tmp_path / "wells_fargo_export.csv"
+    csv.write_text("Date,Description,Amount\n2026-01-15,Coffee,-12.50\n")
+    db = Database(
+        tmp_path / "fmt_inst.duckdb",
+        secret_store=mock_secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
+    )
+    try:
+        svc = ImportService(db)
+        svc.import_file(
+            csv,
+            account_name="Checking",
+            confirm=True,
+            actor_kind="human",
+            save_format=True,
+            refresh=False,
+        )
+        row = db.execute("SELECT institution_name FROM app.tabular_formats").fetchone()
+        assert row is not None and row[0] == "wells_fargo", row
+    finally:
+        db.close()

--- a/tests/scenarios/test_account_identity_cross_source.py
+++ b/tests/scenarios/test_account_identity_cross_source.py
@@ -44,6 +44,16 @@ def _ofx_canonical_id(db: Database, acctid: str) -> str:
     return str(row[0])
 
 
+def _csv_source_native_id(db: Database) -> str:
+    """Canonical account_id the (single) CSV source_native link minted."""
+    row = db.execute(
+        "SELECT account_id FROM app.account_links "
+        "WHERE source_type='csv' AND ref_kind='source_native' AND status='accepted'"
+    ).fetchone()
+    assert row is not None, "no CSV account_link minted"
+    return str(row[0])
+
+
 @pytest.mark.scenarios
 @pytest.mark.slow
 def test_cross_source_twins_collapse_to_canonical_accounts() -> None:
@@ -296,6 +306,75 @@ def test_csv_twin_matches_accepts_and_collapses_end_to_end() -> None:
         assert account_ids == [checking_id], account_ids
         # The 3 twin transactions (hand-counted from the fixtures) dedup to 3 gold
         # records, each contributed by both sources (source_count = 2).
+        rows = db.execute("SELECT source_count FROM core.fct_transactions").fetchall()
+        assert len(rows) == 3, f"expected 3 deduped rows, got {len(rows)}"
+        assert all(sc == 2 for (sc,) in rows), rows
+
+
+@pytest.mark.scenarios
+@pytest.mark.slow
+def test_csv_first_then_ofx_matches_accepts_and_collapses_end_to_end() -> None:
+    """End-to-end match->accept->collapse in the CSV-FIRST direction.
+
+    The sibling above lands the OFX first; here the CSV twin arrives FIRST and mints
+    the canonical account, then the OFX statement lands second. For the bridge to
+    fire in this direction the CSV's dim_accounts row must carry its filename-resolved
+    institution (not NULL) so the OFX-second resolver can match on (institution,
+    last4). A single NULL institution on the CSV's dim row silently broke this
+    direction while the OFX-first direction kept working — exactly the one-directional
+    coverage gap the "No Shortcuts" rule warns about (caught in PR #258 review).
+    """
+    from moneybin.services.account_links_service import AccountLinksService
+
+    scenario = Scenario(
+        scenario="account-identity-cross-source",
+        setup=SetupSpec(persona="family"),
+        pipeline=[],
+    )
+    with scenario_env(scenario) as (db, _tmp, env):
+        svc = ImportService(db)
+        # 1) CSV twin FIRST via the agent path, NO account_bindings -> mints the
+        #    canonical account. dim is empty, so there is no candidate yet (no
+        #    proposal); the only thing under test here is that its dim row keeps the
+        #    filename institution for the second source to match against.
+        svc.import_file(
+            _FIXTURES / "wells_fargo_checking.csv",
+            account_name="WF Checking (...1111)",
+            confirm=True,
+            actor_kind="agent",
+            refresh=False,
+        )
+        csv_account_id = _csv_source_native_id(db)
+        run_step("transform", scenario.setup, db, env=env)  # dim gets institution+last4
+        # 2) OFX statement second -> the bridge fires a pending institution_last4
+        #    proposal whose candidate is the CSV-minted account.
+        svc.import_file(_FIXTURES / "wf_checking.qfx", refresh=False)
+        decision = db.execute(
+            "SELECT decision_id, candidate_account_id FROM app.account_link_decisions "
+            "WHERE status = 'pending' AND match_reason = 'institution_last4'"
+        ).fetchone()
+        assert decision is not None, "matcher produced no institution_last4 proposal"
+        assert decision[1] == csv_account_id, decision
+        # 3) Accept the proposal the way a user reviewing the queue would — this
+        #    re-points the ofx's source_native link onto the csv-minted account.
+        AccountLinksService(db).set(
+            decision[0], target_account_id=csv_account_id, decided_by="user"
+        )
+        # 4) Re-materialize -> dedup -> re-materialize: the ofx re-keys onto the csv
+        #    account and the twin transactions collapse.
+        run_step("transform", scenario.setup, db, env=env)
+        run_step("match", scenario.setup, db, env=env)
+        run_step("transform", scenario.setup, db, env=env)
+        # Both sources collapsed to ONE canonical account (no orphan twin).
+        account_ids = [
+            r[0]
+            for r in db.execute(
+                "SELECT account_id FROM core.dim_accounts ORDER BY account_id"
+            ).fetchall()
+        ]
+        assert account_ids == [csv_account_id], account_ids
+        # Same twin fixtures as the sibling: 3 distinct transactions, each in both
+        # sources -> 3 deduped rows at source_count = 2.
         rows = db.execute("SELECT source_count FROM core.fct_transactions").fetchall()
         assert len(rows) == 3, f"expected 3 deduped rows, got {len(rows)}"
         assert all(sc == 2 for (sc,) in rows), rows

--- a/tests/scenarios/test_account_identity_cross_source.py
+++ b/tests/scenarios/test_account_identity_cross_source.py
@@ -232,3 +232,70 @@ def test_shared_last4_collision_agent_queues_both_never_merges() -> None:
         assert merged is not None and merged[0] == 0, (
             "shared last4 must NOT auto-merge onto either ofx account"
         )
+
+
+@pytest.mark.scenarios
+@pytest.mark.slow
+def test_csv_twin_matches_accepts_and_collapses_end_to_end() -> None:
+    """End-to-end match->accept->collapse with NO forced binding.
+
+    The FULL automatic chain (no account_bindings): import the .qfx, then its .csv
+    twin (agent path) — the matcher fires a pending institution_last4 PROPOSAL, the
+    user ACCEPTS it through the real review-queue accept, and the twins then dedup
+    to one gold set. This is the path a user who relies on automatic matching
+    actually takes; the sibling test_cross_source_twins_collapse_* covers the
+    EXPLICIT-binding path. Without this, every cross-source scenario forced the
+    account link and the matcher was never exercised end-to-end ("No Shortcuts",
+    testing.md).
+    """
+    from moneybin.services.account_links_service import AccountLinksService
+
+    scenario = Scenario(
+        scenario="account-identity-cross-source",
+        setup=SetupSpec(persona="family"),
+        pipeline=[],
+    )
+    with scenario_env(scenario) as (db, _tmp, env):
+        svc = ImportService(db)
+        # 1) OFX statement mints the canonical checking account (ACCTID 1111).
+        svc.import_file(_FIXTURES / "wf_checking.qfx", refresh=False)
+        checking_id = _ofx_canonical_id(db, "1111")
+        run_step("transform", scenario.setup, db, env=env)  # dim gets derived last4
+        # 2) CSV twin via the agent path, NO account_bindings -> the bridge fires a
+        #    pending institution_last4 proposal (provisional account + decision).
+        svc.import_file(
+            _FIXTURES / "wells_fargo_checking.csv",
+            account_name="WF Checking (...1111)",
+            confirm=True,
+            actor_kind="agent",
+            refresh=False,
+        )
+        decision = db.execute(
+            "SELECT decision_id, candidate_account_id FROM app.account_link_decisions "
+            "WHERE status = 'pending' AND match_reason = 'institution_last4'"
+        ).fetchone()
+        assert decision is not None, "matcher produced no institution_last4 proposal"
+        assert decision[1] == checking_id, decision
+        # 3) Accept the proposal the way a user reviewing the queue would — this
+        #    re-points the csv's source_native link onto the ofx account.
+        AccountLinksService(db).set(
+            decision[0], target_account_id=checking_id, decided_by="user"
+        )
+        # 4) Re-materialize -> dedup -> re-materialize: the csv re-keys onto the ofx
+        #    account and the twin transactions collapse.
+        run_step("transform", scenario.setup, db, env=env)
+        run_step("match", scenario.setup, db, env=env)
+        run_step("transform", scenario.setup, db, env=env)
+        # Both sources collapsed to ONE canonical account (no orphan twin).
+        account_ids = [
+            r[0]
+            for r in db.execute(
+                "SELECT account_id FROM core.dim_accounts ORDER BY account_id"
+            ).fetchall()
+        ]
+        assert account_ids == [checking_id], account_ids
+        # The 3 twin transactions (hand-counted from the fixtures) dedup to 3 gold
+        # records, each contributed by both sources (source_count = 2).
+        rows = db.execute("SELECT source_count FROM core.fct_transactions").fetchall()
+        assert len(rows) == 3, f"expected 3 deduped rows, got {len(rows)}"
+        assert all(sc == 2 for (sc,) in rows), rows


### PR DESCRIPTION
Builds on #257 (M1S.7 capture layer, merged). With last4 captured, the cross-source matcher *fires*; this increment makes the surrounding account model **bind-first** and splits the **exporter axis from per-account institution**, and closes a long-standing scenario shortcut that hid the original bug.

## M1S.8 — bind-first / format-account decoupling

- **A saved tabular format carries columns only, never an account binding.** The auto-saved `institution_name` is now the resolved (filename/format) institution or `"unknown"` — never the per-account `--account-name` label (bug #5). A second structurally-identical CSV imported with a *different* explicit account name lands on a distinct account (regression-pinned).
- **A renamed aggregator account re-associates instead of duplicating.** An aggregator account renamed `Everyday Spending (...0001)` → `Fun Money (...0001)` (same last4, new slug) misses the exact-slug strong-ref and re-associates onto the original via a *pending* `institution_last4` proposal — never a duplicate mint or silent merge (pinned; resolver doc'd).

## M1S.9 — exporter ≠ institution

- **Per-account institution from row data for multi-account formats.** A Tiller-style export with a per-row Institution column now records *each account's own* institution (both the resolver input and `raw → dim`), never the single shared exporter/tool name. Single-account behavior is unchanged. (The Monarch case — institution embedded in the account *label* — needs a label→institution parser and is a later increment.)
- Names the exporter/format axis (`source_origin`) distinct from per-account institution in code + the `app.tabular_formats` schema comment.

## Scenario de-shortcut (the root-cause fix)

The original cross-source bug stayed green for ~6 days because every cross-source scenario **forced** the account link (`account_bindings` / a shared `account:` fixture label) instead of exercising the matcher. This adds an **end-to-end scenario** that imports the `.qfx` + `.csv` twin **without** any binding, runs matching, **accepts the proposal through the real review-queue accept**, and asserts the twins collapse to one gold set — proving the full `match → accept → collapse` chain a user actually relies on. A new testing rule, **"No Shortcuts: Exercise the Real Mechanism,"** codifies this for future scenarios.

## Test plan

- `make check test` → 4356 passed
- account-identity + capture-contract scenarios → 10 passed, incl. the new end-to-end `match → accept → collapse`
- Final whole-branch review (clean; the two findings it raised are fixed in the last commit)
