### PR TITLE
Correct stale CLI command references in hints and docstrings

### DIFF
--- a/scripts/claude-mcp.sh
+++ b/scripts/claude-mcp.sh
@@ -30,14 +30,14 @@ if [[ $rc -ne 0 || -z "$config_path" ]]; then
   cat "$err" >&2
   echo "" >&2
   echo "Hint: moneybin profile create <name>   (if no profile exists)" >&2
-  echo "      moneybin mcp config generate --client claude-code --install --yes --profile <name>" >&2
+  echo "      moneybin mcp install --client claude-code --yes --profile <name>" >&2
   echo "      $0 <name>   (or PROFILE=<name> make claude-mcp)" >&2
   exit 1
 fi
 
 if [[ ! -f "$config_path" ]]; then
   echo "❌ MoneyBin MCP config not found at $config_path." >&2
-  echo "Run: moneybin mcp config generate --client claude-code --install --yes${profile:+ --profile \"$profile\"}" >&2
+  echo "Run: moneybin mcp install --client claude-code --yes${profile:+ --profile \"$profile\"}" >&2
   exit 1
 fi
 

--- a/src/moneybin/cli/commands/synthetic.py
+++ b/src/moneybin/cli/commands/synthetic.py
@@ -229,7 +229,7 @@ def synthetic_reset(
                     )
                     logger.info(
                         f"💡 To destroy a non-generated profile, use "
-                        f"'moneybin db destroy --profile={target_profile}'"
+                        f"'moneybin profile delete {target_profile}'"
                     )
                     raise typer.Exit(1) from None
 

--- a/src/moneybin/config.py
+++ b/src/moneybin/config.py
@@ -445,7 +445,7 @@ class ImportSettings(BaseModel):
 
 
 class DoctorSettings(BaseModel):
-    """`moneybin doctor` integrity-check configuration.
+    """`moneybin system doctor` integrity-check configuration.
 
     Tunes the per-table `app.*` audit-coverage invariants added by the
     repository layer (see `docs/specs/app-integrity-invariant.md` Req 9).
@@ -467,7 +467,7 @@ class DoctorSettings(BaseModel):
         ge=1,
         description=(
             "Maximum rows sampled per table for the audit-coverage check. "
-            "`moneybin doctor --full` bypasses the cap and scans every row."
+            "`moneybin system doctor --full` bypasses the cap and scans every row."
         ),
     )
 


### PR DESCRIPTION
## Summary

`make claude-mcp` failed because the launcher's error hint told users to run `moneybin mcp config generate --install …` — a command renamed to `moneybin mcp install` in #123 but never updated in `scripts/claude-mcp.sh`, so the "fix" it printed was itself a dead command.

Auditing every embedded `moneybin …` reference in the CLI surface against the live command inventory (207 paths) surfaced two more strings pointing at commands that never existed or had moved. This corrects all three so the CLI's help and hint text matches the actual command surface.

## Changes

- **`scripts/claude-mcp.sh`** — both remediation hints: `mcp config generate --client claude-code --install --yes` → `mcp install --client claude-code --yes`.
- **`synthetic.py`** — reset hint: `moneybin db destroy` (never existed) → `moneybin profile delete`, the real command to delete a profile and its data.
- **`config.py`** — `DoctorSettings` docstring + field description: `moneybin doctor` → `moneybin system doctor` (the command lives under the `system` group).

## Test plan

- [ ] `moneybin mcp install --client claude-code --yes --profile <name>` writes the config the launcher expects (verified via `--print`).
- [ ] `moneybin profile delete <name>` resolves and is the actual "destroy a profile" command.
- [ ] `moneybin system doctor` and `... --full` resolve; bare `moneybin doctor` errors.
- [ ] ruff + ruff format + pyright clean on touched files; `bash -n scripts/claude-mcp.sh` parses.
- [ ] Existing regression test asserting `mcp config generate` no longer exists still passes; no test pins the changed strings.
