### PR TITLE
Scope sync identity and tokens to the active profile

### DIFF
--- a/docs/reference/server-api-contract.md
+++ b/docs/reference/server-api-contract.md
@@ -89,8 +89,13 @@ The client reads `user_code` (display), `verification_uri_complete` (open in bro
 **Request:**
 
 ```json
-{ "device_code": "Ag_EE..." }
+{ "device_code": "Ag_EE...", "profile_id": "ab12cd34ef56" }
 ```
+
+`profile_id` is optional — an opaque, stable per-profile identifier the client
+sends so each local profile maps to a distinct broker identity. Omit it for the
+legacy single-identity behavior. When present it must match
+`^[A-Za-z0-9_-]{1,64}$`; the broker namespaces the minted token's subject by it.
 
 **Response (200, approved):** `AuthToken`
 

--- a/src/moneybin/cli/commands/sync.py
+++ b/src/moneybin/cli/commands/sync.py
@@ -38,10 +38,9 @@ def _build_sync_client():
             "sync.server_url is not configured. "
             "Set MONEYBIN_SYNC__SERVER_URL in your environment."
         )
-    # Derive the active profile's directory from the resolved DB path
-    # (<profile_dir>/moneybin.duckdb) so the broker scopes this profile's
-    # identity separately from every other profile's.
-    profile_id = get_or_create_profile_id(settings.database.path.parent)
+    # Scope the broker identity to the active profile so each profile
+    # authenticates as a distinct user.
+    profile_id = get_or_create_profile_id(settings.profile_dir)
     return SyncClient(server_url=str(settings.sync.server_url), profile_id=profile_id)
 
 

--- a/src/moneybin/cli/commands/sync.py
+++ b/src/moneybin/cli/commands/sync.py
@@ -30,6 +30,7 @@ def _build_sync_client():
     """Construct a SyncClient from current settings. Extracted for test mocking."""
     from moneybin.config import get_settings  # noqa: PLC0415
     from moneybin.connectors.sync_client import SyncClient  # noqa: PLC0415
+    from moneybin.utils.user_config import get_or_create_profile_id  # noqa: PLC0415
 
     settings = get_settings()
     if settings.sync.server_url is None:
@@ -37,7 +38,11 @@ def _build_sync_client():
             "sync.server_url is not configured. "
             "Set MONEYBIN_SYNC__SERVER_URL in your environment."
         )
-    return SyncClient(server_url=str(settings.sync.server_url))
+    # Derive the active profile's directory from the resolved DB path
+    # (<profile_dir>/moneybin.duckdb) so the broker scopes this profile's
+    # identity separately from every other profile's.
+    profile_id = get_or_create_profile_id(settings.database.path.parent)
+    return SyncClient(server_url=str(settings.sync.server_url), profile_id=profile_id)
 
 
 @contextmanager

--- a/src/moneybin/config.py
+++ b/src/moneybin/config.py
@@ -884,6 +884,16 @@ class MoneyBinSettings(BaseSettings):
         """Active profile's inbox parent: <inbox_root>/<profile>/."""
         return self.import_.inbox_root / self.profile
 
+    @property
+    def profile_dir(self) -> Path:
+        """Active profile's directory: <base>/profiles/<profile>/.
+
+        Derived from the profile name (not the database path) so callers that
+        need profile-scoped identity — e.g. the sync client's per-profile id —
+        don't couple to where the DB file happens to live.
+        """
+        return get_base_dir() / "profiles" / self.profile
+
 
 # Global settings - single instance for current profile
 _current_settings: MoneyBinSettings | None = None

--- a/src/moneybin/connectors/sync_client.py
+++ b/src/moneybin/connectors/sync_client.py
@@ -125,6 +125,26 @@ class SyncClient:
         """Remove stored tokens from keychain (or fallback file)."""
         self._clear_tokens()
 
