### PR TITLE
Isolate SQLMesh cache per DB to fix scenario restate race

### DIFF
--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -1173,6 +1173,13 @@ def sqlmesh_context(
 
         config = Config(
             default_gateway=_DATABASE_ALIAS,
+            # Pin the SQLMesh cache beside this DB instead of the shared
+            # sqlmesh/.cache. The cache is keyed by model fingerprint, not by
+            # environment, so one cache shared across concurrent restate plans
+            # on different DBs (parallel scenario-test workers) poisons each
+            # other's snapshots and raises ConflictingPlanError. Per-DB scopes
+            # it to one profile (prod) / one test tmpdir (tests).
+            cache_dir=str(db_path.parent / ".sqlmesh-cache"),
             gateways={
                 _DATABASE_ALIAS: GatewayConfig(
                     connection=DuckDBConnectionConfig(database=str(db_path)),

--- a/tests/moneybin/test_services/test_sqlmesh_context.py
+++ b/tests/moneybin/test_services/test_sqlmesh_context.py
@@ -60,6 +60,40 @@ class TestSQLMeshContext:
 
     @patch("sqlmesh.core.engine_adapter.duckdb.DuckDBEngineAdapter")
     @patch("sqlmesh.Context")
+    def test_cache_dir_isolated_per_db(
+        self,
+        mock_ctx_cls: MagicMock,
+        mock_adapter_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """cache_dir is derived from the db path, not the shared project cache.
+
+        SQLMesh's on-disk cache is keyed by model fingerprint, independent of
+        which DB/environment a plan targets. Sharing one cache across concurrent
+        restate plans on different DBs (xdist scenario workers) poisons snapshots
+        and raises ConflictingPlanError. Pinning cache_dir under the db's own
+        directory isolates it per-profile (prod) and per-test tmpdir (tests).
+        """
+        mock_db = MagicMock()
+        mock_db._conn = MagicMock()
+        db_path = tmp_path / "profile_a" / "moneybin.duckdb"
+        mock_db._db_path = db_path
+
+        cache: dict[str, object] = {}
+        with patch(
+            "sqlmesh.core.config.connection.BaseDuckDBConnectionConfig._data_file_to_adapter",
+            cache,
+        ):
+            from moneybin.database import sqlmesh_context
+
+            with sqlmesh_context(mock_db):
+                pass
+
+        config = mock_ctx_cls.call_args.kwargs["config"]
+        assert config.cache_dir == str(db_path.parent / ".sqlmesh-cache")
+
+    @patch("sqlmesh.core.engine_adapter.duckdb.DuckDBEngineAdapter")
+    @patch("sqlmesh.Context")
     def test_cleans_up_on_failure(
         self,
         mock_ctx_cls: MagicMock,


### PR DESCRIPTION
### Summary

Scenario tests share a single `sqlmesh/.cache` across xdist workers. SQLMesh keys that cache by **model fingerprint, not by environment**, so concurrent restate plans on different per-test DBs poison each other's snapshots and raise `ConflictingPlanError` under `make test-all -n auto` — intermittently. (Sharded CI stays green because the colliding modules land on separate runners.) This pins `Config.cache_dir` beside each DB in `sqlmesh_context()`, scoping the cache to one profile (prod) / one test tmpdir (tests) so concurrent plans never share it — and incidentally closes the same latent cross-profile cache-sharing in prod.

### Test plan

- [ ] New boundary test `test_cache_dir_isolated_per_db` asserts `Config.cache_dir` derives from the db path
- [ ] `test_services/test_sqlmesh_context.py` — all 4 pass
- [ ] Full `tests/scenarios/` green under `-n auto` (68 passed)
- [ ] The 5 restate scenario modules pass under `-n auto --dist=loadscope`
- [ ] `tests/moneybin` + `tests/integration` (`-m "unit or integration"`) green
- [ ] `make check` clean (ruff + pyright 0 errors)
