### PR TITLE
Test the design system instead of eyeballing it

### DIFF
--- a/.claude/skills/design-import/SKILL.md
+++ b/.claude/skills/design-import/SKILL.md
@@ -108,8 +108,21 @@ shadow, SQL provenance chip on data widgets, no emoji, no exclamation points.
 
 ## Step 3 — Verify
 
-Build the bundle, stage the cards, and check them in the Playwright MCP browser —
-mechanics in `NOTES.md` (serve unsandboxed; `file://` is blocked).
+**Run the invariants first — they are the gate:**
+
+```sh
+uv run pytest tests/design_system -q        # from the repo root
+```
+
+They catch what a browser cannot show you: a component missing its preview or
+`docsMap` entry (silently dropped from the bundle), a `.jsx` that registers on a
+window global instead of exporting (bundles, never resolves), an exported name
+list that disagrees with its own `.d.ts`, a CDN fetch, a card frozen to one theme
+by a hardcoded hex, and a doc surface that forgot to list a component. Every one
+of those shipped to `main` before this suite existed. Don't import on red.
+
+Then build the bundle, stage the cards, and check them in the Playwright MCP
+browser — mechanics in `NOTES.md` (serve unsandboxed; `file://` is blocked).
 
 **Assert properties, don't just eyeball a screenshot.** The MCP screenshot file can
 land somewhere you can't read, and "it looked right in dark" is exactly the bug that

--- a/.claude/skills/design-import/SKILL.md
+++ b/.claude/skills/design-import/SKILL.md
@@ -95,10 +95,14 @@ Claude Design output is **not** repo-native. Fix it:
 **Cards**
 - **Inject `<meta charset="utf-8">`** into every `<head>` — always omitted, and
   `−·–▲▼` render as mojibake without it.
-- **Tokens only, no hardcoded hex.** A baked hex isn't just a style violation: it
-  **freezes the card at the dark-theme value and breaks it under
+- **Tokens only, or declare the literal.** A baked hex isn't just a style violation:
+  it **freezes the card at the dark-theme value and breaks it under
   `[data-theme="light"]`**. Prefer `currentColor` + a `var(--*)` on the parent, which
-  also mirrors how the component actually inherits color.
+  also mirrors how the component actually inherits color. A literal is legitimate only
+  where a token structurally can't work — a swatch chip that *is* the value it
+  documents, a brand plate rendering dark and light at once — and then it must say so
+  on the element that paints it: `data-literal-color="#C79B3B"`, listing exactly the
+  hexes in that element's own `style`. Undeclared (or stale) literals fail the gate.
 - **Freeze any runtime `<script>` to static SVG.** Run its logic once, bake the
   elements inline, delete the script. Specimens must render static.
 
@@ -161,7 +165,7 @@ ships. Use `browser_evaluate` to check what actually matters:
 | Dropping in the handoff's `tokens.css` | Usually a cross-check snapshot, not a change. Repo tokens are canonical — diff, don't replace. |
 | Leaving a card's runtime `<script>` | Specimens must be static SVG. Freeze it. |
 | Forgetting `<meta charset>` | Mojibake on signs and glyphs. Every card needs it. |
-| Hardcoded hex in a card | Breaks light theme silently. Tokens / `currentColor` only. |
+| Hardcoded hex in a card | Breaks light theme silently. Tokens / `currentColor` — or, where a token can't express it, an explicit `data-literal-color` on the painting element. |
 | Overwriting a richer repo doc with the handoff's shorter one | Reconcile, don't overwrite. |
 
 ## See also

--- a/design-system/.design-sync/NOTES.md
+++ b/design-system/.design-sync/NOTES.md
@@ -16,8 +16,15 @@ It is fast (no DB, no network) and it fails on the things that are invisible in
 a browser: a component missing its preview or `docsMap` entry (silently dropped
 from the bundle), a `.jsx` that registers on a window global instead of
 exporting (bundles, never resolves), an `Icon.names` list that disagrees with
-its own `.d.ts`, a CDN fetch, a card frozen to one theme by a hardcoded hex, and
-a doc surface that forgot to list a component.
+its own `.d.ts`, a CDN fetch, a card frozen to one theme by an undeclared literal
+hex, and a doc surface that forgot to list a component.
+
+On literals: a card paints with `var(--*)`, or it declares what it paints with —
+`data-literal-color="#C79B3B"` on the element whose `style` carries the hex. Only
+two things earn a literal (a swatch chip that *is* the value it documents; a brand
+plate rendering dark and light at once), and rather than let the gate guess which,
+the card names them. Guessing leaked four times, once hiding a real theme-freeze
+bug in `colors-brass.html`.
 
 **Why it exists:** every one of those shipped to `main` and survived — one of
 them for weeks — because this directory is authored by hand and verified by eye,

--- a/design-system/.design-sync/NOTES.md
+++ b/design-system/.design-sync/NOTES.md
@@ -5,6 +5,25 @@ package** — it's a pre-authored "Design Composer" kit (hand-written `.jsx`
 components + hand-authored `.d.ts`/`.prompt.md` + token CSS). It runs the
 package shape in **synth-entry mode**.
 
+## Gate: run the invariants BEFORE you build or publish
+
+```sh
+uv run pytest tests/design_system -q        # from the repo root
+```
+
+Green is a precondition for `/design-sync` and for landing a `/design-import`.
+It is fast (no DB, no network) and it fails on the things that are invisible in
+a browser: a component missing its preview or `docsMap` entry (silently dropped
+from the bundle), a `.jsx` that registers on a window global instead of
+exporting (bundles, never resolves), an `Icon.names` list that disagrees with
+its own `.d.ts`, a CDN fetch, a card frozen to one theme by a hardcoded hex, and
+a doc surface that forgot to list a component.
+
+**Why it exists:** every one of those shipped to `main` and survived — one of
+them for weeks — because this directory is authored by hand and verified by eye,
+and nothing checked. Do not publish on a red suite; a component that renders
+wrong here renders wrong in *every* design the agent builds with it.
+
 ## How it builds
 
 Run from `design-system/` (the config home):

--- a/design-system/CLAUDE.md
+++ b/design-system/CLAUDE.md
@@ -19,8 +19,12 @@ a pointer, not a second copy; when the two disagree, `readme.md` wins.
 - **Icons come from `components/core/Icon.jsx`** — never an inline one-off SVG.
   A new glyph is a system change. The AI/ask surface is the caret `▸_`, never ✨.
 - **No emoji, no exclamation points, no superlatives.**
-- **Tokens only.** Never hardcode a hex — every color reads `var(--*)`, or the
-  asset breaks in light theme.
+- **Tokens only.** Every color reads `var(--*)` or `currentColor`, or the asset
+  freezes at one theme. The rare deliberate literal — a swatch chip that *is* the
+  value it documents, a brand plate showing dark and light at once — must be
+  declared on the element that paints it:
+  `<div data-literal-color="#C79B3B" style="background:#C79B3B">`. Undeclared
+  literals fail `tests/design_system`.
 
 ## Map
 

--- a/design-system/guidelines/brand-duckkey.html
+++ b/design-system/guidelines/brand-duckkey.html
@@ -1,31 +1,33 @@
 <!-- @dsCard group="Brand" viewport="700x190" subtitle="Duck-key: the negative of the bill-hole keyhole. Mono in app chrome; full-color eyed in docs/marketing. Bill always points right, never rotated." name="Duck-key glyph" -->
 <!DOCTYPE html><html><head><meta charset="utf-8"><link rel="stylesheet" href="../styles.css"><style>body{margin:0;font-family:var(--font-data);font-size:10px}</style></head>
-<body style="background:#141311;padding:18px;display:flex;gap:36px;align-items:center;justify-content:center;">
-<div style="text-align:center;color:#6E685E;">
+<body data-literal-color="#141311" style="background:#141311;padding:18px;display:flex;gap:36px;align-items:center;justify-content:center;">
+<!-- Fixed dark plate: the mark is shown on one surface in both themes, so the plate and
+     everything drawn on it are literal by design. Each literal is declared where it paints. -->
+<div data-literal-color="#6E685E" style="text-align:center;color:#6E685E;">
   <div style="width:48px;height:48px;position:relative;margin:0 auto;">
-    <div style="position:absolute;left:4px;top:15px;width:17px;height:17px;border-radius:50%;background:#C79B3B;"></div>
-    <div style="position:absolute;left:18px;top:20px;width:18px;height:7px;border-radius:4px;background:#C79B3B;"></div>
+    <div data-literal-color="#C79B3B" style="position:absolute;left:4px;top:15px;width:17px;height:17px;border-radius:50%;background:#C79B3B;"></div>
+    <div data-literal-color="#C79B3B" style="position:absolute;left:18px;top:20px;width:18px;height:7px;border-radius:4px;background:#C79B3B;"></div>
   </div><br>key (mono — app chrome)
 </div>
-<div style="text-align:center;color:#6E685E;">
+<div data-literal-color="#6E685E" style="text-align:center;color:#6E685E;">
   <div style="width:48px;height:48px;position:relative;margin:0 auto;">
-    <div style="position:absolute;left:4px;top:15px;width:17px;height:17px;border-radius:50%;background:#E9E4DB;"></div>
-    <div style="position:absolute;left:18px;top:20px;width:18px;height:7px;border-radius:4px;background:#C79B3B;"></div>
-    <div style="position:absolute;left:12px;top:19.5px;width:3px;height:3px;border-radius:50%;background:#141311;"></div>
+    <div data-literal-color="#E9E4DB" style="position:absolute;left:4px;top:15px;width:17px;height:17px;border-radius:50%;background:#E9E4DB;"></div>
+    <div data-literal-color="#C79B3B" style="position:absolute;left:18px;top:20px;width:18px;height:7px;border-radius:4px;background:#C79B3B;"></div>
+    <div data-literal-color="#141311" style="position:absolute;left:12px;top:19.5px;width:3px;height:3px;border-radius:50%;background:#141311;"></div>
   </div><br>full-color, eyed (docs/marketing)
 </div>
