### PR TITLE
Don't read a CWD-relative .env when constructing settings

### DIFF
--- a/src/moneybin/config.py
+++ b/src/moneybin/config.py
@@ -856,7 +856,12 @@ class MoneyBinSettings(BaseSettings):
         )
 
     model_config = SettingsConfigDict(
-        env_file=".env",  # Default, but overridden by settings_customise_sources
+        # No default env_file: settings_customise_sources builds the real,
+        # profile-aware dotenv source from get_base_dir(), so a CWD-relative
+        # ".env" default is redundant — and pydantic stats/reads it eagerly at
+        # construction, which breaks sandboxed runs that deny the repo-root .env
+        # (PermissionError). See tests/moneybin/test_config_dotenv_isolation.py.
+        env_file=None,
         env_file_encoding="utf-8",
         env_prefix="MONEYBIN_",
         env_nested_delimiter="__",

--- a/tests/moneybin/test_config_dotenv_isolation.py
+++ b/tests/moneybin/test_config_dotenv_isolation.py
@@ -1,0 +1,42 @@
+"""The settings layer must not read a CWD-relative `.env`.
+
+pydantic-settings' default `env_file` source stats/reads `.env` from the current
+working directory while `MoneyBinSettings` is constructed. The sandbox denies
+reads of the repo-root `.env` (it holds secrets), so that default source makes
+every sandboxed test and CLI invocation die with
+`PermissionError: Operation not permitted: '.env'`. The real, profile-aware
+dotenv source is supplied by `settings_customise_sources` (keyed off
+`get_base_dir()`), so the CWD-relative default is redundant — and must not fire.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from moneybin.config import MoneyBinSettings
+
+
+def test_settings_construction_does_not_read_cwd_dotenv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Constructing settings must not touch a `.env` in the current directory."""
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    # An unreadable .env mimics the sandbox deny-read on the repo-root .env:
+    # the read attempt raises PermissionError, exactly as the sandbox does.
+    bad_env = cwd / ".env"
+    bad_env.write_text("MONEYBIN_DATABASE__PATH=/should/not/be/read\n")
+    bad_env.chmod(0o000)
+    monkeypatch.chdir(cwd)
+    # MONEYBIN_HOME points at a clean dir with no .env, so the profile-aware
+    # source from settings_customise_sources finds nothing to read.
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("MONEYBIN_HOME", str(home))
+
+    # Must construct without reading the unreadable CWD .env.
+    settings = MoneyBinSettings(profile="dev")
+
+    assert settings is not None


### PR DESCRIPTION
## Summary

`MoneyBinSettings` set `model_config` `env_file=".env"`, so pydantic eagerly stat/reads the current directory's `.env` while building its default dotenv source. But `settings_customise_sources` already builds the real, profile-aware dotenv source from `get_base_dir()` and returns *only* that — the default source's **values were discarded anyway**, yet its eager read still fired. In the sandbox (which denies reads of the repo-root `.env`, since it holds secrets), that read raised `PermissionError: Operation not permitted: '.env'`, forcing the whole test suite and every CLI invocation to run unsandboxed. Setting `env_file=None` drops the redundant source; real `.env` / `.env.<profile>` loading is unchanged. No user-facing behavior change.

## Test plan

- [x] New regression test (`test_config_dotenv_isolation.py`): constructing `MoneyBinSettings` with an **unreadable** `.env` in the CWD must not raise (mimics the sandbox deny-read). RED before, GREEN after.
- [x] Full unit + integration suite (~5,183) now runs **in-sandbox** with zero permission errors — previously required `dangerouslyDisableSandbox`.
- [x] config + profile suites pass; pyright 0 errors; ruff clean.
- [ ] Reviewer: confirm real `.env` / `.env.<profile>` loading still works for the CLI (served by `settings_customise_sources`, untouched here).
