### PR TITLE
Capture design inputs from follow-up research in specs

### DIFF
--- a/docs/specs/categorization-overview.md
+++ b/docs/specs/categorization-overview.md
@@ -1,6 +1,6 @@
 # Categorization — Overview
 
-> Last updated: 2026-05-17
+> Last updated: 2026-07-03 — future semantic-tier design inputs (embed exemplars over anchors; margin-over-runner-up abstention)
 > Status: Ready — umbrella doc for the categorization initiative. Child specs listed in [Pillars](#pillars) are written separately.
 > Companions: [`categorization-matching-mechanics.md`](categorization-matching-mechanics.md) (algorithm contract: `match_text` construction, exemplar accumulation, source-precedence enforcement on write, snowball auto-apply), [`smart-import-overview.md`](smart-import-overview.md) (peer initiative, references this spec for pillars D & E), [`matching-overview.md`](matching-overview.md) (peer initiative, owns transfer detection), [`archived/transaction-categorization.md`](archived/transaction-categorization.md) (existing implementation this builds on), [`moneybin-mcp.md`](moneybin-mcp.md) (tool signatures), `CLAUDE.md` "Architecture: Data Layers"
 

--- a/docs/specs/categorization-overview.md
+++ b/docs/specs/categorization-overview.md
@@ -115,6 +115,13 @@ The ML categorizer works by analyzing the words in transaction descriptions to f
 
 The v1 implementation uses TF-IDF (term frequency–inverse document frequency) to convert descriptions into numeric features and SVM (support vector machine) as the classifier. This combination is lightweight (no GPU, sub-second training on personal-scale data), well-proven for short-text classification, and is the same approach used by Beancount's Smart Importer. The model interface is designed to be swappable — alternative approaches (word embeddings, pre-trained language models) can replace the internals without changing the categorization pipeline or user experience.
 
+### If a semantic tier is added later (design inputs, not v1)
+
+The swappable interface above leaves room for a semantic-similarity tier — embed the transaction, compare against reference vectors — between the deterministic rules and the LLM fallback. Two forks are already decided if that tier is ever built, captured here so they are not re-derived:
+
+- **Embed accumulated exemplars, not static category anchors.** Anchoring category vectors on fixed metadata never learns. Embedding the user's accumulated exemplars (the same `oneOf` exemplars [`categorization-matching-mechanics.md`](categorization-matching-mechanics.md) accumulates from every correction) gets *both* correction-learning and generalization to unseen merchant variants. A shipped competitor's semantic tier anchors on static category metadata and cannot learn from corrections — the fork we would not take.
+- **Abstain on a thin margin, not just a low score.** Accept a semantic match only when similarity ≥ `T_sim` **and** its margin over the runner-up category ≥ `T_margin`; otherwise abstain and fall through to the next tier. A bare similarity threshold over-commits on ambiguous ties where two categories are both plausible. A competing implementation uses ≈ 0.78 / 0.06 for these two thresholds — a reference point to recalibrate on our own data, not adopt as-is.
+
 ### Training
 
 **Data sources** — all categorized transactions contribute to training, weighted by source quality:

--- a/docs/specs/database-writer-coordination.md
+++ b/docs/specs/database-writer-coordination.md
@@ -790,7 +790,7 @@ wait-time distribution observability theater):
 
 - No read-side lock — reads must remain unblocked.
 - No write queue / serializer — DuckDB writer semantics unchanged.
-- No Treeline-style read serialization — different problem.
+- No whole-file read serialization (as some local-first apps do) — different problem.
 - No singleton `Database` cache — per-call connections per ADR-010.
 - No writer-priority arbitration / starvation prevention — the 10 s
   ceiling is the safety net at single-user scale.

--- a/docs/specs/investments-data-model.md
+++ b/docs/specs/investments-data-model.md
@@ -315,7 +315,11 @@ and consuming them on disposals.
 > implement would silently miscompute basis, so the constraint is a guard, not an
 > oversight. HIFO/LIFO (listed as future methods in `investments-overview.md`) are added
 > by widening the `CHECK` when their engine paths ship — a lightweight `app.*` migration,