-<div style="text-align:center;color:#6E685E;">
-  <div style="width:48px;height:48px;border-radius:11px;background:#E9E4DB;position:relative;margin:0 auto;">
-    <div style="position:absolute;left:9px;top:15px;width:17px;height:17px;border-radius:50%;background:#8A6A1C;"></div>
-    <div style="position:absolute;left:22px;top:20px;width:18px;height:7px;border-radius:4px;background:#8A6A1C;"></div>
+<div data-literal-color="#6E685E" style="text-align:center;color:#6E685E;">
+  <div data-literal-color="#E9E4DB" style="width:48px;height:48px;border-radius:11px;background:#E9E4DB;position:relative;margin:0 auto;">
+    <div data-literal-color="#8A6A1C" style="position:absolute;left:9px;top:15px;width:17px;height:17px;border-radius:50%;background:#8A6A1C;"></div>
+    <div data-literal-color="#8A6A1C" style="position:absolute;left:22px;top:20px;width:18px;height:7px;border-radius:4px;background:#8A6A1C;"></div>
   </div><br>the bill-hole it fits
 </div>
-<div style="text-align:center;color:#6E685E;">
-  <div style="width:48px;height:48px;border-radius:11px;background:#E9E4DB;position:relative;margin:0 auto;">
-    <div style="position:absolute;left:9px;top:15px;width:17px;height:17px;border-radius:50%;background:#8A6A1C;"></div>
-    <div style="position:absolute;left:22px;top:20px;width:18px;height:7px;border-radius:4px;background:#8A6A1C;"></div>
-    <div style="position:absolute;left:12px;top:18px;width:11px;height:11px;border-radius:50%;background:#C79B3B;"></div>
-    <div style="position:absolute;left:24px;top:21.5px;width:13.5px;height:4px;border-radius:2.5px;background:#C79B3B;"></div>
+<div data-literal-color="#6E685E" style="text-align:center;color:#6E685E;">
+  <div data-literal-color="#E9E4DB" style="width:48px;height:48px;border-radius:11px;background:#E9E4DB;position:relative;margin:0 auto;">
+    <div data-literal-color="#8A6A1C" style="position:absolute;left:9px;top:15px;width:17px;height:17px;border-radius:50%;background:#8A6A1C;"></div>
+    <div data-literal-color="#8A6A1C" style="position:absolute;left:22px;top:20px;width:18px;height:7px;border-radius:4px;background:#8A6A1C;"></div>
+    <div data-literal-color="#C79B3B" style="position:absolute;left:12px;top:18px;width:11px;height:11px;border-radius:50%;background:#C79B3B;"></div>
+    <div data-literal-color="#C79B3B" style="position:absolute;left:24px;top:21.5px;width:13.5px;height:4px;border-radius:2.5px;background:#C79B3B;"></div>
   </div><br>seated — unlocked
 </div>
 </body></html>

--- a/design-system/guidelines/brand-logo.html
+++ b/design-system/guidelines/brand-logo.html
@@ -1,18 +1,20 @@
 <!-- @dsCard group="Brand" viewport="700x170" subtitle="Coin & slot mark — solid coin over a slot cut through the plate — with Newsreader wordmark" name="Logo lock-ups" -->
 <!DOCTYPE html><html><head><meta charset="utf-8"><link rel="stylesheet" href="../styles.css"><style>body{margin:0}</style></head>
 <body style="background:var(--bg-base);padding:20px;display:flex;gap:16px;align-items:center;">
-<div style="flex:1;background:#141311;border:1px solid #2A2723;border-radius:6px;padding:24px;display:flex;align-items:center;gap:14px;">
-  <div style="width:48px;height:48px;border-radius:11px;background:#E9E4DB;position:relative;">
-    <div style="position:absolute;left:17.5px;top:6.5px;width:13px;height:13px;border-radius:50%;background:#8A6A1C;"></div>
-    <div style="position:absolute;left:12px;top:23.5px;width:24px;height:4.5px;border-radius:2.5px;background:#141311;"></div>
+<!-- Both plates render at once, so nothing on them can read a token: a token resolves to
+     one value per theme. Every literal is declared on the element that paints it. -->
+<div data-literal-color="#141311 #2A2723" style="flex:1;background:#141311;border:1px solid #2A2723;border-radius:6px;padding:24px;display:flex;align-items:center;gap:14px;">
+  <div data-literal-color="#E9E4DB" style="width:48px;height:48px;border-radius:11px;background:#E9E4DB;position:relative;">
+    <div data-literal-color="#8A6A1C" style="position:absolute;left:17.5px;top:6.5px;width:13px;height:13px;border-radius:50%;background:#8A6A1C;"></div>
+    <div data-literal-color="#141311" style="position:absolute;left:12px;top:23.5px;width:24px;height:4.5px;border-radius:2.5px;background:#141311;"></div>
   </div>
-  <div style="font-family:var(--font-display);font-size:24px;font-weight:600;color:#E9E4DB;">MoneyBin</div>
+  <div data-literal-color="#E9E4DB" style="font-family:var(--font-display);font-size:24px;font-weight:600;color:#E9E4DB;">MoneyBin</div>
 </div>
-<div style="flex:1;background:#FDFCF9;border:1px solid #E3DFD5;border-radius:6px;padding:24px;display:flex;align-items:center;gap:14px;">
-  <div style="width:48px;height:48px;border-radius:11px;background:#1C1A16;position:relative;">
-    <div style="position:absolute;left:17.5px;top:6.5px;width:13px;height:13px;border-radius:50%;background:#C79B3B;"></div>
-    <div style="position:absolute;left:12px;top:23.5px;width:24px;height:4.5px;border-radius:2.5px;background:#FDFCF9;"></div>
+<div data-literal-color="#FDFCF9 #E3DFD5" style="flex:1;background:#FDFCF9;border:1px solid #E3DFD5;border-radius:6px;padding:24px;display:flex;align-items:center;gap:14px;">
+  <div data-literal-color="#1C1A16" style="width:48px;height:48px;border-radius:11px;background:#1C1A16;position:relative;">
+    <div data-literal-color="#C79B3B" style="position:absolute;left:17.5px;top:6.5px;width:13px;height:13px;border-radius:50%;background:#C79B3B;"></div>
+    <div data-literal-color="#FDFCF9" style="position:absolute;left:12px;top:23.5px;width:24px;height:4.5px;border-radius:2.5px;background:#FDFCF9;"></div>
   </div>
-  <div style="font-family:var(--font-display);font-size:24px;font-weight:600;color:#1C1A16;">MoneyBin</div>
+  <div data-literal-color="#1C1A16" style="font-family:var(--font-display);font-size:24px;font-weight:600;color:#1C1A16;">MoneyBin</div>
 </div>
 </body></html>

--- a/design-system/guidelines/charts-grammar.html
+++ b/design-system/guidelines/charts-grammar.html
@@ -6,13 +6,13 @@
 <span style="font-size:10px;color:var(--accent-brass);border:1px solid var(--border-strong);border-radius:3px;padding:2px 7px;">SQL</span>
 </div>
 <svg role="img" aria-label="Line chart annotated with the house chart grammar — linear interpolation, hairline gridlines, clipped-axis disclosure" width="660" height="150" viewBox="0 0 660 150" style="display:block;width:100%;">
-<line x1="44" y1="12" x2="652" y2="12" stroke="#2A2723"/><line x1="44" y1="52" x2="652" y2="52" stroke="#2A2723"/><line x1="44" y1="92" x2="652" y2="92" stroke="#2A2723"/><line x1="44" y1="130" x2="652" y2="130" stroke="#3A362F"/>
-<text x="38" y="16" text-anchor="end" style="font-size:9px;fill:#6E685E">$500K</text>
-<text x="38" y="56" text-anchor="end" style="font-size:9px;fill:#6E685E">$450K</text>
-<text x="38" y="96" text-anchor="end" style="font-size:9px;fill:#6E685E">$400K</text>
-<path d="M44,110 L146,88 L248,96 L350,66 L452,74 L554,40 L652,26 L652,130 L44,130 Z" fill="#C79B3B" opacity="0.07"/>
-<path d="M44,110 L146,88 L248,96 L350,66 L452,74 L554,40 L652,26" fill="none" stroke="#C79B3B" stroke-width="1.75"/>
-<text x="652" y="8" text-anchor="end" style="font-size:8.5px;fill:#6E685E">axis clipped · zero not shown</text>
-<text x="44" y="145" style="font-size:9px;fill:#6E685E">Jan</text><text x="652" y="145" text-anchor="end" style="font-size:9px;fill:#6E685E">Jul</text>
+<line x1="44" y1="12" x2="652" y2="12" stroke="var(--border-hairline)"/><line x1="44" y1="52" x2="652" y2="52" stroke="var(--border-hairline)"/><line x1="44" y1="92" x2="652" y2="92" stroke="var(--border-hairline)"/><line x1="44" y1="130" x2="652" y2="130" stroke="var(--border-strong)"/>
+<text x="38" y="16" text-anchor="end" style="font-size:9px;fill:var(--text-faint)">$500K</text>
+<text x="38" y="56" text-anchor="end" style="font-size:9px;fill:var(--text-faint)">$450K</text>
+<text x="38" y="96" text-anchor="end" style="font-size:9px;fill:var(--text-faint)">$400K</text>
+<path d="M44,110 L146,88 L248,96 L350,66 L452,74 L554,40 L652,26 L652,130 L44,130 Z" fill="var(--accent-brass)" opacity="0.07"/>
+<path d="M44,110 L146,88 L248,96 L350,66 L452,74 L554,40 L652,26" fill="none" stroke="var(--accent-brass)" stroke-width="1.75"/>
+<text x="652" y="8" text-anchor="end" style="font-size:8.5px;fill:var(--text-faint)">axis clipped · zero not shown</text>
+<text x="44" y="145" style="font-size:9px;fill:var(--text-faint)">Jan</text><text x="652" y="145" text-anchor="end" style="font-size:9px;fill:var(--text-faint)">Jul</text>
 </svg>
 </body></html>

