### PR TITLE
Add Wordmark component to the design system

### DIFF
--- a/design-system/.design-sync/config.json
+++ b/design-system/.design-sync/config.json
@@ -14,6 +14,7 @@
     "WidgetCard": "components/data/WidgetCard.prompt.md",
     "VaultStatusBar": "components/chrome/VaultStatusBar.prompt.md",
     "Mark": "components/brand/Mark.prompt.md",
+    "Wordmark": "components/brand/Wordmark.prompt.md",
     "DuckKey": "components/brand/DuckKey.prompt.md"
   }
 }

--- a/design-system/.design-sync/previews/Wordmark.tsx
+++ b/design-system/.design-sync/previews/Wordmark.tsx
@@ -1,0 +1,37 @@
+import { Wordmark } from 'moneybin-design-system';
+
+// The three size presets. Mark size and gap are paired to each wordmark size.
+export const Sizes = () => (
+  <div
+    style={{
+      background: 'var(--bg-base)',
+      padding: 24,
+      borderRadius: 6,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 24,
+      alignItems: 'flex-start',
+    }}
+  >
+    <Wordmark size="hero" />
+    <Wordmark size="nav" />
+    <Wordmark size="bar" />
+  </div>
+);
+
+// bin="mono" — when another brass element shares the bar, drop brass on "Bin".
+export const Mono = () => (
+  <div
+    style={{
+      background: 'var(--bg-base)',
+      padding: 24,
+      borderRadius: 6,
+      display: 'flex',
+      gap: 28,
+      alignItems: 'center',
+    }}
+  >
+    <Wordmark size="nav" />
+    <Wordmark size="nav" bin="mono" />
+  </div>
+);

--- a/design-system/components/brand/Wordmark.d.ts
+++ b/design-system/components/brand/Wordmark.d.ts
@@ -1,0 +1,27 @@
+/**
+ * The MoneyBin wordmark lock-up — the Mark paired with the "MoneyBin" name.
+ * Promotes the ad-hoc Mark + span pairing to a system component so the two
+ * decisions that are easy to get wrong stay correct by construction: the
+ * optical baseline nudge (Rule 1) and brass on "Bin" (Rule 2), both baked in.
+ */
+export interface WordmarkProps {
+  /**
+   * Size preset — 'nav' (17px), 'bar' (15px, default), or 'hero' (52px) — or an
+   * explicit wordmark px. Mark size and gap are paired to the wordmark size;
+   * prefer a preset (a raw number derives Mark ≈1.5× and gap ≈0.6× the text).
+   */
+  size?: 'nav' | 'bar' | 'hero' | number;
+  /**
+   * Color of the "Bin" letters. 'brass' (default) is the brand default; use
+   * 'mono' whenever another brass element shares the same bar or header, so
+   * brass stays unique to a single lock-up.
+   */
+  bin?: 'brass' | 'mono';
+  /**
+   * Passed through to the Mark. Omit for theme-aware auto-contrast (recommended);
+   * pass 'dark' / 'light' to force a plate. See MarkProps.
+   */
+  plate?: 'dark' | 'light';
+  style?: React.CSSProperties;
+}
+export declare function Wordmark(props: WordmarkProps): JSX.Element;

