### PR TITLE
Stop V032 from ALTERing the SQLMesh-owned seeds.categories view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,6 +305,13 @@ M2 closing out and M3 underway. M2A curator state shipped (transaction notes, ta
   key is ignored).
 
 ### Fixed
+- **`moneybin sync pull` no longer stuck-fails on a fully-materialized
+  database.** Migration V032 issued `ALTER TABLE seeds.categories`, but on a
+  database whose SQLMesh virtual layer is materialized that relation is a view —
+  DuckDB rejects the ALTER, leaving the migration stuck and blocking every DB
+  open. V032 now only rebuilds `app.user_categories`; the seed table's `class`
+  column is owned by SQLMesh and derived by `refresh_views()`, so an upgraded
+  database recovers automatically on the next run. (#306)
 - **`import_preview` surfaces header detection and row-count reconciliation.**
   Silent header-eating (a real data row mistaken for a header) was invisible in
   the preview envelope. The envelope now carries `has_header`, `skip_rows`, and

--- a/src/moneybin/sql/migrations/V032__add_category_source_map_and_class.py
+++ b/src/moneybin/sql/migrations/V032__add_category_source_map_and_class.py
@@ -1,4 +1,4 @@
-"""V032: add app.category_source_map, app.user_categories.class, and seeds.categories.class.
+"""V032: add app.category_source_map and app.user_categories.class.
 
 DuckDB rejects both `ADD COLUMN ... NOT NULL` (`Adding columns with
 constraints not yet supported`) and `ADD CONSTRAINT CHECK` (`No support for
@@ -14,30 +14,26 @@ the migration runner's single transaction — no interim COMMIT is needed
 because there's no longer a separate ALTER ... SET NOT NULL step that must
 follow a durable backfill.
 
-`seeds.categories` needs the same `class` column so `refresh_views()` (called
-right after migrations, on every ``Database`` open) can build
-``core.dim_categories`` without a BinderException. V014 unconditionally
-`CREATE TABLE IF NOT EXISTS seeds.categories` with the pre-``class`` shape
-earlier in the migration chain (every install runs it, fresh or upgrade), so
-by the time V032 runs the table always exists and needs the column added.
-Rows are backfilled by the same category_id-prefix rule the seed CSV uses
-(``INC``/``TRN``/``LNP``/else) rather than a blanket default, since these are
-reference rows a real user may already be relying on — not user data with no
-inferable class. `seeds.categories` is SQLMesh-owned reference data with no
-NOT NULL requirement in the model, so it stays nullable here.
+`seeds.categories` is intentionally NOT touched here. It is a SQLMesh SEED
+model: on a fully-materialized database it is exposed as a *view* over the
+physical snapshot, and `ALTER TABLE seeds.categories` raises `Can only modify
+view with ALTER VIEW statement`. The `class` column on the seed data is owned
+by SQLMesh (the model declares it) and by `refresh_views()`, which derives
+`class` from the `category_id` prefix on the fly whenever the column is absent
+(see `moneybin.seeds._has_column`). `core.dim_categories` resolves `class`
+either way, so a migration mutating SQLMesh-owned reference data would only
+duplicate that pattern — and break on the view.
 """
 
 from __future__ import annotations
 
 import logging
 
-from moneybin.sql.category_class import CATEGORY_CLASS_FROM_ID_CASE_SQL
-
 logger = logging.getLogger(__name__)
 
 
 def migrate(conn: object) -> None:
-    """Create app.category_source_map; add class to user_categories + seeds.categories. Idempotent."""
+    """Create app.category_source_map; add class to app.user_categories. Idempotent."""
     logger.debug("V032: creating app.category_source_map")
     conn.execute(  # type: ignore[union-attr]
         """
@@ -102,22 +98,3 @@ def migrate(conn: object) -> None:
     conn.execute(  # type: ignore[union-attr]
         "COMMENT ON COLUMN app.user_categories.class IS 'Accounting class: income | expense | transfer | debt'"
     )
-
-    seed_cols: list[str] = [
-        r[0]
-        for r in conn.execute(  # type: ignore[union-attr]
-            "SELECT column_name FROM duckdb_columns() "
-            "WHERE schema_name = 'seeds' AND table_name = 'categories'"
-        ).fetchall()
-    ]
-    if seed_cols and "class" not in seed_cols:
-        logger.debug("V032: adding class column to seeds.categories")
-        conn.execute(  # type: ignore[union-attr]
-            "ALTER TABLE seeds.categories ADD COLUMN class VARCHAR"
-        )
-        conn.execute(  # type: ignore[union-attr]
-            f"UPDATE seeds.categories SET class = {CATEGORY_CLASS_FROM_ID_CASE_SQL}"  # noqa: S608  # category_class module constant, not user input
-        )
-        conn.execute(  # type: ignore[union-attr]
-            "COMMENT ON COLUMN seeds.categories.class IS 'Accounting class: income | expense | transfer | debt'"
-        )

--- a/tests/moneybin/test_migration_v032.py
+++ b/tests/moneybin/test_migration_v032.py
@@ -56,11 +56,10 @@ def _recreate_pre_v032_state(db: Database) -> None:
     `ALTER TABLE ... DROP COLUMN` is allowed (unlike V030's case where the
     new column preceded a PK-indexed column).
 
-    `seeds.categories.class` needs no DROP here: `_ensure_seed_tables_exist`
-    bootstraps the table in frozen V014's original shape (`plaid_detailed`,
-    no `class`) rather than the post-V032 shape, so the table is already in
-    its pre-V032 state — the test only seeds representative rows (one per
-    class-rule prefix) to exercise the prefix-derived backfill in migrate().
+    `seeds.categories` is intentionally not touched: V032 no longer mutates the
+    SQLMesh-owned seed table (an `ALTER TABLE` there breaks on the virtual-layer
+    view — see `test_v032_tolerates_seeds_categories_as_view`), so there is
+    nothing to reverse for it here.
     """
     db.execute("DROP TABLE IF EXISTS app.category_source_map")
     db.execute("ALTER TABLE app.user_categories DROP COLUMN class")
@@ -74,23 +73,6 @@ def _recreate_pre_v032_state(db: Database) -> None:
         "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP), "
         "('u_c3d4e5f6a1b2', 'Gifts', 'Given', '', false, "
         "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
-    )
-    db.execute(
-        "INSERT INTO seeds.categories "
-        "(category_id, category, subcategory, description) VALUES "
-        "('INC-TST', 'Income', 'Test', ''), "
-        "('TRN-TST', 'Transfer', 'Test', ''), "
-        "('LNP-TST', 'Loan Payments', 'Test', ''), "
-        "('FND-TST', 'Food & Drink', 'Test', '')"
-    )
-
-
-def _seed_category_classes(db: Database) -> dict[str, str]:
-    return dict(
-        db.execute(
-            "SELECT category_id, class FROM seeds.categories "
-            "WHERE category_id LIKE '%-TST' ORDER BY category_id"
-        ).fetchall()
     )
 
 
@@ -120,13 +102,33 @@ def test_v032_creates_bridge_and_class(db: Database) -> None:
     }
     assert _BRIDGE_COLUMNS <= cols
 
-    # seeds.categories.class backfilled by category_id prefix (BLOCK B rule).
-    assert _seed_category_classes(db) == {
-        "INC-TST": "income",
-        "TRN-TST": "transfer",
-        "LNP-TST": "debt",
-        "FND-TST": "expense",
-    }
+
+def test_v032_tolerates_seeds_categories_as_view(db: Database) -> None:
+    """V032 must not fail when seeds.categories is a SQLMesh view, not a table.
+
+    On a database where SQLMesh has materialized its virtual layer,
+    ``seeds.categories`` is a VIEW over a physical snapshot table. A migration
+    that issues ``ALTER TABLE seeds.categories`` against it raises DuckDB's
+    ``Can only modify view with ALTER VIEW statement`` — the stuck-migration
+    failure seen on a fully-materialized production database. ``class`` on the
+    seed data is owned by SQLMesh + ``refresh_views`` (which derives it when
+    absent), so the migration must leave the SQLMesh-owned seed table alone.
+    """
+    _recreate_pre_v032_state(db)
+    # Re-present seeds.categories the way a fully-materialized SQLMesh DB does:
+    # a view in the queryable schema over a physical snapshot table.
+    db.execute("CREATE TABLE seeds.categories__phys AS SELECT * FROM seeds.categories")
+    db.execute("DROP TABLE seeds.categories")
+    db.execute("CREATE VIEW seeds.categories AS SELECT * FROM seeds.categories__phys")
+
+    run_migration(db, migrate)  # must not raise on the view
+
+    # The real migration work still lands on the mutable app table.
+    _, is_nullable = column_info(db, "app", "user_categories", "class")
+    assert is_nullable is False
+    assert _table_exists(db, "app", "category_source_map")
+    # The SQLMesh-owned seed table is left untouched — not the migration's job.
+    assert not column_exists(db, "seeds", "categories", "class")
 
 
 def test_v032_is_idempotent(db: Database) -> None:
@@ -149,12 +151,6 @@ def test_v032_is_idempotent(db: Database) -> None:
         for row in db.execute("PRAGMA table_info('app.category_source_map')").fetchall()
     }
     assert _BRIDGE_COLUMNS <= cols
-    assert _seed_category_classes(db) == {
-        "INC-TST": "income",
-        "TRN-TST": "transfer",
-        "LNP-TST": "debt",
-        "FND-TST": "expense",
-    }
 
 
 def test_v032_idempotent_on_fresh_install(db: Database) -> None:
@@ -166,7 +162,6 @@ def test_v032_idempotent_on_fresh_install(db: Database) -> None:
     assert _table_exists(db, "app", "category_source_map")
     _, is_nullable = column_info(db, "app", "user_categories", "class")
     assert is_nullable is False
-    assert column_exists(db, "seeds", "categories", "class")
 
 
 def test_v032_class_check_constraint_enforced(db: Database) -> None:


### PR DESCRIPTION
## Summary

`moneybin sync pull` (and any DB open) crashed with a stuck migration on a
fully-materialized database:

```
❌ Migration V032 failed: Catalog Error: Can only modify view with ALTER VIEW statement
```

V032 ran `ALTER TABLE seeds.categories ADD COLUMN class`, assuming a table — but
`seeds.categories` is a SQLMesh SEED model, exposed as a **view** over its
physical snapshot on any materialized database, so DuckDB rejects the
`ALTER TABLE`. This removes the `seeds.categories` block so V032 does only what a
migration uniquely must: rebuild the mutable `app.user_categories` to add
`class NOT NULL + CHECK`. Editing the failed migration's body auto-clears its
stuck failure row on the next run (hash mismatch → self-heal), so an upgraded
database recovers with no manual step.

## Background

The block was redundant as well as broken. `refresh_views()` already derives
`class` from the `category_id` prefix when the column is absent
(`moneybin.seeds._has_column`), so `core.dim_categories` builds without it, and
the SQLMesh model declares the column for its own materialization. A migration
mutating SQLMesh-owned reference data duplicated a pattern `refresh_views`
deliberately avoids — and broke on the view.

CI and fresh installs never caught it: on a fresh DB the migration ladder runs
*before* SQLMesh materializes its virtual layer, so `seeds.categories` is still
the migration-bootstrapped **table** and the `ALTER` succeeds. The failure only
surfaces on the real upgrade path — a new migration landing on a database whose
SQLMesh virtual layer already exists.

## Test plan

- [x] New `test_v032_tolerates_seeds_categories_as_view` runs V032 against a
  view-shaped `seeds.categories`: fails on the old code with the exact
  production error, passes on the fix.
- [x] Updated the three V032 tests that asserted `seeds.categories.class` — no
  longer the migration's responsibility.
- [x] `make check test` — 4980 passed (format, lint, type-check, unit).
- [x] `make test-scenarios` — pass.
- [ ] Reviewer: confirm dropping the `seeds.categories` ALTER is safe given
  `refresh_views()` derives `class` when absent (`src/moneybin/seeds.py:167`).
