### PR TITLE
Fix security findings: bump pyasn1 to 0.6.4

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2583,11 +2583,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bumps `pyasn1` 0.6.3 → 0.6.4 in `uv.lock` to clear the failing dependency
audit. `pyasn1` is a transitive dependency (via `pyasn1-modules`) with no
direct constraint in `pyproject.toml`, so a targeted lock upgrade is the
minimal fix.

## Findings resolved

- PYSEC-2026-3455
- PYSEC-2026-3456
- PYSEC-2026-3457

All three affect `pyasn1` 0.6.3 and are fixed in the 0.6.4 patch release.
No suppressions added; the audit's existing `--ignore-vuln` list is untouched.

## Verification

- `make audit` → `No known vulnerabilities found, 7 ignored` (was `Found 3 known vulnerabilities` + `Error 1`)
- `uv lock --check` → consistent (exit 0)
- Diff is lockfile-only (pyasn1 version + sdist/wheel hashes; nothing else moved)

CodeQL Analysis had no open alerts.