### PR TITLE
Give the browser link flow a 5-minute poll deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,10 @@ M2 closing out and M3 underway. M2A curator state shipped (transaction notes, ta
   key is ignored).
 
 ### Fixed
+- **The Plaid `sync link` flow no longer times out mid-approval.** The browser
+  link-completion poll now allows 5 minutes (its own `_LINK_POLL_DEADLINE`,
+  decoupled from the 120s `/sync/trigger` timeout), so completing a real bank's
+  OAuth + MFA no longer aborts the link. (#282)
 - **Bare single-account imports now elicit account confirmation instead of
   erroring (M1S.4 extension).** A single-account tabular file (CSV/TSV/Excel)
   imported with no account identifier — no `--account-name`/`--account-id`, no

--- a/src/moneybin/connectors/sync_client.py
+++ b/src/moneybin/connectors/sync_client.py
@@ -11,7 +11,9 @@ Secret Service, some Docker setups).
 
 Timeouts:
 - _DEFAULT_TIMEOUT (15s) for most endpoints
-- _LONG_TIMEOUT (120s) for POST /sync/trigger and link polling deadline
+- _LONG_TIMEOUT (120s) for POST /sync/trigger
+- _LINK_POLL_DEADLINE (300s) for the browser link flow (decoupled from the HTTP
+  timeouts: completing a bank's OAuth + MFA can take minutes)
 Per design — no per-endpoint configuration knobs unless evidence demands them.
 """
 
@@ -56,6 +58,10 @@ _KEYRING_REFRESH_KEY = "refresh_token"
 _DEFAULT_TIMEOUT = httpx.Timeout(15.0, connect=10.0)
 _LONG_TIMEOUT = httpx.Timeout(120.0, connect=10.0)
 _LINK_POLL_INTERVAL = 3.0
+# How long the CLI waits for the user to finish the browser link flow before
+# giving up. Decoupled from the HTTP timeouts above: completing a real bank's
+# OAuth + MFA can legitimately take minutes, far longer than any single request.
+_LINK_POLL_DEADLINE = 300.0
 
 
 class SyncClient:
@@ -403,10 +409,9 @@ class SyncClient:
         """Poll GET /sync/link/status until status reaches a terminal state.
 
         Terminal: 'linked' (returns) or 'failed' (raises SyncLinkError).
-        Times out after _LONG_TIMEOUT seconds → SyncTimeoutError.
+        Times out after _LINK_POLL_DEADLINE seconds → SyncTimeoutError.
         """
-        read_timeout: float = _LONG_TIMEOUT.read or 120.0
-        deadline = time.time() + read_timeout
+        deadline = time.time() + _LINK_POLL_DEADLINE
         while time.time() < deadline:
             self._sleep(_LINK_POLL_INTERVAL)
             resp = self._authed_request(

--- a/tests/moneybin/connectors/test_sync_client.py
+++ b/tests/moneybin/connectors/test_sync_client.py
@@ -14,10 +14,15 @@ from moneybin.connectors.sync_client import (
     _KEYRING_JWT_KEY,  # type: ignore[reportPrivateUsage]
     _KEYRING_REFRESH_KEY,  # type: ignore[reportPrivateUsage]
     _KEYRING_SERVICE,  # type: ignore[reportPrivateUsage]
+    _LINK_POLL_DEADLINE,  # type: ignore[reportPrivateUsage]
     _LONG_TIMEOUT,  # type: ignore[reportPrivateUsage]
     SyncClient,
 )
-from moneybin.connectors.sync_errors import SyncAuthError, SyncLinkError
+from moneybin.connectors.sync_errors import (
+    SyncAuthError,
+    SyncLinkError,
+    SyncTimeoutError,
+)
 from moneybin.connectors.sync_models import SyncAckResponse, SyncDataResponse
 
 
@@ -59,9 +64,10 @@ def test_sync_client_clear_tokens(sync_client: SyncClient) -> None:
 
 
 def test_timeout_constants() -> None:
-    """Two timeout constants — default and long — per design decision (no per-endpoint config knobs)."""
+    """Timeout constants per design decision (no per-endpoint config knobs)."""
     assert _DEFAULT_TIMEOUT.read == 15.0  # type: ignore[reportPrivateUsage]
     assert _LONG_TIMEOUT.read == 120.0  # type: ignore[reportPrivateUsage]
+    assert _LINK_POLL_DEADLINE == 300.0  # type: ignore[reportPrivateUsage]
 
 
 @respx.mock
@@ -362,6 +368,48 @@ def test_poll_link_failed_raises(sync_client: SyncClient) -> None:
     sync_client._sleep = lambda _: None  # type: ignore[method-assign]
     with pytest.raises(SyncLinkError, match="user cancelled"):
         sync_client.poll_link_status("sess_abc")
+
+
+class _FakeClock:
+    """A deterministic clock: each .time() call returns the next preset value."""
+
+    def __init__(self, values: list[float]) -> None:
+        self._it = iter(values)
+
+    def time(self) -> float:
+        return next(self._it)
+
+
+@respx.mock
+def test_poll_link_status_keeps_polling_past_old_two_minute_deadline(
+    sync_client: SyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The link deadline is 5 min, decoupled from the 120s sync-trigger HTTP
+    # timeout: completing a real bank's OAuth + MFA can take minutes. A simulated
+    # clock that crosses the OLD 120s mark while the session is still pending must
+    # keep polling rather than time out.
+    sync_client._store_tokens(access_token="jwt", refresh_token="r")  # type: ignore[reportPrivateUsage]  # noqa: S106  # test fixture, not a real credential
+    route = respx.get("https://test.api/sync/link/status").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "session_id": "sess_abc",
+                "status": "pending",
+                "expiration": "2026-05-13T13:30:00Z",
+            },
+        )
+    )
+    sync_client._sleep = lambda _: None  # type: ignore[method-assign]
+    # deadline = first time.time() (0.0) + _LINK_POLL_DEADLINE (300) = 300. The
+    # checks at t=130 and t=200 are past the old 120s deadline but under 300, so
+    # two polls happen; t=301 ends the loop → SyncTimeoutError.
+    monkeypatch.setattr(
+        "moneybin.connectors.sync_client.time",
+        _FakeClock([0.0, 130.0, 200.0, 301.0]),
+    )
+    with pytest.raises(SyncTimeoutError):
+        sync_client.poll_link_status("sess_abc")
+    assert route.call_count == 2
 
 
 @respx.mock


### PR DESCRIPTION
## What
Add a dedicated `_LINK_POLL_DEADLINE = 300s` for `SyncClient.poll_link_status`, decoupled from `_LONG_TIMEOUT` (which stays 120s, now used only for the `/sync/trigger` HTTP call).

## Why
The link-completion poll derived its deadline from `_LONG_TIMEOUT.read` (120s) — the same constant as the `/sync/trigger` HTTP timeout — so it could not be tuned independently, and 120s is not enough to finish a real bank's OAuth + MFA. The poll timed out mid-approval and failed the entire link flow.

## Verification
- New behavioral test (written RED first → GREEN): a simulated clock that crosses the old 120s mark while the session is still `pending` keeps polling instead of timing out.
- `test_timeout_constants` extended to lock `_LINK_POLL_DEADLINE == 300`.
- Full `sync_client` suite + ruff + pyright clean.

## Follow-up
Replacing fixed-interval polling with long-polling (the broker already learns completion via the `SESSION_FINISHED` webhook) would remove this timeout class entirely; tracked as separate follow-up work.