### PR TITLE
Inject GH_TOKEN in MCP launcher so gh works in-session

### DIFF
--- a/scripts/claude-mcp.sh
+++ b/scripts/claude-mcp.sh
@@ -47,5 +47,14 @@ if ! command -v claude >/dev/null 2>&1; then
   exit 1
 fi
 
+# gh stores its token in the macOS keychain, which Claude Code's sandbox can't
+# reach. Resolve it here (outside the sandbox) and pass it in as an env var so
+# `gh` works inside the session. Mirrors the interactive `claude()` zsh wrapper,
+# but lives in the launcher so it applies however this script is invoked.
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  token=$(gh auth token 2>/dev/null || true)
+  [[ -n "$token" ]] && export GH_TOKEN="$token"
+fi
+
 echo "🚀 Launching Claude Code with MoneyBin MCP ($config_path)"
 exec claude --strict-mcp-config --mcp-config "$config_path"


### PR DESCRIPTION
## Summary

`scripts/claude-mcp.sh` execs `claude` directly, so `make`-launched sessions bypass the interactive `claude()` zsh wrapper that injects `GH_TOKEN` from the macOS keychain. Without the token, `gh` (and GraphQL-backed skills) return 401 for the whole session.

This resolves the token in the launcher itself — outside Claude Code's sandbox, which can't reach the keychain — and exports it before `exec`. It mirrors the zsh wrapper but applies however the script is invoked: it respects an already-set `GH_TOKEN` and only exports when `gh auth token` returns a non-empty value.

## Test plan

- [ ] Launch a session via the launcher (`scripts/claude-mcp.sh` / `make`) with no `GH_TOKEN` in the environment and confirm `gh api user` succeeds in-session (no 401).
- [ ] Confirm an already-exported `GH_TOKEN` is left untouched (guard skips resolution).
- [ ] Confirm a machine with no `gh` token still launches cleanly — `gh auth token` fails silently, `token` is empty, no export, no error.
