### PR TITLE
Guard sqlmesh_context against mock dbs that litter cache dirs

### DIFF
--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -1159,6 +1159,18 @@ def sqlmesh_context(
     # Use the supplied db's actual path, not settings — during `profile create`
     # the new profile isn't yet the active one, so get_settings() would fail.
     db_path = db._db_path  # pyright: ignore[reportPrivateUsage]
+    # Contract guard: a real Database always has a Path here. A test that drives
+    # the real sqlmesh_context with a bare mock db (and forgets to patch
+    # sqlmesh.Context) reaches this line with an auto-mock _db_path, then
+    # silently mkdir's sqlmesh/<MagicMock ...>/ from the stringified cache_dir
+    # below. Fail loudly here instead — the traceback names the offending test.
+    if not isinstance(db_path, Path):  # pyright: ignore[reportUnnecessaryIsInstance]  # static type is Path; the guard exists for tests that pass a mock that violates it at runtime
+        raise TypeError(
+            "sqlmesh_context requires an open Database; got "
+            f"{type(db).__name__} whose _db_path is {type(db_path).__name__}, "
+            "not a Path. A test is driving the real sqlmesh_context with a mock "
+            "db — patch sqlmesh_context (or pass a real Database) in that test."
+        )
 
     cache_key = str(db_path)
     try:

--- a/tests/moneybin/test_services/test_sqlmesh_context.py
+++ b/tests/moneybin/test_services/test_sqlmesh_context.py
@@ -23,6 +23,28 @@ class TestSQLMeshContext:
             with sqlmesh_context(mock_db):
                 pass
 
+    def test_rejects_mock_db_with_non_path_db_path(self) -> None:
+        """A mock db that slips past the conn check fails loudly, never littering.
+
+        Regression for the #11 junk-dir leak: a test driving the real
+        ``sqlmesh_context`` with a bare ``MagicMock`` (``_db_path`` left as an
+        auto-mock) and ``sqlmesh.Context`` un-patched silently mkdir'd
+        ``sqlmesh/<MagicMock ...>/`` under the project root — because
+        ``cache_dir=str(db._db_path.parent / ...)`` stringified the mock. The
+        guard converts that into an immediate ``TypeError`` (raised before any
+        ``Context`` is built) whose traceback names the offending test, so the
+        intermittent leak can never recur silently.
+        """
+        from moneybin.database import sqlmesh_context
+
+        mock_db = MagicMock()
+        mock_db._conn = MagicMock()  # truthy → passes the closed-connection check
+        # _db_path deliberately left as an auto-mock — the exact bug condition.
+
+        with pytest.raises(TypeError, match="requires an open Database"):
+            with sqlmesh_context(mock_db):
+                pass
+
     @patch("sqlmesh.core.engine_adapter.duckdb.DuckDBEngineAdapter")
     @patch("sqlmesh.Context")
     def test_injects_and_cleans_adapter_cache(


### PR DESCRIPTION
## Summary

`sqlmesh_context(db)` borrows a `Database`'s internals to inject an encrypted DuckDB adapter into SQLMesh. When a test drove the *real* `sqlmesh_context` with a bare `MagicMock` db (and forgot to patch `sqlmesh.Context`), it reached `cache_dir=str(db._db_path.parent / ".sqlmesh-cache")` with an auto-mock `_db_path`, stringified the mock, and silently `mkdir`'d a `sqlmesh/<MagicMock ...>/` junk directory under the project root. The leak was intermittent under `-n auto` and not reproducible under `-n0`, so it resisted a direct test fix.

This adds a contract guard at the `_db_path` read: a non-`Path` `_db_path` now raises `TypeError` *before* any `Context` is built, so the misuse fails loudly and the traceback names the offending test instead of littering. Real `Database` instances always carry a `Path`, so production behavior is unchanged.

## Test plan

- [ ] New regression test `test_rejects_mock_db_with_non_path_db_path` reproduces the exact leak (bare mock db, `Context` un-patched) — verified it fails *and litters* without the guard, passes *with no litter* with it.
- [ ] Full `test_sqlmesh_context.py` + `test_database.py` pass — the 4 legitimate mock-based tests (which set a real `_db_path`) are unaffected by the guard.
- [ ] Unit suite **4406 passed**; Integration **120 passed, 1 xfailed** (pre-existing surface-parity). No `sqlmesh/*MagicMock*` junk dirs created during either run.
