### PR TITLE
Cut per-test DB setup cost with a template-copy db fixture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -340,6 +340,7 @@ markers = [
     "e2e: marks tests as end-to-end subprocess tests",
     "scenarios: marks whole-pipeline scenario tests (slow, real DB, real SQLMesh)",
     "perf: marks performance regression tests (require a fully-loaded persona DB)",
+    "fresh_db: build a real per-test schema instead of copying the fast session template; for tests whose subject is schema creation / migration / init",
 ]
 filterwarnings = [
     # Ignore deprecation warnings from third-party libraries we don't control

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -276,6 +276,7 @@ class Database:
         read_only: bool,
         secret_store: SecretStore | None = None,
         no_auto_upgrade: bool | None = None,
+        assume_initialized: bool = False,
     ) -> None:
         """Initialize and open the encrypted database connection.
 
@@ -288,6 +289,12 @@ class Database:
                 creates a new one.
             no_auto_upgrade: If True, skip versioned migrations and SQLMesh
                 migrate on startup. If None, reads from config.
+            assume_initialized: If True, skip ``init_schemas``, the migration
+                block, and ``refresh_views`` entirely. The caller asserts the
+                file is already schema-current — i.e. a copy of a
+                fully-initialized template DB. Default ``False``; production
+                opens always leave this ``False`` and run the full sequence.
+                Intended only for the test template-copy fixture.
 
         Raises:
             DatabaseKeyError: If the encryption key cannot be retrieved.
@@ -295,6 +302,8 @@ class Database:
                 not exist.
             DatabaseLockError: If DuckDB reports a conflicting lock or
                 configuration mismatch on ATTACH.
+            ValueError: If assume_initialized=True combined with read_only=True,
+                or if assume_initialized=True but db_path does not exist.
         """
         self._db_path = db_path
         self._conn: duckdb.DuckDBPyConnection | None = None
@@ -309,6 +318,17 @@ class Database:
             raise DatabaseNotInitializedError(
                 f"Database not found at {db_path}.\n"
                 f"Run 'moneybin db init' to initialize it first."
+            )
+
+        if assume_initialized and read_only:
+            raise ValueError(
+                "assume_initialized is incompatible with read_only "
+                "(read-only opens never initialize the schema)."
+            )
+        if assume_initialized and not db_path.exists():
+            raise ValueError(
+                "assume_initialized requires an existing, already-initialized "
+                "database file (e.g. a copy of a built template)."
             )
 
         store = secret_store or SecretStore()
@@ -374,6 +394,20 @@ class Database:
 
             if not is_new and sys.platform != "win32":
                 self._check_permissions(db_path)
+
+            if assume_initialized:
+                # Caller asserts the attached file is already schema-current — a
+                # copy of a fully-initialized template DB. Skip the idempotent but
+                # expensive schema build (init_schemas + migration check +
+                # refresh_views) so per-test fixtures don't re-pay it ~1,600×.
+                # Test-only contract: production opens leave this False and always
+                # run the full sequence below. The construct-or-rollback ExitStack
+                # still guards the attach/USE above.
+                stack.pop_all()
+                logger.debug(
+                    f"Database connection established (assume_initialized): {db_path}"
+                )
+                return
 
             from moneybin.schema import init_schemas
 