+    @classmethod
+    def clear_tokens_for_profile(cls, profile_id: str) -> None:
+        """Delete a single profile's scoped broker tokens (keyring + fallback file).
+
+        For profile deletion: removes only that profile's scoped slots — never the
+        legacy unscoped slots (which may belong to another or legacy identity) or
+        another profile's slots. Best-effort; missing entries are ignored.
+        """
+        for key in (
+            f"{profile_id}:{_KEYRING_JWT_KEY}",
+            f"{profile_id}:{_KEYRING_REFRESH_KEY}",
+        ):
+            try:
+                keyring.delete_password(_KEYRING_SERVICE, key)
+            except KeyringError:
+                pass
+        fallback = Path.home() / ".moneybin" / f".sync_token-{profile_id}"
+        if fallback.exists():
+            fallback.unlink()
+
     def _clear_tokens(self) -> None:
         if self._token_path is not None:
             if self._token_path.exists():

--- a/src/moneybin/connectors/sync_client.py
+++ b/src/moneybin/connectors/sync_client.py
@@ -130,17 +130,26 @@ class SyncClient:
             if self._token_path.exists():
                 self._token_path.unlink()
             return
-        try:
-            keyring.delete_password(_KEYRING_SERVICE, self._jwt_key)
-        except KeyringError:
-            pass
-        try:
-            keyring.delete_password(_KEYRING_SERVICE, self._refresh_key)
-        except KeyringError:
-            pass
-        fallback = self._effective_token_path()
-        if fallback.exists():
-            fallback.unlink()
+        # Clear this profile's scoped slots AND the legacy unscoped slots, so a
+        # user upgrading from the pre-per-profile version doesn't leave an
+        # orphaned token behind on logout. The set dedups when no profile is set
+        # (scoped keys == legacy keys).
+        for key in {
+            self._jwt_key,
+            self._refresh_key,
+            _KEYRING_JWT_KEY,
+            _KEYRING_REFRESH_KEY,
+        }:
+            try:
+                keyring.delete_password(_KEYRING_SERVICE, key)
+            except KeyringError:
+                pass
+        for path in {
+            self._effective_token_path(),
+            Path.home() / ".moneybin" / ".sync_token",
+        }:
+            if path.exists():
+                path.unlink()
 
     def _write_token_file(
         self,

--- a/src/moneybin/connectors/sync_client.py
+++ b/src/moneybin/connectors/sync_client.py
@@ -69,10 +69,27 @@ class SyncClient:
     # Test hook — overridable for fast tests (e.g. client._sleep = list.append)
     _sleep = staticmethod(time.sleep)
 
-    def __init__(self, server_url: str, token_path: Path | None = None) -> None:
+    def __init__(
+        self,
+        server_url: str,
+        token_path: Path | None = None,
+        profile_id: str | None = None,
+    ) -> None:
         """Set up the HTTP client and optional test-only token path override."""
         self._server_url = server_url.rstrip("/")
         self._token_path = token_path  # if set, bypass keyring entirely (tests)
+        self._profile_id = profile_id
+        # Namespace token storage by profile so two profiles never share a slot —
+        # each profile's token encodes a distinct broker subject. Absent a
+        # profile_id, fall back to the legacy unscoped keys.
+        self._jwt_key = (
+            f"{profile_id}:{_KEYRING_JWT_KEY}" if profile_id else _KEYRING_JWT_KEY
+        )
+        self._refresh_key = (
+            f"{profile_id}:{_KEYRING_REFRESH_KEY}"
+            if profile_id
+            else _KEYRING_REFRESH_KEY
+        )
         self._client = httpx.Client(base_url=self._server_url, timeout=_DEFAULT_TIMEOUT)
 
     # ------------------------------ Token storage ------------------------------
@@ -82,8 +99,8 @@ class SyncClient:
             self._write_token_file(access_token, refresh_token)
             return
         try:
-            keyring.set_password(_KEYRING_SERVICE, _KEYRING_JWT_KEY, access_token)
-            keyring.set_password(_KEYRING_SERVICE, _KEYRING_REFRESH_KEY, refresh_token)
+            keyring.set_password(_KEYRING_SERVICE, self._jwt_key, access_token)
+            keyring.set_password(_KEYRING_SERVICE, self._refresh_key, refresh_token)
         except KeyringError as e:
             logger.warning(f"Keyring unavailable ({e}); falling back to file storage.")
             self._write_token_file(access_token, refresh_token)
@@ -92,7 +109,7 @@ class SyncClient:
         if self._token_path is not None:
             return self._read_token_file().get("jwt")
         try:
-            return keyring.get_password(_KEYRING_SERVICE, _KEYRING_JWT_KEY)
+            return keyring.get_password(_KEYRING_SERVICE, self._jwt_key)
         except KeyringError:
             return self._read_token_file().get("jwt")
 
@@ -100,7 +117,7 @@ class SyncClient:
         if self._token_path is not None:
             return self._read_token_file().get("refresh_token")
         try:
-            return keyring.get_password(_KEYRING_SERVICE, _KEYRING_REFRESH_KEY)
+            return keyring.get_password(_KEYRING_SERVICE, self._refresh_key)
         except KeyringError:
             return self._read_token_file().get("refresh_token")
 
@@ -114,14 +131,14 @@ class SyncClient:
                 self._token_path.unlink()
             return
         try:
-            keyring.delete_password(_KEYRING_SERVICE, _KEYRING_JWT_KEY)
+            keyring.delete_password(_KEYRING_SERVICE, self._jwt_key)
         except KeyringError:
             pass
         try:
-            keyring.delete_password(_KEYRING_SERVICE, _KEYRING_REFRESH_KEY)
+            keyring.delete_password(_KEYRING_SERVICE, self._refresh_key)
         except KeyringError:
             pass
-        fallback = Path.home() / ".moneybin" / ".sync_token"
+        fallback = self._effective_token_path()
         if fallback.exists():
             fallback.unlink()
 
@@ -157,7 +174,8 @@ class SyncClient:
     def _effective_token_path(self) -> Path:
         if self._token_path is not None:
             return self._token_path
-        return Path.home() / ".moneybin" / ".sync_token"
+        name = f".sync_token-{self._profile_id}" if self._profile_id else ".sync_token"
+        return Path.home() / ".moneybin" / name
 
     # ------------------------------ Login ------------------------------
 
@@ -188,12 +206,17 @@ class SyncClient:
             except webbrowser.Error:
                 pass  # fall through; URL already printed
 
+        # Send profile_id only when set, so the request to a legacy server (no
+        # such field) is byte-for-byte unchanged. The broker namespaces the JWT
+        # subject per profile when present.
+        token_body: dict[str, str] = {"device_code": device_code}
+        if self._profile_id:
+            token_body["profile_id"] = self._profile_id
+
         while True:
             self._sleep(interval)
             try:
-                poll = self._client.post(
-                    "/auth/device/token", json={"device_code": device_code}
-                )
+                poll = self._client.post("/auth/device/token", json=token_body)
             except httpx.RequestError as e:
                 raise SyncAPIError(
                     f"sync server unreachable at {self._server_url}: {e}"

--- a/src/moneybin/mcp/tools/sync.py
+++ b/src/moneybin/mcp/tools/sync.py
@@ -39,9 +39,16 @@ logger = logging.getLogger(__name__)
 
 
 def _build_sync_client() -> Any:
-    """Construct a SyncClient from current settings."""
+    """Construct a SyncClient from current settings.
+
+    Mirrors the CLI builder (``cli/commands/sync.py``) exactly — including the
+    per-profile identity — so MCP and CLI read and write the same scoped token
+    slot. (The two builders are duplicated; consolidating them is tracked as a
+    follow-up.)
+    """
     from moneybin.config import get_settings  # noqa: PLC0415
     from moneybin.connectors.sync_client import SyncClient  # noqa: PLC0415
+    from moneybin.utils.user_config import get_or_create_profile_id  # noqa: PLC0415
 
     settings = get_settings()
     if settings.sync.server_url is None:
@@ -49,7 +56,10 @@ def _build_sync_client() -> Any:
             "sync.server_url is not configured. "
             "Set MONEYBIN_SYNC__SERVER_URL in your environment."
         )
-    return SyncClient(server_url=str(settings.sync.server_url))
+    # Scope the broker identity to the active profile so each profile
+    # authenticates as a distinct user.
+    profile_id = get_or_create_profile_id(settings.profile_dir)
+    return SyncClient(server_url=str(settings.sync.server_url), profile_id=profile_id)
 
 
 @contextmanager

--- a/src/moneybin/services/profile_service.py
+++ b/src/moneybin/services/profile_service.py
@@ -234,6 +234,12 @@ class ProfileService:
                 f"Cannot delete the active profile '{normalized}'. "
                 "Switch to another profile first: moneybin profile switch <name>"
             )
