### PR TITLE
Harden design-sync build-output hygiene

### DIFF
--- a/design-system/.design-sync/NOTES.md
+++ b/design-system/.design-sync/NOTES.md
@@ -22,6 +22,15 @@ node .ds-sync/package-validate.mjs ./ds-bundle --no-render-check
 - `.ds-sync/node_modules` holds both the converter deps (esbuild, ts-morph,
   @types/react) **and** react/react-dom@18 (pinned to 18 for the UMD builds
   `vendorReact` copies into `_vendor/`; react 19 dropped UMD).
+- **`--out` must be empty or a prior bundle, and never the session's cwd.** The
+  converter's `OUT_UNSAFE` guard refuses to `rmSync` a non-empty `--out` that
+  lacks the `.ds-bundle`/`_ds_bundle.js` marker. If `ds-bundle/` happens to be
+  the session's working directory, the agent seeds `.claude/.cc-writes` inside
+  it → the guard trips. When that happens, build to a clean fallback
+  (`--out ./ds-bundle-out`, gitignored via `ds-bundle*/`) rather than `rm`-ing
+  the polluted dir — its `.claude/` triggers a protective delete prompt. This is
+  an anomaly (the cwd normally isn't the build dir), so the fallback is a safety
+  net, not the default.
 
 ## CSS / tokens (the non-obvious part)
 
@@ -69,6 +78,9 @@ bind fails `listen EPERM`, so the server must run **unsandboxed**
   write-denied in-sandbox).
 - Network fetch (`fetch-fonts.mjs`) and the http server need
   `dangerouslyDisableSandbox` (DNS + socket bind blocked in-sandbox).
+- `package-build.mjs` calls `rmSync(--out)` to wipe the output dir → the build
+  needs `dangerouslyDisableSandbox` (in-sandbox `rm` is EPERM). See the `--out`
+  note under *How it builds* for the guard interaction.
 - `ps`/`pkill` are sandbox-blocked (can't manage processes from Bash).
 
 ## Guidelines & other original content (NOT synced by the converter)

--- a/design-system/.gitignore
+++ b/design-system/.gitignore
@@ -1,6 +1,7 @@
 # design-sync machinery (regenerated per clone; never committed)
 .ds-sync/
-ds-bundle/
+# canonical output + any fallback build dir (ds-bundle-out, …)
+ds-bundle*/
 
 # Re-include component sources that the repo-root `data/` ignore would otherwise
 # swallow (design-system/components/data/ holds the Amount + WidgetCard sources).


### PR DESCRIPTION
## What

Belt-and-suspenders so a `/design-sync` re-sync can't leave git clutter or trip the converter's output-dir guard.

- **`.gitignore`** — ignore `ds-bundle*/` (not just `ds-bundle/`), so a fallback build dir (`ds-bundle-out`, …) never shows up as untracked.
- **`.design-sync/NOTES.md`** — document the converter's `OUT_UNSAFE` guard / cwd interaction: if the build dir is ever the session's working directory it collects `.claude` scaffolding, and the guard then refuses to wipe it. Build to a clean fallback `--out` instead of `rm`-ing the polluted dir (its `.claude/` triggers a protective delete prompt). Also notes that `package-build.mjs`'s `rmSync(--out)` needs an unsandboxed run.

## Why

During the post-merge design-system re-sync, `design-system/ds-bundle` happened to be the session's working directory, so it collected Claude Code's `.claude/.cc-writes`. The converter's guard then refused to wipe it, and the fallback dir the build fell back to wasn't gitignored. This makes both failure modes safe without changing how the session is launched — the cwd normally isn't the build dir, so this is a safety net, not a workflow change.

Docs/config only; no code paths touched.
