### PR TITLE
Document the design-system update workflow

### DIFF
--- a/.claude/skills/design-import/SKILL.md
+++ b/.claude/skills/design-import/SKILL.md
@@ -9,7 +9,7 @@ description: Use when bringing design work created in claude.ai/design — a com
 
 Inbound counterpart to `/design-sync`. Two facts drive everything:
 
-- **The claude.ai/design project is the source of truth; the downloaded zip is a lossy handoff** — usually docs + a value cross-check, often with NO authorable component/card source. Pull the real assets from the project with the `DesignSync` tool (`get_file`), not the zip.
+- **The claude.ai/design project is the source of truth; the downloaded zip is a lossy handoff** — usually docs + a value cross-check, often with NO authorable component/card source. Pull the real assets from the project with the `DesignSync` tool (`get_file`), not the zip. When both a `<Name>.dc.html` and a `<Name> (standalone).html` exist for the same asset, fetch the **`.dc.html`** — it embeds the authorable `<x-dc>` markup + logic inline; the `(standalone).html` is a self-extracting runtime loader (base64 fonts + dc-runtime that *fetches* its content at render), so its 256 KB hold no offline page source.
 - **This is a judgment call, not a copy.** Most of the value is classifying each asset, routing it, and NOT importing what doesn't belong. Two decision points are the human's (see Checkpoints).
 
 Build / stage / verify / upload / sandbox mechanics are already documented — read `design-system/.design-sync/NOTES.md`. This skill is the inbound *judgment* layer on top of it; it does not repeat those mechanics.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,8 @@ Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, sim
 
 MoneyBin's visual language lives in `design-system/` — the source of truth (it also backs the `/moneybin-design` skill and the synced claude.ai/design project). Before any UI, artifact, or frontend work, read `design-system/readme.md`, `design-system/tokens/`, and `design-system/guidelines/`. Non-negotiables: dark theme leads; brass (`--accent-brass`) is the only accent, never blue; money is always JetBrains Mono via the `Amount` component, with explicit +/− signs on income/expense flows (balances stay unsigned); hairline borders, no resting shadows; every data widget carries a SQL provenance chip; linear chart interpolation only; no emoji, no exclamation points.
 
+Update flow: prototype and spec visually in the claude.ai **Design Kit** project, promote into `design-system/` via `/design-import` (with PR review), then publish the repo → the claude.ai **Design System** project via `/design-sync`. The repo is canonical; the Design System project is a generated mirror — never hand-edit it as the source. See `design-system/readme.md` → "Updating the design system".
+
 ## Critical Rules
 
 - **Package manager**: `uv` only. Never `pip install`, `uv pip install`, or `python -m`.

--- a/design-system/readme.md
+++ b/design-system/readme.md
@@ -30,13 +30,13 @@ Sources: authored from scratch in this project (no external Figma/codebase). The
 ## Iconography
 Custom-drawn line icons: 20×20 grid, 1.5px stroke, squared caps, no fills, one weight, literal metaphors (see `guidelines/icons-grammar.html` — copy these SVGs). The AI/ask surface is the terminal caret `▸_`, never ✨. Unicode used sparingly as glyphs (⌘K, ⇄ transfers, ▲▼ deltas, ● status). No icon font; inline SVG. No emoji ever. Banned metaphors: coins raining, sparkles, magic wands. If a stock icon is unavoidable, restroke to spec (nearest CDN match: Lucide at 1.5px, squared caps where possible — flag any substitution).
 
