### PR TITLE
Un-skip categorize-commit audit e2e (wiring already landed)

### DIFF
--- a/tests/e2e/test_e2e_transaction_curation.py
+++ b/tests/e2e/test_e2e_transaction_curation.py
@@ -359,15 +359,6 @@ class TestImportLabelsGoldenPath:
         assert "needs-review" in labels
 
 
-@pytest.mark.skip(
-    reason=(
-        "CategorizationService.set_category emits category.set audit events, "
-        "but the only CLI/MCP surface today (categorize_items via "
-        "transactions categorize commit-from-file) does not invoke set_category — "
-        "it inserts via direct SQL UPSERT without audit emission. Wiring that "
-        "is out of scope for Task 14 (polish/docs only)."
-    )
-)
 class TestCategoryEditAudit:
     """Editing a transaction's category writes an audit event with before/after."""
 
@@ -394,7 +385,9 @@ class TestCategoryEditAudit:
         txn_id = _loads(result.stdout)["data"]["transaction_id"]
         run_cli("transform", "apply", env=env, timeout=180).assert_success()
 
-        # Apply a category via commit-from-file (writes through CategorizationService.set_category).
+        # Apply a category via commit-from-file. The batch path
+        # (categorize_items → write_categorization → TransactionCategoriesRepo
+        # .upsert_guarded) emits a category.set audit on every landed write.
         bulk = [{"transaction_id": txn_id, "category": "Shopping"}]
         bulk_path = Path(env["MONEYBIN_HOME"]) / "categorize.json"
         bulk_path.write_text(json.dumps(bulk))


### PR DESCRIPTION
## Summary

`TestCategoryEditAudit` — the e2e verifying that editing a transaction's category emits a `category.set` audit event — was skipped on the premise that the `transactions categorize commit-from-file` path wrote to `app.transaction_categories` via a direct SQL UPSERT with no audit. That premise is **stale**: the Invariant 10 repository work routes the batch path (`categorize_items` → `write_categorization` → `TransactionCategoriesRepo.upsert_guarded`) through an audited upsert that emits `category.set` (with before/after) on every landed write, skipping audit only on a precedence-blocked write. Removing the skip re-enables the end-to-end check; the inline comment that still pointed at the single-item `set_category` path is corrected.

## Test plan

- [ ] `TestCategoryEditAudit::test_category_set_emits_audit` (re-enabled) passes — verified locally **1 passed in 11.84s**. It creates a manual txn, transforms, applies a category twice via `commit-from-file`, and asserts `system audit list --action category.% --target-id <txn>` returns a `category.set` event carrying `after_value`.
- [ ] `test_e2e_transaction_curation.py` collects cleanly (7 items); pyright + ruff clean.