-> the same deliberate trade-off as `security_type`.
+> the same deliberate trade-off as `security_type`. When that widening happens,
+> **prioritize HIFO and leave LIFO out absent demand**: a shipped competitor
+> cost-basis engine offers FIFO / HIFO / specific-ID and notably no LIFO, so HIFO
+> carries an external demand signal LIFO does not. Add LIFO only if a real user
+> needs it, not speculatively alongside HIFO.
 
 ### Short-term / long-term split (shared across all methods)
 

--- a/docs/specs/investments-overview.md
+++ b/docs/specs/investments-overview.md
@@ -166,9 +166,13 @@ data; charts often use adjusted).
 When a current price is unavailable — market closed, feed gap, or a security the
 feed does not cover — valuation falls back to the most recent stored close, but
 the fallback is always visible. Any priced response carries the `price_date` it
-actually used and a derived `staleness_days`; past a configurable threshold the
-response envelope adds an explicit staleness warning. A stale close is never
-silently presented as the current price. This is the price-side application of
+actually used plus a staleness measure; past a configurable threshold the
+response envelope adds an explicit staleness warning. Reuse the staleness
+vocabulary [`asset-tracking.md`](asset-tracking.md) already establishes
+(`days_since_observed` + `staleness_threshold_days`) rather than coining a
+parallel `staleness_days`, so prices and physical assets share one shape for the
+staleness concept. A stale close is never silently presented as the current
+price. This is the price-side application of
 "magic stays visible": the fallback itself is fine, silently misrepresenting its
 age is not. A shipped competitor already does exactly this (snapshot fallback
 plus gap-day staleness marking), confirming the shape.

--- a/docs/specs/investments-overview.md
+++ b/docs/specs/investments-overview.md
@@ -161,6 +161,18 @@ from a real-time call or short cache; everything past is stored. Raw vs.
 split/dividend-adjusted prices is a Pillar C concern (cost basis uses raw ledger
 data; charts often use adjusted).
 
+### Stale prices surface, never masquerade as current (Pillar C)
+
+When a current price is unavailable — market closed, feed gap, or a security the
+feed does not cover — valuation falls back to the most recent stored close, but
+the fallback is always visible. Any priced response carries the `price_date` it
+actually used and a derived `staleness_days`; past a configurable threshold the
+response envelope adds an explicit staleness warning. A stale close is never
+silently presented as the current price. This is the price-side application of
+"magic stays visible": the fallback itself is fine, silently misrepresenting its
+age is not. A shipped competitor already does exactly this (snapshot fallback
+plus gap-day staleness marking), confirming the shape.
+
 ### Currency: column now, conversion later
 
 A `currency` column lands on the ledger, lots, prices, and holdings in the

--- a/docs/specs/investments-overview.md
+++ b/docs/specs/investments-overview.md
@@ -1,6 +1,6 @@
 # Investments — Overview
 
