### PR TITLE
Shard e2e tests 2-way to clear the Scenarios floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,10 +183,14 @@ jobs:
         run: uv run pytest tests/ -m integration -v --durations=25
 
   test-e2e:
-    name: E2E tests
+    name: E2E tests (shard ${{ matrix.group }})
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2]
     steps:
       - uses: actions/checkout@v7
 
@@ -203,5 +207,13 @@ jobs:
           curl -fsSL https://install.duckdb.org | sh
           echo "$HOME/.duckdb/cli/latest" >> $GITHUB_PATH
 
+      # Shard the e2e suite with pytest-split, same pattern as test-unit.
+      # 2-way is enough: overall PR time is floored by the ~5 min Scenarios
+      # workflow, so halving e2e (~6 min -> ~3 min) already clears it. Count-
+      # based split is fine -- e2e tests are uniform and this job no longer
+      # gates the critical path. No coverage here, so no combine job.
       - name: Test
-        run: uv run pytest tests/ -m e2e -v --durations=25
+        run: |
+          uv run pytest tests/ -m e2e -v \
+            --splits ${{ strategy.job-total }} --group ${{ matrix.group }} \
+            --durations=25


### PR DESCRIPTION
## Summary

After unit sharding (#263/#264), the **e2e job (~6.4 min)** was the CI critical path. This splits it **2-way** with `pytest-split` (same pattern as `test-unit`), dropping it to ~3 min. 2-way is deliberate: overall PR feedback is floored by the separate **Scenarios** workflow (~5 min), so e2e only needs to clear *that* — 4-way would burn extra runners for no overall gain. Count-based (no `.test_durations` change) since e2e tests are uniform and this job no longer gates the critical path.

After this, CI's critical path becomes `test-unit` (~5 min) and overall PR time is **Scenarios-bound (~5–6 min)** — down from the original ~23 min.

## Test plan

- [ ] Both `E2E tests (shard 1|2)` jobs go green, each ~149 tests
- [ ] Each e2e shard finishes in ~3 min (was one ~6.4 min job)
- [ ] No other job regressed; CI critical path is now `test-unit`, overall PR ≤ Scenarios (~5–6 min)