--- a/design-system/components/brand/Wordmark.jsx
+++ b/design-system/components/brand/Wordmark.jsx
@@ -1,0 +1,44 @@
+import { Mark } from './Mark.jsx';
+
+// Size presets → [wordmark px, Mark px, gap px]. The three numbers are a
+// normative set: never pair a wordmark size with a foreign Mark size or gap.
+// A numeric `size` is the wordmark px and derives Mark ≈1.5× / gap ≈0.6×
+// (reproduces the 'nav' preset; a rough escape hatch — prefer a named preset).
+const PRESETS = {
+  nav: [17, 26, 10],
+  bar: [15, 22, 9],
+  hero: [52, 52, 20],
+};
+
+export function Wordmark({ size = 'bar', bin = 'brass', plate, style }) {
+  const [wm, mk, gap] =
+    typeof size === 'number'
+      ? [size, Math.round(size * 1.5), Math.round(size * 0.6)]
+      : PRESETS[size] ?? PRESETS.bar;
+  // "Bin" carries brass by default — the one place brass is decorative, not
+  // semantic. Switch to 'mono' when another brass element shares the bar so
+  // brass stays unique to a single lock-up.
+  const binColor = bin === 'mono' ? 'var(--text-primary)' : 'var(--accent-brass)';
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: gap + 'px', ...style }}>
+      <Mark size={mk} plate={plate} />
+      {/* Optical baseline nudge (spec Rule 1): Newsreader's "y" descender sits
+          the wordmark high against the square Mark under align-items:center.
+          Nudge the text ONLY — never the Mark or the whole lock-up. em-relative
+          so it scales with size. Baked in (not a prop) so it can't be dropped. */}
+      <span
+        style={{
+          fontFamily: 'var(--font-display)',
+          fontWeight: 600,
+          fontSize: wm + 'px',
+          letterSpacing: '-0.012em',
+          color: 'var(--text-primary)',
+          transform: 'translateY(0.06em)',
+          display: 'inline-block',
+        }}
+      >
+        Money<span style={{ color: binColor }}>Bin</span>
+      </span>
+    </span>
+  );
+}

--- a/design-system/components/brand/Wordmark.prompt.md
+++ b/design-system/components/brand/Wordmark.prompt.md
@@ -1,0 +1,6 @@
+The wordmark lock-up — the Mark paired with the "MoneyBin" name. Composes `Mark` and bakes in the two things that are easy to get wrong: the optical baseline nudge on the text, and brass on "Bin". Use a size preset; switch `bin="mono"` when another brass element shares the same bar or header.
+
+```jsx
+<Wordmark size="nav" />              // gold "Bin", nudge baked in
+<Wordmark size="hero" bin="mono" />  // marketing, monochrome
+```

