### PR TITLE
Fix doctor FK-check hang from correlated subquery on fct view

### DIFF
--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -555,27 +555,25 @@ class DoctorService:
         try:
             rows = self._db.execute(
                 f"""
-                SELECT 'note:' || note_id AS aid
+                -- Materialize valid transaction_ids ONCE (core.fct_transactions is
+                -- an expensive view); the prior correlated NOT EXISTS re-evaluated
+                -- it per note/tag row — O(N × view). A row is an orphan when its
+                -- transaction_id is in neither the fact view nor raw manuals, so
+                -- valid_txn = fct ∪ manual and orphan = anti-join miss.
+                WITH valid_txn AS MATERIALIZED (
+                    SELECT transaction_id FROM {FCT_TRANSACTIONS.full_name}
+                    UNION
+                    SELECT transaction_id FROM {MANUAL_TRANSACTIONS.full_name}
+                )
+                SELECT 'note:' || n.note_id AS aid
                 FROM {TRANSACTION_NOTES.full_name} n
-                WHERE NOT EXISTS (
-                    SELECT 1 FROM {FCT_TRANSACTIONS.full_name} t
-                    WHERE t.transaction_id = n.transaction_id
-                )
-                AND NOT EXISTS (
-                    SELECT 1 FROM {MANUAL_TRANSACTIONS.full_name} m
-                    WHERE m.transaction_id = n.transaction_id
-                )
+                LEFT JOIN valid_txn v ON v.transaction_id = n.transaction_id
+                WHERE v.transaction_id IS NULL
                 UNION
-                SELECT 'tag:' || transaction_id
+                SELECT 'tag:' || g.transaction_id
                 FROM {TRANSACTION_TAGS.full_name} g
-                WHERE NOT EXISTS (
-                    SELECT 1 FROM {FCT_TRANSACTIONS.full_name} t
-                    WHERE t.transaction_id = g.transaction_id
-                )
-                AND NOT EXISTS (
-                    SELECT 1 FROM {MANUAL_TRANSACTIONS.full_name} m
-                    WHERE m.transaction_id = g.transaction_id
-                )
+                LEFT JOIN valid_txn v ON v.transaction_id = g.transaction_id
+                WHERE v.transaction_id IS NULL
                 ORDER BY aid
                 """  # noqa: S608  # TableRef constants, no user input
             ).fetchall()
@@ -662,12 +660,18 @@ class DoctorService:
         try:
             rows = self._db.execute(
                 f"""
+                -- Anti-join against a once-materialized id set, NOT a correlated
+                -- NOT EXISTS. core.fct_transactions is an expensive view (the full
+                -- merge/dedup/categorization pipeline); a correlated subquery
+                -- re-evaluates it per app.transaction_categories row — O(N × view) —
+                -- which wedges the doctor once this table is populated and the
+                -- optimizer can't decorrelate the view.
                 SELECT c.transaction_id
                 FROM {TRANSACTION_CATEGORIES.full_name} c
-                WHERE NOT EXISTS (
-                    SELECT 1 FROM {FCT_TRANSACTIONS.full_name} t
-                    WHERE t.transaction_id = c.transaction_id
-                )
+                LEFT JOIN (
+                    SELECT DISTINCT transaction_id FROM {FCT_TRANSACTIONS.full_name}
+                ) t ON t.transaction_id = c.transaction_id
+                WHERE t.transaction_id IS NULL
                 ORDER BY c.transaction_id
                 """  # noqa: S608  # TableRef constants, no user input
             ).fetchall()


### PR DESCRIPTION
## Summary

`moneybin doctor` wedged for >73s — effectively hung — once `app.transaction_categories` (and `app.transaction_notes` / `app.transaction_tags`) held rows. Two integrity checks used correlated `NOT EXISTS` subqueries against `core.fct_transactions`, which is an expensive view (the full merge → dedup → categorization pipeline). DuckDB re-evaluated that view once per app-state row — O(N × view) — and couldn't decorrelate it.

This rewrites both checks as anti-joins against a once-materialized valid-id set. The output semantics (which rows are flagged as orphans / FK violations) are unchanged; runtime drops from a >73s hang to ~2.1s on the populated DB.

## Test plan

- [ ] Existing behavioral coverage is green — `test_doctor_app_integrity.py::test_transaction_categories_fk_flags_orphan` / `test_transaction_categories_fk_passes_when_all_resolve` and `test_doctor_orphan_app_state.py` (orphan-note flagged, all-resolve pass) assert the exact flag/pass semantics the rewrite preserves.
- [ ] `moneybin doctor` completes in ~2.1s (was a >73s hang) on a DB with populated `app.transaction_categories`.
- [ ] No new automated test is added: the defect is a wall-clock hang, the rewrite's correctness is already guarded by the behavioral tests above, and a timing assertion would be flaky.