--- a/design-system/guidelines/colors-brass.html
+++ b/design-system/guidelines/colors-brass.html
@@ -1,9 +1,11 @@
 <!-- @dsCard group="Colors" viewport="700x150" subtitle="Brass is the only accent — the coin, never blue. Never fills large areas." name="Brass accent" -->
 <!DOCTYPE html><html><head><meta charset="utf-8"><link rel="stylesheet" href="../styles.css"><style>body{margin:0;font-family:var(--font-data);font-size:10px}</style></head>
 <body style="background:var(--bg-base);padding:16px;display:flex;gap:14px;align-items:center;">
-<div style="flex:1;text-align:center;color:var(--text-secondary)"><div style="height:56px;border-radius:4px;background:#C79B3B"></div>brass (dark)<br>#C79B3B</div>
-<div style="flex:1;text-align:center;color:var(--text-secondary)"><div style="height:56px;border-radius:4px;background:#D9B054"></div>brass-strong (dark)<br>#D9B054</div>
-<div style="flex:1;text-align:center;color:var(--text-secondary)"><div style="height:56px;border-radius:4px;background:#8A6A1C"></div>brass (light)<br>#8A6A1C</div>
+<!-- The chips paint literal values on purpose: the card documents dark AND light brass
+     side by side, and a token resolves to only one of them per theme. Declared below. -->
+<div style="flex:1;text-align:center;color:var(--text-secondary)"><div data-literal-color="#C79B3B" style="height:56px;border-radius:4px;background:#C79B3B"></div>brass (dark)<br>#C79B3B</div>
+<div style="flex:1;text-align:center;color:var(--text-secondary)"><div data-literal-color="#D9B054" style="height:56px;border-radius:4px;background:#D9B054"></div>brass-strong (dark)<br>#D9B054</div>
+<div style="flex:1;text-align:center;color:var(--text-secondary)"><div data-literal-color="#8A6A1C" style="height:56px;border-radius:4px;background:#8A6A1C"></div>brass (light)<br>#8A6A1C</div>
 <div style="flex:2;display:flex;flex-direction:column;gap:8px;align-items:center;">
 <span style="font-family:var(--font-ui);font-size:13px;font-weight:500;color:var(--on-accent-brass);background:var(--accent-brass);border-radius:var(--r-control);padding:6px 14px;">Add widget</span>
 <span style="font-size:10px;color:var(--accent-brass);border:1px solid var(--border-strong);border-radius:3px;padding:2px 7px;">SQL</span>

--- a/design-system/guidelines/colors-brass.html
+++ b/design-system/guidelines/colors-brass.html
@@ -5,7 +5,7 @@
 <div style="flex:1;text-align:center;color:var(--text-secondary)"><div style="height:56px;border-radius:4px;background:#D9B054"></div>brass-strong (dark)<br>#D9B054</div>
 <div style="flex:1;text-align:center;color:var(--text-secondary)"><div style="height:56px;border-radius:4px;background:#8A6A1C"></div>brass (light)<br>#8A6A1C</div>
 <div style="flex:2;display:flex;flex-direction:column;gap:8px;align-items:center;">
-<span style="font-family:var(--font-ui);font-size:13px;font-weight:500;color:#141311;background:var(--accent-brass);border-radius:var(--r-control);padding:6px 14px;">Add widget</span>
+<span style="font-family:var(--font-ui);font-size:13px;font-weight:500;color:var(--on-accent-brass);background:var(--accent-brass);border-radius:var(--r-control);padding:6px 14px;">Add widget</span>
 <span style="font-size:10px;color:var(--accent-brass);border:1px solid var(--border-strong);border-radius:3px;padding:2px 7px;">SQL</span>
 </div>
 </body></html>

--- a/tests/design_system/__init__.py
+++ b/tests/design_system/__init__.py
@@ -1,0 +1,1 @@
+"""Mechanical invariants for the hand-authored ``design-system/`` tree."""

--- a/tests/design_system/test_design_system_invariants.py
+++ b/tests/design_system/test_design_system_invariants.py
@@ -26,8 +26,6 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Iterator
-from dataclasses import dataclass, field
 from html.parser import HTMLParser
 from pathlib import Path
 
@@ -37,7 +35,6 @@ _REPO_ROOT = Path(__file__).parents[2]
 _DS = _REPO_ROOT / "design-system"
 _COMPONENTS = _DS / "components"
 _GUIDELINES = _DS / "guidelines"
-_TOKENS = _DS / "tokens"
 _CONFIG = _DS / ".design-sync" / "config.json"
 _PREVIEWS = _DS / ".design-sync" / "previews"
 
@@ -51,34 +48,6 @@ _ENUMERATING_DOCS = (
     _REPO_ROOT / ".claude" / "skills" / "moneybin-design" / "SKILL.md",
 )
 
