### PR TITLE
Ack the sync broker to complete the cursor-ack loop

### DIFF
--- a/src/moneybin/connectors/sync_client.py
+++ b/src/moneybin/connectors/sync_client.py
@@ -41,6 +41,7 @@ from moneybin.connectors.sync_models import (
     ConnectedInstitution,
     ConnectInitiateResponse,
     ConnectStatusResponse,
+    SyncAckResponse,
     SyncDataResponse,
     SyncTriggerResponse,
 )
@@ -397,10 +398,24 @@ class SyncClient:
         return SyncTriggerResponse.model_validate(resp.json())
 
     def get_data(self, job_id: str) -> SyncDataResponse:
-        """GET /sync/data — one-shot read; server deletes from TTL store after."""
+        """GET /sync/data — re-readable until ack or the broker's hold TTL expires.
+
+        Reading does not advance cursors or drop the window; the broker holds the
+        sync's data until POST /sync/ack confirms a durable load (or the TTL lapses).
+        """
         resp = self._authed_request(
             "GET",
             "/sync/data",
             params={"job_id": job_id},
         )
         return SyncDataResponse.model_validate(resp.json())
+
+    def ack(self, job_id: str) -> SyncAckResponse:
+        """POST /sync/ack — confirm durable load so the broker advances cursors.
+
+        Idempotent: a re-ack of an already-acked job is a no-op 200. Until the
+        client acks, the broker holds the sync's advanced cursors and re-serves
+        the data, so a crash before ack yields a loss-free re-pull.
+        """
+        resp = self._authed_request("POST", "/sync/ack", json_body={"job_id": job_id})
+        return SyncAckResponse.model_validate(resp.json())

--- a/src/moneybin/connectors/sync_models.py
+++ b/src/moneybin/connectors/sync_models.py
@@ -53,6 +53,13 @@ class SyncTriggerResponse(BaseModel):
     transaction_count: int | None = None
 
 
+class SyncAckResponse(BaseModel):
+    """Response from POST /sync/ack."""
+
+    job_id: str
+    status: Literal["acked"]
+
+
 class SyncAccount(BaseModel):
     """One account entry in GET /sync/data response."""
 

--- a/src/moneybin/services/sync_service.py
+++ b/src/moneybin/services/sync_service.py
@@ -128,6 +128,19 @@ class SyncService:
             SYNC_PULL_TRANSACTIONS_LOADED.labels(provider=_PROVIDER).inc(
                 load_result.transactions_loaded
             )
+            # Ack the broker so it advances its per-institution cursors. Done
+            # unconditionally once the load is durable (even an empty completed
+            # sync advanced cursors broker-side; acking persists them and frees
+            # the held window). Best-effort: the data is already durable, so an
+            # ack failure (network blip, broker 5xx/410) just leaves the cursor
+            # un-advanced — the next pull re-pulls from it and the loader dedups,
+            # loss-free. So a failure must not flip this pull's success.
+            try:
+                self.client.ack(trigger_resp.job_id)
+            except Exception as e:  # noqa: BLE001  # best-effort post-load ack
+                logger.warning(
+                    f"Ack failed after pull (job_id={trigger_resp.job_id}): {e}"
+                )
             # Populate app.account_links for each synced account (mirrors the
             # import path, A6/A7). Best-effort: raw rows are already durable and
             # this pull has been counted a success, so a resolver failure must

--- a/tests/moneybin/connectors/test_sync_client.py
+++ b/tests/moneybin/connectors/test_sync_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import httpx
@@ -14,7 +15,7 @@ from moneybin.connectors.sync_client import (
     SyncClient,
 )
 from moneybin.connectors.sync_errors import SyncAuthError, SyncConnectError
-from moneybin.connectors.sync_models import SyncDataResponse
+from moneybin.connectors.sync_models import SyncAckResponse, SyncDataResponse
 
 
 @pytest.fixture
@@ -440,3 +441,18 @@ def test_get_data_returns_parsed_sync_data(sync_client: SyncClient) -> None:
     assert isinstance(result, SyncDataResponse)
     assert result.metadata.job_id == "job-abc"
     assert len(result.transactions) == 1
+
+
+@respx.mock
+def test_ack_posts_job_id_and_returns_ack_response(sync_client: SyncClient) -> None:
+    sync_client._store_tokens(access_token="jwt", refresh_token="r")  # type: ignore[reportPrivateUsage]  # noqa: S106  # test fixture, not a real credential
+    route = respx.post("https://test.api/sync/ack").mock(
+        return_value=httpx.Response(200, json={"job_id": "job-123", "status": "acked"})
+    )
+
+    result = sync_client.ack("job-123")
+
+    assert isinstance(result, SyncAckResponse)
+    assert result.job_id == "job-123"
+    assert result.status == "acked"
+    assert json.loads(route.calls.last.request.content) == {"job_id": "job-123"}

