### PR TITLE
Scope the pre-commit gate to the layers the diff touches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ Update flow: prototype and spec visually in the claude.ai **Design Kit** project
 - **Linting/formatting**: `make format && make lint` (Ruff, line length 88).
 - **Type checking**: `uv run pyright` on modified files (not mypy).
 - **Tests**: Dev `uv run pytest <path> -v`; pre-commit `make test`. Always `uv run pytest`; wrong interpreter → `uv sync --reinstall`.
-- **Pre-commit checklist**: `make check test` — format, lint, type-check, tests. Run once before committing.
+- **Pre-commit checklist**: `make check test` — format, lint, type-check, tests. Run once before committing. **Scope the gate to what the diff touches, and never to less:** a diff containing no `.py` files runs its own layer's gate instead (e.g. `uv run pytest tests/design_system` for `design-system/`), and relies on CI for the rest — the 5,800-test Python suite returns no signal on a markdown-only change. Any diff touching `src/` or `tests/` runs the full checklist. This selects the covering gate; it is not licence to skip one.
 - **SQL formatting**: `make format-sql` (sets `MAX_FORK_WORKERS=1`; the bare `uv run sqlmesh -p src/moneybin/sqlmesh format` forks a worker pool the encrypted-DB design disallows and the sandbox blocks).
 - **Check library docs first**: Before implementing patterns with SQLMesh, DuckDB, Pydantic, etc., verify the correct API in official docs. Training knowledge may be outdated.
 


### PR DESCRIPTION
## Summary

Surfaced by a session retrospective. Two markdown-only PRs (#336, #338) each ran the full `make check test` — **5,835 Python tests** — over diffs containing **zero `.py` files**. The gate that actually covered those changes was `tests/design_system` (98 tests, seconds). The Python suite returned no signal either time, and one of the two runs was additionally wasted because it was launched before the final edits landed.

The existing wording ("Run once before committing") is unconditional, and the global "never skip process steps" rule correctly discourages judgement calls about it — so the fix is to make the *scoping* explicit rather than leave agents choosing between an unnecessary 8-minute run and an unsanctioned skip.

## Changes

- `AGENTS.md` → Critical Rules → Pre-commit checklist: a diff with no `.py` files runs its own layer's gate (e.g. `uv run pytest tests/design_system`) plus CI; anything touching `src/` or `tests/` runs the full checklist.

The condition is mechanically checkable (`.py` present or not), the substitute is named rather than implied, and the last clause states plainly that this selects the covering gate rather than permitting a skip.

## Test plan

- [x] `uv run pytest tests/design_system` — 98 passed (and, per the rule this PR adds, the correct gate for this diff: no `.py` files touched)
- [ ] Reviewer: confirm the `src/`-or-`tests/` boundary is the right line, and that naming CI as the backstop for non-Python diffs matches how you want the gate to read

## Related

- Follows #336, #338
