### PR TITLE
Demote migration-step and checkpoint logs to debug

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -121,6 +121,12 @@ Fixtures must insert **≥3 rows** into each affected table with realistic shape
 
 Tests must also reproduce the runner's enclosing `BEGIN TRANSACTION` wrap when the bug class depends on it. Wrap the `migrate()` call in `BEGIN`/`COMMIT` (or call through `MigrationRunner.apply_one`) so any "outstanding writes" interaction with subsequent DDL surfaces in the test.
 
+### Logging
+
+A `migrate()` body logs step-level detail (`ADD COLUMN`, `CREATE INDEX`, backfill progress) at `logger.debug` — matching the runner's own per-migration `debug` line (`Applying migration …` in `migrations.py`). The `info`-level signal is the runner's count summary (`⚙️ N pending… / ✅ N applied`); warnings and errors stay at their level. The detail returns under `moneybin --verbose`. A migration that adds many columns otherwise emits a wall of `info` lines on the one-time upgrade that applies it.
+
+Don't change an already-shipped migration's log level. Editing an applied migration changes its file checksum, which `check_drift()` flags as `⚠️ … modified since it was applied` in `moneybin db migrate status` on every DB that already ran it. The convention is forward-only; older migrations keep whatever level they shipped with.
+
 ## Table and Column Comments
 
 Every column should have a comment. Use existing schema files as examples for style and content.

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -787,7 +787,7 @@ class Database:
 
         self.conn.execute("CHECKPOINT")
         DB_CHECKPOINT_TOTAL.labels(reason=reason).inc()
-        logger.info(f"checkpoint: reason={reason}")
+        logger.debug(f"checkpoint: reason={reason}")
 
     def __enter__(self) -> "Database":  # noqa: D105
         return self

--- a/src/moneybin/sql/migrations/V030__add_plaid_transaction_fields.py
+++ b/src/moneybin/sql/migrations/V030__add_plaid_transaction_fields.py
@@ -76,7 +76,7 @@ _COLUMNS: list[tuple[str, str, str]] = [
 def migrate(conn: object) -> None:
     """Add the extended Plaid transaction columns. Idempotent."""
     for name, sql_type, comment in _COLUMNS:
-        logger.info(f"V030: ADD COLUMN IF NOT EXISTS raw.plaid_transactions.{name}")
+        logger.debug(f"V030: ADD COLUMN IF NOT EXISTS raw.plaid_transactions.{name}")
         conn.execute(  # type: ignore[attr-defined]
             f"ALTER TABLE raw.plaid_transactions ADD COLUMN IF NOT EXISTS {name} {sql_type}"
         )

--- a/tests/moneybin/test_database/test_checkpoint.py
+++ b/tests/moneybin/test_database/test_checkpoint.py
@@ -43,12 +43,14 @@ def test_checkpoint_increments_metric_counter_with_reason_label(
     assert after == before + 1
 
 
-def test_checkpoint_logs_at_info_level(
+def test_checkpoint_logs_at_debug_level(
     db: Database, caplog: pytest.LogCaptureFixture
 ) -> None:
-    caplog.set_level(logging.INFO, logger="moneybin.database")
+    caplog.set_level(logging.DEBUG, logger="moneybin.database")
     db.checkpoint("pre_backup")
     assert any(
-        "checkpoint" in record.message.lower() and "pre_backup" in record.message
+        record.levelno == logging.DEBUG
+        and "checkpoint" in record.message.lower()
+        and "pre_backup" in record.message
         for record in caplog.records
     )


### PR DESCRIPTION
## Summary

Default `moneybin` output carried internal log noise that isn't user-facing signal. Migration V030 printed a 16-line `ADD COLUMN IF NOT EXISTS` wall at INFO on the one-time upgrade that applies it, and every write command logged a `checkpoint: reason=…` boundary line. This demotes both to `debug` (recoverable with `--verbose`), leaving the migration runner's count summary (`⚙️ N pending… / ✅ N applied`) as the default signal. The `DB_CHECKPOINT_TOTAL` metric already carries checkpoint observability, so nothing is lost. A new convention note in `database.md` keeps future migrations at this altitude.

Editing V030's log level changes its file checksum, so any database that already applied V030 will show a one-time `⚠️ V030 modified since applied` in `moneybin db migrate status` until recreated — pre-launch, dev-only. Historical migrations (V006–V029) are left frozen for this reason.

## Test plan

- [ ] `uv run pytest tests/moneybin/test_database/test_checkpoint.py tests/moneybin/test_migration_v030.py tests/moneybin/test_migrations.py` — all green
- [ ] At default verbosity, a write command (e.g. `moneybin db migrate apply` on a fresh DB) shows only the `⚙️/✅` summary — no per-column or `checkpoint:` lines
- [ ] `moneybin --verbose …` still surfaces the per-column `V030: ADD COLUMN…` and `checkpoint: reason=…` detail
