### PR TITLE
Add AI-cadence drift notes to the documentation voice rule

### DIFF
--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -72,6 +72,31 @@ two failure modes to avoid are equally bad — marketing cadence (superlatives,
   it. If no, don't hedge it — the hedge costs the reader information and buys
   nothing.
 
+### Recognizing drift — the two AI cadences
+
+Doc-pass drift lands in one of two cadences, and both read as machine-written
+(origin: the PR #323 voice pass and its survey of 27 admired OSS READMEs):
+
+- **Marketing cadence** — superlatives, "not just X but Y", rule-of-three
+  lists, emoji-templated headings, competitor-framed heroes, adjectives asked
+  to carry claims. Polished marketing rhythm now *is* the generated-text
+  smell: the most human-sounding lines in admired OSS docs are a concession,
+  a number, or a blunt fact — none of which a template produces.
+- **Compliance cadence** — hedge-stacking (two qualifiers in one paragraph
+  means there is no claim), the negation-restatement tic, mechanism
+  descriptions that hide the claim ("their corresponding data operations
+  use..."), nominalizations ("client configurations", "completion work
+  remains"), and the reader vanishing from their own sentence ("a compatible
+  assistant" where "you" belongs). Softening a true, checkable sentence
+  deletes information and buys nothing.
+
+The register to hold is austere-and-numerate (the curl/hledger end of the
+spectrum), never jokey or narrative: say the number, show the mechanism,
+state the limitation plainly with its next action. Austerity *is* the
+personality — public docs get no humor budget, because money, errors, and
+security are the whole surface. Confidence lives in the prose; caveats live
+in precise, named boundaries.
+
 ## Diagrams
 
 - **Mermaid over ASCII**: When generating `.md` files that include diagrams, use Mermaid code blocks (` ```mermaid `) instead of ASCII art.


### PR DESCRIPTION
## What

Extends the `.claude/rules/documentation.md` voice section (merged in #323) with a **Recognizing drift** subsection: the two machine-written cadences a docs pass falls into — marketing (superlatives, triads, emoji-templated structure) and compliance (hedge-stacking, negation-restatement, nominalizations, the reader vanishing from the sentence) — plus the register anchor (austere-and-numerate; no humor budget in public docs; confidence in the prose, caveats as named boundaries).

## Why

The merged rule set says what to write. These notes make drift *recognizable*, so a future doc pass (agent or human) can self-check against the failure modes instead of rediscovering them. Distilled from the #323 voice work and its survey of 27 admired OSS READMEs.

## Test plan

Docs-only change to a rules file; no runtime surface. `tests/test_documentation_policy.py` does not scan `.claude/rules/`.