### PR TITLE
Gate unauthenticated HTTP MCP transport behind --insecure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,17 @@ M2 closing out and M3 underway. M2A curator state shipped (transaction notes, ta
   times per transform) are now suppressed within the SQLMesh boundary — neither
   is actionable signal for users or agents driving the CLI/MCP.
 
+### Security
+- **The unauthenticated HTTP MCP transport is now gated behind `--insecure`.**
+  `moneybin mcp serve` refuses to start any non-stdio transport (`sse`,
+  `streamable-http`) unless `--insecure` is passed, exiting with a usage error
+  that names the risk plainly. MoneyBin has no HTTP authentication yet, so a
+  network transport would expose all financial data to anyone who can reach the
+  port. With `--insecure` the server starts but prints a loud startup warning;
+  stdio — the supported install path — is unaffected. Install docs and CLI help
+  no longer present the unauthenticated HTTP path as a normal setup route.
+  (#287)
+
 ### Added
 - **PDF import (seed path).** Native-text PDFs import via `moneybin import <file.pdf>` and the inbox; their tables land as a queryable JSON seed (`raw.pdf_seeds`) with an auto-generated typed view (`raw.pdf_<alias>`), reversible like any import. Mapping PDFs to transactions/core is a later phase.
 - **Report auto-generation framework — one runner generates every surface.**

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -425,7 +425,7 @@ MCP server lifecycle and client install.
 
 | Command | Purpose | Key flags |
 |---|---|---|
-| `mcp serve` | Start the MCP server. | `--transport {stdio,http}`, `--port`, `--host` |
+| `mcp serve` | Start the MCP server (stdio by default). Non-stdio transports are unauthenticated and refuse to start without `--insecure`. | `-t, --transport {stdio,sse,streamable-http}`, `--insecure` |
 | `mcp install` | Install MoneyBin into an MCP client's config. Supported clients: claude-desktop, claude-code, codex, vscode, cursor, windsurf, gemini, chatgpt-desktop. | `-c, --client`, `-p, --profile`, `--print`, `-y, --yes` |
 | `mcp list-tools` | List every registered MCP tool with its sensitivity tier. | `-o, --output` |
 | `mcp list-prompts` | List every registered MCP prompt. | `-o, --output` |

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -202,7 +202,7 @@ This invocation always prints the canonical snippet plus a numbered Connector-se
 - **Config file:** none — the snippet is informational. Copy fields into the Connector UI by hand.
 - **Restart required:** Yes — restart ChatGPT Desktop after adding the connector.
 - **Server lifecycle:** One server process per app instance.
-- **MCP support gating:** ChatGPT Desktop's MCP support depends on app version and account plan. If your build only accepts HTTP connectors, run `moneybin mcp serve --transport streamable-http` and register the resulting URL as a custom connector. (HTTP transport is supported by FastMCP today but is not the default install path — see [Transport](#transport) below.)
+- **MCP support gating:** ChatGPT Desktop's MCP support depends on app version and account plan. Use the local/stdio connector above — it is the supported path. MoneyBin's HTTP transport is **unauthenticated** (no HTTP auth exists yet) and refuses to start without an explicit `--insecure` opt-in. If your build accepts no stdio connector, `moneybin mcp serve --transport streamable-http --insecure` is a last-resort escape hatch — localhost-only, on a machine you trust, never exposed to a network. See [Transport](#transport) below.
 
 ## Concurrency: which clients share a server
 
@@ -292,7 +292,7 @@ Where the client doesn't render a distinct destructive-tool confirmation, treat 
 
 Today MoneyBin's MCP server speaks **stdio only** for the install paths above — the client launches MoneyBin as a child process and communicates over stdin/stdout. One server process per client session; the server's lifetime is bound to the client's.
 
-`moneybin mcp serve --transport streamable-http` is supported by the underlying FastMCP runtime today and is the path ChatGPT Desktop's HTTP-connector fallback uses, but the install snippets above all assume stdio. A fully-supported HTTP transport (with proper auth, tunneling, and a remote-client story) is planned alongside the web UI but does not ship today.
+The network transports (`sse`, `streamable-http`) exist in the underlying FastMCP runtime, but MoneyBin ships **no HTTP authentication** — an HTTP listener would let anyone who can reach the port read and write your financial data. So `moneybin mcp serve` refuses to start any non-stdio transport unless you pass `--insecure`, and even then only as a localhost-only escape hatch (e.g. ChatGPT Desktop builds that accept no stdio connector), printing a loud startup warning. A fully-supported HTTP transport — with real authentication, tunneling, and a remote-client story — is planned alongside the web UI but does not ship today. Never expose the `--insecure` listener to an untrusted network.
 
 ### Headless and daemon use
 
@@ -301,7 +301,7 @@ Because the transport is stdio, "MoneyBin as a long-running daemon with remote c
 - **Headless MCP clients on the same host.** Codex CLI, Gemini CLI, and Claude Code (via `make claude-mcp`) run without a GUI. Drop them in a tmux session on a NAS / homelab box and they'll spawn MoneyBin per invocation against the local DuckDB profile.
 - **Desktop client on a workstation, data on the same workstation.** Standard install path; no networking involved.
 
-What does not work today: running `moneybin mcp serve` as a systemd unit or Docker container with a Claude Desktop on a separate laptop connecting in. That requires the planned streamable-HTTP transport plus an auth model.
+What does not work today: running `moneybin mcp serve` as a systemd unit or Docker container with a Claude Desktop on a separate laptop connecting in. The `--insecure` HTTP transport is unauthenticated and localhost-only — safe remote access requires the planned authenticated HTTP transport, which does not ship today.
 
 ## Troubleshooting
 

--- a/docs/specs/moneybin-cli.md
+++ b/docs/specs/moneybin-cli.md
@@ -413,7 +413,8 @@ moneybin [--profile NAME] [--verbose] <command> [--output text|json] [--quiet] [
 |       +-- status                 -- Show migration state
 |
 +-- mcp
-|   +-- serve [--transport stdio|sse|streamable-http]
+|   +-- serve [--transport stdio|sse|streamable-http] [--insecure]
+|   |     (non-stdio transports are UNAUTHENTICATED; refuse without --insecure)
 |   |     (catches DB lock error -> recommends db ps / db kill)
 |   +-- list-tools                 -- Show available MCP tools
 |   +-- list-prompts               -- Show available MCP prompts

--- a/src/moneybin/cli/commands/mcp.py
+++ b/src/moneybin/cli/commands/mcp.py
@@ -543,10 +543,13 @@ def _print_chatgpt_desktop_instructions(
     typer.echo("  4. Save. ChatGPT will spawn the server on demand.")
     typer.echo("")
     typer.echo(
-        "Note: ChatGPT Desktop's MCP support is gated by version and plan. "
-        "If your build only accepts HTTP connectors, run "
-        "`moneybin mcp serve --transport streamable-http` and add the resulting "
-        "URL as a custom connector instead."
+        "Note: ChatGPT Desktop's MCP support is gated by version and plan. Use "
+        "the local/stdio connector above — it is the supported, authenticated "
+        "path. MoneyBin's HTTP transport is UNAUTHENTICATED (no HTTP auth exists "
+        "yet): `moneybin mcp serve --transport streamable-http --insecure` opens "
+        "a port anyone who can reach it can read and write your finances through. "
+        "Only use it on a trusted, localhost-only machine as a last resort if "
+        "your build accepts no stdio connector."
     )
 
 
@@ -686,6 +689,38 @@ def mcp_list_prompts(
 # ── serve ────────────────────────────────────────────────────────────────────
 
 
+def _gate_network_transport(transport: str, *, insecure: bool) -> None:
+    """Refuse to start a network transport without an explicit insecure opt-in.
+
+    stdio is local-only and always allowed. Every other transport (sse,
+    streamable-http) binds a network-reachable port, and MoneyBin has no HTTP
+    authentication yet — so an unauthenticated listener exposes all financial
+    data to anyone who can reach the port. Without --insecure, exit with a usage
+    error that names the risk; with it, emit a loud stderr warning and return so
+    the caller can start the server. Keep this gate until authenticated HTTP
+    transport ships.
+    """
+    if transport == "stdio":
+        return
+    if not insecure:
+        logger.error(
+            f"❌ Refusing to start the MCP server on transport '{transport}' "
+            "without authentication. This opens a network-reachable MCP server "
+            "with NO authentication — anyone who can reach the port can read and "
+            "write your financial data. MoneyBin has no HTTP authentication yet; "
+            "use the default stdio transport (`moneybin mcp serve`) for local AI "
+            "clients. To override on a trusted, localhost-only network, re-run "
+            "with --insecure."
+        )
+        raise typer.Exit(2)
+    logger.warning(
+        f"⚠️  Starting the MCP server on transport '{transport}' with NO "
+        "authentication (--insecure). Anyone who can reach this port can read "
+        "and write your financial data. Bind to localhost only and never expose "
+        "this port to an untrusted network."
+    )
+
+
 def _is_unconfigured() -> bool:
     """True when no profile is resolvable without the interactive wizard.
 
@@ -708,16 +743,37 @@ def serve(
         typer.Option(
             "--transport",
             "-t",
-            help="MCP transport type: stdio, sse, or streamable-http",
+            help=(
+                "MCP transport. Default: stdio (local stdin/stdout — the supported "
+                "path for AI clients). The network transports (sse, streamable-http) "
+                "are UNAUTHENTICATED and require --insecure."
+            ),
         ),
     ] = "stdio",
+    insecure: Annotated[
+        bool,
+        typer.Option(
+            "--insecure",
+            help=(
+                "Allow an UNAUTHENTICATED network transport (sse/streamable-http). "
+                "Opens a port with no authentication — anyone who can reach it can "
+                "read and write your financial data. Localhost-only, trusted "
+                "networks only. Ignored for stdio."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Start the MoneyBin MCP server.
 
     This launches an MCP server that gives AI assistants full access to
     your financial data in DuckDB — querying, importing, categorizing,
     and budgeting. The server communicates via stdio (standard input/output)
-    by default, which is the standard transport for local MCP integrations.
+    by default, which is the supported transport for local MCP integrations.
+
+    The network transports (sse, streamable-http) are UNAUTHENTICATED —
+    MoneyBin has no HTTP auth yet — so they refuse to start unless you pass
+    --insecure, and even then only on a trusted, localhost-only network. Use
+    stdio for real AI-client installs (`moneybin mcp install`).
 
     The server uses the currently active profile to determine which
     database to connect to. With no profile configured, it still boots —
@@ -734,6 +790,19 @@ def serve(
 
         # Typically invoked by AI clients, not run manually
     """
+    # Validate the transport and enforce the auth gate before doing any work —
+    # a refused insecure listener must not even import the server stack.
+    if transport not in _VALID_TRANSPORTS:
+        logger.error(
+            f"Invalid transport '{transport}'. Must be one of: {', '.join(_VALID_TRANSPORTS)}"
+        )
+        raise typer.Exit(2)
+
+    _gate_network_transport(transport, insecure=insecure)
+
+    # Cast validated string to the literal type
+    validated_transport: TransportType = transport  # type: ignore[assignment] — validated above
+
     from moneybin.cli.utils import get_verbose_flag, handle_cli_errors
     from moneybin.mcp.server import check_schema_at_boot, close_db, init_db, mcp
     from moneybin.observability import setup_observability
@@ -745,15 +814,6 @@ def serve(
         "moneybin.mcp.prompts",
     ):
         importlib.import_module(module)
-
-    if transport not in _VALID_TRANSPORTS:
-        logger.error(
-            f"Invalid transport '{transport}'. Must be one of: {', '.join(_VALID_TRANSPORTS)}"
-        )
-        raise typer.Exit(1)
-
-    # Cast validated string to the literal type
-    validated_transport: TransportType = transport  # type: ignore[assignment] — validated above
 
     # Convert SIGTERM to SystemExit so the finally block runs and we close
     # the DuckDB connection cleanly. Without this, parent-driven shutdowns

--- a/tests/e2e/test_e2e_mcp.py
+++ b/tests/e2e/test_e2e_mcp.py
@@ -477,6 +477,41 @@ class TestMatchesTools:
                 assert "transactions_matches_history" in tools
 
 
+class TestMCPServeTransportGate:
+    """The unauthenticated network transport refuses to start without --insecure.
+
+    Exercises the real subprocess so we verify what CliRunner + caplog can't:
+    that `main_callback` has configured logging by the time the gate fires, so
+    the refusal message actually reaches stderr and the process exits non-zero.
+    The gate runs before any profile/DB work, so no MONEYBIN_HOME is needed.
+    """
+
+    async def test_streamable_http_without_insecure_refuses(self) -> None:
+        """`mcp serve --transport streamable-http` exits 2 and names the auth risk."""
+        import asyncio
+
+        proc = await asyncio.create_subprocess_exec(
+            "uv",  # noqa: S607 — uv is on PATH in dev environments
+            "run",
+            "moneybin",
+            "mcp",
+            "serve",
+            "--transport",
+            "streamable-http",
+            env={**os.environ, **FAST_ARGON2_ENV},
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=60)
+        combined = (stdout + stderr).decode()
+
+        assert proc.returncode == 2, (
+            f"expected exit 2, got {proc.returncode}: {combined}"
+        )
+        assert "authentication" in combined.lower()
+        assert "--insecure" in combined
+
+
 class TestMCPFirstRunSetup:
     """First-run setup over real stdio with no pre-existing profile.
 

--- a/tests/moneybin/test_cli/test_cli_mcp_enhancements.py
+++ b/tests/moneybin/test_cli/test_cli_mcp_enhancements.py
@@ -1,12 +1,19 @@
 """Tests for MCP CLI enhancements."""
 
+import logging
+from collections.abc import Generator
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
-from moneybin.cli.commands.mcp import app
+from moneybin.cli.commands.mcp import (
+    _gate_network_transport,  # pyright: ignore[reportPrivateUsage]
+    app,
+)
 
 runner = CliRunner()
 
@@ -533,3 +540,114 @@ class TestMCPInstallGeminiCLI:
         assert "mcpServers" in payload
         # Concurrency guardrail must fire on per-invocation client installs.
         assert "auto-loads" in result.output
+
+
+class TestGateNetworkTransport:
+    """The `_gate_network_transport` helper enforces the unauthenticated-HTTP gate.
+
+    stdio is local-only and always allowed. Every network transport (sse,
+    streamable-http) binds an UNAUTHENTICATED port and must be opted into with
+    --insecure; without it the helper refuses with a usage error (exit 2), with
+    it the helper emits a loud warning and returns.
+    """
+
+    def test_stdio_is_a_noop_regardless_of_insecure(self) -> None:
+        """Stdio never triggers the gate — no raise, no warning."""
+        _gate_network_transport("stdio", insecure=False)
+        _gate_network_transport("stdio", insecure=True)
+
+    def test_streamable_http_without_insecure_raises_usage_error(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A network transport without --insecure refuses with exit 2 + risk message."""
+        with pytest.raises(typer.Exit) as exc_info:
+            _gate_network_transport("streamable-http", insecure=False)
+        assert exc_info.value.exit_code == 2
+        assert "authentication" in caplog.text.lower()
+        assert "--insecure" in caplog.text
+
+    def test_sse_without_insecure_also_refuses(self) -> None:
+        """The gate covers every non-stdio transport, not just streamable-http."""
+        with pytest.raises(typer.Exit) as exc_info:
+            _gate_network_transport("sse", insecure=False)
+        assert exc_info.value.exit_code == 2
+
+    def test_streamable_http_with_insecure_warns_and_returns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """With --insecure the gate warns loudly on stderr and allows startup."""
+        with caplog.at_level(logging.WARNING):
+            _gate_network_transport("streamable-http", insecure=True)
+        assert "authentication" in caplog.text.lower()
+        assert "⚠️" in caplog.text
+
+
+@contextmanager
+def _mock_server_start() -> Generator[MagicMock, None, None]:
+    """Patch out the real MCP server boot so `serve` can reach `mcp.run` inertly.
+
+    Forces the unconfigured branch (fewest external calls) and replaces the
+    FastMCP server, DB lifecycle, observability setup, and profile-resolver
+    wiring with mocks. Yields the mock server so callers can assert on
+    `mock.run(...)`.
+    """
+    mock_mcp = MagicMock()
+    with (
+        patch("moneybin.cli.commands.mcp.importlib"),
+        patch("moneybin.cli.commands.mcp._is_unconfigured", return_value=True),
+        patch("moneybin.mcp.server.init_db"),
+        patch("moneybin.mcp.server.close_db"),
+        patch("moneybin.mcp.server.mcp", mock_mcp),
+        patch("moneybin.observability.setup_observability"),
+        patch("moneybin.config.register_profile_resolver"),
+        patch("moneybin.mcp.first_run.FirstRunSetupMiddleware"),
+    ):
+        yield mock_mcp
+
+
+class TestMCPServe:
+    """The `serve` command wires the unauthenticated-HTTP gate to a CLI flag."""
+
+    def test_network_transport_without_insecure_refuses(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """`serve --transport streamable-http` (no --insecure) exits 2 with the risk stated.
+
+        No server mock is needed: the gate raises before `serve` imports the
+        server stack, so the command never reaches startup.
+        """
+        result = runner.invoke(app, ["serve", "--transport", "streamable-http"])
+        assert result.exit_code == 2
+        assert "authentication" in caplog.text.lower()
+        assert "--insecure" in caplog.text
+
+    def test_invalid_transport_is_a_usage_error(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An unknown transport value exits 2 (usage error), matching the flag conventions."""
+        result = runner.invoke(app, ["serve", "--transport", "bogus"])
+        assert result.exit_code == 2
+        assert "Invalid transport" in caplog.text
+
+    def test_insecure_flag_starts_network_transport_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """`--insecure` allows the network transport to start after a loud warning."""
+        with _mock_server_start() as mock_mcp:
+            with caplog.at_level(logging.WARNING):
+                result = runner.invoke(
+                    app, ["serve", "--transport", "streamable-http", "--insecure"]
+                )
+        assert result.exit_code == 0
+        mock_mcp.run.assert_called_once_with(transport="streamable-http")
+        assert "authentication" in caplog.text.lower()
+
+    def test_stdio_default_starts_without_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The default stdio path is unaffected — it starts and emits no auth warning."""
+        with _mock_server_start() as mock_mcp:
+            result = runner.invoke(app, ["serve"])
+        assert result.exit_code == 0
+        mock_mcp.run.assert_called_once_with(transport="stdio")
+        assert "authentication" not in caplog.text.lower()


### PR DESCRIPTION
## Summary

`moneybin mcp serve` could start a network-reachable MCP server with **no authentication** — anyone able to reach the port could read and write a user's financial data. MoneyBin has no HTTP auth yet, and the install docs/help actively recommended the HTTP path. This is pre-release security hardening: every non-stdio transport now refuses to start unless the operator explicitly opts in with `--insecure`, and even then only after a loud startup warning. stdio — the supported install path — is unchanged.

This also keeps the suppression rationale valid for the gated starlette Host-header advisory (PYSEC-2026-161), which is nil-exposure only while no HTTP transport is reachable or recommended.

## Changes

- **Gate (`cli/commands/mcp.py`):** new `_gate_network_transport()` — `stdio` passes through; `sse`/`streamable-http` without `--insecure` exit `2` with a message naming the risk and pointing at stdio; with `--insecure` the server starts after a loud `⚠️` stderr warning. Transport validation + the gate moved above the server-stack import so a refused listener does no work; the invalid-transport exit code is aligned `1 → 2` (usage error).
- **Surface:** `serve` help, the `--transport` help, and the ChatGPT-Desktop install note no longer present the unauthenticated HTTP path as a normal route. `docs/guides/mcp-clients.md`, `docs/guides/cli-reference.md` (which also listed `--port`/`--host` flags that never existed), and the `moneybin-cli.md` spec tree are updated to match.
- **Tests:** 4 helper unit tests, 4 `serve`-command tests (refusal / invalid-transport / insecure-starts-with-warning / stdio-unaffected), and 1 e2e subprocess test proving the refusal reaches stderr through the real logging pipeline.

## Test plan

- [ ] `make check test` green (4576 passed, 4 pre-existing skips locally).
- [ ] `moneybin mcp serve --transport streamable-http` → exit 2, risk stated on stderr.
- [ ] `moneybin mcp serve --transport sse` → exit 2.
- [ ] `moneybin mcp serve --transport streamable-http --insecure` → loud `⚠️` warning on stderr, then starts.
- [ ] `moneybin mcp serve` (stdio default) → unaffected.
- [ ] `moneybin mcp serve --help` shows `--insecure` and the unauthenticated framing.

## Breaking changes

- Any invocation relying on `moneybin mcp serve --transport streamable-http` (or `sse`) now exits `2` unless `--insecure` is added. Intentional — that transport was never authenticated. Add `--insecure` only on a trusted, localhost-only machine.
- `moneybin mcp serve --transport <invalid>` now exits `2` (was `1`), matching the CLI usage-error convention.
