### PR TITLE
Use sys.monitoring coverage core on unit shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,9 @@ jobs:
       - name: Test
         env:
           COVERAGE_FILE: .coverage.${{ matrix.group }}
+          # sys.monitoring-based coverage (PEP 669) on Python 3.12 — far lower
+          # tracing overhead than the default C tracer. Needs coverage >= 7.4.
+          COVERAGE_CORE: sysmon
         run: |
           uv run pytest tests/ -m unit -v \
             --splits ${{ strategy.job-total }} --group ${{ matrix.group }} \


### PR DESCRIPTION
## Summary

Sets `COVERAGE_CORE=sysmon` on the unit-shard test step. On Python 3.12 with coverage ≥7.4, this uses the PEP 669 `sys.monitoring` tracer instead of the default C trace function, cutting coverage measurement overhead (often roughly halved) on the only jobs that run `--cov`. Line coverage only (no `--cov-branch`), where sysmon is fully mature in coverage 7.14.

## Test plan

- [ ] All 4 `Unit tests (shard N)` jobs stay green with coverage data intact
- [ ] `Coverage report` job combines the shards and uploads `coverage.xml` as before
- [ ] A unit shard's wall-clock ticks down vs the pre-change ~280s (measurement overhead removed)
- [ ] Verified locally: a probe run measured 334 files cleanly under sysmon
