### PR TITLE
Shard unit-test CI across 4 runners and cancel stale runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
 
+# Cancel superseded runs on the same ref so rapid pushes (common with agents)
+# don't pile up behind stale runs. Mirrors scenarios.yml.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Detect whether any non-docs files changed. For pushes to main we always
   # run the full suite; for PRs we skip code jobs when only docs changed.
@@ -68,10 +74,16 @@ jobs:
   # `unit` when no category marker is present and errors on conflicts,
   # so each job can use a plain `-m <category>` selection.
   test-unit:
-    name: Unit tests
+    name: Unit tests (shard ${{ matrix.group }})
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      # Don't cancel sibling shards on one failure — surface every failing
+      # test across the suite in a single run, not just the first shard's.
+      fail-fast: false
+      matrix:
+        group: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v7
 
@@ -88,8 +100,56 @@ jobs:
           curl -fsSL https://install.duckdb.org | sh
           echo "$HOME/.duckdb/cli/latest" >> $GITHUB_PATH
 
+      # pytest-split shards the unit suite across the matrix so wall-clock
+      # scales with the number of free standard runners. strategy.job-total is
+      # the matrix size, so --splits stays in lockstep with the `group` array.
+      # Each shard writes its own coverage data file; the `coverage` job below
+      # combines them into a single report.
       - name: Test
-        run: uv run pytest tests/ -m unit -v --cov=src --cov-report=xml --durations=25
+        env:
+          COVERAGE_FILE: .coverage.${{ matrix.group }}
+        run: |
+          uv run pytest tests/ -m unit -v \
+            --splits ${{ strategy.job-total }} --group ${{ matrix.group }} \
+            --cov=src --cov-report= --durations=25
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: coverage-data-${{ matrix.group }}
+          path: .coverage.${{ matrix.group }}
+          include-hidden-files: true
+
+  # Combine the per-shard coverage data into one report. Runs even when a
+  # shard failed, so partial coverage still lands; waits on every shard.
+  coverage:
+    name: Coverage report
+    needs: [changes, test-unit]
+    if: ${{ always() && needs.changes.outputs.code == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Download coverage data
+        uses: actions/download-artifact@v7
+        with:
+          pattern: coverage-data-*
+          merge-multiple: true
+
+      - name: Combine and report
+        run: |
+          uv run coverage combine
+          uv run coverage xml
+          uv run coverage report
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ dev = [
     "pytest-xdist>=3.8.0",
     "respx>=0.21",
     "pytest-memray>=1.8.0",
+    "pytest-split>=0.11.0",
 ]
 
 docs = [

--- a/uv.lock
+++ b/uv.lock
@@ -1783,6 +1783,7 @@ dev = [
     { name = "pytest-json-report" },
     { name = "pytest-memray" },
     { name = "pytest-mock" },
+    { name = "pytest-split" },
     { name = "pytest-xdist" },
     { name = "respx" },
     { name = "ruff" },
@@ -1847,6 +1848,7 @@ dev = [
     { name = "pytest-json-report", specifier = ">=1.5.0" },
     { name = "pytest-memray", specifier = ">=1.8.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
+    { name = "pytest-split", specifier = ">=0.11.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "respx", specifier = ">=0.21" },
     { name = "ruff", specifier = ">=0.15.10" },
@@ -2901,6 +2903,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-split"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/16/8af4c5f2ceb3640bb1f78dfdf5c184556b10dfe9369feaaad7ff1c13f329/pytest_split-0.11.0.tar.gz", hash = "sha256:8ebdb29cc72cc962e8eb1ec07db1eeb98ab25e215ed8e3216f6b9fc7ce0ec2b5", size = 13421, upload-time = "2026-02-03T09:14:31.469Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/a1/d4423657caaa8be9b31e491592b49cebdcfd434d3e74512ce71f6ec39905/pytest_split-0.11.0-py3-none-any.whl", hash = "sha256:899d7c0f5730da91e2daf283860eb73b503259cb416851a65599368849c7f382", size = 11911, upload-time = "2026-02-03T09:14:33.708Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The `test-unit` CI job ran the full ~4,400-test unit suite on a single **2-core** runner (`-n auto` saw only 2 workers), taking 15–23 min and gating every PR. Profiling showed per-test cost is **flat** (slowest 10s, 25th-slowest 3.7s) — there's no slow tail to defer, so parallelism is the lever. The repo is public (unlimited free Actions minutes on standard runners), so this shards the suite across **4 free runners** with `pytest-split` and combines per-shard coverage into one report. Also adds a `concurrency` group so rapid pushes cancel superseded runs. Expected wall-clock **~23 min → ~7–8 min**, with **no change to what's tested**.

## Test plan

- [ ] All 4 `Unit tests (shard N)` jobs go green, each running ~1,100 tests
- [ ] `Coverage report` job combines the four shards and uploads `coverage.xml`
- [ ] Total unit wall-clock is well under the previous ~20 min (the point of the change)
- [ ] A second push cancels the in-progress run (concurrency group)
- [ ] Locally verified: split partitions cleanly (4402 = 1101×3+1099), coverage `COVERAGE_FILE`→`combine`→`xml` works under xdist, `make check` green