--- a/design-system/guidelines/brand-wordmark.html
+++ b/design-system/guidelines/brand-wordmark.html
@@ -1,0 +1,43 @@
+<!-- @dsCard group="Brand" viewport="720x240" subtitle="Mark + Newsreader name — brass on Bin, optical baseline nudge baked in" name="Wordmark" -->
+<!DOCTYPE html><html><head><meta charset="utf-8"><link rel="stylesheet" href="../styles.css"><style>body{margin:0}</style></head>
+<body style="background:var(--bg-base);padding:24px;display:flex;flex-direction:column;gap:22px;">
+
+  <!-- hero preset: Mark 52 / wordmark 52 / gap 20 -->
+  <div style="display:inline-flex;align-items:center;gap:20px;">
+    <svg width="52" height="52" viewBox="0 0 48 48">
+      <defs><mask id="mb-wm-a"><rect width="48" height="48" fill="white"/><rect x="12" y="23.5" width="24" height="4.5" rx="2.25" fill="black"/></mask></defs>
+      <rect width="48" height="48" rx="11" fill="var(--mark-plate)" mask="url(#mb-wm-a)"/>
+      <circle cx="24" cy="13" r="6.5" fill="var(--mark-coin)"/>
+    </svg>
+    <span style="font-family:var(--font-display);font-weight:600;font-size:52px;letter-spacing:-0.012em;color:var(--text-primary);transform:translateY(0.06em);display:inline-block">Money<span style="color:var(--accent-brass)">Bin</span></span>
+  </div>
+
+  <div style="height:1px;background:var(--border-hairline);"></div>
+
+  <!-- nav preset, brass vs mono: Mark 26 / wordmark 17 / gap 10 -->
+  <div style="display:flex;gap:36px;flex-wrap:wrap;">
+    <div style="display:flex;flex-direction:column;gap:10px;">
+      <span style="font-family:var(--font-data);font-size:10px;letter-spacing:0.12em;color:var(--accent-brass)">NAV · BRASS</span>
+      <div style="display:inline-flex;align-items:center;gap:10px;">
+        <svg width="26" height="26" viewBox="0 0 48 48">
+          <defs><mask id="mb-wm-b"><rect width="48" height="48" fill="white"/><rect x="12" y="23.5" width="24" height="4.5" rx="2.25" fill="black"/></mask></defs>
+          <rect width="48" height="48" rx="11" fill="var(--mark-plate)" mask="url(#mb-wm-b)"/>
+          <circle cx="24" cy="13" r="6.5" fill="var(--mark-coin)"/>
+        </svg>
+        <span style="font-family:var(--font-display);font-weight:600;font-size:17px;letter-spacing:-0.012em;color:var(--text-primary);transform:translateY(0.06em);display:inline-block">Money<span style="color:var(--accent-brass)">Bin</span></span>
+      </div>
+    </div>
+    <div style="display:flex;flex-direction:column;gap:10px;">
+      <span style="font-family:var(--font-data);font-size:10px;letter-spacing:0.12em;color:var(--text-faint)">NAV · MONO</span>
+      <div style="display:inline-flex;align-items:center;gap:10px;">
+        <svg width="26" height="26" viewBox="0 0 48 48">
+          <defs><mask id="mb-wm-c"><rect width="48" height="48" fill="white"/><rect x="12" y="23.5" width="24" height="4.5" rx="2.25" fill="black"/></mask></defs>
+          <rect width="48" height="48" rx="11" fill="var(--mark-plate)" mask="url(#mb-wm-c)"/>
+          <circle cx="24" cy="13" r="6.5" fill="var(--mark-coin)"/>
+        </svg>
+        <span style="font-family:var(--font-display);font-weight:600;font-size:17px;letter-spacing:-0.012em;color:var(--text-primary);transform:translateY(0.06em);display:inline-block">MoneyBin</span>
+      </div>
+    </div>
+  </div>
+
+</body></html>


### PR DESCRIPTION
## Summary

Adds a `Wordmark` component to the design system — the Mark paired with the "MoneyBin" name — promoting the previously ad-hoc `Mark` + `<span>` pairing to a system component. Two decisions that are easy to get wrong are now baked in so they can't be dropped:

- **Optical baseline nudge** — Newsreader's "y" descender makes `align-items:center` sit the name high against the square Mark, so the wordmark text (only) is nudged down `translateY(0.06em)`, em-relative.
- **Brass on "Bin"** — "Money" is `--text-primary`, "Bin" is `--accent-brass` (the one place brass is decorative); a `bin="mono"` variant drops it when another brass element shares the bar.

`nav`/`bar`/`hero` size presets pair the wordmark size with the Mark size and gap. The component composes the existing `Mark` (single source for the glyph) and follows the established `Mark`/`DuckKey` triad + preview + `docsMap` pattern; a `brand-wordmark` specimen card lands alongside `brand-logo`/`brand-duckkey`.

## Test plan

- [ ] Bundle rebuilds with the component: `8 components` (was 7), `docs 8/8 via docsMap`, `[DTS] 8/8`; `package-validate` passes (8 render hashes match; only the expected `[RENDER_SKIPPED]`).
- [ ] Component preview and `brand-wordmark` card render on-brand in a browser: Newsreader "MoneyBin", brass "Bin", coin-&-slot Mark, optical nudge centering the text; dark-lead; no console errors (only a benign favicon 404).
- [ ] Presets match the spec — wordmark/Mark/gap: `nav` 17/26/10, `bar` 15/22/9, `hero` 52/52/20; `bin="mono"` renders "Bin" in `--text-primary`.
- [ ] `Wordmark` composes `Mark` (no duplicated SVG).