+        # Capture the opaque sync id before the dir (and its profile_id file) are
+        # removed, so the broker tokens scoped to it can be cleared afterward.
+        sync_id_file = profile_dir / "profile_id"
+        sync_profile_id = (
+            sync_id_file.read_text().strip() if sync_id_file.exists() else None
+        )
         shutil.rmtree(profile_dir)
         # Clear the profile's keychain entries — each profile has its own
         # service ("moneybin-<profile>"), so this never touches sibling profiles.
@@ -248,6 +254,12 @@ class ProfileService:
                 # if keyring cleanup fails (e.g. NoKeyringError on headless
                 # systems, locked keychain, network keyring unreachable).
                 logger.debug(f"Keychain cleanup for {key_name} failed: {e}")
+        # Clear the profile's scoped broker sync tokens (a separate keyring
+        # service from the SecretStore above), so a delete leaves nothing behind.
+        if sync_profile_id:
+            from moneybin.connectors.sync_client import SyncClient
+
+            SyncClient.clear_tokens_for_profile(sync_profile_id)
         logger.debug(f"Deleted profile directory: {normalized}")
 
     def show(

--- a/src/moneybin/utils/user_config.py
+++ b/src/moneybin/utils/user_config.py
@@ -6,6 +6,7 @@ including default profile settings and user preferences.
 
 import logging
 import re
+import uuid
 from datetime import date
 from pathlib import Path
 
@@ -214,6 +215,33 @@ def generate_profile_config(profile_dir: Path, profile_name: str) -> Path:
         yaml.safe_dump(config_data, f, default_flow_style=False, sort_keys=False)
 
     return config_path
+
+
+def get_or_create_profile_id(profile_dir: Path) -> str:
+    """Return the profile's stable, opaque id, generating it on first use.
+
+    The id is a truncated UUID4 stored in ``<profile_dir>/profile_id``. It is
+    opaque on purpose: it is sent to moneybin-sync to namespace the JWT subject,
+    so it must never carry the (potentially personal) profile name. Generated
+    lazily — profiles created before this existed get one on first sync — and
+    stable across processes once written. The enclosing profile directory is
+    already created mode ``0o700``, so the file inherits owner-only access.
+
+    Args:
+        profile_dir: The profile's directory (``<base>/profiles/<name>``).
+
+    Returns:
+        The 12-character hex profile id.
+    """
+    id_path = profile_dir / "profile_id"
+    if id_path.exists():
+        existing = id_path.read_text().strip()
+        if existing:
+            return existing
+    profile_id = uuid.uuid4().hex[:12]
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    id_path.write_text(profile_id)
+    return profile_id
 
 
 def prompt_for_profile_name() -> str:

--- a/src/moneybin/utils/user_config.py
+++ b/src/moneybin/utils/user_config.py
@@ -224,8 +224,9 @@ def get_or_create_profile_id(profile_dir: Path) -> str:
     opaque on purpose: it is sent to moneybin-sync to namespace the JWT subject,
     so it must never carry the (potentially personal) profile name. Generated
     lazily — profiles created before this existed get one on first sync — and
-    stable across processes once written. The enclosing profile directory is
-    already created mode ``0o700``, so the file inherits owner-only access.
+    stable across processes once written. The file's own mode follows the
+    umask, but the enclosing profile directory is created mode ``0o700``, so
+    only the owner can traverse into it to read the id.
 
     Args:
         profile_dir: The profile's directory (``<base>/profiles/<name>``).

--- a/src/moneybin/utils/user_config.py
+++ b/src/moneybin/utils/user_config.py
@@ -224,9 +224,9 @@ def get_or_create_profile_id(profile_dir: Path) -> str:
     opaque on purpose: it is sent to moneybin-sync to namespace the JWT subject,
     so it must never carry the (potentially personal) profile name. Generated
     lazily — profiles created before this existed get one on first sync — and
-    stable across processes once written. The file's own mode follows the
-    umask, but the enclosing profile directory is created mode ``0o700``, so
-    only the owner can traverse into it to read the id.
+    stable across processes once written. The id is not a credential — it names
+    a profile's broker identity; access still requires the loopback-minted
+    token — so the file is left at the umask default rather than tightened.
 
     Args:
         profile_dir: The profile's directory (``<base>/profiles/<name>``).

--- a/tests/moneybin/connectors/test_sync_client.py
+++ b/tests/moneybin/connectors/test_sync_client.py
@@ -479,7 +479,7 @@ def test_login_sends_profile_id_when_set(
     client = SyncClient(
         server_url="https://test.api",
         token_path=tmp_path / ".sync_token",
-        profile_id="prof12345678",
+        profile_id="ab12cd34ef56",
     )
     respx.post("https://test.api/auth/device/code").mock(
         return_value=httpx.Response(
@@ -508,7 +508,7 @@ def test_login_sends_profile_id_when_set(
     client.login(open_browser=False)
 
     sent = json.loads(token_route.calls.last.request.content)
-    assert sent["profile_id"] == "prof12345678"
+    assert sent["profile_id"] == "ab12cd34ef56"
 
 
 @respx.mock

--- a/tests/moneybin/connectors/test_sync_client.py
+++ b/tests/moneybin/connectors/test_sync_client.py
@@ -515,14 +515,15 @@ def test_tokens_are_isolated_per_profile(monkeypatch: pytest.MonkeyPatch) -> Non
     """Two profiles must not share a keychain slot — tokens encode a per-profile subject."""
     _clear_proxy_env(monkeypatch)
     store: dict[tuple[str, str], str] = {}
-    monkeypatch.setattr(
-        "moneybin.connectors.sync_client.keyring.set_password",
-        lambda service, user, pw: store.__setitem__((service, user), pw),
-    )
-    monkeypatch.setattr(
-        "moneybin.connectors.sync_client.keyring.get_password",
-        lambda service, user: store.get((service, user)),
-    )
+
+    def _set(service: str, user: str, pw: str) -> None:
+        store[(service, user)] = pw
+
+    def _get(service: str, user: str) -> str | None:
+        return store.get((service, user))
+
+    monkeypatch.setattr("moneybin.connectors.sync_client.keyring.set_password", _set)
+    monkeypatch.setattr("moneybin.connectors.sync_client.keyring.get_password", _get)
 
     alice = SyncClient(server_url="https://test.api", profile_id="aaaaaaaaaaaa")
     bob = SyncClient(server_url="https://test.api", profile_id="bbbbbbbbbbbb")

--- a/tests/moneybin/connectors/test_sync_client.py
+++ b/tests/moneybin/connectors/test_sync_client.py
@@ -511,6 +511,45 @@ def test_login_sends_profile_id_when_set(
     assert sent["profile_id"] == "prof12345678"
 
 
+@respx.mock
+def test_login_omits_profile_id_when_not_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Legacy-server compat: profile_id must be absent from the token body when not set."""
+    _clear_proxy_env(monkeypatch)
+    client = SyncClient(
+        server_url="https://test.api", token_path=tmp_path / ".sync_token"
+    )
+    respx.post("https://test.api/auth/device/code").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "device_code": "dev",
+                "user_code": "X",
+                "verification_uri_complete": "https://x",
+                "interval": 0,
+                "expires_in": 900,
+            },
+        )
+    )
+    token_route = respx.post("https://test.api/auth/device/token").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "access_token": "jwt",  # noqa: S106  # test fixture, not a real credential
+                "refresh_token": "ref",  # noqa: S106  # test fixture, not a real credential
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            },
+        )
+    )
+
+    client.login(open_browser=False)
+
+    sent = json.loads(token_route.calls.last.request.content)
+    assert "profile_id" not in sent
+
+
 def test_tokens_are_isolated_per_profile(monkeypatch: pytest.MonkeyPatch) -> None:
     """Two profiles must not share a keychain slot — tokens encode a per-profile subject."""
     _clear_proxy_env(monkeypatch)

--- a/tests/moneybin/connectors/test_sync_client.py
+++ b/tests/moneybin/connectors/test_sync_client.py
@@ -11,6 +11,9 @@ import respx
 
 from moneybin.connectors.sync_client import (
     _DEFAULT_TIMEOUT,  # type: ignore[reportPrivateUsage]
+    _KEYRING_JWT_KEY,  # type: ignore[reportPrivateUsage]
+    _KEYRING_REFRESH_KEY,  # type: ignore[reportPrivateUsage]
+    _KEYRING_SERVICE,  # type: ignore[reportPrivateUsage]
     _LONG_TIMEOUT,  # type: ignore[reportPrivateUsage]
     SyncClient,
 )
@@ -571,3 +574,53 @@ def test_tokens_are_isolated_per_profile(monkeypatch: pytest.MonkeyPatch) -> Non
 
     assert alice._read_token() == "jwt-a"  # type: ignore[reportPrivateUsage]
     assert bob._read_token() is None  # type: ignore[reportPrivateUsage]
+
+
+def test_logout_clears_scoped_and_legacy_keyring_slots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Logout clears the profile's scoped keys and the legacy unscoped keys.
+
+    Other profiles' tokens stay intact. Exercises the keyring path of
+    _clear_tokens (the _token_path fixture used by other tests short-circuits
+    it); HOME is redirected so the fallback-file cleanup never touches the real
+    ~/.moneybin.
+    """
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    store: dict[tuple[str, str], str] = {}
+
+    def _set(service: str, user: str, pw: str) -> None:
+        store[(service, user)] = pw
+
+    def _get(service: str, user: str) -> str | None:
+        return store.get((service, user))
+
+    def _delete(service: str, user: str) -> None:
+        store.pop((service, user), None)
+
+    monkeypatch.setattr("moneybin.connectors.sync_client.keyring.set_password", _set)
+    monkeypatch.setattr("moneybin.connectors.sync_client.keyring.get_password", _get)
+    monkeypatch.setattr(
+        "moneybin.connectors.sync_client.keyring.delete_password", _delete
+    )
+
+    # A legacy (unscoped) token left by a pre-per-profile version of the client.
+    store[(_KEYRING_SERVICE, _KEYRING_JWT_KEY)] = "legacy-jwt"
+    store[(_KEYRING_SERVICE, _KEYRING_REFRESH_KEY)] = "legacy-ref"
+
+    alice = SyncClient(server_url="https://test.api", profile_id="aaaaaaaaaaaa")
+    bob = SyncClient(server_url="https://test.api", profile_id="bbbbbbbbbbbb")
+    alice._store_tokens(access_token="jwt-a", refresh_token="ref-a")  # type: ignore[reportPrivateUsage]  # noqa: S106  # test fixture
+    bob._store_tokens(access_token="jwt-b", refresh_token="ref-b")  # type: ignore[reportPrivateUsage]  # noqa: S106  # test fixture
+
+    alice.logout()
+
+    # Alice's scoped slots are gone; the legacy unscoped slots are wiped too.
+    assert alice._read_token() is None  # type: ignore[reportPrivateUsage]
+    assert alice._read_refresh_token() is None  # type: ignore[reportPrivateUsage]
+    assert (_KEYRING_SERVICE, _KEYRING_JWT_KEY) not in store
+    assert (_KEYRING_SERVICE, _KEYRING_REFRESH_KEY) not in store
+    # Bob's scoped slots are untouched.
+    assert bob._read_token() == "jwt-b"  # type: ignore[reportPrivateUsage]
+    assert bob._read_refresh_token() == "ref-b"  # type: ignore[reportPrivateUsage]

--- a/tests/moneybin/connectors/test_sync_client.py
+++ b/tests/moneybin/connectors/test_sync_client.py
@@ -456,3 +456,78 @@ def test_ack_posts_job_id_and_returns_ack_response(sync_client: SyncClient) -> N
     assert result.job_id == "job-123"
     assert result.status == "acked"
     assert json.loads(route.calls.last.request.content) == {"job_id": "job-123"}
+
+
+def _clear_proxy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "ALL_PROXY",
+        "all_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "HTTP_PROXY",
+        "http_proxy",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+@respx.mock
+def test_login_sends_profile_id_when_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The client forwards its opaque profile_id so the broker namespaces the subject."""
+    _clear_proxy_env(monkeypatch)
+    client = SyncClient(
+        server_url="https://test.api",
+        token_path=tmp_path / ".sync_token",
+        profile_id="prof12345678",
+    )
+    respx.post("https://test.api/auth/device/code").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "device_code": "dev",
+                "user_code": "X",
+                "verification_uri_complete": "https://x",
+                "interval": 0,
+                "expires_in": 900,
+            },
+        )
+    )
+    token_route = respx.post("https://test.api/auth/device/token").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "access_token": "jwt",  # noqa: S106  # test fixture, not a real credential
+                "refresh_token": "ref",  # noqa: S106  # test fixture, not a real credential
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            },
+        )
+    )
+
+    client.login(open_browser=False)
+
+    sent = json.loads(token_route.calls.last.request.content)
+    assert sent["profile_id"] == "prof12345678"
+
+
+def test_tokens_are_isolated_per_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two profiles must not share a keychain slot — tokens encode a per-profile subject."""
+    _clear_proxy_env(monkeypatch)
+    store: dict[tuple[str, str], str] = {}
+    monkeypatch.setattr(
+        "moneybin.connectors.sync_client.keyring.set_password",
+        lambda service, user, pw: store.__setitem__((service, user), pw),
+    )
+    monkeypatch.setattr(
+        "moneybin.connectors.sync_client.keyring.get_password",
+        lambda service, user: store.get((service, user)),
+    )
+
+    alice = SyncClient(server_url="https://test.api", profile_id="aaaaaaaaaaaa")
+    bob = SyncClient(server_url="https://test.api", profile_id="bbbbbbbbbbbb")
+
+    alice._store_tokens(access_token="jwt-a", refresh_token="ref-a")  # type: ignore[reportPrivateUsage]  # noqa: S106  # test fixture
+
+    assert alice._read_token() == "jwt-a"  # type: ignore[reportPrivateUsage]
+    assert bob._read_token() is None  # type: ignore[reportPrivateUsage]

--- a/tests/moneybin/connectors/test_sync_client.py
+++ b/tests/moneybin/connectors/test_sync_client.py
@@ -624,3 +624,45 @@ def test_logout_clears_scoped_and_legacy_keyring_slots(
     # Bob's scoped slots are untouched.
     assert bob._read_token() == "jwt-b"  # type: ignore[reportPrivateUsage]
     assert bob._read_refresh_token() == "ref-b"  # type: ignore[reportPrivateUsage]
+
+
+def test_clear_tokens_for_profile_deletes_only_that_profiles_scoped_slots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """clear_tokens_for_profile removes one profile's scoped slots, sparing siblings + legacy.
+
+    Used when a profile is deleted: it must NOT touch the legacy unscoped slots
+    (which may belong to another/legacy identity) or other profiles' tokens.
+    """
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    store: dict[tuple[str, str], str] = {}
+
+    def _set(service: str, user: str, pw: str) -> None:
+        store[(service, user)] = pw
+
+    def _get(service: str, user: str) -> str | None:
+        return store.get((service, user))
+
+    def _delete(service: str, user: str) -> None:
+        store.pop((service, user), None)
+
+    monkeypatch.setattr("moneybin.connectors.sync_client.keyring.set_password", _set)
+    monkeypatch.setattr("moneybin.connectors.sync_client.keyring.get_password", _get)
+    monkeypatch.setattr(
+        "moneybin.connectors.sync_client.keyring.delete_password", _delete
+    )
+
+    alice = SyncClient(server_url="https://test.api", profile_id="aaaaaaaaaaaa")
+    bob = SyncClient(server_url="https://test.api", profile_id="bbbbbbbbbbbb")
+    alice._store_tokens(access_token="jwt-a", refresh_token="ref-a")  # type: ignore[reportPrivateUsage]  # noqa: S106  # test fixture
+    bob._store_tokens(access_token="jwt-b", refresh_token="ref-b")  # type: ignore[reportPrivateUsage]  # noqa: S106  # test fixture
+    store[(_KEYRING_SERVICE, _KEYRING_JWT_KEY)] = "legacy-jwt"
+
+    SyncClient.clear_tokens_for_profile("aaaaaaaaaaaa")
+
+    assert alice._read_token() is None  # type: ignore[reportPrivateUsage]
+    assert alice._read_refresh_token() is None  # type: ignore[reportPrivateUsage]
+    # Sibling profile and legacy unscoped slot are untouched.
+    assert bob._read_token() == "jwt-b"  # type: ignore[reportPrivateUsage]
+    assert store[(_KEYRING_SERVICE, _KEYRING_JWT_KEY)] == "legacy-jwt"

--- a/tests/moneybin/test_services/test_profile_service.py
+++ b/tests/moneybin/test_services/test_profile_service.py
@@ -212,6 +212,38 @@ class TestProfileDelete:
         with pytest.raises(ValueError, match="Cannot delete the active profile"):
             svc.delete("alice")
 
+    def test_delete_clears_scoped_sync_tokens(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Deleting a profile clears its scoped broker sync tokens by profile_id."""
+        monkeypatch.setenv("MONEYBIN_HOME", str(tmp_path))
+        svc = ProfileService()
+        svc.create("alice")
+        # The sync id is normally written lazily on first sync; seed it here.
+        (tmp_path / "profiles" / "alice" / "profile_id").write_text("ab12cd34ef56")
+
+        with patch(
+            "moneybin.connectors.sync_client.SyncClient.clear_tokens_for_profile"
+        ) as mock_clear:
+            svc.delete("alice")
+
+        mock_clear.assert_called_once_with("ab12cd34ef56")
+
+    def test_delete_without_sync_id_skips_token_cleanup(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A profile with no profile_id file deletes without attempting token cleanup."""
+        monkeypatch.setenv("MONEYBIN_HOME", str(tmp_path))
+        svc = ProfileService()
+        svc.create("alice")  # create() does not write a profile_id file
+
+        with patch(
+            "moneybin.connectors.sync_client.SyncClient.clear_tokens_for_profile"
+        ) as mock_clear:
+            svc.delete("alice")
+
+        mock_clear.assert_not_called()
+
 
 class TestProfileShow:
     """Test profile show (resolved settings)."""

--- a/tests/moneybin/test_utils/test_user_config.py
+++ b/tests/moneybin/test_utils/test_user_config.py
@@ -301,3 +301,34 @@ class TestProfileConfigYaml:
         generate_profile_config(profile_dir, "bob")
         content = (profile_dir / "config.yaml").read_text()
         assert "# Profile: bob" in content
+
+
+class TestProfileId:
+    """Test suite for the stable, opaque per-profile id."""
+
+    def test_generates_opaque_id_and_persists(self, tmp_path: Path) -> None:
+        """First call generates a 12-hex id and writes it to <profile_dir>/profile_id."""
+        from moneybin.utils.user_config import get_or_create_profile_id
+
+        profile_dir = tmp_path / "alice"
+        profile_dir.mkdir()
+
+        profile_id = get_or_create_profile_id(profile_dir)
+
+        # 12 hex chars (truncated UUID4, per the identifiers convention).
+        assert len(profile_id) == 12
+        assert all(c in "0123456789abcdef" for c in profile_id)
+        # Persisted verbatim so the id is stable across processes.
+        assert (profile_dir / "profile_id").read_text().strip() == profile_id
+
+    def test_returns_same_id_on_subsequent_calls(self, tmp_path: Path) -> None:
+        """The id is stable: a second call returns the first call's value."""
+        from moneybin.utils.user_config import get_or_create_profile_id
+
+        profile_dir = tmp_path / "alice"
+        profile_dir.mkdir()
+
+        first = get_or_create_profile_id(profile_dir)
+        second = get_or_create_profile_id(profile_dir)
+
+        assert first == second


### PR DESCRIPTION
## What

The sync client now authenticates as a distinct broker user per profile, instead of all profiles sharing one token slot and one server identity.

- **Stable opaque profile id** — `get_or_create_profile_id()` lazily generates a truncated-UUID4 id under `<profile_dir>/profile_id` (profiles created before this get one on first sync). Opaque on purpose: no profile name reaches the broker subject.
- **Per-profile token storage** — `SyncClient` namespaces its keychain entries (and fallback token file) by `profile_id`, so switching profiles uses the right token and one profile can't reuse another's identity.
- **Login** — `SyncClient` forwards `profile_id` at `/auth/device/token`; `_build_sync_client` derives the active profile from the resolved DB path and passes its id.

## Why

A "profile" was purely local (its own DB / config / keychain) but invisible to the broker — every profile minted the same `self-hosted-user` subject, so sandbox items linked under one profile followed you into another. This makes each profile a distinct broker identity.

## Coordination

Pairs with the broker change (moneybin-sync `feat/per-profile-identity-and-env-guard`), which must merge/deploy first — the client sends `profile_id` only when set (always, in practice), and a broker without the matching change would reject the extra field.

## Tests

New tests for the profile-id helper (generate + stability) and `SyncClient` (per-profile keychain isolation + login forwarding the id). Full moneybin unit suite green (4413); ruff + pyright clean.