--- a/tests/moneybin/conftest.py
+++ b/tests/moneybin/conftest.py
@@ -300,6 +300,28 @@ def module_db(
     database.close()
 
 
+@pytest.fixture(scope="session")
+def _db_template(  # pyright: ignore[reportUnusedFunction]  # pytest fixture referenced by parameter name
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Path:
+    """Build the encrypted, schema-only DB once per session; return its path.
+
+    A real ``Database()`` open runs the full schema build (init_schemas +
+    refresh_views) exactly once per xdist worker; no data is inserted, so the
+    template matches what the function-scoped ``db`` fixture used to produce
+    fresh per test. Closed before returning so the file is safe to copy
+    (DuckDB flushes on a clean close — see testing.md Performance Patterns).
+    The fast ``db`` fixture copies this file instead of rebuilding the schema.
+    """
+    store = MagicMock()
+    store.get_key.return_value = "test-encryption-key-for-unit-tests"
+    template_path = tmp_path_factory.mktemp("db_template") / "template.duckdb"
+    Database(
+        template_path, secret_store=store, no_auto_upgrade=True, read_only=False
+    ).close()
+    return template_path
+
+
 @pytest.fixture()
 def simple_statement_pdf() -> Path:
     """Path to the committed simple-statement fixture PDF.
@@ -342,29 +364,42 @@ def empty_statement_pdf() -> Path:
 
 
 @pytest.fixture()
-def db(tmp_path: Path, mock_secret_store: MagicMock) -> Generator[Database, None, None]:
+def db(
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+    mock_secret_store: MagicMock,
+    _db_template: Path,
+) -> Generator[Database, None, None]:
     """Provide a test Database instance with encryption.
 
-    Creates a temporary encrypted database suitable for unit and integration
-    tests. The database is initialized with all base schemas (raw, core, app)
-    but contains no pre-populated data.
+    Fast by default: copies the session-scoped template (built once via a real
+    schema init) into this test's tmp_path and opens it with
+    ``assume_initialized=True`` — skipping the per-test schema rebuild. The
+    object, schema, and per-test isolation are identical to a fresh build.
 
-    For tests that need specific core tables (dim_accounts, fct_transactions),
-    use db_helpers.create_core_tables(db) or create_core_tables_raw(db.conn).
-
-    Args:
-        tmp_path: pytest temporary directory fixture.
-        mock_secret_store: Mocked SecretStore that provides a test key.
-
-    Yields:
-        A Database instance ready for test queries.
+    Mark a test or module ``@pytest.mark.fresh_db`` to force a real per-test
+    schema build instead — required for tests whose *subject* is schema
+    creation, migration, or init (so they exercise the real mechanism rather
+    than a pre-baked copy). See ``test_template_copy_matches_fresh_build`` for
+    the invariant that keeps the two paths equivalent.
     """
     db_path = tmp_path / "test.duckdb"
-    database = Database(
-        db_path,
-        secret_store=mock_secret_store,
-        no_auto_upgrade=True,
-        read_only=False,
-    )
+    if request.node.get_closest_marker("fresh_db"):  # type: ignore[reportUnknownMemberType]  # pytest stub incomplete
+        database = Database(
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            read_only=False,
+        )
+    else:
+        shutil.copy(_db_template, db_path)
+        db_path.chmod(0o600)  # match the 0600 a fresh open sets; keep output pristine
+        database = Database(
+            db_path,
+            secret_store=mock_secret_store,
+            no_auto_upgrade=True,
+            assume_initialized=True,
+            read_only=False,
+        )
     yield database
     database.close()

--- a/tests/moneybin/conftest.py
+++ b/tests/moneybin/conftest.py
@@ -382,9 +382,15 @@ def db(
     creation, migration, or init (so they exercise the real mechanism rather
     than a pre-baked copy). See ``test_template_copy_matches_fresh_build`` for
     the invariant that keeps the two paths equivalent.
+
+    Fast-path key constraint: the template is encrypted with the conftest
+    default key (``"test-encryption-key-for-unit-tests"``). A module that
+    overrides ``mock_secret_store`` with a *different* key MUST also mark
+    ``fresh_db`` — otherwise the copied template fails to decrypt with a raw
+    DuckDB error. (See ``test_database.py``'s ``TestCheckCoreSchemaDrift``.)
     """
     db_path = tmp_path / "test.duckdb"
-    if request.node.get_closest_marker("fresh_db"):  # type: ignore[reportUnknownMemberType]  # pytest stub incomplete
+    if request.node.get_closest_marker("fresh_db"):  # pyright: ignore[reportUnknownMemberType]  # pytest stub incomplete
         database = Database(
             db_path,
             secret_store=mock_secret_store,

--- a/tests/moneybin/test_database.py
+++ b/tests/moneybin/test_database.py
@@ -803,6 +803,7 @@ class TestGetDatabaseNew:
         db.close()
 
 
+@pytest.mark.fresh_db
 class TestCheckCoreSchemaDrift:
     """check_core_schema_drift() — detect missing columns on FULL core tables."""
 

--- a/tests/moneybin/test_database/test_assume_initialized.py
+++ b/tests/moneybin/test_database/test_assume_initialized.py
@@ -1,0 +1,84 @@
+"""Tests for Database(assume_initialized=True): the test-fixture skip-init path."""
+
+import shutil
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import moneybin.schema as schema_mod
+from moneybin.database import Database
+
+
+def _store() -> MagicMock:
+    store = MagicMock()
+    store.get_key.return_value = "test-encryption-key-for-unit-tests"
+    return store
+
+
+def _build_template(path: Path) -> None:
+    """A real, fully-initialized DB closed so it is safe to copy."""
+    Database(path, secret_store=_store(), no_auto_upgrade=True, read_only=False).close()
+
+
+def test_assume_initialized_skips_init_schemas(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    template = tmp_path / "template.duckdb"
+    _build_template(template)
+    copy = tmp_path / "copy.duckdb"
+    shutil.copy(template, copy)
+    copy.chmod(0o600)
+
+    calls: list[int] = []
+
+    def _noop_init_schemas(*_args: object, **_kwargs: object) -> None:
+        calls.append(1)
+
+    monkeypatch.setattr(schema_mod, "init_schemas", _noop_init_schemas)
+
+    db = Database(
+        copy,
+        secret_store=_store(),
+        no_auto_upgrade=True,
+        assume_initialized=True,
+        read_only=False,
+    )
+    try:
+        assert calls == []  # init_schemas was NOT called
+        # ...and the DB is a usable read-write current-schema DB:
+        db.execute(
+            "INSERT INTO app.transaction_notes (note_id, transaction_id, text, author)"
+            " VALUES (?, ?, ?, ?)",
+            ["n1", "t1", "x", "cli"],
+        )
+        row = db.execute(
+            "SELECT text FROM app.transaction_notes WHERE transaction_id = ?",
+            ["t1"],
+        ).fetchone()
+        assert row is not None and row[0] == "x"
+    finally:
+        db.close()
+
+
+def test_assume_initialized_rejects_read_only(tmp_path: Path) -> None:
+    template = tmp_path / "template.duckdb"
+    _build_template(template)
+    with pytest.raises(ValueError, match="incompatible with read_only"):
+        Database(
+            template,
+            secret_store=_store(),
+            assume_initialized=True,
+            read_only=True,
+        )
+
+
+def test_assume_initialized_rejects_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="requires an existing"):
+        Database(
+            tmp_path / "does_not_exist.duckdb",
+            secret_store=_store(),
+            no_auto_upgrade=True,
+            assume_initialized=True,
+            read_only=False,
+        )

--- a/tests/moneybin/test_database/test_assume_initialized.py
+++ b/tests/moneybin/test_database/test_assume_initialized.py
@@ -68,6 +68,7 @@ def test_assume_initialized_rejects_read_only(tmp_path: Path) -> None:
         Database(
             template,
             secret_store=_store(),
+            no_auto_upgrade=True,
             assume_initialized=True,
             read_only=True,
         )
@@ -85,7 +86,7 @@ def test_assume_initialized_rejects_missing_file(tmp_path: Path) -> None:
 
 
 def _catalog(db: Database) -> dict[str, object]:
-    """Full schema fingerprint: tables, columns (+types), views, and comments."""
+    """Full schema fingerprint: tables, columns (+types), views, comments, constraints."""
     tables = db.execute(
         "SELECT schema_name, table_name, comment FROM duckdb_tables() "
         "ORDER BY schema_name, table_name"
@@ -98,31 +99,47 @@ def _catalog(db: Database) -> dict[str, object]:
         "SELECT schema_name, view_name FROM duckdb_views() "
         "ORDER BY schema_name, view_name"
     ).fetchall()
-    return {"tables": tables, "columns": columns, "views": views}
+    # Constraints (PK/unique/check/not-null) — the dimension test_repo_metadata's
+    # PK check relies on; included so schema drift in keys can't slip past.
+    constraints = db.execute(
+        "SELECT schema_name, table_name, constraint_type, constraint_text "
+        "FROM duckdb_constraints() "
+        "ORDER BY schema_name, table_name, constraint_type, constraint_text"
+    ).fetchall()
+    return {
+        "tables": tables,
+        "columns": columns,
+        "views": views,
+        "constraints": constraints,
+    }
 
 
 def test_template_copy_matches_fresh_build(tmp_path: Path) -> None:
-    # A fresh, real init build:
-    fresh_path = tmp_path / "fresh.duckdb"
-    fresh = Database(
-        fresh_path, secret_store=_store(), no_auto_upgrade=True, read_only=False
-    )
-
-    # The template-copy path the fast `db` fixture uses:
+    # Build the copy artifacts first, so a failure here opens no connection.
     template = tmp_path / "template.duckdb"
     _build_template(template)
     copy = tmp_path / "copy.duckdb"
     shutil.copy(template, copy)
     copy.chmod(0o600)
-    copied = Database(
-        copy,
+
+    # A fresh, real init build vs the template-copy path the fast `db` fixture uses.
+    fresh = Database(
+        tmp_path / "fresh.duckdb",
         secret_store=_store(),
         no_auto_upgrade=True,
-        assume_initialized=True,
         read_only=False,
     )
     try:
-        assert _catalog(copied) == _catalog(fresh)
+        copied = Database(
+            copy,
+            secret_store=_store(),
+            no_auto_upgrade=True,
+            assume_initialized=True,
+            read_only=False,
+        )
+        try:
+            assert _catalog(copied) == _catalog(fresh)
+        finally:
+            copied.close()
     finally:
-        copied.close()
         fresh.close()

--- a/tests/moneybin/test_database/test_assume_initialized.py
+++ b/tests/moneybin/test_database/test_assume_initialized.py
@@ -82,3 +82,47 @@ def test_assume_initialized_rejects_missing_file(tmp_path: Path) -> None:
             assume_initialized=True,
             read_only=False,
         )
+
+
+def _catalog(db: Database) -> dict[str, object]:
+    """Full schema fingerprint: tables, columns (+types), views, and comments."""
+    tables = db.execute(
+        "SELECT schema_name, table_name, comment FROM duckdb_tables() "
+        "ORDER BY schema_name, table_name"
+    ).fetchall()
+    columns = db.execute(
+        "SELECT schema_name, table_name, column_name, data_type, comment "
+        "FROM duckdb_columns() ORDER BY schema_name, table_name, column_name"
+    ).fetchall()
+    views = db.execute(
+        "SELECT schema_name, view_name FROM duckdb_views() "
+        "ORDER BY schema_name, view_name"
+    ).fetchall()
+    return {"tables": tables, "columns": columns, "views": views}
+
+
+def test_template_copy_matches_fresh_build(tmp_path: Path) -> None:
+    # A fresh, real init build:
+    fresh_path = tmp_path / "fresh.duckdb"
+    fresh = Database(
+        fresh_path, secret_store=_store(), no_auto_upgrade=True, read_only=False
+    )
+
+    # The template-copy path the fast `db` fixture uses:
+    template = tmp_path / "template.duckdb"
+    _build_template(template)
+    copy = tmp_path / "copy.duckdb"
+    shutil.copy(template, copy)
+    copy.chmod(0o600)
+    copied = Database(
+        copy,
+        secret_store=_store(),
+        no_auto_upgrade=True,
+        assume_initialized=True,
+        read_only=False,
+    )
+    try:
+        assert _catalog(copied) == _catalog(fresh)
+    finally:
+        copied.close()
+        fresh.close()

--- a/tests/moneybin/test_meta/test_schema_pdf.py
+++ b/tests/moneybin/test_meta/test_schema_pdf.py
@@ -7,9 +7,9 @@ from moneybin.tables import PDF_SEEDS
 
 
 @pytest.mark.integration
-def test_pdf_seeds_table_exists_after_init(db: Database) -> None:
+def test_pdf_seeds_table_exists_after_init(module_db: Database) -> None:
     """Verify raw.pdf_seeds table exists with correct columns after schema init."""
-    cols = db.execute(
+    cols = module_db.execute(
         "SELECT column_name FROM information_schema.columns "
         "WHERE table_schema = 'raw' AND table_name = 'pdf_seeds' "
         "ORDER BY column_name"

--- a/tests/moneybin/test_meta/test_schema_pdf_formats.py
+++ b/tests/moneybin/test_meta/test_schema_pdf_formats.py
@@ -7,9 +7,9 @@ from moneybin.tables import PDF_FORMATS
 
 
 @pytest.mark.integration
-def test_pdf_formats_table_exists_after_init(db: Database) -> None:
+def test_pdf_formats_table_exists_after_init(module_db: Database) -> None:
     """Verify app.pdf_formats table exists with correct columns after schema init."""
-    cols = db.execute(
+    cols = module_db.execute(
         "SELECT column_name FROM information_schema.columns "
         "WHERE table_schema = 'app' AND table_name = 'pdf_formats' "
         "ORDER BY ordinal_position"

--- a/tests/moneybin/test_migration_runner_self_heal.py
+++ b/tests/moneybin/test_migration_runner_self_heal.py
@@ -23,6 +23,8 @@ from moneybin.migrations import (
 )
 from tests.moneybin.migration_helpers import insert_rows
 
+pytestmark = pytest.mark.fresh_db
+
 _FAILURE_COLUMNS = (
     "version",
     "filename",

--- a/tests/moneybin/test_migration_v003.py
+++ b/tests/moneybin/test_migration_v003.py
@@ -1,7 +1,11 @@
 """Tests for V003: add import_id/source_type/source_origin to raw.ofx_* tables."""
 
+import pytest
+
 from moneybin.database import Database
 from moneybin.sql.migrations.V003__ofx_import_batch_columns import migrate
+
+pytestmark = pytest.mark.fresh_db
 
 
 class TestV003Migration:

--- a/tests/moneybin/test_migration_v007.py
+++ b/tests/moneybin/test_migration_v007.py
@@ -15,8 +15,12 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from moneybin.database import Database
 from moneybin.sql.migrations.V007__transaction_curation import migrate
+
+pytestmark = pytest.mark.fresh_db
 
 
 def _drop_and_recreate_legacy_notes(db: Database) -> None:

--- a/tests/moneybin/test_migration_v008.py
+++ b/tests/moneybin/test_migration_v008.py
@@ -20,6 +20,8 @@ from tests.moneybin.migration_helpers import (
     run_migration,
 )
 
+pytestmark = pytest.mark.fresh_db
+
 
 def _reset_to_pre_v008_state(db: Database) -> None:
     """Reverse the V008 end-state: drop `exemplars`, restore raw_pattern NOT NULL."""

--- a/tests/moneybin/test_migration_v009.py
+++ b/tests/moneybin/test_migration_v009.py
@@ -20,6 +20,8 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V009__purge_redundant_table_migrations import migrate
 from tests.moneybin.migration_helpers import insert_rows, run_migration
 
+pytestmark = pytest.mark.fresh_db
+
 _SCHEMA_MIGRATIONS_COLS = (
     "version",
     "filename",

--- a/tests/moneybin/test_migration_v010.py
+++ b/tests/moneybin/test_migration_v010.py
@@ -31,6 +31,8 @@ from tests.moneybin.migration_helpers import (
     run_migration,
 )
 
+pytestmark = pytest.mark.fresh_db
+
 
 def _reset_to_pre_v010_state(db: Database) -> None:
     """Reverse the V010 end-state so the migration has work to do.

--- a/tests/moneybin/test_migration_v011.py
+++ b/tests/moneybin/test_migration_v011.py
@@ -29,6 +29,8 @@ from tests.moneybin.migration_helpers import (
     run_migration,
 )
 
+pytestmark = pytest.mark.fresh_db
+
 
 def _reset_to_pre_v011_state(db: Database) -> None:
     """Drop the V011 `updated_at` column so the migration has work to do."""

--- a/tests/moneybin/test_migration_v012.py
+++ b/tests/moneybin/test_migration_v012.py
@@ -15,6 +15,8 @@ import pytest
 from moneybin.database import Database
 from moneybin.sql.migrations.V012__drop_merchant_overrides import migrate
 
+pytestmark = pytest.mark.fresh_db
+
 
 def _table_exists(db: Database, schema: str, table: str) -> bool:
     row = db.execute(

--- a/tests/moneybin/test_migration_v013.py
+++ b/tests/moneybin/test_migration_v013.py
@@ -22,6 +22,8 @@ from moneybin.sql.migrations.V013__add_content_hash_to_schema_migrations import 
 )
 from tests.moneybin.migration_helpers import column_exists, insert_rows, run_migration
 
+pytestmark = pytest.mark.fresh_db
+
 _SEED_COLUMNS = ("version", "filename", "checksum", "success")
 
 

--- a/tests/moneybin/test_migration_v014.py
+++ b/tests/moneybin/test_migration_v014.py
@@ -22,6 +22,8 @@ from moneybin.sql.migrations.V014__add_category_id_columns import migrate
 from tests.moneybin.db_helpers import create_core_tables, seed_categories_view
 from tests.moneybin.migration_helpers import run_migration
 
+pytestmark = pytest.mark.fresh_db
+
 
 @pytest.fixture()
 def v014_db(db: Database) -> Database:

--- a/tests/moneybin/test_migration_v015.py
+++ b/tests/moneybin/test_migration_v015.py
@@ -27,6 +27,8 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V015__relax_user_categories_text_unique import migrate
 from tests.moneybin.migration_helpers import run_migration
 
+pytestmark = pytest.mark.fresh_db
+
 
 @pytest.fixture()
 def v015_db(db: Database) -> Database:

--- a/tests/moneybin/test_migration_v016.py
+++ b/tests/moneybin/test_migration_v016.py
@@ -18,6 +18,8 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V016__add_rule_id_to_proposed_rules import migrate
 from tests.moneybin.migration_helpers import run_migration
 
+pytestmark = pytest.mark.fresh_db
+
 LINKED_PATTERN = "STARBUCKS"
 ORPHAN_PATTERN = "WHOLE_FOODS"
 PENDING_PATTERN = "TARGET"

--- a/tests/moneybin/test_migration_v019.py
+++ b/tests/moneybin/test_migration_v019.py
@@ -21,6 +21,8 @@ from moneybin.sql.migrations.V019__add_deleted_from_source_at_to_tabular import 
 )
 from tests.moneybin.migration_helpers import column_exists, run_migration
 
+pytestmark = pytest.mark.fresh_db
+
 CSV_TXN_ID = "csv_aaaa11112222bbbb"
 TSV_TXN_ID = "tsv_cccc33334444dddd"
 EXCEL_TXN_ID = "xls_eeee55556666ffff"

--- a/tests/moneybin/test_migration_v020.py
+++ b/tests/moneybin/test_migration_v020.py
@@ -26,6 +26,8 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V020__create_app_gsheet_connections import migrate
 from tests.moneybin.migration_helpers import column_exists, run_migration
 
+pytestmark = pytest.mark.fresh_db
+
 _ALL_COLUMNS: tuple[str, ...] = (
     "connection_id",
     "spreadsheet_id",

--- a/tests/moneybin/test_migration_v021.py
+++ b/tests/moneybin/test_migration_v021.py
@@ -27,6 +27,8 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V021__create_raw_gsheet_seeds import migrate
 from tests.moneybin.migration_helpers import column_exists, run_migration
 
+pytestmark = pytest.mark.fresh_db
+
 _ALL_COLUMNS: tuple[str, ...] = (
     "connection_id",
     "spreadsheet_id",

--- a/tests/moneybin/test_migration_v022.py
+++ b/tests/moneybin/test_migration_v022.py
@@ -9,6 +9,8 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V022__create_app_ai_consent_grants import migrate
 from tests.moneybin.migration_helpers import column_exists, run_migration
 
+pytestmark = pytest.mark.fresh_db
+
 _ALL_COLUMNS: tuple[str, ...] = (
     "grant_id",
     "feature_category",

--- a/tests/moneybin/test_migration_v023.py
+++ b/tests/moneybin/test_migration_v023.py
@@ -21,6 +21,8 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V023__add_operation_id_to_audit_log import migrate
 from tests.moneybin.migration_helpers import column_info, run_migration
 
+pytestmark = pytest.mark.fresh_db
+
 # Realistic pre-spec audit rows: full 32-hex audit_ids, varied actors/targets.
 _LEGACY_ROWS: tuple[tuple[str, str, str], ...] = (
     ("a1b2c3d4e5f60718293a4b5c6d7e8f90", "cli", "note.add"),

--- a/tests/moneybin/test_migration_v024.py
+++ b/tests/moneybin/test_migration_v024.py
@@ -24,6 +24,8 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V024__add_undo_columns_to_audit_log import migrate
 from tests.moneybin.migration_helpers import column_info, run_migration
 
+pytestmark = pytest.mark.fresh_db
+
 # Realistic pre-spec audit rows: full 32-hex audit_ids + their op group ids.
 _LEGACY_ROWS: tuple[tuple[str, str, str, str], ...] = (
     ("a1b2c3d4e5f60718293a4b5c6d7e8f90", "cli", "note.add", "op_" + "1" * 32),

--- a/tests/moneybin/test_migration_v026.py
+++ b/tests/moneybin/test_migration_v026.py
@@ -39,6 +39,8 @@ from moneybin.sql.migrations.V026__add_transaction_id_to_manual_transactions imp
 )
 from tests.moneybin.migration_helpers import column_exists, run_migration
 
+pytestmark = pytest.mark.fresh_db
+
 
 def _expected_hash(source_transaction_id: str, account_id: str) -> str:
     """V026's frozen backfill hash: ``manual|source_transaction_id|account_id``.

--- a/tests/moneybin/test_migrations.py
+++ b/tests/moneybin/test_migrations.py
@@ -16,6 +16,8 @@ from moneybin.migrations import (
     record_version,
 )
 
+pytestmark = pytest.mark.fresh_db
+
 
 class TestMigrationSchema:
     """Verify migration tracking tables are created by init_schemas."""

--- a/tests/moneybin/test_repositories/test_repo_metadata.py
+++ b/tests/moneybin/test_repositories/test_repo_metadata.py
@@ -34,10 +34,10 @@ def test_all_repos_declare_metadata() -> None:
         )
 
 
-def test_pk_columns_match_catalog(db: Database) -> None:
+def test_pk_columns_match_catalog(module_db: Database) -> None:
     for cls in concrete_repo_classes():
         ref = cls.table_ref
-        row = db.execute(
+        row = module_db.execute(
             "SELECT constraint_column_names FROM duckdb_constraints() "
             "WHERE schema_name = ? AND table_name = ? "
             "AND constraint_type = 'PRIMARY KEY'",


### PR DESCRIPTION
## Summary

Most unit tests rebuild an encrypted DuckDB and re-run the full schema DDL (`init_schemas` + `refresh_views`, ~0.3–0.5s) on every test. This adds a narrow, **test-only** `assume_initialized` flag to `Database` that skips the schema rebuild when opening an already-initialized file, builds the encrypted schema **once per session** into a template, and rewires the shared `db` fixture to copy that template per test instead of rebuilding it.

Measured **~18% CPU / ~21% wall-clock** on the local unit loop; coverage unchanged (87%). This is a deliberately partial win — the heaviest modules define their own `Database()` fixtures and bypass the shared `db`, so the fast path doesn't reach them; extending to those is tracked as follow-up work.

## Changes

- **`Database` (`src/moneybin/database.py`) — review first.** New `assume_initialized` keyword-only flag, default `False`. On an already-initialized write open it skips `init_schemas`, the migration check, and `refresh_views`. It **never weakens the default open path** (production opens leave it `False`), preserves the construct-or-rollback `ExitStack`, and validates against `read_only` / a missing file.
- **Test fixtures (`conftest.py`, `pyproject.toml`).** Session-scoped `_db_template` (real build, closed before copy); the `db` fixture copies the template by default, or builds fresh under a new `@pytest.mark.fresh_db` marker (registered for `--strict-markers`).
- **Carve-out + guard.** 20 migration/init modules marked `fresh_db` so they exercise real init; a catalog-equivalence test (tables, columns+types, views, comments, constraints) proves the template is identical to a fresh build — the invariant the whole scheme rests on.
- **Read-only sweep.** 3 read-only modules moved to the shared `module_db` fixture.

## Test plan

- [ ] `make check test` green (4402 passed, output pristine)
- [ ] `assume_initialized` proven to skip init yet yield a usable read-write DB; both validation guards covered
- [ ] catalog-equivalence test passes (template == fresh build)
- [ ] migration/init modules still build fresh (real `init_schemas`)
- [ ] coverage unchanged (base 87% → branch 87%, no regression)
- [ ] CI green