-> Last updated: 2026-05-29 — 1099-B tie-out reaffirmed as the hard M1J close gate.
+> Last updated: 2026-07-03 — added Pillar C stale-price fallback design input (`price_date` + staleness surfacing).
 > Umbrella doc for the investments initiative (milestone M1J). Child specs listed
 > in [The four pillars](#the-four-pillars) are written separately; the foundation
 > child is [`investments-data-model.md`](investments-data-model.md).

--- a/docs/specs/mcp-architecture.md
+++ b/docs/specs/mcp-architecture.md
@@ -586,14 +586,14 @@ This spec's job is to ensure that when the Apps spec arrives, it finds a tool su
 
 ### Remote HTTP transport (future milestone — design inputs)
 
-Today the server ships full-capability stdio plus an **unauthenticated** streamable-HTTP fallback; authenticated remote HTTP is a future milestone, not part of v1. The auth model, token lifecycle, and scope semantics are a one-way-door surface, so capturing the shape now — while it costs nothing — keeps the eventual spec from re-deriving it. Shipped competitor implementations prove out each piece:
+Today the server ships full-capability stdio plus **unauthenticated** HTTP fallbacks (`--transport streamable-http` and `--transport sse` — both run with no auth branch and expose the identical full tool surface); authenticated remote HTTP is a future milestone, not part of v1. The auth model, token lifecycle, and scope semantics are a one-way-door surface, so capturing the shape now — while it costs nothing — keeps the eventual spec from re-deriving it. Shipped competitor implementations prove out each piece:
 
 - **Scope-filtered tool registration at connect.** Tools outside the session's granted scope are never registered, so they never appear in the tool list — better AX than registering everything and refusing at call time. This composes with, rather than reopens, the §3 "full surface at connect" decision: full surface *within the granted scope*.
 - **Self-issued OAuth for self-hosters.** A self-hosted instance mints its own per-client, scope-exact tokens with no dependency on a cloud identity provider — a shipped open-source implementation demonstrates this end to end. A hosted deployment may still front a managed IdP; the self-hosted path must not require one.
 - **User-visible, revocable token lifecycle.** `moneybin mcp tokens list` / `revoke` (CLI, with MCP parity where it fits the taxonomy); RFC 7009 token revocation; dynamic-client-registration clients that auto-expire after a bounded window; a connected-apps view showing what holds a token and when it was last used.
 - **Profile key wrapped under token secrets.** A granted token unlocks only what its scope allows and revocation is meaningful at rest — never a bearer token that hands over the whole encrypted profile.
 
-These are design inputs, not commitments; the milestone itself is large. The constraint that holds regardless: the unauthenticated HTTP fallback stays gated behind an explicit opt-in and is never the recommended path.
+These are design inputs, not commitments; the milestone itself is large. The constraint that holds regardless: both unauthenticated HTTP transports (`streamable-http` and `sse`) stay gated behind an explicit opt-in and are never the recommended path — the future milestone must bring either under the auth model, not just one.
 
 ---
 

--- a/docs/specs/mcp-architecture.md
+++ b/docs/specs/mcp-architecture.md
@@ -584,6 +584,17 @@ The follow-on MCP Apps spec will define:
 
 This spec's job is to ensure that when the Apps spec arrives, it finds a tool surface that's ready to consume. The Apps spec is planned as the immediate follow-on to ship a proof-of-concept App MVP as soon as the tool surface is implemented.
 
+### Remote HTTP transport (future milestone — design inputs)
+
+Today the server ships full-capability stdio plus an **unauthenticated** streamable-HTTP fallback; authenticated remote HTTP is a future milestone, not part of v1. The auth model, token lifecycle, and scope semantics are a one-way-door surface, so capturing the shape now — while it costs nothing — keeps the eventual spec from re-deriving it. Shipped competitor implementations prove out each piece:
+
+- **Scope-filtered tool registration at connect.** Tools outside the session's granted scope are never registered, so they never appear in the tool list — better AX than registering everything and refusing at call time. This composes with, rather than reopens, the §3 "full surface at connect" decision: full surface *within the granted scope*.
+- **Self-issued OAuth for self-hosters.** A self-hosted instance mints its own per-client, scope-exact tokens with no dependency on a cloud identity provider — a shipped open-source implementation demonstrates this end to end. A hosted deployment may still front a managed IdP; the self-hosted path must not require one.
+- **User-visible, revocable token lifecycle.** `moneybin mcp tokens list` / `revoke` (CLI, with MCP parity where it fits the taxonomy); RFC 7009 token revocation; dynamic-client-registration clients that auto-expire after a bounded window; a connected-apps view showing what holds a token and when it was last used.
+- **Profile key wrapped under token secrets.** A granted token unlocks only what its scope allows and revocation is meaningful at rest — never a bearer token that hands over the whole encrypted profile.
+
+These are design inputs, not commitments; the milestone itself is large. The constraint that holds regardless: the unauthenticated HTTP fallback stays gated behind an explicit opt-in and is never the recommended path.
+
 ---
 
 ## 9. Dependencies & Foundational Work

--- a/docs/specs/multi-currency.md
+++ b/docs/specs/multi-currency.md
@@ -86,6 +86,19 @@ The rejected alternative — storing `home_amount`/`home_currency` at row grain 
 forces conversion to exist before any row lands, freezes the home currency, and
 makes rate corrections a data-rewrite. Not chosen.
 
+**Shipped prior art (both rejected alternatives, both regretted in practice).**
+Two competing products have shipped the very designs this decision rejects, and
+their mechanics confirm the cost:
+
+- One persists converted amounts at row grain — its own release notes describe
+  amounts "stored at the historical date rate per transaction," with reports
+  summing the stored figures. A corrected historical rate then means rewriting
+  stored data, exactly the data-rewrite this spec avoids by converting on read.
+- Another maintains derived valuation snapshots in mutable tables that require
+  session-gated rebuilds and reaping of orphaned rows on every recompute — the
+  standing maintenance burden that deriving in SQLMesh (Invariant 8,
+  derive-don't-snapshot) removes entirely.
+
 ## Phasing
 
 | Phase | Scope | Depends on | Notes |
@@ -194,6 +207,17 @@ Numbered, testable. Tagged by phase.
 17. **Conversion-pair identity.** A currency conversion event (e.g. a EUR debit paired
     with a USD credit) is modeled as a first-class pair, not inferred from two
     unrelated rows.
+
+    **Reserved import shape — single-row FX transfer.** Some source formats express
+    an FX transfer as one row carrying *both* legs (the sent amount/currency plus a
+    received amount and target currency), rather than two rows. Reserve the field
+    pair `amount_received` + `currency_to` on the capture grain as the landing spot
+    for that shape, so an importer that meets it has somewhere to put the second leg
+    instead of dropping it or fabricating a paired row. The conversion-pair model
+    consumes either shape; reserving the names now (schema reservation, not yet
+    built) keeps a later importer from inventing an ad-hoc currency column. The
+    directional `_to` suffix matches the existing `from_currency`/`to_currency`
+    convention on `raw.exchange_rates`, not the row's own `currency_code`.
 18. **Currency-lot accounting.** Realized FX gain/loss on disposing a foreign-currency
     holding is computed via the **investments cost-basis engine** (FIFO / average per
     the elected method in `investments-data-model.md`), treating currency holdings as

--- a/docs/specs/multi-currency.md
+++ b/docs/specs/multi-currency.md
@@ -210,14 +210,18 @@ Numbered, testable. Tagged by phase.
 
     **Reserved import shape — single-row FX transfer.** Some source formats express
     an FX transfer as one row carrying *both* legs (the sent amount/currency plus a
-    received amount and target currency), rather than two rows. Reserve the field
-    pair `amount_received` + `currency_to` on the capture grain as the landing spot
-    for that shape, so an importer that meets it has somewhere to put the second leg
-    instead of dropping it or fabricating a paired row. The conversion-pair model
-    consumes either shape; reserving the names now (schema reservation, not yet
-    built) keeps a later importer from inventing an ad-hoc currency column. The
-    directional `_to` suffix matches the existing `from_currency`/`to_currency`
-    convention on `raw.exchange_rates`, not the row's own `currency_code`.
+    received amount and target currency), rather than two rows. Reserve a
+    received-leg column pair — `to_amount` + `to_currency` — on the raw import tables
+    (`raw.*`, e.g. `raw.tabular_transactions`) where a source row lands, so an
+    importer that meets this shape has somewhere to put the second leg instead of
+    dropping it or fabricating a paired row; the row's own `amount`/`currency_code`
+    is then the sent leg, and the conversion-pair model consumes either shape.
+    `to_amount`/`to_currency` follow the directional `from_currency`/`to_currency`
+    prefix convention already used on `raw.exchange_rates` — reserving them now
+    (schema reservation, not yet built) keeps a later importer from coining an
+    ad-hoc, differently-ordered name and compounding the currency-column naming
+    drift §Key Decisions already flags. (A shipped competitor carries this shape as
+    `amount_received` / `currency_to`.)
 18. **Currency-lot accounting.** Realized FX gain/loss on disposing a foreign-currency
     holding is computed via the **investments cost-basis engine** (FIFO / average per
     the elected method in `investments-data-model.md`), treating currency holdings as

--- a/docs/specs/privacy-and-ai-trust.md
+++ b/docs/specs/privacy-and-ai-trust.md
@@ -1,6 +1,6 @@
 # Privacy & AI Trust
 
-> Last updated: 2026-05-29 — deterministic-computation / LLM-prose invariant added
+> Last updated: 2026-07-03 — prose-invariant enforcement design inputs (code-enforced grounding + approved-correction capture)
 > Status: Ready — framework spec for MoneyBin's privacy model across all AI data flows.
 > Companions: [`privacy-security-roadmap.md`](privacy-security-roadmap.md) (data custody tiers), [`ADR-002: Privacy Tiers`](../decisions/002-privacy-tiers.md) (data custody architecture), [`smart-import-overview.md`](smart-import-overview.md) (pillar F depends on this), [`matching-overview.md`](matching-overview.md) (audit log shared), `CLAUDE.md` Security section, `.claude/rules/security.md`
 

--- a/docs/specs/privacy-and-ai-trust.md
+++ b/docs/specs/privacy-and-ai-trust.md
@@ -22,6 +22,13 @@ MoneyBin is an AI-first financial application. AI makes it better — smarter im
 4. **Capabilities matter alongside privacy.** When a user chooses an AI backend, they should see both the provider's privacy stance and what features it unlocks. MoneyBin does not artificially limit features to the lowest common denominator across providers — it helps the user make an informed choice.
 5. **Deterministic code owns the numbers.** LLMs may explain, summarize, or draft prose from already-computed MoneyBin results; they must not be the source of financial calculations, classifications that bypass review, or report truth. Any AI-written summary cites the deterministic result/report/lineage reference it summarizes.
 
+### Enforcing the prose invariant (design inputs for `llm-prose-summaries.md`)
+
+Principle 5 is a contract; the planned `llm-prose-summaries.md` feature is where it gets enforced. Two requirements land there, captured now so they are not lost:
+
+- **Grounding is a code check, not a prompt instruction.** Before an AI-written summary is returned, code verifies that every number (and every named entity) in the prose appears in the cited `result_ref` / retrieved rows. If any figure is not grounded, the summary is refused — not softened, not warned. A prompt that merely *asks* the model to stay grounded is insufficient; the check is mechanical and post-generation. A shipped competitor already gates its free-form answers this way (the model narrates only numbers present in retrieved data, else it refuses), validating the shape.
+- **Approved corrections become learned routing overrides.** When a user corrects or approves a generated diagnosis/summary, persist that decision as a routing override consulted *before* generation thereafter — so the same question does not re-earn the same correction. The override is mutable `app.*` user state (audited via a `*Repo`), not baked into a prompt.
+
 ## Data sensitivity taxonomy
 
 MoneyBin classifies financial data fields into sensitivity tiers. These tiers determine default redaction behavior across all AI data flows.

--- a/docs/specs/sync-overview.md
+++ b/docs/specs/sync-overview.md
@@ -1,6 +1,6 @@
 # Sync — Overview
 
-> Last updated: 2026-05-17
+> Last updated: 2026-07-03 — partial-payload provider guard + multi-device merge-at-matcher/provenance note
 > Status: In-progress — umbrella doc for the sync initiative. Phase 1 shipped in [`sync-plaid.md`](sync-plaid.md) (PR #151 added the post-pull refresh umbrella; PR #160 made `MONEYBIN_PROFILE` honored from non-CLI SQLMesh entry points). Phase 2 (scheduling) is unstarted; Phases 3-4 (E2E encryption, post-quantum) remain forward-looking design sketches within this doc.
 > Companions: [`privacy-and-ai-trust.md`](privacy-and-ai-trust.md) (AI data flow governance, consent model), [`matching-overview.md`](matching-overview.md) (peer initiative, dedup of synced data), [`moneybin-mcp.md`](moneybin-mcp.md) (MCP tool conventions), `CLAUDE.md` "Architecture: Data Layers"
 > Server contract: the moneybin-sync HTTP API is the authoritative integration surface. Endpoint shapes are restated inline where this spec depends on them; cross-repo paths intentionally omitted to keep this doc self-contained.

--- a/docs/specs/sync-overview.md
+++ b/docs/specs/sync-overview.md
@@ -583,6 +583,8 @@ Add `{provider}_transactions` CTE in `fct_transactions.sql`, `{provider}_account
 - `app.sync_connections` — `provider` column discriminates; schema is shared
 - `EncryptionBackend` — encryption is at the transport layer, not the provider layer
 
+**Partial-payload guard (provider robustness).** A provider response can be internally incomplete — some accounts, holdings, or securities present, others missing — while still returning success at the transport layer. This is distinct from [Partial success handling](#partial-success-handling), which is per-institution success/failure across a sync job; here a single institution's response is itself partial. A loader must never treat a partial payload as complete (e.g. inferring an absent account was closed, or that missing holdings mean an empty portfolio). Detect the partial condition, load what arrived, and surface which accounts/entities were skipped so downstream reconciliation and the user can see the gap. This matters most for the investments product (holdings/securities frequently arrive partial), but the guard is provider-agnostic and belongs here so every provider inherits it — a shipped competitor pairs its bank sync with exactly this guardrail.
+
 ### Cross-provider response shape (open design question)
 
 Two architectural decisions intersect when a second provider lands. The artifact-level decision is already made in the "Provider contract" section above: per-provider raw tables, per-provider loaders, per-provider staging views. The **HTTP-layer decision** — what shape the server returns to the client — is currently implicit, and the answer Phase 1 baked in deserves a deliberate revisit before provider #2 ships.
@@ -758,7 +760,7 @@ Infrastructure spec. The `Database` class that sync loaders write through handle
 
 Not designed here. Architectural constraints noted so the current design does not preclude them.
 
-1. **`sync push`** — multi-device sync. Push encrypted DuckDB state (or deltas) to the server so another device can pull it. Would add `moneybin sync push` command and bidirectional protocol extensions.
+1. **`sync push`** — multi-device sync. Push encrypted DuckDB state (or deltas) to the server so another device can pull it. Would add `moneybin sync push` command and bidirectional protocol extensions. **Merge at the matcher/provenance layer, never at raw rows.** A generic row-level three-way merge treats the same real transaction imported on two devices as two distinct rows and "cleanly" duplicates it; MoneyBin's transaction-identity semantics — content-derived identity plus the cross-source matcher and `meta.fct_transaction_provenance` — are exactly what collapse that duplicate. A shipped competitor's whole-file row-diff replication exhibits the duplication this avoids. Any replication design routes conflict resolution through matching/provenance, not raw-row diffing.
 2. **Plaid Investments** — sync holdings, securities, and investment transactions. Gated on `investments-data-model.md` (M1J). New child spec: `sync-plaid-investments.md`.
 3. **Plaid Liabilities** — sync loan, mortgage, and credit card debt details. Separate child spec.
 4. **Webhook-based sync** — server pushes notifications when new data is available, eliminating polling. Requires a client-side listener or notification mechanism.


### PR DESCRIPTION
## Summary

Captures design inputs from follow-up research into the relevant specs so they
are not re-derived (or lost) when each spec's milestone runs. Docs-only — no
behavior change, no spec status changes, no CHANGELOG (spec design notes aren't
user-visible).

## What changed

Design-input notes added to eight specs:

- **investments-data-model** — when widening `cost_basis_method`, prioritize
  HIFO over LIFO (external demand signal favors HIFO; the enum stays
  deliberately closed until the engine path ships).
- **investments-overview** (Pillar C) — stale-price fallback must expose
  `price_date` + `staleness_days` and warn past a threshold; never present a
  stale close as current.
- **categorization-overview** (Pillar D) — a future semantic tier embeds
  accumulated exemplars (not static anchors) and abstains unless similarity
  clears a threshold **and** beats the runner-up by a margin.
- **multi-currency** — reserve `to_amount` + `to_currency` (matching the
  existing `from_currency`/`to_currency` convention) for single-row FX-transfer
  imports; add two shipped case studies to the rejected-alternatives note
  (row-grain persisted conversion; snapshot rebuilds).
- **sync-overview** — partial-payload provider guard (never treat a partial
  response as complete); multi-device replication must merge at the
  matcher/provenance layer, never raw rows.
- **privacy-and-ai-trust** — prose grounding enforced by code (not a prompt);
  approved corrections persist as learned routing overrides.
- **mcp-architecture** — remote HTTP transport design inputs (scope-filtered
  registration, self-issued OAuth for self-hosters, token lifecycle, profile
  key wrapped under token secrets).
- **database-writer-coordination** — restated an out-of-scope note structurally
  (dropped a product name).

## Routing notes

Four intended target specs are planned but not yet written, so their inputs were
routed to the nearest coherent existing home rather than minting a new spec:

- `categorization-ml.md` → `categorization-overview.md` Pillar D (the umbrella's
  ML-pillar section is the current home for that design)
- `sync-plaid-investments.md` → `sync-overview.md` provider contract (the guard
  is provider-agnostic and lives durably there, applying to every provider)
- `llm-prose-summaries.md` → `privacy-and-ai-trust.md` (owns the
  deterministic-computation / LLM-prose invariant the requirements strengthen)

One input had no coherent existing home and is **deferred**: the `export.md`
bundle contract (enumerate learned artifacts — saved formats, recipes,
exemplars/rules, account/merchant links, match decisions). It should land when
`export.md` is authored.

## Verification

`make check` green — format, ruff lint ("All checks passed!"), pyright 0 errors.