-**Logo:** the "coin & slot" mark — solid coin poised over a slot cut clean through a rounded-square plate (`components/brand/Mark.jsx`). Wordmark: "MoneyBin" Newsreader semibold. **Duck-key** (`components/brand/DuckKey.jsx`): reusable glyph — the negative of the "bill-hole" keyhole; mono in app chrome, full-color eyed in docs/marketing; never rotated, bill always right. **Mascot ("Bill")** is docs/CLI only, never app chrome; NEVER a duck swimming/splashing in coins, no coin piles, no top hat/cane/spats (Disney IP adjacency).
+**Logo:** the "coin & slot" mark — solid coin poised over a slot cut clean through a rounded-square plate (`components/brand/Mark.jsx`). Wordmark: "MoneyBin" Newsreader semibold — the `components/brand/Wordmark.jsx` lock-up composes the Mark, with the optical baseline nudge and brass on "Bin" baked in. **Duck-key** (`components/brand/DuckKey.jsx`): reusable glyph — the negative of the "bill-hole" keyhole; mono in app chrome, full-color eyed in docs/marketing; never rotated, bill always right. **Mascot ("Bill")** is docs/CLI only, never app chrome; NEVER a duck swimming/splashing in coins, no coin piles, no top hat/cane/spats (Disney IP adjacency).
 
 ## Index
 - `styles.css` → `tokens/` (colors, typography, shape) — global CSS entry
-- `guidelines/` — specimen cards (Colors ×5, Type ×3, Shape ×3, Brand ×2, Charts ×12, Voice ×2, Iconography)
+- `guidelines/` — specimen cards (Colors ×5, Type ×3, Shape ×3, Brand ×3, Charts ×12, Voice ×2, Iconography)
 - `charts.md` — binding chart grammar (prose companion to the 12 `guidelines/charts-*.html` specimens)
-- `components/core/` — Button, Chip · `components/data/` — Amount, WidgetCard · `components/chrome/` — VaultStatusBar · `components/brand/` — Mark, DuckKey
+- `components/core/` — Button, Chip · `components/data/` — Amount, WidgetCard · `components/chrome/` — VaultStatusBar · `components/brand/` — Mark, DuckKey, Wordmark
 - `ui_kits/web_app/` — dashboard home (static reference extraction of the brand kit §09)
 - `MoneyBin Brand Kit.dc.html` — the full argued spec (sections 01–10 incl. rationale)
 
@@ -45,3 +45,13 @@ Custom-drawn line icons: 20×20 grid, 1.5px stroke, squared caps, no fills, one 
 
 ### Caveats
 - The dashboard UI kit is a static extraction of the brand-kit mockup (hover states and SQL toggle are not interactive there; see the DC file for the live version).
+
+## Updating the design system
+
+`design-system/` is the source of truth. Changes flow one way, always through the repo:
+
+1. **Prototype / spec visually** in the claude.ai/design **Design Kit** project — the scratchpad for screens, studies, and spec docs; it renders against the current components.
+2. **Promote into the repo** with `/design-import` — classify each asset (component vs specimen card vs screen-to-park), reconstruct it repo-native (tokens, card contract), and land it via a PR.
+3. **Publish** the repo → the claude.ai **Design System** project with `/design-sync` (outbound), so the live design surface mirrors the repo.
+
+The Design System project is a **generated mirror** — never hand-edit it as the authoritative copy; edits there drift from the repo and are overwritten on the next sync. Explore in claude.ai freely; it only becomes real once it lands in the repo via a PR.


### PR DESCRIPTION
## Summary

Codifies the design-system update workflow (settled in a session retro): prototype/spec visually in the claude.ai **Design Kit** project, promote into `design-system/` via `/design-import` (PR review), then publish the repo → the claude.ai **Design System** project via `/design-sync`. The repo is canonical; the Design System project is a **generated mirror**, never hand-edited. Also adds a `design-import` tip and fixes readme drift from the merged Wordmark component (#295).

## Changes

- **AGENTS.md** — one-paragraph update-flow + mirror rule in the Design System section.
- **design-system/readme.md** — new "Updating the design system" section; Wordmark added to the Logo note and the index (Brand ×3; `components/brand/` lists Wordmark).
- **.claude/skills/design-import** — prefer the `.dc.html` (embeds authorable source inline) over the `(standalone).html` runtime loader when fetching an asset.

## Test plan

- [ ] AGENTS.md and `design-system/readme.md` describe the same one-way loop and the "generated mirror, never hand-edit" rule.
- [ ] `design-import` overview notes fetching `.dc.html` over `(standalone).html`.
- [ ] readme index reflects the Wordmark component (Brand ×3; `components/brand/` lists Wordmark).