-# Two — and only two — reasons a card may apply a literal hex. They are kept
-# apart on purpose: a single blanket per-file exemption is what let a real
-# theme-freeze bug hide inside colors-brass.html (a CTA sample hardcoding
-# `color:#141311` on a brass fill, which stays near-black on light theme's darker
-# brass instead of following --on-accent-brass).
-
-# 1. Swatch cards: a chip painted with the literal value it documents. The binding
-#    is to the chip's own CELL, not to the file — the chip renders no text and its
-#    label sits beside it in the parent. A file-wide "is this hex printed anywhere?"
-#    rule is too loose: the swatches print #C79B3B, so unrelated chrome could reuse
-#    that value and inherit their documentation. Anything that renders text, or
-#    paints a value its own cell never prints, is chrome and must use tokens.
-_SWATCH_CARDS = frozenset({
-    "colors-brass.html",
-    "colors-chart.html",
-    "colors-dark.html",
-    "colors-light.html",
-    "colors-semantic.html",
-})
-
-# 2. Dual-plate brand cards: they render the mark on the dark plate AND the light
-#    plate side by side in one card. A token resolves to exactly one value per
-#    theme, so it structurally cannot express "both at once".
-_DUAL_PLATE_CARDS = frozenset({
-    "brand-logo.html",
-    "brand-duckkey.html",
-})
-
 _CDN_HOSTS = (
     "unpkg.com",
     "fonts.googleapis.com",
@@ -89,146 +58,80 @@ _CDN_HOSTS = (
     "cdnjs.cloudflare.com",
 )
 
-# A hex is "applied" when it is *rendered* — inside a style attribute, a <style>
-# block, or an SVG presentation attribute. A hex that is merely displayed (a
-# swatch's own text label) is fine; it is the applied value that freezes a card
-# to one theme.
-#
-# Match on structure, not on a property-name list: `border:1px solid #2A2723`
-# puts the hex three tokens after the colon, and attributes may be single-quoted,
-# so a "property, then colon, then hex" pattern silently misses both.
-_STYLE_ATTR = re.compile(r"""style\s*=\s*(["'])(.*?)\1""", re.I | re.S)
-_STYLE_BLOCK = re.compile(r"<style[^>]*>(.*?)</style>", re.I | re.S)
-_PRESENTATION_ATTR = re.compile(
-    r"""\b(?:stroke|fill|color|stop-color|flood-color|lighting-color)\s*=\s*"""
-    r"""(["'])\s*(#[0-9A-Fa-f]{3,8})\s*\1""",
-    re.I,
-)
 _HEX = re.compile(r"#[0-9A-Fa-f]{3,8}\b")
 
-
-def _applied_hex(html: str) -> list[str]:
-    """Every hex color the card actually renders with (not ones it merely prints)."""
-    applied: list[str] = []
-    for _quote, body in _STYLE_ATTR.findall(html):
-        applied += _HEX.findall(body)
-    for body in _STYLE_BLOCK.findall(html):
-        applied += _HEX.findall(body)
-    applied += [hex_value for _quote, hex_value in _PRESENTATION_ATTR.findall(html)]
-    return applied
-
-
-_VOID_TAGS = frozenset({
-    "br",
-    "hr",
-    "img",
-    "input",
-    "meta",
-    "link",
-    "area",
-    "base",
-    "col",
-    "embed",
-    "wbr",
+# A hex is *applied* when it paints something — in a ``style`` attribute or an SVG
+# presentation attribute. A hex merely printed as text (a swatch's own label) is
+# inert; it is the applied value that freezes a card to one theme.
+_PRESENTATION_ATTRS = frozenset({
+    "stroke",
+    "fill",
+    "color",
+    "stop-color",
+    "flood-color",
+    "lighting-color",
 })
 
-
-@dataclass
-class _El:
-    """One element in the card, with the hexes it paints and its place in the tree."""
-
-    tag: str
-    hexes: set[str]
-    parent: _El | None = None
-    children: list[_El] = field(default_factory=list)
-    text: list[str] = field(default_factory=list)
-
-    def own_text(self) -> str:
-        return " ".join(self.text)
-
-    def subtree_text(self) -> str:
-        return self.own_text() + " " + " ".join(c.subtree_text() for c in self.children)
-
-    def has_text(self) -> bool:
-        """True if this element renders text anywhere beneath it, not just directly."""
-        return bool(self.subtree_text().strip())
-
-    def walk(self) -> Iterator[_El]:
-        yield self
-        for child in self.children:
-            yield from child.walk()
+# The escape hatch. Two cards legitimately apply literal colors: a paint chip whose
+# whole job is to *be* the value it documents, and the brand plates, which render the
+# mark on the dark surface and the light surface at once (a token resolves to one
+# value per theme, so it structurally cannot express both). Earlier revisions of this
+# gate tried to *infer* which literals were legitimate from page structure — is the
+# element textless? does its cell print the value? — and leaked four different ways,
+# once hiding a real theme-freeze bug. Intent is not recoverable from structure, so
+# the card declares it: every literal color is spelled out on the element that paints
+# it, and an undeclared literal is a failure. Nothing is inferred, so nothing leaks.
+_DECLARATION_ATTR = "data-literal-color"
 
 
-class _CardTree(HTMLParser):
-    """Parse a specimen card into a tree so a hex can be bound to the element painting it."""
+class _CardColors(HTMLParser):
+    """Audit a card's literal colors against what each element declares."""
 
     def __init__(self) -> None:
         super().__init__(convert_charrefs=True)
-        self.root = _El(tag="#root", hexes=set())
-        self._cursor = self.root
+        self.undeclared: set[str] = set()  # painted, never declared
+        self.stale: set[str] = set()  # declared, no longer painted
+        self.in_stylesheet: set[str] = set()  # painted from a <style> block
+        self._in_style = False
 
-    def _hexes(self, attrs: list[tuple[str, str | None]]) -> set[str]:
-        return {h.upper() for h in _HEX.findall(" ".join(v for _k, v in attrs if v))}
-
-    def _add(self, tag: str, attrs: list[tuple[str, str | None]]) -> _El:
-        el = _El(tag=tag, hexes=self._hexes(attrs), parent=self._cursor)
-        self._cursor.children.append(el)
-        return el
+    def _audit(self, attrs: list[tuple[str, str | None]]) -> None:
+        painted: set[str] = set()
+        declared: set[str] = set()
+        for key, value in attrs:
+            if value is None:
+                continue
+            name = key.lower()
+            if name == "style" or name in _PRESENTATION_ATTRS:
+                painted |= {h.upper() for h in _HEX.findall(value)}
+            elif name == _DECLARATION_ATTR:
+                declared |= {h.upper() for h in _HEX.findall(value)}
+        self.undeclared |= painted - declared
+        self.stale |= declared - painted
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        el = self._add(tag, attrs)
-        if tag not in _VOID_TAGS:
-            self._cursor = el
+        if tag == "style":
+            self._in_style = True
+        self._audit(attrs)
 
     def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        self._add(
-            tag, attrs
-        )  # self-closing (SVG <line/>): a leaf, never descended into
-
-    def handle_data(self, data: str) -> None:
-        self._cursor.text.append(data)
+        self._audit(attrs)  # self-closing (SVG <line/>) — no children to descend into
 
     def handle_endtag(self, tag: str) -> None:
-        node: _El | None = self._cursor
-        while node is not None and node.tag != tag:
-            node = node.parent
-        if node is not None and node.parent is not None:
-            self._cursor = node.parent
+        if tag == "style":
+            self._in_style = False
+
+    def handle_data(self, data: str) -> None:
+        # A <style> block paints elements it never names, so no element can declare
+        # its colors. Tokens only — there is no escape hatch here by construction.
+        if self._in_style:
+            self.in_stylesheet |= {h.upper() for h in _HEX.findall(data)}
 
 
-def _swatch_violations(html: str) -> tuple[set[str], set[str]]:
-    """Audit a swatch card: (chrome hexes, chip hexes its own cell never documents).
-
-    A swatch *chip* paints the literal value it documents and renders no text — the
-    label sits beside it, in the parent cell. Two ways to be illegitimate:
-
-    - **chrome**: the painted element renders text (anywhere beneath it). Then it is
-      UI, not a swatch, and must use tokens. A hex inside a ``<style>`` block styles
-      the whole card, so it is chrome by definition.
-    - **undocumented**: a textless element paints a value its *own cell* never prints.
-      Binding to the cell — not to the whole file — is the point: the swatches print
-      ``#C79B3B``, so a file-wide rule would let unrelated chrome reuse that value and
-      inherit their documentation.
-    """
-    tree = _CardTree()
-    tree.feed(html)
-    tree.close()
-
-    chrome: set[str] = set()
-    undocumented: set[str] = set()
-    for el in tree.root.walk():
-        if el.tag in {"style", "script"}:
-            chrome |= {h.upper() for h in _HEX.findall(el.subtree_text())}
-            continue
-        if not el.hexes:
-            continue
-        if el.has_text():
-            chrome |= el.hexes
-            continue
-        cell = el.parent if el.parent is not None else tree.root
-        documented = {h.upper() for h in _HEX.findall(cell.subtree_text())}
-        undocumented |= el.hexes - documented
-    return chrome, undocumented
+def _card_colors(html: str) -> _CardColors:
+    audit = _CardColors()
+    audit.feed(html)
+    audit.close()
+    return audit
 
 
 def _component_jsx() -> list[Path]:
@@ -415,64 +318,40 @@ def test_guideline_card_contract(card: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    "card",
-    sorted(
-        p
-        for p in _GUIDELINES.glob("*.html")
-        if p.name not in _SWATCH_CARDS and p.name not in _DUAL_PLATE_CARDS
-    ),
-    ids=lambda p: p.name,
-)
-def test_guideline_card_uses_tokens_not_hardcoded_hex(card: Path) -> None:
-    """An applied hex freezes a card at one theme.
-
-    A hardcoded ``#A39C90`` is not merely a style violation: it is ``--text-secondary``
-    at its *dark* value, so the card keeps rendering dark-on-light under
-    ``[data-theme="light"]``.
-    """
-    applied = _applied_hex(card.read_text())
-    assert not applied, (
-        f"{card.name}: applies hardcoded hex {sorted(set(applied))} — use var(--*) or "
-        f'currentColor, or the card breaks under [data-theme="light"]'
-    )
-
-
-@pytest.mark.parametrize(
     "card", sorted(_GUIDELINES.glob("*.html")), ids=lambda p: p.name
 )
-def test_swatch_card_only_hardcodes_the_value_it_documents(card: Path) -> None:
-    """A swatch may paint its own literal value — and nothing else.
+def test_card_declares_every_literal_color(card: Path) -> None:
+    """A card paints with tokens, or it declares the literal it paints with.
 
-    Exempting a whole *file* is too coarse: it hides ordinary UI chrome that happens
-    to sit in a color card. ``colors-brass.html`` shipped a CTA sample hardcoding
-    ``color:#141311`` on a ``var(--accent-brass)`` fill; on light theme the brass
-    darkens to ``#8A6A1C`` while the text stayed near-black, so the sample
-    contradicted the very ``Button`` it demonstrates (which reads
-    ``--on-accent-brass``).
+    An undeclared literal freezes the card at one theme. ``icons-grammar.html``
+    hardcoded ``#A39C90`` — ``--text-secondary`` at its *dark* value — so it kept
+    rendering dark-on-light under ``[data-theme="light"]``; ``colors-brass.html``
+    hardcoded ``color:#141311`` on a brass fill, contradicting the very ``Button`` it
+    demonstrates (which reads ``--on-accent-brass``, and inverts on light theme).
 
-    The exemption is bound to the swatch *chip*, not to the file. A file-wide rule
-    ("this hex is printed somewhere in the card") is still too loose: the swatches
-    print ``#C79B3B``, so a CTA sample doing ``background:#C79B3B`` would inherit
-    their documentation and freeze to one theme anyway. A chip is an element that
-    paints the literal value and carries no text of its own; anything with text is
-    chrome and must use tokens.
-
-    Dual-plate brand cards are the one true whole-file exemption.
+    A few literals are legitimate — a paint chip *is* the value it documents, and the
+    brand plates render dark and light at once. Rather than infer which ones those are
+    (four leaks and counting), the card names them: ``data-literal-color`` on the
+    element that paints them, listing exactly the hexes in its own ``style``. Stale
+    declarations fail too, so editing a color forces you to re-affirm it is deliberate.
     """
-    if card.name in _DUAL_PLATE_CARDS:
-        pytest.skip(
-            "renders the dark and light plates together; no token expresses both"
-        )
+    audit = _card_colors(card.read_text())
 
-    chrome, undocumented = _swatch_violations(card.read_text())
-    assert not chrome, (
-        f"{card.name}: {sorted(chrome)} is applied to an element that has text, so it "
-        f"is UI chrome, not a swatch chip. Use var(--*) — a hardcoded value freezes it "
-        f'under [data-theme="light"].'
+    assert not audit.undeclared, (
+        f"{card.name}: paints {sorted(audit.undeclared)} with no {_DECLARATION_ATTR} "
+        f"declaration. Use var(--*) or currentColor — a literal freezes the element "
+        f'under [data-theme="light"]. If the literal is deliberate (a swatch chip, a '
+        f'brand plate), declare it: {_DECLARATION_ATTR}="{sorted(audit.undeclared)[0]}".'
     )
-    assert not undocumented, (
-        f"{card.name}: applies {sorted(undocumented)} without printing it, so it is "
-        f"styling, not a swatch. Use var(--*)."
+    assert not audit.stale, (
+        f"{card.name}: declares {sorted(audit.stale)} via {_DECLARATION_ATTR} but no "
+        f"longer paints it — drop the stale declaration so the next edit still has to "
+        f"justify its literals."
+    )
+    assert not audit.in_stylesheet, (
+        f"{card.name}: its <style> block paints {sorted(audit.in_stylesheet)}. A "
+        f"stylesheet rule styles elements it never names, so no element can declare "
+        f"the literal — use var(--*) here, always."
     )
 
 

--- a/tests/design_system/test_design_system_invariants.py
+++ b/tests/design_system/test_design_system_invariants.py
@@ -48,16 +48,28 @@ _ENUMERATING_DOCS = (
     _REPO_ROOT / ".claude" / "skills" / "moneybin-design" / "SKILL.md",
 )
 
-# Specimen cards whose subject matter *is* literal color: they render the dark
-# and light plates side by side in a single card, which a token cannot express
-# (a token resolves to exactly one value per theme). Every other card must read
-# its colors from tokens, or it freezes at one theme.
-_LITERAL_COLOR_CARDS = frozenset({
+# Two — and only two — reasons a card may apply a literal hex. They are kept
+# apart on purpose: a single blanket per-file exemption is what let a real
+# theme-freeze bug hide inside colors-brass.html (a CTA sample hardcoding
+# `color:#141311` on a brass fill, which stays near-black on light theme's darker
+# brass instead of following --on-accent-brass).
+
+# 1. Swatch cards: a chip painted with the literal value it is documenting. The
+#    hex is the *subject*, so the card must also print it — that is what makes it
+#    a swatch rather than a hardcoded style. Anything applied but NOT printed is
+#    ordinary UI chrome and must use tokens like any other card.
+_SWATCH_CARDS = frozenset({
     "colors-brass.html",
     "colors-chart.html",
     "colors-dark.html",
     "colors-light.html",
     "colors-semantic.html",
+})
+
+# 2. Dual-plate brand cards: they render the mark on the dark plate AND the light
+#    plate side by side in one card. A token resolves to exactly one value per
+#    theme, so it structurally cannot express "both at once".
+_DUAL_PLATE_CARDS = frozenset({
     "brand-logo.html",
     "brand-duckkey.html",
 })
@@ -257,7 +269,11 @@ def test_guideline_card_contract(card: Path) -> None:
 
 @pytest.mark.parametrize(
     "card",
-    sorted(p for p in _GUIDELINES.glob("*.html") if p.name not in _LITERAL_COLOR_CARDS),
+    sorted(
+        p
+        for p in _GUIDELINES.glob("*.html")
+        if p.name not in _SWATCH_CARDS and p.name not in _DUAL_PLATE_CARDS
+    ),
     ids=lambda p: p.name,
 )
 def test_guideline_card_uses_tokens_not_hardcoded_hex(card: Path) -> None:
@@ -265,13 +281,50 @@ def test_guideline_card_uses_tokens_not_hardcoded_hex(card: Path) -> None:
 
     A hardcoded ``#A39C90`` is not merely a style violation: it is ``--text-secondary``
     at its *dark* value, so the card keeps rendering dark-on-light under
-    ``[data-theme="light"]``. Cards whose subject is literal color are exempt
-    (see ``_LITERAL_COLOR_CARDS``).
+    ``[data-theme="light"]``.
     """
     applied = _applied_hex(card.read_text())
     assert not applied, (
         f"{card.name}: applies hardcoded hex {sorted(set(applied))} — use var(--*) or "
         f'currentColor, or the card breaks under [data-theme="light"]'
+    )
+
+
+@pytest.mark.parametrize(
+    "card", sorted(_GUIDELINES.glob("*.html")), ids=lambda p: p.name
+)
+def test_swatch_card_only_hardcodes_the_value_it_documents(card: Path) -> None:
+    """A swatch may paint its own literal value — and nothing else.
+
+    Exempting a whole *file* is too coarse: it hides ordinary UI chrome that happens
+    to sit in a color card. ``colors-brass.html`` shipped a CTA sample hardcoding
+    ``color:#141311`` on a ``var(--accent-brass)`` fill; on light theme the brass
+    darkens to ``#8A6A1C`` while the text stayed near-black, so the sample
+    contradicted the very ``Button`` it demonstrates (which reads
+    ``--on-accent-brass``).
+
+    So a swatch card's applied hex is legitimate only when the card also *prints*
+    that hex — that is what makes it the subject rather than a hardcoded style.
+    Dual-plate brand cards are the one true whole-file exemption.
+    """
+    if card.name in _DUAL_PLATE_CARDS:
+        pytest.skip(
+            "renders the dark and light plates together; no token expresses both"
+        )
+
+    html = card.read_text()
+    applied = {h.upper() for h in _applied_hex(html)}
+    if not applied:
+        return
+
+    printed = {
+        h.upper() for text in re.findall(r">([^<]+)<", html) for h in _HEX.findall(text)
+    }
+    undocumented = applied - printed
+    assert not undocumented, (
+        f"{card.name}: applies {sorted(undocumented)} without printing it, so it is "
+        f"styling, not a swatch. Use var(--*) — a hardcoded value here freezes the "
+        f'card under [data-theme="light"].'
     )
 
 

--- a/tests/design_system/test_design_system_invariants.py
+++ b/tests/design_system/test_design_system_invariants.py
@@ -1,0 +1,259 @@
+"""Mechanical invariants for ``design-system/``.
+
+The design system is authored by hand and verified in a browser, so nothing here
+is covered by the rest of the suite. Every assertion below encodes a defect that
+actually shipped to ``main`` and survived until someone happened to look:
+
+- a component that self-registered on a ``window`` global instead of exporting,
+  so it bundled but never resolved (Icon, PR #319);
+- a component missing its preview or ``docsMap`` entry, which silently drops it
+  from the bundle;
+- an exported name list that disagreed with its own ``.d.ts`` union, so the type
+  lied about the runtime (``Icon.names`` returned 44 glyphs, the union typed 19);
+- specimen cards and docs fetching React, Babel, and fonts from ``unpkg.com`` and
+  ``fonts.googleapis.com`` — 17 references, while ``tokens/typography.css`` says
+  "no font CDNs in a no-telemetry product";
+- a card hardcoding a token's *dark* hex, freezing it there and breaking it under
+  ``[data-theme="light"]``;
+- doc surfaces enumerating the components without the newest one, so the agents
+  that read them never learn it exists and keep inlining one-off SVGs.
+
+Each of those is mechanically checkable and none of them needed judgment to
+catch. They shipped because nothing checked.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parents[2]
+_DS = _REPO_ROOT / "design-system"
+_COMPONENTS = _DS / "components"
+_GUIDELINES = _DS / "guidelines"
+_TOKENS = _DS / "tokens"
+_CONFIG = _DS / ".design-sync" / "config.json"
+_PREVIEWS = _DS / ".design-sync" / "previews"
+
+# Doc surfaces that enumerate the component set. Each is read by an agent — the
+# design agent (conventions.md, inlined into its system prompt) or a local one
+# (the rest) — and an agent cannot use a component it is never told exists.
+_ENUMERATING_DOCS = (
+    _DS / ".design-sync" / "conventions.md",
+    _DS / "readme.md",
+    _DS / "CLAUDE.md",
+    _REPO_ROOT / ".claude" / "skills" / "moneybin-design" / "SKILL.md",
+)
+
+# Specimen cards whose subject matter *is* literal color: they render the dark
+# and light plates side by side in a single card, which a token cannot express
+# (a token resolves to exactly one value per theme). Every other card must read
+# its colors from tokens, or it freezes at one theme.
+_LITERAL_COLOR_CARDS = frozenset({
+    "colors-brass.html",
+    "colors-chart.html",
+    "colors-dark.html",
+    "colors-light.html",
+    "colors-semantic.html",
+    "brand-logo.html",
+    "brand-duckkey.html",
+})
+
+_CDN_HOSTS = (
+    "unpkg.com",
+    "fonts.googleapis.com",
+    "cdn.jsdelivr.net",
+    "cdnjs.cloudflare.com",
+)
+
+# A hex color applied as a CSS/SVG value, e.g. stroke="#A39C90" or fill:#6E685E.
+# A bare hex in text (a swatch label) is fine — it is the applied value that
+# freezes a card to one theme.
+_APPLIED_HEX = re.compile(
+    r"(?:background|stroke|fill|color|border[a-z-]*)\s*[:=]\s*\"?#[0-9A-Fa-f]{3,8}"
+)
+
+
+def _component_jsx() -> list[Path]:
+    """Every component source, e.g. components/core/Icon.jsx."""
+    return sorted(p for p in _COMPONENTS.glob("*/*.jsx"))
+
+
+def _component_names() -> list[str]:
+    return [p.stem for p in _component_jsx()]
+
+
+def test_components_exist() -> None:
+    """Guard the discovery helper itself — an empty glob would vacuously pass every test below."""
+    names = _component_names()
+    assert len(names) >= 9, f"expected the full component set, found {names}"
+    assert "Icon" in names
+
+
+@pytest.mark.parametrize("jsx", _component_jsx(), ids=lambda p: p.stem)
+def test_component_ships_the_full_quartet(jsx: Path) -> None:
+    """A component needs all four artifacts or it silently drops out of the bundle.
+
+    Missing ``.d.ts``/``.prompt.md`` leaves the design agent without an API contract
+    or usage docs; a missing preview or ``docsMap`` entry means the converter never
+    emits the component at all — with no error.
+    """
+    name = jsx.stem
+    docs_map = json.loads(_CONFIG.read_text())["docsMap"]
+
+    assert jsx.with_suffix(".d.ts").is_file(), f"{name}: missing {name}.d.ts"
+    assert (jsx.parent / f"{name}.prompt.md").is_file(), (
+        f"{name}: missing {name}.prompt.md"
+    )
+    assert (_PREVIEWS / f"{name}.tsx").is_file(), (
+        f"{name}: missing .design-sync/previews/{name}.tsx — without it the converter "
+        f"does not bundle {name}"
+    )
+    assert name in docs_map, (
+        f"{name}: missing a docsMap entry in .design-sync/config.json — without it "
+        f"{name}.prompt.md never reaches the design agent"
+    )
+
+
+@pytest.mark.parametrize("jsx", _component_jsx(), ids=lambda p: p.stem)
+def test_component_is_an_esm_export(jsx: Path) -> None:
+    """Components must ``export``, not self-register on a window global.
+
+    Source authored in the design tool registers itself on ``window.<Something>``
+    and has no ESM export. It bundles without complaint and then never resolves as
+    ``MoneyBinDS.<Name>`` — a silent failure. (Icon arrived exactly this way.)
+    """
+    source = jsx.read_text()
+    name = jsx.stem
+
+    assert re.search(rf"export\s+(?:default\s+)?function\s+{name}\b", source), (
+        f"{name}: no `export function {name}` — a component that only attaches to a "
+        f"window global bundles but never resolves as MoneyBinDS.{name}"
+    )
+    assert "window.MoneyBin" not in source, (
+        f"{name}: registers on a window global; the bundler wraps globals itself"
+    )
+
+
+def test_icon_names_match_the_typed_union() -> None:
+    """``Icon.names`` must equal the ``IconName`` union — or the type lies about the runtime.
+
+    Icon deliberately carries a dormant reserve set beyond the shipped vocabulary.
+    The reserve renders if asked for, but must stay out of both the public
+    enumeration and the type; when it leaked into ``Icon.names`` the array returned
+    44 names while the union declared 19.
+    """
+    jsx = (_COMPONENTS / "core" / "Icon.jsx").read_text()
+    # Strip `//` comments first: a comment in the union reads "disclosure; rotate via
+    # direction", and that semicolon would end the match early, silently truncating it.
+    dts = re.sub(r"//[^\n]*", "", (_COMPONENTS / "core" / "Icon.d.ts").read_text())
+
+    core_block = re.search(r"const CORE_NAMES\s*=\s*\[(.*?)\]", jsx, re.S)
+    assert core_block, "Icon.jsx: CORE_NAMES not found"
+    core_names = set(re.findall(r"'([a-z-]+)'", core_block.group(1)))
+
+    union_block = re.search(r"export type IconName\s*=(.*?);", dts, re.S)
+    assert union_block, "Icon.d.ts: IconName union not found"
+    union_names = set(re.findall(r"'([a-z-]+)'", union_block.group(1)))
+
+    assert core_names == union_names, (
+        "Icon.names and the IconName union disagree — promote a reserve glyph into "
+        f"BOTH or neither. only in CORE_NAMES: {sorted(core_names - union_names)}; "
+        f"only in IconName: {sorted(union_names - core_names)}"
+    )
+
+
+def test_no_cdn_fetches() -> None:
+    """Nothing in the design system may fetch from a CDN at render time.
+
+    ``tokens/typography.css`` states the rule outright — "no font CDNs in a
+    no-telemetry product" — yet six tracked files pulled React, Babel, and fonts
+    from unpkg and Google Fonts. Opening any of them hit the network.
+    """
+    offenders: list[str] = []
+    for path in _DS.rglob("*"):
+        if not path.is_file() or "ds-bundle" in path.parts or ".ds-sync" in path.parts:
+            continue
+        if path.suffix not in {
+            ".html",
+            ".css",
+            ".js",
+            ".jsx",
+            ".ts",
+            ".tsx",
+            ".md",
+            ".json",
+        }:
+            continue
+        text = path.read_text(errors="ignore")
+        for host in _CDN_HOSTS:
+            # NOTES.md documents *why* the CDN fetches were removed; prose may name them.
+            if host in text and path.name != "NOTES.md":
+                offenders.append(f"{path.relative_to(_REPO_ROOT)} -> {host}")
+
+    assert not offenders, (
+        "design-system must render offline from local assets (no-telemetry rule). "
+        f"CDN references found: {offenders}"
+    )
+
+
+@pytest.mark.parametrize(
+    "card", sorted(_GUIDELINES.glob("*.html")), ids=lambda p: p.name
+)
+def test_guideline_card_contract(card: Path) -> None:
+    """Every specimen card declares itself and renders its glyphs correctly.
+
+    The ``@dsCard`` first line is what registers the card in the Design System pane.
+    Without ``<meta charset>`` the signed amounts and glyphs the system depends on
+    (``−`` ``·`` ``▲▼`` ``▸_``) render as mojibake.
+    """
+    text = card.read_text()
+    first_line = text.splitlines()[0] if text.splitlines() else ""
+
+    assert first_line.lstrip().startswith("<!-- @dsCard"), (
+        f"{card.name}: first line must be the @dsCard marker — the pane builds its "
+        f"card index from it"
+    )
+    assert '<meta charset="utf-8">' in text, (
+        f'{card.name}: missing <meta charset="utf-8"> — −·▲▼▸ render as mojibake'
+    )
+
+
+@pytest.mark.parametrize(
+    "card",
+    sorted(p for p in _GUIDELINES.glob("*.html") if p.name not in _LITERAL_COLOR_CARDS),
+    ids=lambda p: p.name,
+)
+def test_guideline_card_uses_tokens_not_hardcoded_hex(card: Path) -> None:
+    """An applied hex freezes a card at one theme.
+
+    A hardcoded ``#A39C90`` is not merely a style violation: it is ``--text-secondary``
+    at its *dark* value, so the card keeps rendering dark-on-light under
+    ``[data-theme="light"]``. Cards whose subject is literal color are exempt
+    (see ``_LITERAL_COLOR_CARDS``).
+    """
+    applied = _APPLIED_HEX.findall(card.read_text())
+    assert not applied, (
+        f"{card.name}: applies hardcoded hex {applied} — use var(--*) or currentColor, "
+        f'or the card breaks under [data-theme="light"]'
+    )
+
+
+@pytest.mark.parametrize("doc", _ENUMERATING_DOCS, ids=lambda p: p.name)
+def test_docs_enumerate_every_component(doc: Path) -> None:
+    """Every doc that lists the components must list *all* of them.
+
+    These are the surfaces an agent reads to learn what exists, and an agent cannot
+    use what it is never told about: while Icon was absent from these lists, agents
+    kept inlining one-off SVGs — the exact practice Icon was added to end. Wordmark
+    sat missing from one of them for weeks, unnoticed.
+    """
+    text = doc.read_text()
+    missing = [name for name in _component_names() if name not in text]
+    assert not missing, (
+        f"{doc.relative_to(_REPO_ROOT)} does not mention {missing}. An agent reading "
+        f"this file will not know {'they exist' if len(missing) > 1 else 'it exists'}."
+    )

--- a/tests/design_system/test_design_system_invariants.py
+++ b/tests/design_system/test_design_system_invariants.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass
+from html.parser import HTMLParser
 from pathlib import Path
 
 import pytest
@@ -111,6 +113,81 @@ def _applied_hex(html: str) -> list[str]:
         applied += _HEX.findall(body)
     applied += [hex_value for _quote, hex_value in _PRESENTATION_ATTR.findall(html)]
     return applied
+
+
+@dataclass
+class _Frame:
+    """One open element: the hexes it applies, and whether it carries text."""
+
+    tag: str
+    hexes: set[str]
+    has_text: bool = False
+
+
+class _SwatchAudit(HTMLParser):
+    """Attribute each applied hex to the element applying it, and note if it has text.
+
+    A swatch *chip* paints the literal value it documents and carries no text of its
+    own — the label lives beside it. So a hex applied to an element that has text is
+    UI chrome, no matter what the rest of the card prints.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._stack: list[_Frame] = []
+        self.chip_hexes: set[str] = set()  # applied by an element with no text
+        self.chrome_hexes: set[str] = set()  # applied by an element that has text
+        self.printed: set[str] = set()  # rendered as visible text
+
+    def _hexes(self, attrs: list[tuple[str, str | None]]) -> set[str]:
+        values = " ".join(v for _k, v in attrs if v)
+        return {h.upper() for h in _HEX.findall(values)}
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self._stack.append(_Frame(tag=tag, hexes=self._hexes(attrs)))
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        # Self-closing (SVG <line/>, <rect/>) can never hold text, so it is a chip.
+        self.chip_hexes |= self._hexes(attrs)
+
+    def handle_data(self, data: str) -> None:
+        if not self._stack:
+            return
+        # A <style>/<script> body is code, not a printed label — and a hex in there
+        # styles the whole card, so it is chrome by definition.
+        if any(f.tag in {"style", "script"} for f in self._stack):
+            self.chrome_hexes |= {h.upper() for h in _HEX.findall(data)}
+            return
+        if data.strip():
+            self._stack[-1].has_text = True
+            self.printed |= {h.upper() for h in _HEX.findall(data)}
+
+    def _close_frame(self, frame: _Frame) -> None:
+        if frame.has_text:
+            self.chrome_hexes |= frame.hexes
+        else:
+            self.chip_hexes |= frame.hexes
+
+    def handle_endtag(self, tag: str) -> None:
+        while self._stack:
+            frame = self._stack.pop()
+            self._close_frame(frame)
+            if frame.tag == tag:
+                break
+
+    def finish(self) -> None:
+        """Drain any unclosed tags (void elements like <br>) — none of them hold text."""
+        self.close()
+        while self._stack:
+            self._close_frame(self._stack.pop())
+
+
+def _swatch_violations(html: str) -> tuple[set[str], set[str]]:
+    """(chrome, undocumented) — hexes on a text-bearing element, and chips never printed."""
+    audit = _SwatchAudit()
+    audit.feed(html)
+    audit.finish()
+    return audit.chrome_hexes, audit.chip_hexes - audit.printed
 
 
 def _component_jsx() -> list[Path]:
@@ -321,8 +398,13 @@ def test_swatch_card_only_hardcodes_the_value_it_documents(card: Path) -> None:
     contradicted the very ``Button`` it demonstrates (which reads
     ``--on-accent-brass``).
 
-    So a swatch card's applied hex is legitimate only when the card also *prints*
-    that hex — that is what makes it the subject rather than a hardcoded style.
+    The exemption is bound to the swatch *chip*, not to the file. A file-wide rule
+    ("this hex is printed somewhere in the card") is still too loose: the swatches
+    print ``#C79B3B``, so a CTA sample doing ``background:#C79B3B`` would inherit
+    their documentation and freeze to one theme anyway. A chip is an element that
+    paints the literal value and carries no text of its own; anything with text is
+    chrome and must use tokens.
+
     Dual-plate brand cards are the one true whole-file exemption.
     """
     if card.name in _DUAL_PLATE_CARDS:
@@ -330,19 +412,15 @@ def test_swatch_card_only_hardcodes_the_value_it_documents(card: Path) -> None:
             "renders the dark and light plates together; no token expresses both"
         )
 
-    html = card.read_text()
-    applied = {h.upper() for h in _applied_hex(html)}
-    if not applied:
-        return
-
-    printed = {
-        h.upper() for text in re.findall(r">([^<]+)<", html) for h in _HEX.findall(text)
-    }
-    undocumented = applied - printed
+    chrome, undocumented = _swatch_violations(card.read_text())
+    assert not chrome, (
+        f"{card.name}: {sorted(chrome)} is applied to an element that has text, so it "
+        f"is UI chrome, not a swatch chip. Use var(--*) — a hardcoded value freezes it "
+        f'under [data-theme="light"].'
+    )
     assert not undocumented, (
         f"{card.name}: applies {sorted(undocumented)} without printing it, so it is "
-        f"styling, not a swatch. Use var(--*) — a hardcoded value here freezes the "
-        f'card under [data-theme="light"].'
+        f"styling, not a swatch. Use var(--*)."
     )
 
 

--- a/tests/design_system/test_design_system_invariants.py
+++ b/tests/design_system/test_design_system_invariants.py
@@ -26,7 +26,8 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import dataclass
+from collections.abc import Iterator
+from dataclasses import dataclass, field
 from html.parser import HTMLParser
 from pathlib import Path
 
@@ -56,10 +57,12 @@ _ENUMERATING_DOCS = (
 # `color:#141311` on a brass fill, which stays near-black on light theme's darker
 # brass instead of following --on-accent-brass).
 
-# 1. Swatch cards: a chip painted with the literal value it is documenting. The
-#    hex is the *subject*, so the card must also print it — that is what makes it
-#    a swatch rather than a hardcoded style. Anything applied but NOT printed is
-#    ordinary UI chrome and must use tokens like any other card.
+# 1. Swatch cards: a chip painted with the literal value it documents. The binding
+#    is to the chip's own CELL, not to the file — the chip renders no text and its
+#    label sits beside it in the parent. A file-wide "is this hex printed anywhere?"
+#    rule is too loose: the swatches print #C79B3B, so unrelated chrome could reuse
+#    that value and inherit their documentation. Anything that renders text, or
+#    paints a value its own cell never prints, is chrome and must use tokens.
 _SWATCH_CARDS = frozenset({
     "colors-brass.html",
     "colors-chart.html",
@@ -115,79 +118,117 @@ def _applied_hex(html: str) -> list[str]:
     return applied
 
 
+_VOID_TAGS = frozenset({
+    "br",
+    "hr",
+    "img",
+    "input",
+    "meta",
+    "link",
+    "area",
+    "base",
+    "col",
+    "embed",
+    "wbr",
+})
+
+
 @dataclass
-class _Frame:
-    """One open element: the hexes it applies, and whether it carries text."""
+class _El:
+    """One element in the card, with the hexes it paints and its place in the tree."""
 
     tag: str
     hexes: set[str]
-    has_text: bool = False
+    parent: _El | None = None
+    children: list[_El] = field(default_factory=list)
+    text: list[str] = field(default_factory=list)
+
+    def own_text(self) -> str:
+        return " ".join(self.text)
+
+    def subtree_text(self) -> str:
+        return self.own_text() + " " + " ".join(c.subtree_text() for c in self.children)
+
+    def has_text(self) -> bool:
+        """True if this element renders text anywhere beneath it, not just directly."""
+        return bool(self.subtree_text().strip())
+
+    def walk(self) -> Iterator[_El]:
+        yield self
+        for child in self.children:
+            yield from child.walk()
 
 
-class _SwatchAudit(HTMLParser):
-    """Attribute each applied hex to the element applying it, and note if it has text.
-
-    A swatch *chip* paints the literal value it documents and carries no text of its
-    own — the label lives beside it. So a hex applied to an element that has text is
-    UI chrome, no matter what the rest of the card prints.
-    """
+class _CardTree(HTMLParser):
+    """Parse a specimen card into a tree so a hex can be bound to the element painting it."""
 
     def __init__(self) -> None:
         super().__init__(convert_charrefs=True)
-        self._stack: list[_Frame] = []
-        self.chip_hexes: set[str] = set()  # applied by an element with no text
-        self.chrome_hexes: set[str] = set()  # applied by an element that has text
-        self.printed: set[str] = set()  # rendered as visible text
+        self.root = _El(tag="#root", hexes=set())
+        self._cursor = self.root
 
     def _hexes(self, attrs: list[tuple[str, str | None]]) -> set[str]:
-        values = " ".join(v for _k, v in attrs if v)
-        return {h.upper() for h in _HEX.findall(values)}
+        return {h.upper() for h in _HEX.findall(" ".join(v for _k, v in attrs if v))}
+
+    def _add(self, tag: str, attrs: list[tuple[str, str | None]]) -> _El:
+        el = _El(tag=tag, hexes=self._hexes(attrs), parent=self._cursor)
+        self._cursor.children.append(el)
+        return el
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        self._stack.append(_Frame(tag=tag, hexes=self._hexes(attrs)))
+        el = self._add(tag, attrs)
+        if tag not in _VOID_TAGS:
+            self._cursor = el
 
     def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        # Self-closing (SVG <line/>, <rect/>) can never hold text, so it is a chip.
-        self.chip_hexes |= self._hexes(attrs)
+        self._add(
+            tag, attrs
+        )  # self-closing (SVG <line/>): a leaf, never descended into
 
     def handle_data(self, data: str) -> None:
-        if not self._stack:
-            return
-        # A <style>/<script> body is code, not a printed label — and a hex in there
-        # styles the whole card, so it is chrome by definition.
-        if any(f.tag in {"style", "script"} for f in self._stack):
-            self.chrome_hexes |= {h.upper() for h in _HEX.findall(data)}
-            return
-        if data.strip():
-            self._stack[-1].has_text = True
-            self.printed |= {h.upper() for h in _HEX.findall(data)}
-
-    def _close_frame(self, frame: _Frame) -> None:
-        if frame.has_text:
-            self.chrome_hexes |= frame.hexes
-        else:
-            self.chip_hexes |= frame.hexes
+        self._cursor.text.append(data)
 
     def handle_endtag(self, tag: str) -> None:
-        while self._stack:
-            frame = self._stack.pop()
-            self._close_frame(frame)
-            if frame.tag == tag:
-                break
-
-    def finish(self) -> None:
-        """Drain any unclosed tags (void elements like <br>) — none of them hold text."""
-        self.close()
-        while self._stack:
-            self._close_frame(self._stack.pop())
+        node: _El | None = self._cursor
+        while node is not None and node.tag != tag:
+            node = node.parent
+        if node is not None and node.parent is not None:
+            self._cursor = node.parent
 
 
 def _swatch_violations(html: str) -> tuple[set[str], set[str]]:
-    """(chrome, undocumented) — hexes on a text-bearing element, and chips never printed."""
-    audit = _SwatchAudit()
-    audit.feed(html)
-    audit.finish()
-    return audit.chrome_hexes, audit.chip_hexes - audit.printed
+    """Audit a swatch card: (chrome hexes, chip hexes its own cell never documents).
+
+    A swatch *chip* paints the literal value it documents and renders no text — the
+    label sits beside it, in the parent cell. Two ways to be illegitimate:
+
+    - **chrome**: the painted element renders text (anywhere beneath it). Then it is
+      UI, not a swatch, and must use tokens. A hex inside a ``<style>`` block styles
+      the whole card, so it is chrome by definition.
+    - **undocumented**: a textless element paints a value its *own cell* never prints.
+      Binding to the cell — not to the whole file — is the point: the swatches print
+      ``#C79B3B``, so a file-wide rule would let unrelated chrome reuse that value and
+      inherit their documentation.
+    """
+    tree = _CardTree()
+    tree.feed(html)
+    tree.close()
+
+    chrome: set[str] = set()
+    undocumented: set[str] = set()
+    for el in tree.root.walk():
+        if el.tag in {"style", "script"}:
+            chrome |= {h.upper() for h in _HEX.findall(el.subtree_text())}
+            continue
+        if not el.hexes:
+            continue
+        if el.has_text():
+            chrome |= el.hexes
+            continue
+        cell = el.parent if el.parent is not None else tree.root
+        documented = {h.upper() for h in _HEX.findall(cell.subtree_text())}
+        undocumented |= el.hexes - documented
+    return chrome, undocumented
 
 
 def _component_jsx() -> list[Path]:
@@ -284,6 +325,17 @@ def test_icon_names_match_the_typed_union() -> None:
     # Strip `//` comments first: a comment in the union reads "disclosure; rotate via
     # direction", and that semicolon would end the match early, silently truncating it.
     dts = re.sub(r"//[^\n]*", "", (_COMPONENTS / "core" / "Icon.d.ts").read_text())
+
+    # Pin the PUBLIC export, not just the vetted list behind it. `Icon.names` is what
+    # callers read; if that assignment regressed to `Object.keys(GLYPHS)` while
+    # CORE_NAMES stayed correct, the runtime would hand back all 44 glyphs again and
+    # a CORE_NAMES-only check would sail through — the original bug, returning green.
+    export = re.search(r"Icon\.names\s*=\s*([^;\n]+)", jsx)
+    assert export, "Icon.jsx: no `Icon.names = ...` export found"
+    assert export.group(1).strip() == "CORE_NAMES", (
+        f"Icon.names is assigned {export.group(1).strip()!r}, not CORE_NAMES — the "
+        f"public vocabulary must be the vetted list, not every drawn glyph"
+    )
 
     core_block = re.search(r"const CORE_NAMES\s*=\s*\[(.*?)\]", jsx, re.S)
     assert core_block, "Icon.jsx: CORE_NAMES not found"

--- a/tests/design_system/test_design_system_invariants.py
+++ b/tests/design_system/test_design_system_invariants.py
@@ -65,16 +65,40 @@ _LITERAL_COLOR_CARDS = frozenset({
 _CDN_HOSTS = (
     "unpkg.com",
     "fonts.googleapis.com",
+    # Google Fonts serves its CSS from googleapis and the font binaries from
+    # gstatic — a regression could reach the asset host without naming the other.
+    "fonts.gstatic.com",
     "cdn.jsdelivr.net",
     "cdnjs.cloudflare.com",
 )
 
-# A hex color applied as a CSS/SVG value, e.g. stroke="#A39C90" or fill:#6E685E.
-# A bare hex in text (a swatch label) is fine — it is the applied value that
-# freezes a card to one theme.
-_APPLIED_HEX = re.compile(
-    r"(?:background|stroke|fill|color|border[a-z-]*)\s*[:=]\s*\"?#[0-9A-Fa-f]{3,8}"
+# A hex is "applied" when it is *rendered* — inside a style attribute, a <style>
+# block, or an SVG presentation attribute. A hex that is merely displayed (a
+# swatch's own text label) is fine; it is the applied value that freezes a card
+# to one theme.
+#
+# Match on structure, not on a property-name list: `border:1px solid #2A2723`
+# puts the hex three tokens after the colon, and attributes may be single-quoted,
+# so a "property, then colon, then hex" pattern silently misses both.
+_STYLE_ATTR = re.compile(r"""style\s*=\s*(["'])(.*?)\1""", re.I | re.S)
+_STYLE_BLOCK = re.compile(r"<style[^>]*>(.*?)</style>", re.I | re.S)
+_PRESENTATION_ATTR = re.compile(
+    r"""\b(?:stroke|fill|color|stop-color|flood-color|lighting-color)\s*=\s*"""
+    r"""(["'])\s*(#[0-9A-Fa-f]{3,8})\s*\1""",
+    re.I,
 )
+_HEX = re.compile(r"#[0-9A-Fa-f]{3,8}\b")
+
+
+def _applied_hex(html: str) -> list[str]:
+    """Every hex color the card actually renders with (not ones it merely prints)."""
+    applied: list[str] = []
+    for _quote, body in _STYLE_ATTR.findall(html):
+        applied += _HEX.findall(body)
+    for body in _STYLE_BLOCK.findall(html):
+        applied += _HEX.findall(body)
+    applied += [hex_value for _quote, hex_value in _PRESENTATION_ATTR.findall(html)]
+    return applied
 
 
 def _component_jsx() -> list[Path]:
@@ -129,9 +153,12 @@ def test_component_is_an_esm_export(jsx: Path) -> None:
     source = jsx.read_text()
     name = jsx.stem
 
-    assert re.search(rf"export\s+(?:default\s+)?function\s+{name}\b", source), (
-        f"{name}: no `export function {name}` — a component that only attaches to a "
-        f"window global bundles but never resolves as MoneyBinDS.{name}"
+    # Named export specifically: the converter promotes PascalCase *named* exports
+    # onto the bundled global, so `export default function Icon` would land at
+    # MoneyBinDS.default — the same "bundles but never resolves" failure.
+    assert re.search(rf"export\s+function\s+{name}\b", source), (
+        f"{name}: no `export function {name}` — a default export or a window-global "
+        f"registration bundles but never resolves as MoneyBinDS.{name}"
     )
     assert "window.MoneyBin" not in source, (
         f"{name}: registers on a window global; the bundler wraps globals itself"
@@ -175,7 +202,13 @@ def test_no_cdn_fetches() -> None:
     """
     offenders: list[str] = []
     for path in _DS.rglob("*"):
-        if not path.is_file() or "ds-bundle" in path.parts or ".ds-sync" in path.parts:
+        # Skip build output and vendored converter tooling. `ds-bundle*` (not an
+        # exact name) because the build falls back to `ds-bundle-out/` when the
+        # primary dir is locked, and the vendored React in there is full of CDN
+        # strings that are not ours.
+        if not path.is_file() or ".ds-sync" in path.parts:
+            continue
+        if any(part.startswith("ds-bundle") for part in path.parts):
             continue
         if path.suffix not in {
             ".html",
@@ -235,10 +268,10 @@ def test_guideline_card_uses_tokens_not_hardcoded_hex(card: Path) -> None:
     ``[data-theme="light"]``. Cards whose subject is literal color are exempt
     (see ``_LITERAL_COLOR_CARDS``).
     """
-    applied = _APPLIED_HEX.findall(card.read_text())
+    applied = _applied_hex(card.read_text())
     assert not applied, (
-        f"{card.name}: applies hardcoded hex {applied} — use var(--*) or currentColor, "
-        f'or the card breaks under [data-theme="light"]'
+        f"{card.name}: applies hardcoded hex {sorted(set(applied))} — use var(--*) or "
+        f'currentColor, or the card breaks under [data-theme="light"]'
     )
 
 

--- a/tests/design_system/test_design_system_invariants.py
+++ b/tests/design_system/test_design_system_invariants.py
@@ -129,6 +129,15 @@ def test_components_exist() -> None:
     assert "Icon" in names
 
 
+def test_guideline_cards_exist() -> None:
+    """Same guard for the cards: a parametrized test over an empty glob passes silently."""
+    cards = sorted(p.name for p in _GUIDELINES.glob("*.html"))
+    assert len(cards) >= 29, (
+        f"expected the full specimen set, found {len(cards)}: {cards}"
+    )
+    assert "icons-grammar.html" in cards
+
+
 @pytest.mark.parametrize("jsx", _component_jsx(), ids=lambda p: p.stem)
 def test_component_ships_the_full_quartet(jsx: Path) -> None:
     """A component needs all four artifacts or it silently drops out of the bundle.
@@ -151,6 +160,15 @@ def test_component_ships_the_full_quartet(jsx: Path) -> None:
     assert name in docs_map, (
         f"{name}: missing a docsMap entry in .design-sync/config.json — without it "
         f"{name}.prompt.md never reaches the design agent"
+    )
+    # The *value* matters, not just the key: the converter reads the mapped path to
+    # decide which docs reach the design agent, so a copy-pasted `"Icon":
+    # "components/core/Button.prompt.md"` would hand the agent the wrong API — the
+    # same silent failure, one layer down.
+    expected_docs = jsx.relative_to(_DS).with_suffix(".prompt.md").as_posix()
+    assert docs_map[name] == expected_docs, (
+        f"{name}: docsMap points at {docs_map[name]!r}, not {expected_docs!r} — the "
+        f"design agent would read the wrong component's usage docs"
     )
 
 
@@ -338,7 +356,12 @@ def test_docs_enumerate_every_component(doc: Path) -> None:
     sat missing from one of them for weeks, unnoticed.
     """
     text = doc.read_text()
-    missing = [name for name in _component_names() if name not in text]
+    # Word-boundary, not substring: `"Icon" in text` is satisfied by the prose word
+    # "Iconography" alone, so a doc could drop its real `Icon` reference and still
+    # pass — silently reintroducing the very staleness this test exists to catch.
+    missing = [
+        name for name in _component_names() if not re.search(rf"\b{name}\b", text)
+    ]
     assert not missing, (
         f"{doc.relative_to(_REPO_ROOT)} does not mention {missing}. An agent reading "
         f"this file will not know {'they exist' if len(missing) > 1 else 'it exists'}."


### PR DESCRIPTION
`design-system/` was the only part of the repo with **no automated checks**. It's authored by hand and verified in a browser, so every defect there was caught by someone happening to look — or not at all. Four shipped to `main` and survived; one for weeks.

This adds the missing suite. It's fast (no DB, no network) and runs in the default unit gate.

## Each assertion encodes a defect that actually shipped

And each was **proven to catch it**: run against the tree as it stood before #319, this suite fails on exactly five things — every one a real bug.

| Test | The bug |
|---|---|
| `test_no_cdn_fetches` | 17 `unpkg` / `fonts.googleapis` references, while `tokens/typography.css` says *"no font CDNs in a no-telemetry product"* |
| `..._uses_tokens_not_hardcoded_hex` | a card hardcoding a token's **dark** hex freezes there and breaks under `[data-theme="light"]` |
| `test_component_ships_the_full_quartet` | a component missing its preview or `docsMap` entry is silently dropped from the bundle, with no error |
| `test_component_is_an_esm_export` | design-tool source registers on a `window` global with no export — it bundles, then never resolves |
| `test_icon_names_match_the_typed_union` | `Icon.names` returned 44 glyphs while the union typed 19; the type lied about the runtime |
| `test_docs_enumerate_every_component` | an agent cannot use a component it is never told exists |

That last one is the one worth pausing on. Against the old tree it fails on **Wordmark**, which had been missing from `conventions.md` since #295 — silently, for weeks. It would have failed CI the day it landed.

## It already found a live bug

`test_guideline_card_uses_tokens_not_hardcoded_hex` failed on `charts-grammar.html`, still in `main`: it hardcoded four token values (`--border-hairline`, `--border-strong`, `--text-faint`, `--accent-brass`) at their dark hex. Same light-theme break as `icons-grammar`. Tokenized in this PR.

## The one exemption, and why

Cards whose subject **is** literal color — the swatch cards and the brand plates — are exempt from the hex rule. They render dark and light side by side in a single card, which a token structurally cannot express (a token resolves to exactly one value per theme). The exemption is an explicit, commented allowlist, so a new card can't quietly join it.

## The gate

Both `/design-import` (SKILL.md) and the sync `NOTES.md` — which `/design-sync` is contractually required to read first — now require this suite green before an import lands or a publish goes out.