### PR TITLE
Rename sync connector connect->link to match broker

### DIFF
--- a/docs/reference/server-api-contract.md
+++ b/docs/reference/server-api-contract.md
@@ -45,12 +45,12 @@ Every endpoint below is exercised by `SyncClient`. Paths and methods are taken d
 | `POST` | `/auth/refresh` | refresh token | Exchange a refresh token for a new access token (with a rotated refresh token). |
 | `GET` | `/institutions` | bearer | List the user's connected institutions across providers. |
 | `DELETE` | `/institutions/{id}` | bearer | Disconnect an institution by its internal connection ID. |
-| `POST` | `/sync/connect/initiate` | bearer | Start a connect session (Plaid Link today). Returns a hosted `link_url` for the user to open. |
-| `GET` | `/sync/connect/status` | bearer | Read the current state of a connect session (`pending` / `connected` / `failed`). |
+| `POST` | `/sync/link/initiate` | bearer | Start a link session (Plaid Link today). Returns a hosted `link_url` for the user to open. |
+| `GET` | `/sync/link/status` | bearer | Read the current state of a link session (`pending` / `linked` / `failed`). |
 | `POST` | `/sync/trigger` | bearer | Run a sync. Synchronous from the client's perspective — blocks until the server completes the pull. |
 | `GET` | `/sync/data` | bearer | One-shot read of the most recent sync payload by `job_id`. Server deletes from its TTL store after read. |
 
-Properties across the catalog: bearer-token auth everywhere except the device-flow bootstrap (no cookies, no sessions); JSON request and response bodies (errors included); synchronous semantics — `POST /sync/trigger` blocks until the server-side pull completes, then `GET /sync/data` returns the payload. No webhooks; polling exists only for the connect flow, where the user takes the wheel.
+Properties across the catalog: bearer-token auth everywhere except the device-flow bootstrap (no cookies, no sessions); JSON request and response bodies (errors included); synchronous semantics — `POST /sync/trigger` blocks until the server-side pull completes, then `GET /sync/data` returns the payload. No webhooks; polling exists only for the link flow, where the user takes the wheel.
 
 ### Sync sequence (canonical)
 
@@ -169,9 +169,9 @@ Any non-200 response clears both tokens on the client and requires re-login.
 
 **Errors:** `404` if the connection does not exist or belongs to another user.
 
-### `POST /sync/connect/initiate`
+### `POST /sync/link/initiate`
 