--- a/tests/moneybin/test_services/test_sync_service.py
+++ b/tests/moneybin/test_services/test_sync_service.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 import yaml
 
+from moneybin.connectors.sync_client import SyncAPIError
 from moneybin.connectors.sync_models import (
     ConnectedInstitution,
     ConnectInitiateResponse,
@@ -65,6 +66,9 @@ def test_pull_happy_path(
         reset_cursor=False,
     )
     mock_client.get_data.assert_called_once_with(sync_data.metadata.job_id)
+    # Canonical happy-path witness also asserts the ack, so an accidental removal
+    # of the cursor-ack call is caught here, not only in the dedicated ack test.
+    mock_client.ack.assert_called_once_with(sync_data.metadata.job_id)
     assert result.transactions_loaded == 3
     assert result.accounts_loaded == 2
     assert result.balances_loaded == 2
@@ -73,6 +77,47 @@ def test_pull_happy_path(
     # PullResult.transactions_removed reflects rows touched, not IDs requested.
     assert result.transactions_removed == 0
     assert result.institutions[0].provider_item_id == "item_chase_abc"
+
+
+def test_pull_acks_after_successful_load(
+    mock_client: MagicMock,
+    db: Database,
+    loader: PlaidExtractor,
+    sync_data: SyncDataResponse,
+) -> None:
+    """A successful pull acks the broker so it advances cursors.
+
+    Ack is unconditional once the load is durable — it persists the broker's
+    held cursors and releases the served window. The job_id passed is the
+    trigger response's job_id.
+    """
+    service = SyncService(client=mock_client, db=db, loader=loader)
+    service.pull()
+    mock_client.ack.assert_called_once_with(sync_data.metadata.job_id)
+
+
+def test_pull_ack_failure_does_not_fail_the_pull(
+    mock_client: MagicMock,
+    db: Database,
+    loader: PlaidExtractor,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An ack failure soft-fails: raw data stays loaded, pull succeeds.
+
+    Ack is best-effort post-load: the data is already durable, so a broker
+    blip just leaves the cursor un-advanced and the next pull re-pulls and
+    dedups — loss-free. The failure must not flip the pull's success
+    accounting or raise.
+    """
+    mock_client.ack.side_effect = SyncAPIError("broker unreachable")
+    service = SyncService(client=mock_client, db=db, loader=loader)
+    with caplog.at_level("WARNING"):
+        result = service.pull()
+
+    assert result.transactions_loaded == 3
+    assert result.accounts_loaded == 2
+    assert result.balances_loaded == 2
+    assert any("ack" in r.message.lower() for r in caplog.records)
 
 
 def test_pull_with_institution_resolves_to_provider_item_id(


### PR DESCRIPTION
Completes the client half of the broker's cursor-ack sync protocol.

## Why

The sync broker holds each sync's advanced per-institution cursors until the client confirms a durable load via `POST /sync/ack`; only then does it advance them. The client had `trigger_sync` and `get_data` but **no `ack`** — so cursors never advanced. Every pull re-fetched the same window until the broker's hold TTL lapsed, silently defeating the loss-free guarantee the cursor-ack design exists to provide. A stale `get_data` docstring ("server deletes from TTL store after") encoded the old, pre-cursor-ack mental model.

## What

- **`SyncClient.ack(job_id) -> SyncAckResponse`** (`POST /sync/ack`) + the `SyncAckResponse` model — a thin `_authed_request` wrapper mirroring `trigger_sync`/`get_data` (inherits auth, 401-refresh, and error mapping).
- **Wire a best-effort `ack` into `SyncService.pull()`** right after the durable load. It's deliberately **best-effort**: if ack fails, the data is already durably loaded, so the cursor simply isn't advanced and the next pull re-fetches from it and the loader dedups — loss-free. The ack sits *after* the main try/except, so an ack failure can never flip a successful pull to failed; a failure is logged (warning, job_id + error only — no tokens/financial data) and swallowed, matching the existing `_resolve_accounts` post-load best-effort pattern.
- **Corrected the stale `get_data` docstring** to describe the actual non-destructive, re-readable-until-ack semantics.

## Verification

Built TDD (fresh implementer + independent two-stage review per task), then `/code-review medium --fix` (zero actionable findings). Tests: client ack (respx — return value + request body) and the pull integration (ack called once with the job_id; an injected ack failure still yields a successful `PullResult`). `ruff` + `pyright` clean; affected modules green (sync_client: 19, sync_service: 26).

Pairs with the broker-side `POST /sync/ack` shipped in moneybin-sync Phase 4.