### PR TITLE
Process data on refresh; CLI/transform output hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,10 @@ M2 closing out and M3 underway. M2A curator state shipped (transaction notes, ta
   and the `budget_*` mutation tools are unaffected.
 - **`reports health` CLI stub** — an unimplemented placeholder with no backing
   spec.
+- **`sync.enabled` config field.** It was seeded into every profile's
+  `config.yaml` and shown by `moneybin profile show` but never read — sync
+  gating is server-side. Existing `config.yaml` files keep working (the stale
+  key is ignored).
 
 ### Fixed
 - **Bare single-account imports now elicit account confirmation instead of
@@ -268,6 +272,18 @@ M2 closing out and M3 underway. M2A curator state shipped (transaction notes, ta
   (M1S.8).** An auto-saved format records its resolved (filename/format)
   institution or `unknown`, never the per-account `--account-name` — a format
   describes a column layout, not an account. (#258)
+- **`refresh` now rebuilds materialized models after a data-only load.** A
+  second import or sync pull (new `raw.*` rows, unchanged model SQL) left
+  `core.dim_accounts` — the only `FULL` model — stale and `transforms_pending`
+  stuck true, because the refresh drove SQLMesh with `plan` alone (which acts on
+  model-definition changes, not data). `refresh`/transform `apply` now also runs
+  SQLMesh data processing (`run`) and restates `FULL` models, so newly-pulled
+  accounts appear and the pending flag clears.
+- **Quieter refresh/import output.** The per-connection `Synced N privacy
+  classification comment(s)` line dropped from INFO to DEBUG, and sqlglot's
+  `REGEXP_REPLACE with non-literal position` transpile warnings (emitted several
+  times per transform) are now suppressed within the SQLMesh boundary — neither
+  is actionable signal for users or agents driving the CLI/MCP.
 
 ### Added
 - **PDF import (seed path).** Native-text PDFs import via `moneybin import <file.pdf>` and the inbox; their tables land as a queryable JSON seed (`raw.pdf_seeds`) with an auto-generated typed view (`raw.pdf_<alias>`), reversible like any import. Mapping PDFs to transactions/core is a later phase.

--- a/docs/guides/profiles.md
+++ b/docs/guides/profiles.md
@@ -107,11 +107,11 @@ Prints the resolved settings for a profile (defaults to the active one). Fields:
 
 ### `moneybin profile set <section>.<field> <value>`
 
-Writes a value into the profile-level `config.yaml`. Keys are two-level dotted (`logging.level`, `sync.enabled`, `database.encryption_key_mode`). Boolean strings (`true`, `false`) and digit-only strings are coerced to native types before writing. Targets the active profile unless `--profile/-p` overrides it.
+Writes a value into the profile-level `config.yaml`. Keys are two-level dotted (`logging.level`, `logging.log_to_file`, `database.encryption_key_mode`). Boolean strings (`true`, `false`) and digit-only strings are coerced to native types before writing. Targets the active profile unless `--profile/-p` overrides it.
 
 ```bash
 moneybin profile set logging.level DEBUG
-moneybin profile set sync.enabled true --profile business
+moneybin profile set logging.log_to_file false --profile business
 ```
 
 This only updates the per-profile YAML — env-var overrides like `MONEYBIN_DATABASE__PATH` still take precedence at load time.

--- a/src/moneybin/config.py
+++ b/src/moneybin/config.py
@@ -343,10 +343,6 @@ class SyncConfig(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    enabled: bool = Field(
-        default=False,
-        description="Enable MoneyBin Sync service (paid tier)",
-    )
     server_url: str | None = Field(
         default=None,
         description="MoneyBin Sync server URL (e.g., https://sync.moneybin.app)",

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -1144,6 +1144,13 @@ def sqlmesh_context(
     # still reaches the sqlmesh_*.log file via the stdlib loggers.
     set_console(NoopConsole())
 
+    # sqlglot emits WARNING-level dialect-fidelity notes while generating model
+    # SQL (e.g. "REGEXP_REPLACE with non-literal position" from dim_accounts),
+    # spamming stderr several times per transform. We only ever target DuckDB —
+    # there is no cross-dialect transpile — so these are non-actionable noise.
+    # Quiet to ERROR; genuine sqlglot failures still surface.
+    logging.getLogger("sqlglot").setLevel(logging.ERROR)
+
     root = sqlmesh_root or _SQLMESH_ROOT
 
     # Reuse the caller-supplied connection — DuckDB only allows one

--- a/src/moneybin/privacy/comment_sync.py
+++ b/src/moneybin/privacy/comment_sync.py
@@ -88,5 +88,9 @@ def sync_classification_comments(conn: duckdb.DuckDBPyConnection) -> int:
         updates += 1
 
     if updates:
-        logger.info(f"Synced {updates} privacy classification comment(s)")
+        # DEBUG, not INFO: SQLMesh recreates VIEW models on every apply, wiping
+        # their column comments, so this re-applies classification sigils after
+        # every refresh/import. That is routine housekeeping, not user/agent-
+        # facing signal — keep it off the default CLI/MCP output stream.
+        logger.debug(f"Synced {updates} privacy classification comment(s)")
     return updates

--- a/src/moneybin/services/transform_service.py
+++ b/src/moneybin/services/transform_service.py
@@ -142,7 +142,15 @@ class TransformService:
                     # step 2 keeps it fresh and that it stays out of the restate
                     # set below.
                     ctx.plan(auto_apply=True, no_prompts=True)
-                    ctx.run(ignore_cron=True)
+                    # ctx.run() returns a CompletionStatus; unlike plan() it does
+                    # NOT raise on scheduler/audit/model failure (SQLMesh's own
+                    # CLI checks is_failure and raises "Run failed"). Surface a
+                    # failed data-processing pass so the except below converts it
+                    # to ApplyResult(applied=False) instead of silently proceeding
+                    # to the restate and reporting success.
+                    run_status = ctx.run(ignore_cron=True)
+                    if run_status.is_failure:
+                        raise RuntimeError("SQLMesh run reported a failure status")
                     full_models = [
                         name for name, model in ctx.models.items() if model.kind.is_full
                     ]

--- a/src/moneybin/services/transform_service.py
+++ b/src/moneybin/services/transform_service.py
@@ -122,7 +122,36 @@ class TransformService:
                 # instead of propagating raw to MCP/CLI callers.
                 MatchingService(self._db).seed_priority()
                 with sqlmesh_context(self._db) as ctx:
+                    # raw.* tables are loaded by Python OUTSIDE SQLMesh, so SQLMesh
+                    # gets no signal that data changed. Three steps cover every
+                    # model kind after an import/pull:
+                    #   1. plan()  — absorb model-DEFINITION changes (no-op when
+                    #      the SQL is unchanged) and bootstrap a fresh env.
+                    #   2. run()   — process new intervals for INCREMENTAL models.
+                    #      ignore_cron so a same-day re-pull isn't gated by the
+                    #      per-model cron cadence. (No incremental models exist
+                    #      today, so this is currently a no-op — wired now so the
+                    #      pipeline is correct when one lands.)
+                    #   3. restate FULL models — a FULL model's interval is
+                    #      already "complete" after step 1, so run() skips it; only
+                    #      restatement forces the full rebuild that picks up new
+                    #      raw rows. Scoped to is_full so INCREMENTAL models are
+                    #      NOT blanket-restated (that would reprocess all history
+                    #      every refresh and defeat incrementality).
+                    # DEPRECATED-WHEN: the first INCREMENTAL model lands — verify
+                    # step 2 keeps it fresh and that it stays out of the restate
+                    # set below.
                     ctx.plan(auto_apply=True, no_prompts=True)
+                    ctx.run(ignore_cron=True)
+                    full_models = [
+                        name for name, model in ctx.models.items() if model.kind.is_full
+                    ]
+                    if full_models:
+                        ctx.plan(
+                            restate_models=full_models,
+                            auto_apply=True,
+                            no_prompts=True,
+                        )
                 # Full plan rebuilds seeds.* too, so refresh views that read them.
                 refresh_views(self._db)
             except Exception as e:  # noqa: BLE001 — surface SQLMesh failure as structured result

--- a/src/moneybin/utils/user_config.py
+++ b/src/moneybin/utils/user_config.py
@@ -206,9 +206,6 @@ def generate_profile_config(profile_dir: Path, profile_name: str) -> Path:
             "level": "INFO",
             "log_to_file": True,
         },
-        "sync": {
-            "enabled": False,
-        },
     }
 
     header = f"# Profile: {profile_name}\n# Created: {date.today()}\n\n"

--- a/tests/moneybin/test_cli/test_transform_checkpoint_wiring.py
+++ b/tests/moneybin/test_cli/test_transform_checkpoint_wiring.py
@@ -28,8 +28,10 @@ from moneybin.services.transform_service import TransformService
 
 @contextmanager
 def _fake_sqlmesh_context(_db: object) -> Generator[MagicMock, None, None]:
-    """Yield a mock SQLMesh context whose plan() is a no-op."""
-    yield MagicMock()
+    """Yield a mock SQLMesh context whose plan() is a no-op and run() succeeds."""
+    ctx = MagicMock()
+    ctx.run.return_value.is_failure = False
+    yield ctx
 
 
 def test_transform_apply_emits_post_transform_checkpoint() -> None:

--- a/tests/moneybin/test_services/test_profile_service.py
+++ b/tests/moneybin/test_services/test_profile_service.py
@@ -276,10 +276,10 @@ class TestProfileSet:
         monkeypatch.setenv("MONEYBIN_HOME", str(tmp_path))
         svc = ProfileService()
         svc.create("alice")
-        svc.set("alice", "sync.enabled", "true")
+        svc.set("alice", "logging.log_to_file", "false")
         config_path = tmp_path / "profiles" / "alice" / "config.yaml"
         data = yaml.safe_load(config_path.read_text())
-        assert data["sync"]["enabled"] is True
+        assert data["logging"]["log_to_file"] is False
 
     def test_set_integer_value(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/moneybin/test_services/test_transform_service.py
+++ b/tests/moneybin/test_services/test_transform_service.py
@@ -143,6 +143,7 @@ def test_apply_returns_apply_result_shape(
     from contextlib import contextmanager
 
     fake_ctx = MagicMock()
+    fake_ctx.run.return_value.is_failure = False
 
     @contextmanager
     def fake_sqlmesh_context(_db: Database):  # type: ignore[no-untyped-def]
@@ -173,6 +174,54 @@ def test_apply_returns_apply_result_shape(
     assert result.duration_seconds >= 0
     assert result.error is None
     fake_ctx.plan.assert_called_once_with(auto_apply=True, no_prompts=True)
+
+
+def test_apply_soft_fails_when_run_reports_failure(
+    db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """apply() must fail when ctx.run() returns a failure status.
+
+    SQLMesh's Context.run() returns a CompletionStatus and does NOT raise on
+    scheduler/audit/model errors — it returns is_failure=True (its own CLI
+    checks the status and raises "Run failed"). apply() must detect that and
+    surface applied=False, not proceed to the FULL-model restate and falsely
+    report success.
+    """
+    from contextlib import contextmanager
+
+    fake_ctx = MagicMock()
+    fake_ctx.run.return_value.is_failure = True
+
+    @contextmanager
+    def fake_sqlmesh_context(_db: Database):  # type: ignore[no-untyped-def]
+        yield fake_ctx
+
+    def fake_seed(_self: object) -> None:
+        return None
+
+    def fake_refresh(_db: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "moneybin.services.transform_service.sqlmesh_context",
+        fake_sqlmesh_context,
+    )
+    monkeypatch.setattr(
+        "moneybin.services.matching_service.MatchingService.seed_priority",
+        fake_seed,
+    )
+    monkeypatch.setattr(
+        "moneybin.services.transform_service.refresh_views",
+        fake_refresh,
+    )
+
+    result = TransformService(db).apply()
+
+    assert result.applied is False
+    assert result.error is not None
+    # A run failure short-circuits before the FULL-model restate: only the
+    # definition plan ran, never a second restate plan.
+    assert fake_ctx.plan.call_count == 1
 
 
 def test_apply_soft_fails_with_error_type_on_sqlmesh_exception(

--- a/tests/moneybin/test_transform_apply_refresh.py
+++ b/tests/moneybin/test_transform_apply_refresh.py
@@ -1,0 +1,142 @@
+"""Integration test: TransformService.apply() must reflect NEW raw data.
+
+Regression guard for the "refresh only plans, never runs" bug: the routine
+refresh path (`TransformService.apply()`) drove SQLMesh via `ctx.plan()`, which
+only re-materializes models whose *definition* changed. A second data load (e.g.
+linking/pulling a second institution the same day) changed no model definition,
+so the lone FULL model `core.dim_accounts` was never rebuilt and the new
+institution's accounts never appeared — even though `raw.*`/`prep.*` had them.
+
+The fix wires SQLMesh's data-processing command into apply() so a second apply
+after new raw rows updates the materialized dimension.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from moneybin.database import Database, sqlmesh_context
+from moneybin.services.transform_service import TransformService
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.slow
+def test_sqlmesh_context_silences_sqlglot_transpile_warnings(db: Database) -> None:
+    """Dialect-fidelity warnings from sqlglot must be suppressed in the boundary.
+
+    sqlglot emits WARNING-level noise like 'REGEXP_REPLACE with non-literal
+    position' while generating SQL for our models. We only ever target DuckDB
+    (no cross-dialect transpile), so these are non-actionable and spam stderr 6×
+    on every transform. They must be quieted within sqlmesh_context.
+    """
+    with sqlmesh_context(db):
+        assert logging.getLogger("sqlglot").getEffectiveLevel() >= logging.ERROR
+
+
+def _insert_plaid_account(
+    db: Database,
+    *,
+    native_key: str,
+    canonical_id: str,
+    institution_name: str,
+    account_type: str,
+    mask: str,
+    source_origin: str,
+    extracted_at: str,
+) -> None:
+    """Seed one Plaid raw account plus its accepted canonical link.
+
+    Mirrors what a real sync pull produces: a raw.plaid_accounts row keyed by
+    (native account_id, source_origin=item_id) and an accepted source_native
+    row in app.account_links mapping it to a canonical id.
+    """
+    db.execute(
+        """
+        INSERT INTO raw.plaid_accounts
+            (account_id, account_type, account_subtype, institution_name,
+             mask, source_file, source_type, source_origin,
+             extracted_at, loaded_at)
+        VALUES (?, ?, NULL, ?, ?, '/tmp/sync.json', 'plaid', ?,
+                ?::TIMESTAMP, ?::TIMESTAMP)
+        """,  # noqa: S608  # test fixture, not executing user SQL
+        [
+            native_key,
+            account_type,
+            institution_name,
+            mask,
+            source_origin,
+            extracted_at,
+            extracted_at,
+        ],
+    )
+    db.execute(
+        """
+        INSERT INTO app.account_links
+            (link_id, account_id, ref_kind, ref_value, source_type,
+             source_origin, status, decided_by, decided_at)
+        VALUES (?, ?, 'source_native', ?, 'plaid', ?, 'accepted', 'auto',
+                CURRENT_TIMESTAMP)
+        """,  # noqa: S608  # test fixture, not executing user SQL
+        [f"link-{native_key}", canonical_id, native_key, source_origin],
+    )
+
+
+@pytest.mark.slow
+def test_apply_reflects_second_data_load(db: Database) -> None:
+    """A second apply() after new raw rows must surface the new accounts.
+
+    Reproduces the real flow: link/pull institution A (apply), then link/pull
+    institution B the same day (apply again). Both institutions' accounts must
+    appear in core.dim_accounts after the second apply.
+    """
+    # First pull: institution A.
+    _insert_plaid_account(
+        db,
+        native_key="a-native-checking",
+        canonical_id="canonA00000001",
+        institution_name="Bank A",
+        account_type="depository",
+        mask="0000",
+        source_origin="item_a",
+        extracted_at="2026-06-01 12:00:00",
+    )
+    first = TransformService(db).apply()
+    assert first.applied, f"first apply failed: {first.error}"
+
+    institutions_after_first = {
+        row[0]
+        for row in db.execute(
+            "SELECT institution_name FROM core.dim_accounts"
+        ).fetchall()
+    }
+    assert institutions_after_first == {"Bank A"}, (
+        f"sanity: first apply should materialize Bank A, got {institutions_after_first}"
+    )
+
+    # Second pull, same day: institution B (new raw rows, no model-definition change).
+    _insert_plaid_account(
+        db,
+        native_key="b-native-checking",
+        canonical_id="canonB00000001",
+        institution_name="Bank B",
+        account_type="depository",
+        mask="0000",
+        source_origin="item_b",
+        extracted_at="2026-06-01 12:05:00",
+    )
+    second = TransformService(db).apply()
+    assert second.applied, f"second apply failed: {second.error}"
+
+    institutions_after_second = {
+        row[0]
+        for row in db.execute(
+            "SELECT institution_name FROM core.dim_accounts"
+        ).fetchall()
+    }
+    assert institutions_after_second == {"Bank A", "Bank B"}, (
+        "second apply() did not surface the newly-pulled institution; "
+        f"core.dim_accounts shows {institutions_after_second}"
+    )

--- a/tests/moneybin/test_utils/test_user_config.py
+++ b/tests/moneybin/test_utils/test_user_config.py
@@ -271,7 +271,9 @@ class TestProfileConfigYaml:
         data = yaml.safe_load(config_path.read_text())
         assert data["database"]["encryption_key_mode"] == "auto"
         assert data["logging"]["level"] == "INFO"
-        assert data["sync"]["enabled"] is False
+        # No vestigial sync block: SyncSettings.enabled was never read (gating is
+        # server-side per the sync auth model), so the template no longer seeds it.
+        assert "sync" not in data
 
     def test_generate_profile_config_creates_directory(self, tmp_path: Path) -> None:
         """generate_profile_config creates the profile directory if missing."""

--- a/tests/privacy/test_comment_sync.py
+++ b/tests/privacy/test_comment_sync.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from moneybin.database import Database
@@ -139,3 +141,32 @@ def test_sync_strips_sigil_for_unregistered_column(
     cs.sync_classification_comments(populated_db.conn)
 
     assert _get_comment(populated_db, schema, table, col) == "Account identifier"
+
+
+def test_sync_count_logged_at_debug_not_info(
+    populated_db: Database, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The 'Synced N …' housekeeping line must not surface at INFO.
+
+    SQLMesh recreates VIEW models on every apply, wiping their column
+    comments, so this sync re-applies sigils after every refresh/import.
+    That is expected work, not user/agent-facing signal — it belongs at
+    DEBUG so it stays off the default CLI/MCP output stream.
+    """
+    schema, table, col, _cls = _pick_classified_column(populated_db)
+    _set_comment(populated_db, schema, table, col, "Human description")
+
+    with caplog.at_level(logging.DEBUG, logger="moneybin.privacy.comment_sync"):
+        updated = sync_classification_comments(populated_db.conn)
+
+    assert updated >= 1, "fixture should produce at least one comment write"
+    synced = [
+        r for r in caplog.records if "privacy classification comment" in r.getMessage()
+    ]
+    assert synced, "expected the sync to log its count"
+    offenders = [
+        logging.getLevelName(r.levelno) for r in synced if r.levelno > logging.DEBUG
+    ]
+    assert not offenders, (
+        f"'Synced N …' must be logged at DEBUG, but saw it at {offenders}"
+    )


### PR DESCRIPTION
## Summary

`moneybin refresh` — and every import/sync flow that funnels through it — drove SQLMesh with `ctx.plan()` alone, which only re-materializes models whose *definition* changed. Because `raw.*` tables are loaded by Python outside SQLMesh, a second data load (e.g. linking a second institution the same day) left the one `FULL` model (`core.dim_accounts`) stale and `transforms_pending` stuck true, so newly-pulled accounts never appeared. This fixes that, plus three smaller output-hygiene and dead-config cleanups found alongside.

## Changes

- **Refresh processes data, not just definitions** (`transform_service.py`): `apply()` now runs `plan` (definitions) + `run(ignore_cron)` (new intervals for future incremental models) + restate of `FULL` models (force-rebuild what `run` can't, scoped via `kind.is_full` so incrementals are never blanket-restated). A `DEPRECATED-WHEN` comment marks the seam for the first incremental model.
- **Quieter transform/refresh output**: sqlglot's `REGEXP_REPLACE with non-literal position` WARNINGs are silenced inside `sqlmesh_context` (DuckDB-only target → non-actionable), and `comment_sync`'s per-connection `Synced N privacy classification comment(s)` line drops INFO→DEBUG (it re-applies sigils after SQLMesh recreates views each apply — housekeeping, not signal).
- **Remove unused `sync.enabled`** (`config.py`, profile template): never read (gating is server-side); existing `config.yaml` files keep loading via `extra="ignore"`. Tests + profiles guide point at a live key.

## Test plan

- [x] Integration regression: a second same-day data load surfaces in `core.dim_accounts` (`test_apply_reflects_second_data_load`).
- [x] sqlglot warnings suppressed within `sqlmesh_context` (`test_sqlmesh_context_silences_sqlglot_transpile_warnings`).
- [x] `comment_sync` count logs at DEBUG, not INFO (`test_sync_count_logged_at_debug_not_info`).
- [x] `sync.enabled` gone from model + template; profile set/show + template tests updated.
- [x] ~5,100 unit + integration pass · 70 scenarios pass · pyright 0 errors · ruff clean.
- [ ] Reviewer: after a fresh pull, `moneybin refresh` leaves `transforms_pending=false` with all linked institutions present in `core.dim_accounts`.