-Begin a connect session. The response includes a hosted URL the user opens in a browser; the user completes provider-side flows there (Plaid Link, in today's deployment).
+Begin a link session. The response includes a hosted URL the user opens in a browser; the user completes provider-side flows there (Plaid Link, in today's deployment).
 
 **Request:**
 
@@ -189,34 +189,34 @@ Begin a connect session. The response includes a hosted URL the user opens in a 
 | `provider_item_id` | string \| null | no | If set, opens an **update-mode** Link session for an existing connection (e.g., to resolve `ITEM_LOGIN_REQUIRED`). |
 | `return_to` | string \| null | no | Where the hosted UI should send the user after completion. Server-defined semantics. |
 
-**Response (200):** `ConnectInitiateResponse`
+**Response (200):** `LinkInitiateResponse`
 
 ```json
 {
   "session_id": "sess_abc123",
   "link_url": "https://link.example.com/sessions/sess_abc123",
-  "connect_type": "widget_flow",
+  "link_type": "widget_flow",
   "expiration": "2026-05-17T15:00:00Z"
 }
 ```
 
 | Field | Notes |
 |---|---|
-| `session_id` | Opaque token; the client passes it to `GET /sync/connect/status`. |
+| `session_id` | Opaque token; the client passes it to `GET /sync/link/status`. |
 | `link_url` | Hosted URL the client opens in the user's browser. |
-| `connect_type` | `"widget_flow"` (Plaid Link in a hosted browser) or `"token_paste"` (manual token entry, reserved for headless flows). |
-| `expiration` | After this timestamp, the session can no longer transition to `connected`. |
+| `link_type` | `"widget_flow"` (Plaid Link in a hosted browser) or `"token_paste"` (manual token entry, reserved for headless flows). |
+| `expiration` | After this timestamp, the session can no longer transition to `linked`. |
 
-### `GET /sync/connect/status`
+### `GET /sync/link/status`
 
-**Query parameter:** `session_id` from `/sync/connect/initiate`.
+**Query parameter:** `session_id` from `/sync/link/initiate`.
 
-**Response (200):** `ConnectStatusResponse`
+**Response (200):** `LinkStatusResponse`
 
 ```json
 {
   "session_id": "sess_abc123",
-  "status": "connected",
+  "status": "linked",
   "provider_item_id": "item_abc123...",
   "institution_name": "Chase",
   "error": null,
@@ -226,12 +226,12 @@ Begin a connect session. The response includes a hosted URL the user opens in a 
 
 | Field | Type | Notes |
 |---|---|---|
-| `status` | enum | `"pending"` \| `"connected"` \| `"failed"`. |
-| `provider_item_id` | string \| null | Populated once `status == "connected"`. |
-| `institution_name` | string \| null | Populated once `status == "connected"`. |
+| `status` | enum | `"pending"` \| `"linked"` \| `"failed"`. |
+| `provider_item_id` | string \| null | Populated once `status == "linked"`. |
+| `institution_name` | string \| null | Populated once `status == "linked"`. |
 | `error` | string \| null | Populated when `status == "failed"`. |
 
-`pending` → keep polling. `connected` → success. `failed` → surface `error` to the user. Polling cadence and overall deadline are client-side policy, not part of the contract.
+`pending` → keep polling. `linked` → success. `failed` → surface `error` to the user. Polling cadence and overall deadline are client-side policy, not part of the contract.
 
 ### `POST /sync/trigger`
 
@@ -398,12 +398,12 @@ What the server returns and how the client classifies it:
 | `401` on an authed call | Refresh once, retry. A second `401` clears tokens and prompts re-login. |
 | `403` on `/auth/device/token` | Treated as "user denied authorization." Re-login required. |
 | `400` on `/auth/device/token` | Treated as "device code expired." Re-login required. |
-| Connect session `status == "failed"` | Surfaces the server's `error` string verbatim to the user. |
+| Link session `status == "failed"` | Surfaces the server's `error` string verbatim to the user. |
 | Any other `>= 400` | Surfaces `<METHOD> <path> returned <status>: <truncated body>` to the user. |
 | Connection refused / DNS failure / TLS error | Surfaces "sync server unreachable at &lt;url&gt;". |
 | Client deadline elapsed (connect poll, trigger long timeout) | Surfaces a timeout message; the server-side job may still complete. |
 
-The client wraps each of these into one of `SyncAuthError`, `SyncConnectError`, `SyncTimeoutError`, or `SyncAPIError` — the precise subclass hierarchy is a client implementation detail, defined in `src/moneybin/connectors/sync_errors.py`.
+The client wraps each of these into one of `SyncAuthError`, `SyncLinkError`, `SyncTimeoutError`, or `SyncAPIError` — the precise subclass hierarchy is a client implementation detail, defined in `src/moneybin/connectors/sync_errors.py`.
 
 The contract does **not** mandate a uniform error envelope. The client treats any `>= 400` status with an unstructured body as a generic API error. A future revision may tighten this to a structured `{ "error": { "code": "...", "message": "..." } }` shape; until then, the client relies on Pydantic validation to catch malformed success responses and on HTTP status to gate refresh-and-retry behavior.
 
@@ -463,7 +463,7 @@ What the contract guarantees when things partially fail.
 
 - **TTL atomicity for `/sync/data`.** The contract intent is that the server drops the payload only after handing a complete `200` response to the client; a mid-read drop should leave the payload available for one retry. The exact mechanism is server-implementation detail and not pinned down today. **If the client lost the payload, the safe recovery is to call `POST /sync/trigger` again** — sync is idempotent against the cursor, so re-triggering re-pulls the same incremental window without double-counting.
 - **Concurrent `/sync/trigger` calls.** No `Idempotency-Key` header, no specified lock or queue model. The client never issues concurrent triggers; treat concurrent triggers as undefined behavior in any other client until the contract pins this down.
-- **Connect session reuse.** Opening `link_url` twice is provider-side behavior (Plaid Link manages its own session). The client treats whatever terminal state `/sync/connect/status` reports as authoritative.
+- **Link session reuse.** Opening `link_url` twice is provider-side behavior (Plaid Link manages its own session). The client treats whatever terminal state `/sync/link/status` reports as authoritative.
 - **Payload size for `/sync/data`.** Single JSON body, no chunking, no documented maximum. Initial syncs with multi-year history can be large; the client validates the whole payload in memory. Servers emitting payloads above a few hundred MB will cause client-side memory pressure — a known sharp edge.
 
 ## Versioning

--- a/docs/specs/2026-05-13-plaid-sync-design.md
+++ b/docs/specs/2026-05-13-plaid-sync-design.md
@@ -27,23 +27,23 @@ Key inputs:
 
 Plaid Hosted Link hosts the Link UI on Plaid's infrastructure. The server creates a Link token with `hosted_link: {}`, exposes the resulting `hosted_link_url` to the client, and receives a `SESSION_FINISHED` webhook when the user finishes. The server then exchanges the public token for an access token entirely server-side. **The client never holds Plaid credentials, never sees the public token, and never calls an exchange endpoint.**
 
-### `connect_type` discriminator
+### `link_type` discriminator
 
-The connect API is provider-agnostic via a `connect_type` field in the initiate response. Phase 1 implements only `widget_flow`; the discriminator exists so future providers slot in without breaking the client.
+The link API is provider-agnostic via a `link_type` field in the initiate response. Phase 1 implements only `widget_flow`; the discriminator exists so future providers slot in without breaking the client.
 
-| `connect_type` | Server pattern | Phase 1 status |
+| `link_type` | Server pattern | Phase 1 status |
 |---|---|---|
 | `widget_flow` | Server returns a hosted URL; webhook signals completion | Implemented (Plaid) |
 | `token_paste` | User obtains token externally; CLI submits via separate endpoint | Deferred to Phase 2 (SimpleFIN) |
 
-The client parses `connect_type`. If the value isn't `widget_flow` in Phase 1, the client raises `NotImplementedError("connect_type 'X' is not supported in this version")`.
+The client parses `link_type`. If the value isn't `widget_flow` in Phase 1, the client raises `NotImplementedError("link_type 'X' is not supported in this version")`.
 
 ### Endpoints
 
 **New:**
 
 ```
-POST /sync/connect/initiate
+POST /sync/link/initiate
   Body: {
     "provider": "plaid",
     "provider_item_id": "item_abc",     # optional — update mode for re-auth
@@ -52,16 +52,16 @@ POST /sync/connect/initiate
   Response 200: {
     "session_id": "sess_abc123",
     "link_url": "https://hosted.plaid.com/link/...",
-    "connect_type": "widget_flow",
+    "link_type": "widget_flow",
     "expiration": "2026-05-13T13:30:00Z"
   }
 
-GET /sync/connect/status?session_id=sess_abc123
+GET /sync/link/status?session_id=sess_abc123
   Response 200: {
     "session_id": "sess_abc123",
-    "status": "pending" | "connected" | "failed",
-    "provider_item_id": "item_abc123",   # only when status == "connected"
-    "institution_name": "Chase",          # only when status == "connected"
+    "status": "pending" | "linked" | "failed",
+    "provider_item_id": "item_abc123",   # only when status == "linked"
+    "institution_name": "Chase",          # only when status == "linked"
     "error": null,                        # error message when status == "failed"
     "expiration": "2026-05-13T13:30:00Z"  # session expiration; agent can decide when to give up
   }
@@ -79,7 +79,7 @@ POST /webhooks/plaid                      # internal, not in client API surface
 **Renamed:** `item_id` → `provider_item_id` everywhere in client-visible responses (`GET /institutions`, `GET /sync/status.results[]`, `GET /sync/data.metadata.institutions[]`).
 
 **Removed from client API:**
-- `POST /sync/link-token` (replaced by `POST /sync/connect/initiate`)
+- `POST /sync/link-token` (replaced by `POST /sync/link/initiate`)
 - `POST /sync/exchange-token` (now internal webhook handler)
 
 **Retained:**
@@ -90,13 +90,13 @@ POST /webhooks/plaid                      # internal, not in client API surface
 
 ### `return_to` (forward-compat for web UI)
 
-The `return_to` field is added now so the M3D Web UI doesn't require a breaking API change. CLI sends `null`; the server tells Plaid to display its default "session complete" page; CLI polls `GET /sync/connect/status` for completion. The future web UI sends its callback URL; the server passes it to Plaid Hosted Link's `redirect_uri` config; Plaid redirects the user's browser back to the web app after they finish. The status endpoint remains the authoritative completion signal even when redirect-based UX is in use, since the webhook may race the browser redirect.
+The `return_to` field is added now so the M3D Web UI doesn't require a breaking API change. CLI sends `null`; the server tells Plaid to display its default "session complete" page; CLI polls `GET /sync/link/status` for completion. The future web UI sends its callback URL; the server passes it to Plaid Hosted Link's `redirect_uri` config; Plaid redirects the user's browser back to the web app after they finish. The status endpoint remains the authoritative completion signal even when redirect-based UX is in use, since the webhook may race the browser redirect.
 
 ### Update mode (re-authentication)
 
 When an institution returns `ITEM_LOGIN_REQUIRED`, the user needs to re-authenticate without losing transaction history. Plaid supports "update mode": create a Link token tied to an existing `item_id`; the same `item_id` survives.
 
-The client passes `provider_item_id` to `POST /sync/connect/initiate`; the server detects this and creates an update-mode Link token instead of a new-connection token. From the client's perspective the response shape is identical.
+The client passes `provider_item_id` to `POST /sync/link/initiate`; the server detects this and creates an update-mode Link token instead of a new-connection token. From the client's perspective the response shape is identical.
 
 ---
 
@@ -141,36 +141,36 @@ Refresh is transparent to method callers — they see either success or `SyncAut
 - Default: call `webbrowser.open()`; whether it returns True or False, always also print the URL to stderr so a headless user can copy it
 - `--no-browser` flag: skip the `webbrowser.open()` call entirely; print URL only
 
-### Connect flow
+### Link flow
 
 ```python
-def connect(self, provider_item_id: str | None = None, return_to: str | None = None) -> ConnectResult:
+def initiate_link(self, provider_item_id: str | None = None, return_to: str | None = None) -> LinkInitiateResponse:
     body = {"provider": "plaid"}
     if provider_item_id:
         body["provider_item_id"] = provider_item_id   # update mode
     if return_to:
         body["return_to"] = return_to                  # web UI redirect
-    resp = self._post("/sync/connect/initiate", body)
-    initiate = ConnectInitiateResponse.model_validate(resp)
-    if initiate.connect_type != "widget_flow":
+    resp = self._post("/sync/link/initiate", body)
+    initiate = LinkInitiateResponse.model_validate(resp)
+    if initiate.link_type != "widget_flow":
         raise NotImplementedError(
-            f"connect_type '{initiate.connect_type}' is not supported in this version"
+            f"link_type '{initiate.link_type}' is not supported in this version"
         )
     self._open_url(initiate.link_url)        # honors --no-browser
-    return self._poll_connect(initiate.session_id)
+    return self._poll_link(initiate.session_id)
 
-def _poll_connect(self, session_id: str) -> ConnectResult:
+def _poll_link(self, session_id: str) -> LinkResult:
     deadline = time.time() + _LONG_TIMEOUT
     interval = 3.0
     while time.time() < deadline:
         time.sleep(interval)
-        r = self._get(f"/sync/connect/status?session_id={session_id}")
-        status = ConnectStatusResponse.model_validate(r)
-        if status.status == "connected":
-            return ConnectResult(provider_item_id=status.provider_item_id, ...)
+        r = self._get(f"/sync/link/status?session_id={session_id}")
+        status = LinkStatusResponse.model_validate(r)
+        if status.status == "linked":
+            return LinkResult(provider_item_id=status.provider_item_id, ...)
         if status.status == "failed":
-            raise SyncConnectError(status.error or "connect failed")
-    raise SyncTimeoutError("connect flow timed out — user may have abandoned the browser")
+            raise SyncLinkError(status.error or "link session failed")
+    raise SyncTimeoutError("link flow timed out — user may have abandoned the browser")
 ```
 
 ### Timeouts
@@ -181,7 +181,7 @@ Two constants, not config knobs:
 _DEFAULT_TIMEOUT = httpx.Timeout(15.0, connect=10.0)  # most endpoints
 _LONG_TIMEOUT = httpx.Timeout(
     120.0, connect=10.0
-)  # POST /sync/trigger, connect-poll deadline
+)  # POST /sync/trigger, link-poll deadline
 ```
 
 Promote to `SyncConfig` only when a real user file says they need different values. Don't add knobs speculatively.
@@ -190,7 +190,7 @@ Promote to `SyncConfig` only when a real user file says they need different valu
 
 `SyncClient` raises typed exceptions:
 - `SyncAuthError` — auth failure (401 after refresh attempt, user denied device flow)
-- `SyncConnectError` — connect session failed (`status: "failed"` from server)
+- `SyncLinkError` — link session failed (`status: "failed"` from server)
 - `SyncTimeoutError` — operation exceeded its timeout
 - `SyncAPIError` — generic server error (5xx, unexpected response shape)
 
@@ -220,16 +220,16 @@ class AuthToken(BaseModel):
     token_type: Literal["Bearer"] = "Bearer"
 
 
-class ConnectInitiateResponse(BaseModel):
+class LinkInitiateResponse(BaseModel):
     session_id: str = Field(min_length=1, max_length=128)
     link_url: str
-    connect_type: Literal["widget_flow", "token_paste"]
+    link_type: Literal["widget_flow", "token_paste"]
     expiration: datetime
 
 
-class ConnectStatusResponse(BaseModel):
+class LinkStatusResponse(BaseModel):
     session_id: str
-    status: Literal["pending", "connected", "failed"]
+    status: Literal["pending", "linked", "failed"]
     provider_item_id: str | None = None
     institution_name: str | None = None
     error: str | None = None
@@ -314,7 +314,7 @@ class PullResult(BaseModel):
     institutions: list[InstitutionResult]  # passthrough from sync metadata
 
 
-class ConnectResult(BaseModel):
+class LinkResult(BaseModel):
     provider_item_id: str
     institution_name: str
     pull_result: PullResult | None = None  # populated when auto_pull=True
@@ -350,13 +350,13 @@ class SyncService:
     def pull(
         self, *, institution: str | None = None, force: bool = False
     ) -> PullResult: ...
-    def connect(
+    def link(
         self,
         *,
         institution: str | None = None,
         auto_pull: bool = True,
         return_to: str | None = None,
-    ) -> ConnectResult: ...
+    ) -> LinkResult: ...
     def disconnect(self, *, institution: str) -> None: ...
     def list_connections(self) -> list[SyncConnectionView]: ...
 
@@ -701,7 +701,7 @@ Per `.claude/rules/cli.md`, every mutating command also accepts `--output json` 
 
 The agent then calls `sync link-status --session-id sess_abc123 --output json` to verify.
 
-**`sync link --output json`** (without `--no-browser`): blocks until connected, returns the full result including the auto-pull summary if applicable.
+**`sync link --output json`** (without `--no-browser`): blocks until linked, returns the full result including the auto-pull summary if applicable.
 
 ### `sync link` decision tree
 
@@ -713,7 +713,7 @@ Without `--institution` flag:
   - Non-interactive (`--yes` OR no TTY): exit code 2 with a clear error: "Found 1 institution needing re-auth. Pass `--institution {name}` to confirm intent, or pass `--institution NEW` to create a new connection." Agents must be explicit.
 - **Multiple institutions in `status='error'`:** list them; exit code 2 directing user to pass `--institution NAME`. Even interactive — too easy to pick the wrong one.
 
-With `--institution NAME`: resolve NAME → `provider_item_id` via `GET /institutions`; pass to `POST /sync/connect/initiate` (server detects update mode). If NAME doesn't match any existing connection, treat as new-connection request and let the server's connect flow handle naming.
+With `--institution NAME`: resolve NAME → `provider_item_id` via `GET /institutions`; pass to `POST /sync/link/initiate` (server detects update mode). If NAME doesn't match any existing connection, treat as new-connection request and let the server's link flow handle naming.
 
 `--yes` flag's semantics: skip the single-institution re-auth confirmation prompt only. It never selects an institution on its own — selection is always explicit via `--institution`. This matches `.claude/rules/cli.md` non-interactive parity without papering over ambiguity.
 
@@ -724,7 +724,7 @@ With `--institution NAME`: resolve NAME → `provider_item_id` via `GET /institu
 If the connection succeeds but the auto-pull fails, the connection is kept and the error is reported with a clear next step:
 
 ```
-✅ Connected Chase
+✅ Linked Chase
 ❌ Auto-pull failed: server returned 503
 💡 Run `moneybin sync pull --institution Chase` to retry
 ```
@@ -835,15 +835,15 @@ The prompt is registered alongside the tools via FastMCP's prompts API.
 - `login()` user denied → raises `SyncAuthError`
 - 401 → refresh (with rotation) → retry → success; assert new refresh token stored
 - 401 → refresh fails → raise `SyncAuthError`; assert stored tokens cleared
-- Connect flow polls until `connected`; respects `_LONG_TIMEOUT`
+- Link flow polls until `linked`; respects `_LONG_TIMEOUT`
 - `trigger_sync()` returns synchronous result; honors `_LONG_TIMEOUT`
 
 `tests/test_sync_service.py`:
 - `pull()` happy path → SyncClient + PlaidLoader called in order; returns `PullResult` with correct counts
 - Partial failure (one institution `failed`, one `completed`) → both reflected in `PullResult.institutions`
-- Re-auth path: `connect(institution="Schwab")` resolves name via `GET /institutions` → passes `provider_item_id` to `connect/initiate`
-- `connect(auto_pull=True)` → returns `ConnectResult` with `pull_result` populated
-- `connect(auto_pull=True)` with pull failure → returns `ConnectResult` with `pull_result=None` and a clear error
+- Re-auth path: `link(institution="Schwab")` resolves name via `GET /institutions` → passes `provider_item_id` to `link/initiate`
+- `link(auto_pull=True)` → returns `LinkResult` with `pull_result` populated
+- `link(auto_pull=True)` with pull failure → returns `LinkResult` with `pull_result=None` and a clear error
 
 ### SQL tests
 
@@ -866,8 +866,8 @@ The Phase 1 client doesn't work end-to-end until the moneybin-server implements 
 
 ### Endpoints (new or changed)
 
-- **`POST /sync/connect/initiate`** — body `{provider, provider_item_id?, return_to?}`; response `{session_id, link_url, connect_type, expiration}`. Body shape MUST be supported even when all fields are absent (defaults to new-connection flow for Plaid). With `provider_item_id` → update mode against the existing item. With `return_to` → server configures Plaid Hosted Link's `redirect_uri`; without `return_to` → Plaid displays default completion page.
-- **`GET /sync/connect/status?session_id=...`** — response includes `expiration` so the client can decide when to give up. Filter by `auth.user_id` — session table MUST have a `user_id` column and the endpoint MUST 404 on cross-user lookups.
+- **`POST /sync/link/initiate`** — body `{provider, provider_item_id?, return_to?}`; response `{session_id, link_url, link_type, expiration}`. Body shape MUST be supported even when all fields are absent (defaults to new-connection flow for Plaid). With `provider_item_id` → update mode against the existing item. With `return_to` → server configures Plaid Hosted Link's `redirect_uri`; without `return_to` → Plaid displays default completion page.
+- **`GET /sync/link/status?session_id=...`** — response includes `expiration` so the client can decide when to give up. Filter by `auth.user_id` — session table MUST have a `user_id` column and the endpoint MUST 404 on cross-user lookups.
 - **`POST /auth/refresh`** — body `{refresh_token}`; response `{access_token, refresh_token, expires_in}`. Refresh tokens MUST rotate (single-use): each call returns a new refresh token and invalidates the old one. Proxies refresh to Auth0 with refresh-token rotation enabled.
 - **`POST /webhooks/plaid`** — internal; handles `SESSION_FINISHED` (and `ITEM_LOGIN_REQUIRED`, `ERROR` for re-auth). Implementation requirements below.
 - **Rename in responses:** `item_id` → `provider_item_id` throughout client-visible responses (`GET /institutions`, `GET /sync/status.results[]`, `GET /sync/data.metadata.institutions[]`, `POST /sync/trigger` request body).
@@ -884,8 +884,8 @@ The Phase 1 client doesn't work end-to-end until the moneybin-server implements 
   - **Request-size limit:** cap webhook body at e.g. 1 MB; reject larger.
   - **Rate limiting:** apply rate limits at the IP and at the JWT-issuer level to mitigate webhook flooding attacks (publicly reachable, unauthenticated by JWT).
   - **Idempotency:** dedupe per webhook type. For `SESSION_FINISHED`: dedupe on `link_session_id` (Plaid's stable session identifier; the `webhook_id` field is not reliably present). For item-lifecycle webhooks: dedupe on `(item_id, webhook_code, environment)`. First arrival wins; duplicates are 200-acked without reprocessing.
-  - **On `SESSION_FINISHED`:** lookup session by `link_token`, call `plaid.itemPublicTokenExchange()`. On success: encrypt `access_token` with the existing AES-256-GCM `ENCRYPTION_KEY`, store in `plaid_items`, update session row to `status='connected'` with `provider_item_id` and `institution_name` populated.
-  - **On exchange failure (Plaid 5xx, network blip, retries exhausted):** update session row to `status='failed'` with a clear `error` message. **Sessions must not stay `pending` indefinitely** — the client's `GET /sync/connect/status` poll must eventually see a terminal state.
+  - **On `SESSION_FINISHED`:** lookup session by `link_token`, call `plaid.itemPublicTokenExchange()`. On success: encrypt `access_token` with the existing AES-256-GCM `ENCRYPTION_KEY`, store in `plaid_items`, update session row to `status='linked'` with `provider_item_id` and `institution_name` populated.
+  - **On exchange failure (Plaid 5xx, network blip, retries exhausted):** update session row to `status='failed'` with a clear `error` message. **Sessions must not stay `pending` indefinitely** — the client's `GET /sync/link/status` poll must eventually see a terminal state.
   - **On `ITEM_LOGIN_REQUIRED` / `ERROR`:** update `plaid_items.status` so the next `POST /sync/trigger` for that item reports the error code in `results[]`.
 
 ### Server-side cursor ack (required before launch, not Phase 1)
@@ -907,12 +907,12 @@ Client PR (this branch) and server PR ship paired. Until the server endpoints la
 - Post-quantum cryptography (Phase 4 — designed in `sync-overview.md`)
 - Plaid Investments product (separate spec, gated on `investments-data-model.md`)
 - Plaid Liabilities product
-- SimpleFIN, MX, TrueLayer integration (Phase 2/3 — `connect_type` discriminator is in place for forward compat; `POST /sync/connect/submit` endpoint and the `token_paste` client path are NOT in this PR)
+- SimpleFIN, MX, TrueLayer integration (Phase 2/3 — `link_type` discriminator is in place for forward compat; `POST /sync/link/submit` endpoint and the `token_paste` client path are NOT in this PR)
 - Local web server callback for OAuth on the CLI (Phase 1 polish — no server API changes needed; deferred)
 - Plaid Production OAuth approval — submit the application during this PR's review cycle given the 4–8 week approval timeline; can run in parallel with remaining implementation work
 - Provider sequencing rationale (SimpleFIN/MX/TrueLayer detailed plan) — tracked separately in product strategy docs
 - Server-side cursor ack — required before M3 launch but not blocking Phase 1 client work; see Section 11
-- Web UI surface (M3D) — the `return_to` parameter on `connect/initiate` is forward-compatible, but the actual web UI is out of scope here
+- Web UI surface (M3D) — the `return_to` parameter on `link/initiate` is forward-compatible, but the actual web UI is out of scope here
 
 ---
 
@@ -927,12 +927,12 @@ Client PR (this branch) and server PR ship paired. Until the server endpoints la
 | New table: schema file + migration, or schema file only? | Neither — we don't introduce a new local table (see next row). Convention shift for future cases still applies. |
 | Local mirror of server connection state in `app.sync_connections`? | Dropped. Server is the system of record; `sync status` reads `GET /institutions` per invocation. Avoids drift when web UI lands. |
 | Crash-recovery file for in-flight sync? | Dropped. Server-side cursor-ack is the real fix and tracked as required-before-launch. Phase 1 logs loud warnings on crash; user re-runs `sync pull`. |
-| Forward-compat for web UI's connect-redirect needs? | Added `return_to: string \| null` to `POST /sync/connect/initiate` body. CLI sends null; future web UI sends its callback URL. |
+| Forward-compat for web UI's connect-redirect needs? | Added `return_to: string \| null` to `POST /sync/link/initiate` body. CLI sends null; future web UI sends its callback URL. |
 | Response models: Pydantic everywhere, partial, or dicts? | Pydantic at every API boundary. Single `sync_models.py` module imported by client + loader; service-layer result types live alongside. |
 | Service layer scope: `SyncConnectionService` or broader `SyncService`? | `SyncService` — owns orchestration; no local connection-table operations (state lives on server). |
 | Provider ladder section in design doc: full detail, trimmed, or none? | Trimmed. Public design doc mentions the discriminator; sequencing/rationale stays in strategy docs. |
 | Auto-pull after connect? | Yes, by default. `--no-pull` to opt out. |
 | Per-endpoint timeout configuration? | Two constants in `sync_client.py` (15s default, 120s long-op). No config knobs without evidence of need. |
-| CLI `--output json` on mutating commands? | Yes for `pull`, `connect`, `connect-status`, `disconnect` per agent-surface rule. |
+| CLI `--output json` on mutating commands? | Yes for `pull`, `link`, `link-status`, `disconnect` per agent-surface rule. |
 | Missing `sync link-status` CLI command? | Added (CLI symmetry with `sync_link_status` MCP tool). |
 | `sync_link` MCP sensitivity? | Bumped from `low` to `medium` — `link_url` is a one-time bearer credential. |

--- a/docs/specs/sync-overview.md
+++ b/docs/specs/sync-overview.md
@@ -85,13 +85,13 @@ sequenceDiagram
 
     Note over User,DB: Phase 2: Link
     User->>CLI: moneybin sync link
-    CLI->>Server: POST /sync/link-token
-    Server-->>CLI: link_token
+    CLI->>Server: POST /sync/link/initiate
+    Server-->>CLI: session_id, link_url
     CLI->>User: Open provider UI in browser
     User->>Server: Complete connection in browser
     Server->>Provider: Exchange token, store access
-    CLI->>Server: Poll for connection confirmation
-    Server-->>CLI: item_id, institution_name
+    CLI->>Server: Poll GET /sync/link/status
+    Server-->>CLI: status=linked, provider_item_id, institution_name
     CLI->>DB: Store in app.sync_connections
 
     Note over User,DB: Phase 3: Pull
@@ -123,12 +123,12 @@ sequenceDiagram
 - Automatic refresh via Auth0 refresh token when JWT expires.
 - One-time setup; subsequent commands use the stored token silently.
 
-### Phase 2: Connect
+### Phase 2: Link
 
-- Client calls `POST /sync/link-token` to get a provider connection token.
+- Client calls `POST /sync/link/initiate` to start a link session and receive `session_id` + `link_url`.
 - Server opens provider's connection UI in the user's browser (e.g., Plaid Link).
 - After the user completes the connection flow, the provider redirects to a server callback endpoint. The server stores the access token and confirms the connection.
-- Client polls the server until the connection is confirmed, then receives `item_id` and institution metadata.
+- Client polls `GET /sync/link/status` until status reaches `linked`, then receives `provider_item_id` and institution metadata.
 - Connection metadata stored locally in `app.sync_connections` for health tracking.
 
 ### Phase 3: Pull
@@ -287,7 +287,7 @@ $ moneybin sync link
 ⚙️  Opening bank connection...
 Visit: https://api.moneybin.app/link/abc123
 Waiting for connection...
-✅ Connected Chase (****1234, ****5678)
+✅ Linked Chase (****1234, ****5678)
 
 $ moneybin sync pull
 ⚙️  Starting sync for all connected institutions...

--- a/src/moneybin/cli/commands/sync.py
+++ b/src/moneybin/cli/commands/sync.py
@@ -10,7 +10,7 @@ import typer
 
 from moneybin.cli.output import OutputFormat, output_option, quiet_option
 from moneybin.cli.utils import handle_cli_errors
-from moneybin.connectors.sync_models import ConnectInitiateResponse
+from moneybin.connectors.sync_models import LinkInitiateResponse
 
 from .stubs import _not_implemented
 
@@ -75,9 +75,7 @@ def sync_logout() -> None:
         typer.echo("✅ Logged out.")
 
 
-def _surface_connect_link(
-    initiate: ConnectInitiateResponse, *, open_browser: bool
-) -> None:
+def _surface_link(initiate: LinkInitiateResponse, *, open_browser: bool) -> None:
     """Print the Plaid Hosted Link URL to stderr and optionally open the browser.
 
     Always prints to stderr so headless users can copy the URL even when
@@ -170,12 +168,12 @@ def sync_link(
                 # Event-driven: emit initiate response and exit. Agent verifies
                 # completion via `sync link-status` after the user finishes
                 # the Plaid Hosted Link flow out-of-band.
-                initiate = service.initiate_connect(institution=institution)
+                initiate = service.initiate_link(institution=institution)
                 typer.echo(initiate.model_dump_json(indent=2))
                 return
 
-            def _on_initiate(init: ConnectInitiateResponse) -> None:
-                _surface_connect_link(init, open_browser=not no_browser)
+            def _on_initiate(init: LinkInitiateResponse) -> None:
+                _surface_link(init, open_browser=not no_browser)
 
             result = service.link(
                 institution=institution,
@@ -183,7 +181,7 @@ def sync_link(
                 on_initiate=_on_initiate,
             )
 
-    typer.echo(f"✅ Connected {result.institution_name}")
+    typer.echo(f"✅ Linked {result.institution_name}")
     if result.pull_result is not None:
         typer.echo(f"   Pulled {result.pull_result.transactions_loaded} transactions")
         if result.pull_result.transforms_error:
@@ -210,7 +208,7 @@ def sync_link_status(
     """
     with handle_cli_errors():
         client = _build_sync_client()
-        result = client.get_connect_status(session_id)
+        result = client.get_link_status(session_id)
 
     if output == OutputFormat.JSON:
         typer.echo(result.model_dump_json(indent=2))

--- a/src/moneybin/connectors/sync_client.py
+++ b/src/moneybin/connectors/sync_client.py
@@ -11,7 +11,7 @@ Secret Service, some Docker setups).
 
 Timeouts:
 - _DEFAULT_TIMEOUT (15s) for most endpoints
-- _LONG_TIMEOUT (120s) for POST /sync/trigger and connect polling deadline
+- _LONG_TIMEOUT (120s) for POST /sync/trigger and link polling deadline
 Per design — no per-endpoint configuration knobs unless evidence demands them.
 """
 
@@ -33,14 +33,14 @@ from keyring.errors import KeyringError
 from moneybin.connectors.sync_errors import (
     SyncAPIError,
     SyncAuthError,
-    SyncConnectError,
+    SyncLinkError,
     SyncTimeoutError,
 )
 from moneybin.connectors.sync_models import (
     AuthToken,
     ConnectedInstitution,
-    ConnectInitiateResponse,
-    ConnectStatusResponse,
+    LinkInitiateResponse,
+    LinkStatusResponse,
     SyncAckResponse,
     SyncDataResponse,
     SyncTriggerResponse,
@@ -55,7 +55,7 @@ _KEYRING_REFRESH_KEY = "refresh_token"
 
 _DEFAULT_TIMEOUT = httpx.Timeout(15.0, connect=10.0)
 _LONG_TIMEOUT = httpx.Timeout(120.0, connect=10.0)
-_CONNECT_POLL_INTERVAL = 3.0
+_LINK_POLL_INTERVAL = 3.0
 
 
 class SyncClient:
@@ -314,62 +314,62 @@ class SyncClient:
         """Remove a connected institution by its connection ID."""
         self._authed_request("DELETE", f"/institutions/{connection_id}")
 
-    # ------------------------------ Connect flow ------------------------------
+    # ------------------------------ Link flow ------------------------------
 
-    def initiate_connect(
+    def initiate_link(
         self,
         *,
         provider: str = "plaid",
         provider_item_id: str | None = None,
         return_to: str | None = None,
-    ) -> ConnectInitiateResponse:
+    ) -> LinkInitiateResponse:
         """Start a Plaid Link session; returns session_id and hosted link_url."""
         body: dict[str, object] = {"provider": provider}
         if provider_item_id:
             body["provider_item_id"] = provider_item_id
         if return_to:
             body["return_to"] = return_to
-        resp = self._authed_request("POST", "/sync/connect/initiate", json_body=body)
-        return ConnectInitiateResponse.model_validate(resp.json())
+        resp = self._authed_request("POST", "/sync/link/initiate", json_body=body)
+        return LinkInitiateResponse.model_validate(resp.json())
 
-    def get_connect_status(self, session_id: str) -> ConnectStatusResponse:
-        """Single-shot GET /sync/connect/status — returns whatever state the server holds.
+    def get_link_status(self, session_id: str) -> LinkStatusResponse:
+        """Single-shot GET /sync/link/status — returns whatever state the server holds.
 
         Used by CLI `sync link-status` and MCP `sync_link_status`; both are
         event-driven (caller decides when to check) rather than blocking. Use
-        `poll_connect_status` instead when the caller needs to block until a
+        `poll_link_status` instead when the caller needs to block until a
         terminal state.
         """
         resp = self._authed_request(
             "GET",
-            "/sync/connect/status",
+            "/sync/link/status",
             params={"session_id": session_id},
         )
-        return ConnectStatusResponse.model_validate(resp.json())
+        return LinkStatusResponse.model_validate(resp.json())
 
-    def poll_connect_status(self, session_id: str) -> ConnectStatusResponse:
-        """Poll GET /sync/connect/status until status reaches a terminal state.
+    def poll_link_status(self, session_id: str) -> LinkStatusResponse:
+        """Poll GET /sync/link/status until status reaches a terminal state.
 
-        Terminal: 'connected' (returns) or 'failed' (raises SyncConnectError).
+        Terminal: 'linked' (returns) or 'failed' (raises SyncLinkError).
         Times out after _LONG_TIMEOUT seconds → SyncTimeoutError.
         """
         read_timeout: float = _LONG_TIMEOUT.read or 120.0
         deadline = time.time() + read_timeout
         while time.time() < deadline:
-            self._sleep(_CONNECT_POLL_INTERVAL)
+            self._sleep(_LINK_POLL_INTERVAL)
             resp = self._authed_request(
                 "GET",
-                "/sync/connect/status",
+                "/sync/link/status",
                 params={"session_id": session_id},
             )
-            status = ConnectStatusResponse.model_validate(resp.json())
-            if status.status == "connected":
+            status = LinkStatusResponse.model_validate(resp.json())
+            if status.status == "linked":
                 return status
             if status.status == "failed":
-                raise SyncConnectError(status.error or "connect session failed")
+                raise SyncLinkError(status.error or "link session failed")
             # status == "pending" → continue
         raise SyncTimeoutError(
-            "connect flow timed out — user may have abandoned the browser"
+            "link flow timed out — user may have abandoned the browser"
         )
 
     # ------------------------------ Sync trigger and data ------------------------------

--- a/src/moneybin/connectors/sync_errors.py
+++ b/src/moneybin/connectors/sync_errors.py
@@ -12,8 +12,8 @@ class SyncAuthError(SyncError):
     """Authentication failed: missing token, refresh failed, user denied device flow."""
 
 
-class SyncConnectError(SyncError):
-    """Connect session terminated with status='failed' on the server."""
+class SyncLinkError(SyncError):
+    """Link session terminated with status='failed' on the server."""
 
 
 class SyncTimeoutError(SyncError):

--- a/src/moneybin/connectors/sync_models.py
+++ b/src/moneybin/connectors/sync_models.py
@@ -25,20 +25,20 @@ class AuthToken(BaseModel):
     token_type: Literal["Bearer"] = "Bearer"  # noqa: S105  # literal constant, not a hardcoded password
 
 
-class ConnectInitiateResponse(BaseModel):
-    """Response from POST /sync/connect/initiate."""
+class LinkInitiateResponse(BaseModel):
+    """Response from POST /sync/link/initiate."""
 
     session_id: str = Field(min_length=1, max_length=128)
     link_url: str
-    connect_type: Literal["widget_flow", "token_paste"]
+    link_type: Literal["widget_flow", "token_paste"]
     expiration: datetime
 
 
-class ConnectStatusResponse(BaseModel):
-    """Response from GET /sync/connect/status."""
+class LinkStatusResponse(BaseModel):
+    """Response from GET /sync/link/status."""
 
     session_id: str
-    status: Literal["pending", "connected", "failed"]
+    status: Literal["pending", "linked", "failed"]
     provider_item_id: str | None = None
     institution_name: str | None = None
     error: str | None = None
@@ -159,12 +159,8 @@ class PullResult(BaseModel):
     transforms_error: str | None = None
 
 
-class ConnectResult(BaseModel):
-    """Return value from SyncService.link().
-
-    Named `ConnectResult` for historical reasons — predates the _link/_connect
-    verb split. Kept stable to avoid rippling renames into connector code.
-    """
+class LinkResult(BaseModel):
+    """Return value from SyncService.link()."""
 
     provider_item_id: str
     institution_name: str | None = None

--- a/src/moneybin/mcp/tools/sync.py
+++ b/src/moneybin/mcp/tools/sync.py
@@ -22,9 +22,9 @@ from moneybin.mcp._registration import register
 from moneybin.mcp.decorator import mcp_tool
 from moneybin.privacy.payloads.sync import (
     SyncConnectionRow,
-    SyncConnectPayload,
-    SyncConnectStatusPayload,
     SyncDisconnectPayload,
+    SyncLinkPayload,
+    SyncLinkStatusPayload,
     SyncPullInstitutionRow,
     SyncPullPayload,
     SyncStatusPayload,
@@ -137,7 +137,7 @@ def sync_status() -> ResponseEnvelope[SyncStatusPayload]:
 @mcp_tool(read_only=False, idempotent=False, open_world=True)
 def sync_link(
     institution: str | None = None,
-) -> ResponseEnvelope[SyncConnectPayload]:
+) -> ResponseEnvelope[SyncLinkPayload]:
     """Link a bank account via Plaid (formerly: sync_connect).
 
     Initiates a bank-connection flow via moneybin-server's Plaid Hosted Link.
@@ -173,9 +173,9 @@ def sync_link(
             provider_item_id = matches[0].provider_item_id
         # else: name doesn't match any existing connection → new-connection flow
         # per design Section 8; let the server's Link flow name the institution.
-    initiate = client.initiate_connect(provider_item_id=provider_item_id)
+    initiate = client.initiate_link(provider_item_id=provider_item_id)
     return build_envelope(
-        data=SyncConnectPayload(
+        data=SyncLinkPayload(
             session_id=initiate.session_id,
             link_url=initiate.link_url,
             expiration=initiate.expiration.isoformat(),
@@ -192,28 +192,28 @@ def sync_link(
 @mcp_tool()
 def sync_link_status(
     session_id: str,
-) -> ResponseEnvelope[SyncConnectStatusPayload]:
+) -> ResponseEnvelope[SyncLinkStatusPayload]:
     """Poll a sync_link session for completion (formerly: sync_connect_status).
 
     Check whether a bank-connection session has completed. Call after the user
     indicates they've finished the Plaid Link flow in their browser. Returns
-    connected, pending, or failed. Does NOT loop internally — the agent should
+    linked, pending, or failed. Does NOT loop internally — the agent should
     invoke this when the user signals completion, not poll repeatedly.
     """
     client = _build_sync_client()
-    status = client.get_connect_status(session_id)
+    status = client.get_link_status(session_id)
     actions: list[str] = []
     if status.status == "pending":
         actions = [
             "Connection has not completed yet. Ask the user to finish the flow in their browser, or wait and check again.",
             "If the session expiration has passed, start a new link flow with sync_link.",
         ]
-    elif status.status == "connected":
+    elif status.status == "linked":
         actions = ["Run sync_pull to fetch transactions from the new institution."]
     elif status.status == "failed":
         actions = ["Run sync_link to retry the connection."]
     return build_envelope(
-        data=SyncConnectStatusPayload(
+        data=SyncLinkStatusPayload(
             session_id=status.session_id,
             status=status.status,
             provider_item_id=status.provider_item_id,
@@ -233,7 +233,7 @@ def sync_link_status(
 @mcp_tool(read_only=False, idempotent=False, open_world=True)
 def sync_connect(
     institution: str | None = None,
-) -> ResponseEnvelope[SyncConnectPayload]:
+) -> ResponseEnvelope[SyncLinkPayload]:
     """Deprecated alias for `sync_link`. Will be removed in the next minor release."""
     logger.warning(
         "MCP tool `sync_connect` is deprecated; use `sync_link`. "
@@ -255,7 +255,7 @@ def sync_connect(
 @mcp_tool()
 def sync_connect_status(
     session_id: str,
-) -> ResponseEnvelope[SyncConnectStatusPayload]:
+) -> ResponseEnvelope[SyncLinkStatusPayload]:
     """Deprecated alias for `sync_link_status`. Will be removed in the next minor release."""
     logger.warning(
         "MCP tool `sync_connect_status` is deprecated; use `sync_link_status`. "

--- a/src/moneybin/privacy/payloads/sync.py
+++ b/src/moneybin/privacy/payloads/sync.py
@@ -10,9 +10,9 @@ Tier derivation summary:
                                         contains SyncPullInstitutionRow list)
   - ``SyncConnectionRow``             → Tier.MEDIUM (guidance = DESCRIPTION)
   - ``SyncStatusPayload``             → Tier.MEDIUM (via SyncConnectionRow)
-  - ``SyncConnectPayload``            → Tier.MEDIUM (link_url = DESCRIPTION —
+  - ``SyncLinkPayload``               → Tier.MEDIUM (link_url = DESCRIPTION —
                                         link is a sensitive one-time credential)
-  - ``SyncConnectStatusPayload``      → Tier.MEDIUM (error = DESCRIPTION)
+  - ``SyncLinkStatusPayload``         → Tier.MEDIUM (error = DESCRIPTION)
   - ``SyncDisconnectPayload``         → Tier.LOW (INSTITUTION + TXN_TYPE only)
   - ``SyncSchedulePlaceholderPayload``→ Tier.LOW (stub; not-implemented payloads)
 """
@@ -93,13 +93,13 @@ class SyncStatusPayload:
 
 
 # ---------------------------------------------------------------------------
-# sync_connect — initiate connection payload
+# sync_link — initiate link payload
 # ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True, slots=True)
-class SyncConnectPayload:
-    """Payload for ``sync_connect`` — link URL + session ID."""
+class SyncLinkPayload:
+    """Payload for ``sync_link`` — link URL + session ID."""
 
     session_id: Annotated[str, DataClass.RECORD_ID]
     link_url: Annotated[str, DataClass.DESCRIPTION]
@@ -107,13 +107,13 @@ class SyncConnectPayload:
 
 
 # ---------------------------------------------------------------------------
-# sync_connect_status — connection session status payload
+# sync_link_status — link session status payload
 # ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True, slots=True)
-class SyncConnectStatusPayload:
-    """Payload for ``sync_connect_status`` — connection session check."""
+class SyncLinkStatusPayload:
+    """Payload for ``sync_link_status`` — link session check."""
 
     session_id: Annotated[str, DataClass.RECORD_ID]
     status: Annotated[str, DataClass.TXN_TYPE]

--- a/src/moneybin/services/sync_service.py
+++ b/src/moneybin/services/sync_service.py
@@ -2,7 +2,7 @@
 
 CLI and MCP layers are thin wrappers around this service. Owns:
 - pull() orchestration (trigger → fetch → load)
-- connect() with optional auto-pull
+- link() with optional auto-pull
 - list_connections() with error-code → user-guidance mapping
 - disconnect() with institution name → connection_id resolution
 
@@ -17,8 +17,8 @@ from collections.abc import Callable
 from moneybin.connectors.sync_client import SyncClient
 from moneybin.connectors.sync_models import (
     ConnectedInstitution,
-    ConnectInitiateResponse,
-    ConnectResult,
+    LinkInitiateResponse,
+    LinkResult,
     PullResult,
     SyncConnectionView,
     SyncDataResponse,
@@ -53,7 +53,7 @@ _ERROR_GUIDANCE: dict[str, str] = {
 
 
 class SyncService:
-    """Orchestrates Plaid sync operations: pull, connect, list, disconnect."""
+    """Orchestrates Plaid sync operations: pull, link, list, disconnect."""
 
     def __init__(
         self,
@@ -221,14 +221,14 @@ class SyncService:
             )
             ACCOUNT_LINK_OUTCOMES_TOTAL.labels(result=resolved_account.outcome).inc()
 
-    # ------------------------------ Connect ------------------------------
+    # ------------------------------ Link ------------------------------
 
-    def initiate_connect(
+    def initiate_link(
         self,
         *,
         institution: str | None = None,
         return_to: str | None = None,
-    ) -> ConnectInitiateResponse:
+    ) -> LinkInitiateResponse:
         """Resolve institution and start a Plaid Link session — does not poll.
 
         Used by JSON-mode CLI and MCP sync_link, where the caller surfaces
@@ -245,29 +245,24 @@ class SyncService:
             inst = self._find_institution(institution)
             if inst is not None:
                 provider_item_id = inst.provider_item_id
-        initiate = self.client.initiate_connect(
+        initiate = self.client.initiate_link(
             provider_item_id=provider_item_id,
             return_to=return_to,
         )
-        if initiate.connect_type != "widget_flow":
+        if initiate.link_type != "widget_flow":
             raise NotImplementedError(
-                f"connect_type '{initiate.connect_type}' is not supported in this version"
+                f"link_type '{initiate.link_type}' is not supported in this version"
             )
         return initiate
 
-    # `ConnectInitiateResponse` / `ConnectResult` keep their names for historical
-    # reasons — they predate the _link/_connect verb split formalized in
-    # `connect-gsheet.md`. The method is the user-visible surface; the internal
-    # response types remain stable to avoid rippling renames into the connectors
-    # layer.
     def link(
         self,
         *,
         institution: str | None = None,
         auto_pull: bool = True,
         return_to: str | None = None,
-        on_initiate: Callable[[ConnectInitiateResponse], None] | None = None,
-    ) -> ConnectResult:
+        on_initiate: Callable[[LinkInitiateResponse], None] | None = None,
+    ) -> LinkResult:
         """Link new institution OR re-authenticate existing one.
 
         When `institution` matches an existing connection, runs Plaid update mode
@@ -275,32 +270,32 @@ class SyncService:
         request (per design Section 8); the server's Link flow handles naming.
         Ambiguous matches (same name on multiple connections) raise.
 
-        `on_initiate` is invoked synchronously with the ConnectInitiateResponse before
+        `on_initiate` is invoked synchronously with the LinkInitiateResponse before
         the service starts polling. The CLI uses this hook to display `link_url`
         and optionally open the user's browser. Without it, the service blocks on
         polling without surfacing the URL — only safe for callers that surface it
         themselves (MCP returns the URL in its envelope and never enters this path).
         """
-        initiate = self.initiate_connect(institution=institution, return_to=return_to)
+        initiate = self.initiate_link(institution=institution, return_to=return_to)
         if on_initiate is not None:
             on_initiate(initiate)
         try:
-            status = self.client.poll_connect_status(initiate.session_id)
+            status = self.client.poll_link_status(initiate.session_id)
         except Exception:
-            # poll_connect_status raises SyncConnectError on terminal 'failed'
+            # poll_link_status raises SyncLinkError on terminal 'failed'
             # status, and SyncTimeoutError when the user abandons the browser.
-            # Surface both as failed-connect outcomes; the CLI/MCP layer
+            # Surface both as failed-link outcomes; the CLI/MCP layer
             # re-raises with the specific exception type.
             SYNC_CONNECT_OUTCOMES.labels(status="failed").inc()
             raise
-        SYNC_CONNECT_OUTCOMES.labels(status=status.status or "connected").inc()
+        SYNC_CONNECT_OUTCOMES.labels(status=status.status or "linked").inc()
         pull_result: PullResult | None = None
         if auto_pull:
             try:
                 pull_result = self.pull(provider_item_id=status.provider_item_id)
             except Exception as e:
-                logger.warning(f"Auto-pull failed after connect: {e}")
-        return ConnectResult(
+                logger.warning(f"Auto-pull failed after link: {e}")
+        return LinkResult(
             provider_item_id=status.provider_item_id or "",
             institution_name=status.institution_name,
             pull_result=pull_result,

--- a/tests/moneybin/connectors/test_sync_client.py
+++ b/tests/moneybin/connectors/test_sync_client.py
@@ -14,7 +14,7 @@ from moneybin.connectors.sync_client import (
     _LONG_TIMEOUT,  # type: ignore[reportPrivateUsage]
     SyncClient,
 )
-from moneybin.connectors.sync_errors import SyncAuthError, SyncConnectError
+from moneybin.connectors.sync_errors import SyncAuthError, SyncLinkError
 from moneybin.connectors.sync_models import SyncAckResponse, SyncDataResponse
 
 
@@ -272,49 +272,49 @@ def test_401_after_successful_refresh_raises_auth_not_api(
 
 
 @respx.mock
-def test_initiate_connect_returns_session_and_url(sync_client: SyncClient) -> None:
+def test_initiate_link_returns_session_and_url(sync_client: SyncClient) -> None:
     sync_client._store_tokens(access_token="jwt", refresh_token="r")  # type: ignore[reportPrivateUsage]  # noqa: S106  # test fixture, not a real credential
-    respx.post("https://test.api/sync/connect/initiate").mock(
+    respx.post("https://test.api/sync/link/initiate").mock(
         return_value=httpx.Response(
             200,
             json={
                 "session_id": "sess_abc",
                 "link_url": "https://hosted.plaid.com/link/xyz",
-                "connect_type": "widget_flow",
+                "link_type": "widget_flow",
                 "expiration": "2026-05-13T13:30:00Z",
             },
         )
     )
-    result = sync_client.initiate_connect()
+    result = sync_client.initiate_link()
     assert result.session_id == "sess_abc"
-    assert result.connect_type == "widget_flow"
+    assert result.link_type == "widget_flow"
 
 
 @respx.mock
-def test_initiate_connect_passes_provider_item_id_for_update_mode(
+def test_initiate_link_passes_provider_item_id_for_update_mode(
     sync_client: SyncClient,
 ) -> None:
     sync_client._store_tokens(access_token="jwt", refresh_token="r")  # type: ignore[reportPrivateUsage]  # noqa: S106  # test fixture, not a real credential
-    route = respx.post("https://test.api/sync/connect/initiate").mock(
+    route = respx.post("https://test.api/sync/link/initiate").mock(
         return_value=httpx.Response(
             200,
             json={
                 "session_id": "sess_abc",
                 "link_url": "https://hosted.plaid.com/link/xyz",
-                "connect_type": "widget_flow",
+                "link_type": "widget_flow",
                 "expiration": "2026-05-13T13:30:00Z",
             },
         )
     )
-    sync_client.initiate_connect(provider_item_id="item_existing")
+    sync_client.initiate_link(provider_item_id="item_existing")
     sent_body = route.calls.last.request.content
     assert b"item_existing" in sent_body
 
 
 @respx.mock
-def test_poll_connect_until_connected(sync_client: SyncClient) -> None:
+def test_poll_link_until_linked(sync_client: SyncClient) -> None:
     sync_client._store_tokens(access_token="jwt", refresh_token="r")  # type: ignore[reportPrivateUsage]  # noqa: S106  # test fixture, not a real credential
-    respx.get("https://test.api/sync/connect/status").mock(
+    respx.get("https://test.api/sync/link/status").mock(
         side_effect=[
             httpx.Response(
                 200,
@@ -328,7 +328,7 @@ def test_poll_connect_until_connected(sync_client: SyncClient) -> None:
                 200,
                 json={
                     "session_id": "sess_abc",
-                    "status": "connected",
+                    "status": "linked",
                     "provider_item_id": "item_new",
                     "institution_name": "Chase",
                     "expiration": "2026-05-13T13:30:00Z",
@@ -337,15 +337,15 @@ def test_poll_connect_until_connected(sync_client: SyncClient) -> None:
         ]
     )
     sync_client._sleep = lambda _: None  # skip real sleep  # type: ignore[method-assign]
-    result = sync_client.poll_connect_status("sess_abc")
-    assert result.status == "connected"
+    result = sync_client.poll_link_status("sess_abc")
+    assert result.status == "linked"
     assert result.provider_item_id == "item_new"
 
 
 @respx.mock
-def test_poll_connect_failed_raises(sync_client: SyncClient) -> None:
+def test_poll_link_failed_raises(sync_client: SyncClient) -> None:
     sync_client._store_tokens(access_token="jwt", refresh_token="r")  # type: ignore[reportPrivateUsage]  # noqa: S106  # test fixture, not a real credential
-    respx.get("https://test.api/sync/connect/status").mock(
+    respx.get("https://test.api/sync/link/status").mock(
         return_value=httpx.Response(
             200,
             json={
@@ -357,8 +357,8 @@ def test_poll_connect_failed_raises(sync_client: SyncClient) -> None:
         )
     )
     sync_client._sleep = lambda _: None  # type: ignore[method-assign]
-    with pytest.raises(SyncConnectError, match="user cancelled"):
-        sync_client.poll_connect_status("sess_abc")
+    with pytest.raises(SyncLinkError, match="user cancelled"):
+        sync_client.poll_link_status("sess_abc")
 
 
 @respx.mock

--- a/tests/moneybin/connectors/test_sync_models.py
+++ b/tests/moneybin/connectors/test_sync_models.py
@@ -9,9 +9,9 @@ from pydantic import ValidationError
 from moneybin.connectors.sync_models import (
     AuthToken,
     ConnectedInstitution,
-    ConnectInitiateResponse,
-    ConnectStatusResponse,
     InstitutionResult,
+    LinkInitiateResponse,
+    LinkStatusResponse,
     SyncDataResponse,
     SyncTransaction,
     SyncTriggerResponse,
@@ -33,28 +33,28 @@ def test_auth_token_rejects_zero_expires_in() -> None:
         AuthToken(access_token="x", refresh_token="y", expires_in=0)  # noqa: S106  # test fixture, not a real credential
 
 
-def test_connect_initiate_valid_widget_flow() -> None:
-    resp = ConnectInitiateResponse(
+def test_link_initiate_valid_widget_flow() -> None:
+    resp = LinkInitiateResponse(
         session_id="sess_abc",
         link_url="https://hosted.plaid.com/link/x",
-        connect_type="widget_flow",
+        link_type="widget_flow",
         expiration=datetime(2026, 5, 13, 13, 30, tzinfo=UTC),
     )
-    assert resp.connect_type == "widget_flow"
+    assert resp.link_type == "widget_flow"
 
 
-def test_connect_initiate_rejects_unknown_connect_type() -> None:
+def test_link_initiate_rejects_unknown_link_type() -> None:
     with pytest.raises(ValidationError):
-        ConnectInitiateResponse(
+        LinkInitiateResponse(
             session_id="sess_abc",
             link_url="https://hosted.plaid.com/link/x",
-            connect_type="oauth_redirect",  # type: ignore[arg-type]  # not in Literal
+            link_type="oauth_redirect",  # type: ignore[arg-type]  # not in Literal
             expiration=datetime(2026, 5, 13, 13, 30, tzinfo=UTC),
         )
 
 
-def test_connect_status_pending() -> None:
-    resp = ConnectStatusResponse(
+def test_link_status_pending() -> None:
+    resp = LinkStatusResponse(
         session_id="sess_abc",
         status="pending",
         expiration=datetime(2026, 5, 13, 13, 30, tzinfo=UTC),

--- a/tests/moneybin/test_cli/test_cli_sync.py
+++ b/tests/moneybin/test_cli/test_cli_sync.py
@@ -11,8 +11,8 @@ from typer.testing import CliRunner
 
 from moneybin.cli.main import app
 from moneybin.connectors.sync_models import (
-    ConnectResult,
     InstitutionResult,
+    LinkResult,
     PullResult,
     SyncConnectionView,
 )
@@ -195,7 +195,7 @@ def test_sync_link_status_command_exists() -> None:
 def test_sync_link_new_institution(mock_build: MagicMock) -> None:
     service = MagicMock()
     service.list_connections.return_value = []
-    service.link.return_value = ConnectResult(
+    service.link.return_value = LinkResult(
         provider_item_id="item_new",
         institution_name="Chase",
         pull_result=_fake_pull_result(),
@@ -221,7 +221,7 @@ def test_sync_link_surfaces_transforms_error_from_auto_pull(
     """
     service = MagicMock()
     service.list_connections.return_value = []
-    service.link.return_value = ConnectResult(
+    service.link.return_value = LinkResult(
         provider_item_id="item_new",
         institution_name="Chase",
         pull_result=_fake_pull_result(
@@ -240,7 +240,7 @@ def test_sync_link_surfaces_transforms_error_from_auto_pull(
 def test_sync_link_no_pull(mock_build: MagicMock) -> None:
     service = MagicMock()
     service.list_connections.return_value = []
-    service.link.return_value = ConnectResult(
+    service.link.return_value = LinkResult(
         provider_item_id="item_new",
         institution_name="Chase",
     )
@@ -255,7 +255,7 @@ def test_sync_link_no_pull(mock_build: MagicMock) -> None:
 @patch("moneybin.cli.commands.sync._build_sync_service")
 def test_sync_link_explicit_institution(mock_build: MagicMock) -> None:
     service = MagicMock()
-    service.link.return_value = ConnectResult(
+    service.link.return_value = LinkResult(
         provider_item_id="item_x",
         institution_name="Schwab",
     )
@@ -274,14 +274,14 @@ def test_sync_link_status_command(mock_build: MagicMock) -> None:
     from moneybin.connectors.sync_client import SyncClient
 
     client = MagicMock(spec=SyncClient)
-    # CLI link-status is single-shot via the public get_connect_status,
-    # not the blocking poll_connect_status loop.
-    client.get_connect_status.return_value = MagicMock(
+    # CLI link-status is single-shot via the public get_link_status,
+    # not the blocking poll_link_status loop.
+    client.get_link_status.return_value = MagicMock(
         session_id="sess_x",
-        status="connected",
+        status="linked",
         provider_item_id="item_new",
         institution_name="Chase",
-        model_dump_json=lambda **k: '{"status": "connected"}',  # type: ignore[misc]
+        model_dump_json=lambda **k: '{"status": "linked"}',  # type: ignore[misc]
     )
     # link-status uses the client directly, not the service
     with patch("moneybin.cli.commands.sync._build_sync_client", return_value=client):
@@ -290,7 +290,7 @@ def test_sync_link_status_command(mock_build: MagicMock) -> None:
             ["sync", "link-status", "--session-id", "sess_x", "--output", "json"],
         )
     assert result.exit_code == 0, result.output
-    assert "connected" in result.stdout
+    assert "linked" in result.stdout
 
 
 @pytest.mark.unit
@@ -302,7 +302,7 @@ def test_sync_connect_alias_warns_and_forwards(
     """The deprecated `sync connect` alias warns but still forwards to `sync link`."""
     service = MagicMock()
     service.list_connections.return_value = []
-    service.link.return_value = ConnectResult(
+    service.link.return_value = LinkResult(
         provider_item_id="item_new",
         institution_name="Chase",
     )
@@ -327,12 +327,12 @@ def test_sync_connect_status_alias_warns_and_forwards(mock_logger: MagicMock) ->
     from moneybin.connectors.sync_client import SyncClient
 
     client = MagicMock(spec=SyncClient)
-    client.get_connect_status.return_value = MagicMock(
+    client.get_link_status.return_value = MagicMock(
         session_id="sess_x",
-        status="connected",
+        status="linked",
         provider_item_id="item_new",
         institution_name="Chase",
-        model_dump_json=lambda **k: '{"status": "connected"}',  # type: ignore[misc]
+        model_dump_json=lambda **k: '{"status": "linked"}',  # type: ignore[misc]
     )
     with patch("moneybin.cli.commands.sync._build_sync_client", return_value=client):
         result = runner.invoke(
@@ -340,7 +340,7 @@ def test_sync_connect_status_alias_warns_and_forwards(mock_logger: MagicMock) ->
             ["sync", "connect-status", "--session-id", "sess_x", "--output", "json"],
         )
     assert result.exit_code == 0, result.output
-    assert "connected" in result.stdout
+    assert "linked" in result.stdout
     assert mock_logger.warning.called
     assert any(
         "deprecated" in str(call.args[0]).lower()

--- a/tests/moneybin/test_mcp/test_mcp_sync.py
+++ b/tests/moneybin/test_mcp/test_mcp_sync.py
@@ -9,8 +9,8 @@ import pytest
 from fastmcp import FastMCP
 
 from moneybin.connectors.sync_models import (
-    ConnectInitiateResponse,
     InstitutionResult,
+    LinkInitiateResponse,
     PullResult,
     SyncConnectionView,
 )
@@ -76,10 +76,10 @@ async def test_sync_link_returns_link_url_with_medium_sensitivity(
     mock_client_builder: MagicMock,
 ) -> None:
     client = MagicMock()
-    client.initiate_connect.return_value = ConnectInitiateResponse(
+    client.initiate_link.return_value = LinkInitiateResponse(
         session_id="sess_abc",
         link_url="https://hosted.plaid.com/link/xyz",
-        connect_type="widget_flow",
+        link_type="widget_flow",
         expiration=datetime(2026, 5, 13, 13, 30, tzinfo=UTC),
     )
     mock_client_builder.return_value = client
@@ -99,12 +99,12 @@ async def test_sync_link_returns_link_url_with_medium_sensitivity(
 async def test_sync_link_status_pending(mock_client_builder: MagicMock) -> None:
     from datetime import UTC, datetime
 
-    from moneybin.connectors.sync_models import ConnectStatusResponse
+    from moneybin.connectors.sync_models import LinkStatusResponse
 
     client = MagicMock()
-    # MCP sync_link_status uses the public get_connect_status single-shot
+    # MCP sync_link_status uses the public get_link_status single-shot
     # method on the client (was reaching into _authed_request before).
-    client.get_connect_status.return_value = ConnectStatusResponse(
+    client.get_link_status.return_value = LinkStatusResponse(
         session_id="sess_abc",
         status="pending",
         expiration=datetime(2026, 5, 13, 13, 30, tzinfo=UTC),
@@ -143,10 +143,10 @@ async def test_sync_connect_alias_warns_and_forwards(
 ) -> None:
     """The deprecated `sync_connect` alias warns but still forwards to `sync_link`."""
     client = MagicMock()
-    client.initiate_connect.return_value = ConnectInitiateResponse(
+    client.initiate_link.return_value = LinkInitiateResponse(
         session_id="sess_abc",
         link_url="https://hosted.plaid.com/link/xyz",
-        connect_type="widget_flow",
+        link_type="widget_flow",
         expiration=datetime(2026, 5, 13, 13, 30, tzinfo=UTC),
     )
     mock_client_builder.return_value = client
@@ -154,7 +154,7 @@ async def test_sync_connect_alias_warns_and_forwards(
 
     envelope = await sync_connect()
     # sync_connect is now the deprecated alias → forwards to sync_link and
-    # returns the same typed SyncConnectPayload (link_url: DESCRIPTION → MEDIUM).
+    # returns the same typed SyncLinkPayload (link_url: DESCRIPTION → MEDIUM).
     assert envelope.summary.sensitivity == "medium"
     assert envelope.data.session_id == "sess_abc"
     assert envelope.data.link_url == "https://hosted.plaid.com/link/xyz"
@@ -176,10 +176,10 @@ async def test_sync_connect_status_alias_warns_and_forwards(
     mock_client_builder: MagicMock, mock_logger: MagicMock
 ) -> None:
     """The deprecated `sync_connect_status` alias warns but still forwards."""
-    from moneybin.connectors.sync_models import ConnectStatusResponse
+    from moneybin.connectors.sync_models import LinkStatusResponse
 
     client = MagicMock()
-    client.get_connect_status.return_value = ConnectStatusResponse(
+    client.get_link_status.return_value = LinkStatusResponse(
         session_id="sess_abc",
         status="pending",
         expiration=datetime(2026, 5, 13, 13, 30, tzinfo=UTC),

--- a/tests/moneybin/test_services/test_sync_service.py
+++ b/tests/moneybin/test_services/test_sync_service.py
@@ -12,8 +12,8 @@ import yaml
 from moneybin.connectors.sync_client import SyncAPIError
 from moneybin.connectors.sync_models import (
     ConnectedInstitution,
-    ConnectInitiateResponse,
-    ConnectStatusResponse,
+    LinkInitiateResponse,
+    LinkStatusResponse,
     SyncDataResponse,
     SyncTriggerResponse,
 )
@@ -181,21 +181,21 @@ def test_pull_with_force_passes_reset_cursor(
     )
 
 
-def test_connect_new_institution_auto_pulls(
+def test_link_new_institution_auto_pulls(
     mock_client: MagicMock,
     db: Database,
     loader: PlaidExtractor,
     sync_data: SyncDataResponse,
 ) -> None:
-    mock_client.initiate_connect.return_value = ConnectInitiateResponse(
+    mock_client.initiate_link.return_value = LinkInitiateResponse(
         session_id="sess_x",
         link_url="https://hosted.plaid.com/link/x",
-        connect_type="widget_flow",
+        link_type="widget_flow",
         expiration=datetime(2026, 5, 13, 13, 30, tzinfo=UTC),
     )
-    mock_client.poll_connect_status.return_value = ConnectStatusResponse(
+    mock_client.poll_link_status.return_value = LinkStatusResponse(
         session_id="sess_x",
-        status="connected",
+        status="linked",
         provider_item_id="item_chase_abc",
         institution_name="Chase",
         expiration=datetime(2026, 5, 13, 13, 30, tzinfo=UTC),
@@ -212,18 +212,18 @@ def test_connect_new_institution_auto_pulls(
     )
 
 
-def test_connect_no_pull_returns_without_pull_result(
+def test_link_no_pull_returns_without_pull_result(
     mock_client: MagicMock, db: Database, loader: PlaidExtractor
 ) -> None:
-    mock_client.initiate_connect.return_value = ConnectInitiateResponse(
+    mock_client.initiate_link.return_value = LinkInitiateResponse(
         session_id="sess_x",
         link_url="https://hosted.plaid.com/link/x",
-        connect_type="widget_flow",
+        link_type="widget_flow",
         expiration=datetime(2026, 5, 13, 13, 30, tzinfo=UTC),
     )
-    mock_client.poll_connect_status.return_value = ConnectStatusResponse(
+    mock_client.poll_link_status.return_value = LinkStatusResponse(
         session_id="sess_x",
-        status="connected",
+        status="linked",
         provider_item_id="item_new",
         institution_name="Bank",
         expiration=datetime(2026, 5, 13, 13, 30, tzinfo=UTC),
@@ -234,7 +234,7 @@ def test_connect_no_pull_returns_without_pull_result(
     mock_client.trigger_sync.assert_not_called()
 
 
-def test_connect_re_auth_resolves_institution_name(
+def test_link_re_auth_resolves_institution_name(
     mock_client: MagicMock, db: Database, loader: PlaidExtractor
 ) -> None:
     mock_client.list_institutions.return_value = [
@@ -247,28 +247,28 @@ def test_connect_re_auth_resolves_institution_name(
             created_at=datetime(2026, 3, 15, tzinfo=UTC),
         ),
     ]
-    mock_client.initiate_connect.return_value = ConnectInitiateResponse(
+    mock_client.initiate_link.return_value = LinkInitiateResponse(
         session_id="sess_x",
         link_url="https://hosted.plaid.com/link/x",
-        connect_type="widget_flow",
+        link_type="widget_flow",
         expiration=datetime(2026, 5, 13, 13, 30, tzinfo=UTC),
     )
-    mock_client.poll_connect_status.return_value = ConnectStatusResponse(
+    mock_client.poll_link_status.return_value = LinkStatusResponse(
         session_id="sess_x",
-        status="connected",
+        status="linked",
         provider_item_id="item_existing",
         institution_name="Chase",
         expiration=datetime(2026, 5, 13, 13, 30, tzinfo=UTC),
     )
     service = SyncService(client=mock_client, db=db, loader=loader)
     service.link(institution="Chase", auto_pull=False)
-    mock_client.initiate_connect.assert_called_once_with(
+    mock_client.initiate_link.assert_called_once_with(
         provider_item_id="item_existing",
         return_to=None,
     )
 
 
-def test_connect_falls_through_to_new_when_institution_not_matched(
+def test_link_falls_through_to_new_when_institution_not_matched(
     mock_client: MagicMock, db: Database, loader: PlaidExtractor
 ) -> None:
     """Unknown institution name falls through to new-connection flow.
@@ -277,15 +277,15 @@ def test_connect_falls_through_to_new_when_institution_not_matched(
     intent, not an error — let the server's Link flow name the institution.
     """
     mock_client.list_institutions.return_value = []  # no existing connections
-    mock_client.initiate_connect.return_value = ConnectInitiateResponse(
+    mock_client.initiate_link.return_value = LinkInitiateResponse(
         session_id="sess_x",
         link_url="https://hosted.plaid.com/link/x",
-        connect_type="widget_flow",
+        link_type="widget_flow",
         expiration=datetime(2026, 5, 13, 13, 30, tzinfo=UTC),
     )
-    mock_client.poll_connect_status.return_value = ConnectStatusResponse(
+    mock_client.poll_link_status.return_value = LinkStatusResponse(
         session_id="sess_x",
-        status="connected",
+        status="linked",
         provider_item_id="item_new",
         institution_name="Bank",
         expiration=datetime(2026, 5, 13, 13, 30, tzinfo=UTC),
@@ -293,35 +293,35 @@ def test_connect_falls_through_to_new_when_institution_not_matched(
     service = SyncService(client=mock_client, db=db, loader=loader)
     service.link(institution="Wells Fargo", auto_pull=False)
     # provider_item_id is None — new-connection flow, not update mode
-    mock_client.initiate_connect.assert_called_once_with(
+    mock_client.initiate_link.assert_called_once_with(
         provider_item_id=None,
         return_to=None,
     )
 
 
-def test_connect_invokes_on_initiate_callback_before_polling(
+def test_link_invokes_on_initiate_callback_before_polling(
     mock_client: MagicMock, db: Database, loader: PlaidExtractor
 ) -> None:
-    """on_initiate fires after initiate_connect, before polling.
+    """on_initiate fires after initiate_link, before polling.
 
     The CLI uses on_initiate to print link_url + open the browser. Verify
-    the service invokes it between initiate_connect and poll_connect_status.
+    the service invokes it between initiate_link and poll_link_status.
     """
-    initiate_resp = ConnectInitiateResponse(
+    initiate_resp = LinkInitiateResponse(
         session_id="sess_x",
         link_url="https://hosted.plaid.com/link/x",
-        connect_type="widget_flow",
+        link_type="widget_flow",
         expiration=datetime(2026, 5, 13, 13, 30, tzinfo=UTC),
     )
-    mock_client.initiate_connect.return_value = initiate_resp
-    mock_client.poll_connect_status.return_value = ConnectStatusResponse(
+    mock_client.initiate_link.return_value = initiate_resp
+    mock_client.poll_link_status.return_value = LinkStatusResponse(
         session_id="sess_x",
-        status="connected",
+        status="linked",
         provider_item_id="item_new",
         institution_name="Bank",
         expiration=datetime(2026, 5, 13, 13, 30, tzinfo=UTC),
     )
-    captured: list[ConnectInitiateResponse] = []
+    captured: list[LinkInitiateResponse] = []
     service = SyncService(client=mock_client, db=db, loader=loader)
     service.link(auto_pull=False, on_initiate=captured.append)
     assert captured == [initiate_resp]


### PR DESCRIPTION
## What

Lockstep companion to **moneybin-sync PR #13**, which renamed the broker's bank-attachment flow `connect`→`link` (`/sync/link/*`, status `linked`, field `link_type`). This updates the moneybin **client connector layer** to speak `link` at that boundary — paying down the acknowledged *"predates the `_link`/`_connect` verb split … kept stable to avoid rippling renames"* debt. Behavior-preserving.

> ⚠️ **Merge order:** land broker PR #13 first, then this. The connector now calls `/sync/link/*` and expects status `linked` / field `link_type`.

## Renamed (connector layer)

`ConnectInitiateResponse`→`LinkInitiateResponse`, `ConnectStatusResponse`→`LinkStatusResponse`, the sync `ConnectResult`→`LinkResult` (also removes its name collision with gsheet's `ConnectResult`), `SyncConnectError`→`SyncLinkError`, `initiate_connect`→`initiate_link`, `get/poll_connect_status`→`get/poll_link_status`, `connect_type`→`link_type`, status `"connected"`→`"linked"`, paths `/sync/connect/*`→`/sync/link/*`, and the MCP privacy payloads `SyncConnect[Status]Payload`→`SyncLink[Status]Payload`. Docstrings/specs updated.

## Deliberately kept as `connect` (distinct concepts)

- The **gsheet live-source family** (its own `ConnectResult` / `.connect()`) — `connect` = live first-party sources is the client's settled taxonomy.
- `httpx.Timeout(connect=...)` (httpx connection-timeout param).
- DB / "connection" language.
- The **deprecated `sync connect` / `sync_connect` CLI + MCP aliases** and their deprecation strings (backward-compat; they exist to redirect users to `sync link`).
- **Institution-management nouns:** `ConnectedInstitution`, `list_connections`, `SyncConnectionView`, `disconnect` (established-state "connection" noun — mirrors the broker's keep).
- **`SYNC_CONNECT_OUTCOMES`** metric name — an external observability contract; renaming would break time-series/dashboards. (Flagging in case you'd prefer to rename it pre-launch.)

## Verification

`ruff` clean · `pyright` **0 errors** · **384** sync/connector/cli/mcp/privacy tests pass. Independent review performed; residual scan for `/sync/connect`, `connect_type`, `SyncConnectError`, `SyncConnect*Payload` all return 0.

(2 unrelated `test_system_freshness` failures are a macOS-keychain sandbox issue, not touched by this change.)