### PR TITLE
Trim the always-loaded agent-instruction surface

### DIFF
--- a/.claude/references/agent-experience-report-template.md
+++ b/.claude/references/agent-experience-report-template.md
@@ -1,0 +1,51 @@
+# Agent-experience report — structure and workflow
+
+On-demand companion to [`.claude/rules/agent-experience.md`](../rules/agent-experience.md), which carries the trigger and stays
+always-loaded. Read this when you are actually writing a report.
+
+## Required report structure
+
+```
+## Agent experience report
+
+**Blockers / sharp edges** — anything that forced multiple retries, returned
+a cryptic error, or hid the right path forward.
+
+**Data quality / consistency** — schema oddities, type drift, double-encoded
+text, opaque IDs that turn out to be PII, fields that promise more than they
+deliver.
+
+**Defaults** — anything that returned far more or far less than was useful by
+default; cases where the agent couldn't tell that results were truncated or
+how to widen.
+
+**Strengths (worth keeping)** — what worked well on first contact. This is
+not filler: it documents the bar future changes must not regress past.
+
+**What would have made this easier or more intuitive** — concrete suggestions
+from the agent's perspective. Examples: a parameter that should default
+differently, a tool that should accept an alias, a description string that
+should mention the sign convention, an error message that should list valid
+values, an `actions[]` hint that's missing, a workflow that needed three
+tools when it should have needed one. Be specific — name the tool and the
+suggested change.
+
+**The single biggest fix** — one concrete next change that would most
+improve the agent experience.
+```
+
+## Reporting workflow
+
+AX reports are **session-internal** — they go to the developer in the conversation,
+not into public artifacts. Workflow:
+
+1. At the end of any session that touched MoneyBin's MCP server, present the
+   report directly in chat using the structure above.
+2. The developer triages each finding. Approved findings get filed as one-line
+   entries in `private/followups.md`; the rest are dropped.
+3. The PR shipping the underlying change describes the change only — **never
+   paste the AX report (or a link to it) into the PR body, commit message,
+   CHANGELOG, ADR, or any other checked-in artifact**.
+
+The report is raw feedback for prioritizing future work, not a deliverable.
+The developer's filtering is what gives it signal value.

--- a/.claude/references/design-principles-depth.md
+++ b/.claude/references/design-principles-depth.md
@@ -2,8 +2,8 @@
 
 On-demand companion to [`.claude/rules/design-principles.md`](../rules/design-principles.md),
 which stays always-loaded. Read this when you are actually evolving a locked
-public contract, addressing a milestone, or deciding whether a decision earns
-an ADR.
+public contract, addressing a milestone, checking what the principle does NOT
+mean, wanting the worked example, or deciding whether a decision earns an ADR.
 
 ## Evolving a public contract post-launch
 

--- a/.claude/references/design-principles-depth.md
+++ b/.claude/references/design-principles-depth.md
@@ -1,0 +1,110 @@
+# Design Principles — depth
+
+On-demand companion to [`.claude/rules/design-principles.md`](../rules/design-principles.md),
+which stays always-loaded. Read this when you are actually evolving a locked
+public contract, addressing a milestone, or deciding whether a decision earns
+an ADR.
+
+## Evolving a public contract post-launch
+
+Locked contracts still need to change sometimes. By surface:
+
+- **Schemas:** versioned column additions only; never rename or retype
+  in place. Deprecate-then-remove for column removal across two
+  releases.
+- **MCP tools:** add the new tool alongside, mark the old one
+  deprecated in its description, remove after one minor release.
+- **CLI commands:** add the new command, keep the old one as an alias
+  for one minor release with a deprecation warning, remove on the next.
+- **On-disk formats:** include a format version field; readers handle
+  N-1 and N, writers emit N.
+
+Pattern-changing breaks need an ADR; routine breaks get a CHANGELOG
+entry under `Changed` or `Deprecated`.
+
+## Milestone addressing — one scheme, append don't reinvent
+
+All roadmap work is tracked under a single phase-aligned address scheme.
+**Use it; never fork a parallel numbering or sequencing scheme** — we have
+migrated twice already (Level/Wave → flat M-grid → this), and each migration
+was pure churn.
+
+- **`M0`–`M3`** = the four milestones / build phases: **M0 Foundation ·
+  M1 Ingestion Core · M2 Analysis & Reports · M3 Productization &
+  Distribution**. The milestone *is* the test-functionality gate — testing
+  batches at the phase, not per-item.
+- **`M1J`** = an *increment*: a coherent capability ≈ one spec, closes on its
+  own.
+- **`M1J.2`** = a *work item*: a discrete design / PR / plan within an
+  increment.
+
+When planning, brainstorming, or writing a new spec or plan: attach the work
+to an existing increment, or **append the next free letter (new increment) or
+`.n` (new work item)** — then register it in the canonical reference,
+[`docs/roadmap.md`](../../docs/roadmap.md) (public source of truth), mirrored
+in `private/strategy/milestone-taxonomy.md` (full map + rationale). Don't mint
+a new top-level number for a sub-task, and don't add a per-increment gate. If
+the scheme genuinely can't express the work, raise it — don't invent a second
+one.
+
+## What it does NOT mean
+
+- Not gold-plating, perfectionism, or refusing to ship.
+- Not rewriting in another language for elegance. The stack — Python,
+  DuckDB, SQLMesh, Typer, MCP — is fixed; "inevitable" means inevitable
+  *within that stack*.
+- Not blocking on hypothetical future requirements.
+- Not freezing the public surface before launch. Pre-launch is when
+  iteration is cheap; use it.
+
+## Example: applying the protocol
+
+**Decision:** Add a merchant attribute to `core.fct_transactions` —
+`merchant TEXT` on the fact table, or `merchant_id` FK to a new
+`core.dim_merchants`?
+
+**Classification:** One-way door. `core.fct_transactions` is exposed via
+MCP and CLI; consumers will write queries against this shape.
+
+**Option A (durable) — `merchant_id` + `dim_merchants`:** ~3 days. Locks
+the right shape; merchants are a real entity with attributes (aliases,
+category) that will grow.
+
+**Option B (fast) — `merchant TEXT`:** ~½ day. Breaks the moment a
+second merchant attribute is needed — forces dim-table introduction
+later plus migration of every consumer query.
+
+**Recommend A.** Applies the existing dim-table pattern from ADR-001;
+no new ADR. Capture in the merchants spec and PR description.
+
+## Recording the outcome
+
+Most one-way-door decisions do NOT need their own ADR. ADRs are for
+decisions that *establish* a pattern others will inherit from, not
+decisions that *apply* an existing pattern. The ADR bar is deliberately
+high — sprawl devalues the format and trains contributors to skip them.
+
+**Record an ADR only when all three are true:**
+
+1. The decision **establishes or changes a pattern** others will inherit
+   from (not just applies an existing one).
+2. The **"why" isn't recoverable from reading the code** — only the
+   "what" is.
+3. A reasonable future contributor might **propose undoing it** without
+   that context.
+
+If any one fails: capture the decision in the PR description, the
+relevant spec, or an inline comment. Don't create an ADR.
+
+**ADR-worthy** (establishes a pattern others inherit): embedded analytical
+store (ADR-000), medallion data layers (ADR-001), privacy tiers (ADR-002),
+encryption key management (ADR-009).
+
+**Not ADR-worthy** (applies an existing pattern): a new `merchant_id` column
+or dim table (ADR-001), renaming/restructuring a CLI command (CLI taxonomy
+spec), a new MCP tool (MCP architecture spec), a dependency bump (no pattern
+change), a column-type choice like `DECIMAL(18,2)` (accounting-precision
+convention).
+
+When in doubt: don't create the ADR. The principle's job is to make
+durable choices, not to generate paperwork about them.

--- a/.claude/rules/agent-experience.md
+++ b/.claude/rules/agent-experience.md
@@ -41,49 +41,8 @@ a polished essay. Quote the exact tool name, parameter, or returned string
 when calling something out — vague "the spending endpoint was confusing"
 reports aren't actionable.
 
-## Required report structure
+## Structure and workflow
 
-```
-## Agent experience report
-
-**Blockers / sharp edges** — anything that forced multiple retries, returned
-a cryptic error, or hid the right path forward.
-
-**Data quality / consistency** — schema oddities, type drift, double-encoded
-text, opaque IDs that turn out to be PII, fields that promise more than they
-deliver.
-
-**Defaults** — anything that returned far more or far less than was useful by
-default; cases where the agent couldn't tell that results were truncated or
-how to widen.
-
-**Strengths (worth keeping)** — what worked well on first contact. This is
-not filler: it documents the bar future changes must not regress past.
-
-**What would have made this easier or more intuitive** — concrete suggestions
-from the agent's perspective. Examples: a parameter that should default
-differently, a tool that should accept an alias, a description string that
-should mention the sign convention, an error message that should list valid
-values, an `actions[]` hint that's missing, a workflow that needed three
-tools when it should have needed one. Be specific — name the tool and the
-suggested change.
-
-**The single biggest fix** — one concrete next change that would most
-improve the agent experience.
-```
-
-## Reporting workflow
-
-AX reports are **session-internal** — they go to the developer in the conversation,
-not into public artifacts. Workflow:
-
-1. At the end of any session that touched MoneyBin's MCP server, present the
-   report directly in chat using the structure above.
-2. The developer triages each finding. Approved findings get filed as one-line
-   entries in `private/followups.md`; the rest are dropped.
-3. The PR shipping the underlying change describes the change only — **never
-   paste the AX report (or a link to it) into the PR body, commit message,
-   CHANGELOG, ADR, or any other checked-in artifact**.
-
-The report is raw feedback for prioritizing future work, not a deliverable.
-The developer's filtering is what gives it signal value.
+Follow the six-section structure and the session-internal reporting workflow in
+[`.claude/references/agent-experience-report-template.md`](../references/agent-experience-report-template.md).
+Read it before writing the report — do not improvise the sections.

--- a/.claude/rules/branching.md
+++ b/.claude/rules/branching.md
@@ -48,7 +48,16 @@ Add incremental sync for Plaid transactions
 
 ## Skipping the AI reviewer on a single push
 
-`[skip-review]` in a commit message skips the automated review for that push
-only. Narrow use: merge-prep nits on an already-approved, CI-green PR — never
-across a push that alters logic, security posture, or a public contract. Full
-conditions: `CONTRIBUTING.md` → "Skipping the AI reviewer".
+The `AI Code Review` workflow re-runs on **every** push to an open PR
+(`synchronize`) — it does not check approval state. To skip a redundant review
+on the final nit-fix commit of an already-approved PR you're about to merge,
+put `[skip-review]` (or `[skip review]`) in **that commit's** message. The
+workflow reads the tip commit message and skips that push only.
+
+Apply this narrowly — it is for the merge-prep push, not a way to dodge
+review. Only use it when **all** hold: the PR already carries a green
+`✅ APPROVED` review, CI is passing, and the push contains only nits/trivial
+fixups that won't change the approved verdict. Any substantive change must be
+reviewed: push it without the keyword (or re-summon with `@claude`). Never
+carry an approval across a push that alters logic, security posture, or a
+public contract.

--- a/.claude/rules/branching.md
+++ b/.claude/rules/branching.md
@@ -48,17 +48,7 @@ Add incremental sync for Plaid transactions
 
 ## Skipping the AI reviewer on a single push
 
-The `AI Code Review` workflow re-runs on **every** push to an open PR
-(`synchronize`) — it does not check approval state. To avoid a redundant
-review on the final nit-fix commit of an already-approved PR you're about
-to merge, put `[skip-review]` (or `[skip review]`) in **that commit's**
-message. The workflow reads the tip commit message and skips the automated
-review for that push only.
-
-Apply this narrowly — it is for the merge-prep push, not a way to dodge
-review. Only use it when **all** hold: the PR already carries a green
-`✅ APPROVED` review, CI is passing, and the push contains only
-nits/trivial fixups that won't change the approved verdict. Any
-substantive change must be reviewed: push it without the keyword (or
-re-summon with `@claude`). Never carry an approval across a push that
-alters logic, security posture, or a public contract.
+`[skip-review]` in a commit message skips the automated review for that push
+only. Narrow use: merge-prep nits on an already-approved, CI-green PR — never
+across a push that alters logic, security posture, or a public contract. Full
+conditions: `CONTRIBUTING.md` → "Skipping the AI reviewer".

--- a/.claude/rules/design-principles.md
+++ b/.claude/rules/design-principles.md
@@ -5,7 +5,9 @@ description: "Durable path selection: heuristics for one-way-door decisions, pub
 # Design Principles: Durable Path Selection
 
 Companion to AGENTS.md's "Guiding Principle." Defines what "durable" means
-concretely, when the protocol applies, and how to record the outcome.
+concretely and when the protocol applies. Depth — evolving a locked contract,
+milestone addressing, the worked example, and the ADR bar:
+[`.claude/references/design-principles-depth.md`](../references/design-principles-depth.md).
 
 ## The primary lens: reversibility
 
@@ -13,6 +15,13 @@ AGENTS.md establishes the one-way / two-way door classifier. This file
 fills in: which surfaces are which, what "durable" means for one-way
 doors, what it does NOT mean, and how an outcome lands in the repo. When
 in doubt, treat as one-way and invoke the protocol.
+
+### The protocol (one-way doors)
+
+Surface both paths, name each cost concretely, recommend the durable path
+and state what it costs; wait for explicit override before taking the fast
+path. With no user (subagent / autonomous), default to durable and document
+the choice.
 
 ## Public contracts vs internal abstractions
 
@@ -40,23 +49,6 @@ ADR if it meets the bar below.
 
 **Launch trigger.** Lock at the earlier of: M3E hosted launch, or the
 first tagged release adopted by any non-author user.
-
-### Evolving a public contract post-launch
-
-Locked contracts still need to change sometimes. By surface:
-
-- **Schemas:** versioned column additions only; never rename or retype
-  in place. Deprecate-then-remove for column removal across two
-  releases.
-- **MCP tools:** add the new tool alongside, mark the old one
-  deprecated in its description, remove after one minor release.
-- **CLI commands:** add the new command, keep the old one as an alias
-  for one minor release with a deprecation warning, remove on the next.
-- **On-disk formats:** include a format version field; readers handle
-  N-1 and N, writers emit N.
-
-Pattern-changing breaks need an ADR; routine breaks get a CHANGELOG
-entry under `Changed` or `Deprecated`.
 
 ### Internal abstractions (two-way doors)
 
@@ -144,89 +136,7 @@ This is NOT a license to gold-plate. "Elegant" and "architecturally
 pure" are not goals — they are post-hoc descriptions of code that is
 coherent and durable.
 
-## Milestone addressing — one scheme, append don't reinvent
+## Depth
 
-All roadmap work is tracked under a single phase-aligned address scheme.
-**Use it; never fork a parallel numbering or sequencing scheme** — we have
-migrated twice already (Level/Wave → flat M-grid → this), and each migration
-was pure churn.
-
-- **`M0`–`M3`** = the four milestones / build phases: **M0 Foundation ·
-  M1 Ingestion Core · M2 Analysis & Reports · M3 Productization &
-  Distribution**. The milestone *is* the test-functionality gate — testing
-  batches at the phase, not per-item.
-- **`M1J`** = an *increment*: a coherent capability ≈ one spec, closes on its
-  own.
-- **`M1J.2`** = a *work item*: a discrete design / PR / plan within an
-  increment.
-
-When planning, brainstorming, or writing a new spec or plan: attach the work
-to an existing increment, or **append the next free letter (new increment) or
-`.n` (new work item)** — then register it in the canonical reference,
-[`docs/roadmap.md`](../../docs/roadmap.md) (public source of truth), mirrored
-in `private/strategy/milestone-taxonomy.md` (full map + rationale). Don't mint
-a new top-level number for a sub-task, and don't add a per-increment gate. If
-the scheme genuinely can't express the work, raise it — don't invent a second
-one.
-
-## What it does NOT mean
-
-- Not gold-plating, perfectionism, or refusing to ship.
-- Not rewriting in another language for elegance. The stack — Python,
-  DuckDB, SQLMesh, Typer, MCP — is fixed; "inevitable" means inevitable
-  *within that stack*.
-- Not blocking on hypothetical future requirements.
-- Not freezing the public surface before launch. Pre-launch is when
-  iteration is cheap; use it.
-
-## Example: applying the protocol
-
-**Decision:** Add a merchant attribute to `core.fct_transactions` —
-`merchant TEXT` on the fact table, or `merchant_id` FK to a new
-`core.dim_merchants`?
-
-**Classification:** One-way door. `core.fct_transactions` is exposed via
-MCP and CLI; consumers will write queries against this shape.
-
-**Option A (durable) — `merchant_id` + `dim_merchants`:** ~3 days. Locks
-the right shape; merchants are a real entity with attributes (aliases,
-category) that will grow.
-
-**Option B (fast) — `merchant TEXT`:** ~½ day. Breaks the moment a
-second merchant attribute is needed — forces dim-table introduction
-later plus migration of every consumer query.
-
-**Recommend A.** Applies the existing dim-table pattern from ADR-001;
-no new ADR. Capture in the merchants spec and PR description.
-
-## Recording the outcome
-
-Most one-way-door decisions do NOT need their own ADR. ADRs are for
-decisions that *establish* a pattern others will inherit from, not
-decisions that *apply* an existing pattern. The ADR bar is deliberately
-high — sprawl devalues the format and trains contributors to skip them.
-
-**Record an ADR only when all three are true:**
-
-1. The decision **establishes or changes a pattern** others will inherit
-   from (not just applies an existing one).
-2. The **"why" isn't recoverable from reading the code** — only the
-   "what" is.
-3. A reasonable future contributor might **propose undoing it** without
-   that context.
-
-If any one fails: capture the decision in the PR description, the
-relevant spec, or an inline comment. Don't create an ADR.
-
-**ADR-worthy** (establishes a pattern others inherit): embedded analytical
-store (ADR-000), medallion data layers (ADR-001), privacy tiers (ADR-002),
-encryption key management (ADR-009).
-
-**Not ADR-worthy** (applies an existing pattern): a new `merchant_id` column
-or dim table (ADR-001), renaming/restructuring a CLI command (CLI taxonomy
-spec), a new MCP tool (MCP architecture spec), a dependency bump (no pattern
-change), a column-type choice like `DECIMAL(18,2)` (accounting-precision
-convention).
-
-When in doubt: don't create the ADR. The principle's job is to make
-durable choices, not to generate paperwork about them.
+Evolving a locked public contract, milestone addressing (`M{phase}{letter}.{n}`), the worked example, and the ADR bar:
+[`.claude/references/design-principles-depth.md`](../references/design-principles-depth.md).

--- a/.claude/rules/design-principles.md
+++ b/.claude/rules/design-principles.md
@@ -45,7 +45,8 @@ prematurely freeze a surface before you know it's right.
 
 **Post-launch posture:** lock hard. Treat changes as breaking. Require
 an explicit migration or deprecation path; record the rationale in an
-ADR if it meets the bar below.
+ADR if it meets the bar in
+[`.claude/references/design-principles-depth.md`](../references/design-principles-depth.md).
 
 **Launch trigger.** Lock at the earlier of: M3E hosted launch, or the
 first tagged release adopted by any non-author user.

--- a/.claude/rules/design-principles.md
+++ b/.claude/rules/design-principles.md
@@ -6,15 +6,14 @@ description: "Durable path selection: heuristics for one-way-door decisions, pub
 
 Companion to AGENTS.md's "Guiding Principle." Defines what "durable" means
 concretely and when the protocol applies. Depth — evolving a locked contract,
-milestone addressing, the worked example, and the ADR bar:
+milestone addressing, what it does NOT mean, the worked example, and the ADR bar:
 [`.claude/references/design-principles-depth.md`](../references/design-principles-depth.md).
 
 ## The primary lens: reversibility
 
 AGENTS.md establishes the one-way / two-way door classifier. This file
-fills in: which surfaces are which, what "durable" means for one-way
-doors, what it does NOT mean, and how an outcome lands in the repo. When
-in doubt, treat as one-way and invoke the protocol.
+fills in: which surfaces are which, and what "durable" means for one-way
+doors. When in doubt, treat as one-way and invoke the protocol.
 
 ### The protocol (one-way doors)
 
@@ -139,5 +138,5 @@ coherent and durable.
 
 ## Depth
 
-Evolving a locked public contract, milestone addressing (`M{phase}{letter}.{n}`), the worked example, and the ADR bar:
+Evolving a locked public contract, milestone addressing (`M{phase}{letter}.{n}`), what it does NOT mean, the worked example, and the ADR bar:
 [`.claude/references/design-principles-depth.md`](../references/design-principles-depth.md).

--- a/.claude/rules/mcp.md
+++ b/.claude/rules/mcp.md
@@ -330,4 +330,5 @@ must produce an agent-experience report per
 suite or editing MCP code/tests does not trigger a report; the signal is
 what it felt like to use the surface. Reports are session-internal: present
 to the developer in chat, never paste into PRs, commits, CHANGELOG, or ADRs. See
-`agent-experience.md` for the full trigger list and reporting workflow.
+`agent-experience.md` for the full trigger list; it links the report
+template and reporting workflow.

--- a/.claude/rules/sandboxing.md
+++ b/.claude/rules/sandboxing.md
@@ -24,7 +24,7 @@ Prefer this shape when the work fits.
 
 ## Use the Read tool for file content, not bash `cat`
 
-For reading a file into context, use the `Read` tool — not `cat`. `Read` takes a single absolute path (e.g. `Read(/Users/.../src/foo.py)`), is sandbox-independent, supports `offset`/`limit` for large files, and avoids the bash command-string matcher entirely. Reserve `cat` for cases that genuinely need shell interpretation: piping into another command, multi-file concatenation, or building files via heredoc. To find files by pattern, use `Glob` (or `Grep`), then `Read` the specific paths.
+`Read` is sandbox-independent and avoids the bash command-string matcher entirely; it also takes `offset`/`limit` for large files. Reserve `cat` for cases needing shell interpretation: piping, multi-file concatenation, heredocs. To find files by pattern use `Glob`/`Grep`, then `Read` the specific paths.
 
 ## Pipelines and chains run silently when components are allowlisted
 
@@ -41,15 +41,13 @@ If a pipeline prompts, it usually means one component (or a path it touches) isn
 
 ## Prefer tool-native structured output over regex filtering
 
-When the goal is "find specific items in tool output," reach for the tool's own filtering before grep. Single command, sandbox-eligible, denser output, more reliable to parse:
+To find specific items in tool output, use the tool's own filtering before grep — single command, sandbox-eligible, denser and more reliably parsed:
 
-- `ruff check --output-format json` or `--output-format concise` instead of `ruff | grep ...`
-- `pyright --outputjson` instead of piping pyright through grep
-- `pytest --tb=short -q` for compact failure summaries
-- `gh api ... --jq '.field'` instead of piping gh output through jq
-- `git log --pretty=format:'%h %s'` instead of piping git log through awk/cut
-
-This is also a token savings: structured output is denser than verbose text + filter.
+- `ruff check --output-format json` (or `concise`)
+- `pyright --outputjson`
+- `pytest --tb=short -q`
+- `gh api ... --jq '.field'`
+- `git log --pretty=format:'%h %s'`
 
 ## Don't reach for these
 

--- a/.claude/rules/shipping.md
+++ b/.claude/rules/shipping.md
@@ -65,13 +65,13 @@ The goal is that someone reading the docs gets an accurate picture of what Money
 
 ## When a New Spec Is Written
 
-- Give the spec an **address** — the next free increment letter under its milestone (e.g. `M2F`), per `design-principles.md` → "Milestone addressing." Don't invent a new numbering scheme.
+- Give the spec an **address** — the next free increment letter under its milestone (e.g. `M2F`), per `.claude/references/design-principles-depth.md` → "Milestone addressing." Don't invent a new numbering scheme.
 - Add a 📐 entry in the matching milestone row of `docs/roadmap.md`.
 - Add the spec to `docs/specs/INDEX.md` with status `draft` or `ready`.
 
 ## When a Feature Is Planned (No Spec Yet)
 
-- Attach it to a milestone/increment per the address scheme (`design-principles.md` → "Milestone addressing") — append the next free increment letter; don't fork a parallel sequence.
+- Attach it to a milestone/increment per the address scheme (`.claude/references/design-principles-depth.md` → "Milestone addressing") — append the next free increment letter; don't fork a parallel sequence.
 - Add a 🗓️ entry under that milestone in `docs/roadmap.md` (or the Post-launch section if genuinely beyond M3).
 - No `INDEX.md` entry until a spec exists.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,7 @@ Files in `.claude/rules/` auto-load via `paths:` frontmatter — path-scoped loa
 
 | Rule | Covers |
 |------|--------|
-| `design-principles.md` | Durable path selection: heuristics for "inevitable choice" decisions, the agent-protocol trigger list, and the milestone addressing scheme (`M{phase}{letter}.{n}` — append, don't reinvent) |
+| `design-principles.md` | Durable path selection: one-way-door classifier, public-contract trigger list, the agent protocol, coherence rule. Depth — post-launch contract evolution, the milestone addressing scheme (`M{phase}{letter}.{n}` — append, don't reinvent), the ADR bar: `.claude/references/design-principles-depth.md` |
 | `branching.md` | Branch prefix → PR label mapping, commit message style |
 | `sandboxing.md` | Bash invocation patterns: single commands, allowlisted pipelines, structured-output filtering, policy denials |
 | `agent-experience.md` | Required agent-experience report whenever you interact with MoneyBin's MCP server in a session |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,10 @@ unclear, stop and name what's confusing.
 
 ## Simplicity First
 
-Minimum code that solves the problem. No abstractions for single-use code.
-No error handling for impossible scenarios. If you write 200 lines and it
-could be 50, rewrite it.
+Minimum code that solves the problem. No features beyond what was asked. No
+abstractions for single-use code. No "flexibility" or "configurability" that
+wasn't requested. No error handling for impossible scenarios. If you write 200
+lines and it could be 50, rewrite it.
 
 ## Design Philosophy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,27 +8,11 @@ Be the option a serious user converges on because the foundation is
 rock-solid — inevitable, not first or fastest. A longer development
 lifecycle is acceptable when it buys durability.
 
-Three axes, distinct from "Simplicity First" below:
-
-- **Path selection (this principle):** For one-way-door choices (public
-  contracts, security postures, critical-path deps), default to the path
-  that still feels right in five years, even if it costs months more.
-  Pre-launch: iterate. Post-launch: lock hard.
-- **Coherence (every change):** When adding new X, follow the existing
-  pattern for X. If the pattern is wrong, fix it everywhere — don't
-  introduce a parallel pattern beside it. Two patterns for the same job is
-  the single largest source of codebase rot.
-- **Scope discipline ("Simplicity First"):** Two-way doors (internal
-  abstractions, module boundaries, refactors behind a stable contract) get
-  the minimum code that solves the problem. No protocol.
-
-**Agent protocol (one-way doors):** surface both paths, name each cost
-concretely, recommend the durable path and state what it costs; wait for
-explicit override before taking the fast path. With no user (subagent /
-autonomous), default to durable and document the choice. If you can't tell
-whether a decision is one-way, treat it as one-way. Full protocol, trigger
-list, worked example, and the public-contract / internal-abstraction split:
-`.claude/rules/design-principles.md`.
+Three axes, distinct from "Simplicity First" below: **path selection**
+(one-way doors), **coherence** (every change), **scope discipline**
+(two-way doors). If you can't tell whether a decision is one-way, treat it
+as one-way. Classifier, trigger list, the agent protocol, and what
+"durable" means: `.claude/rules/design-principles.md`.
 
 ## Bias Toward UX / DX / AX
 
@@ -50,24 +34,11 @@ disambiguates) and name the cost honestly ("more work for me" is not
 disqualifying). When audiences conflict (e.g. AX wants verbose envelopes,
 UX wants terse output), surface it and let the user pick.
 
-## Think Before Coding
-Don't assume. Don't hide confusion. Surface tradeoffs.
-
-### Before implementing
-State your assumptions explicitly. If uncertain, ask.
-If multiple interpretations exist, present them - don't pick silently.
-If a simpler approach exists, say so. Push back when warranted.
-If something is unclear, stop. Name what's confusing. Ask.
-
 ## Simplicity First
-Minimum code that solves the problem. Nothing speculative.
 
-No features beyond what was asked.
-No abstractions for single-use code.
-No "flexibility" or "configurability" that wasn't requested.
-No error handling for impossible scenarios.
-If you write 200 lines and it could be 50, rewrite it.
-Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+Minimum code that solves the problem. No abstractions for single-use code.
+No error handling for impossible scenarios. If you write 200 lines and it
+could be 50, rewrite it.
 
 ## Design Philosophy
 
@@ -75,9 +46,12 @@ Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, sim
 
 ## Design System
 
-MoneyBin's visual language lives in `design-system/` — the source of truth (it also backs the `/moneybin-design` skill and the synced claude.ai/design project). Before any UI, artifact, or frontend work, read `design-system/readme.md`, `design-system/tokens/`, and `design-system/guidelines/`, plus whichever of the four binding grammar docs covers what you are building — `charts.md` (charts), `motion.md` (motion), `patterns.md` (app chrome: rail shell, floating layer, ⌘K palette, table, import mapper, chords), `ai-surface.md` (ask surface, consent tiers, provider policy). Each wins in its own domain over any summary, including this one. Non-negotiables: dark theme leads; one metal accent in three tiers — brass (`--accent-brass`) speaks, gilt (`--accent-gilt`) fills, verdigris (`--accent-verdigris`) responds, never blue; money is always JetBrains Mono via the `Amount` component, with explicit +/− signs on income/expense flows (balances stay unsigned); icons always come from the `Icon` component, never a one-off inline SVG; hairline borders, no resting shadows; every data widget carries a SQL provenance chip; linear chart interpolation only; no emoji, no exclamation points.
-
-Update flow: prototype and spec visually in the claude.ai **Design Kit** project, promote into `design-system/` via `/design-import` (with PR review), then publish the repo → the claude.ai **Design System** project via `/design-sync`. The repo is canonical; the Design System project is a generated mirror — never hand-edit it as the source. See `design-system/readme.md` → "Updating the design system".
+MoneyBin's visual language lives in `design-system/`. The repo is canonical;
+the claude.ai Design System project is a generated mirror — never hand-edit it
+as the source. Before any UI, artifact, or frontend work, invoke the
+`moneybin-design` skill: it carries the tokens, the four binding grammar docs,
+and the non-negotiables. Update flow: `design-system/readme.md` → "Updating
+the design system".
 
 ## Critical Rules
 
@@ -106,12 +80,9 @@ Update flow: prototype and spec visually in the claude.ai **Design Kit** project
 - **Inline SQL**: Triple-quoted strings (`"""..."""`).
 - **Suppression comments**: Always include a reason: `# noqa: S608  # test input, not executing SQL`.
 - **Acronyms**: ALL CAPS in class names: `OFXExtractor`, `CSVReader`, `PDFExtractor`.
-- **Comments and docstrings**: Default to one short line. A longer comment or
-  multi-paragraph module docstring is warranted when it documents a
-  *non-obvious why* a future reader would otherwise undo — a workaround for an
-  upstream bug, a hidden constraint, a platform-specific quirk, or an
-  invariant the code relies on but doesn't enforce. Don't restate what the
-  code already says; do explain context that lives outside the code.
+- **Comments and docstrings**: Default to one short line. Go longer only for a
+  *non-obvious why* a future reader would otherwise undo — an upstream-bug
+  workaround, a hidden constraint, a platform quirk, an unenforced invariant.
 
 ## Architecture: Data Layers
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,10 @@ UX wants terse output), surface it and let the user pick.
 
 ## Think Before Coding
 
-If multiple interpretations exist, present them — don't pick one silently. If
-a simpler approach exists, say so; push back when warranted. When something is
-unclear, stop and name what's confusing.
+State assumptions explicitly; if uncertain, ask. If multiple interpretations
+exist, present them — don't pick one silently. If a simpler approach exists,
+say so; push back when warranted. When something is unclear, stop and name
+what's confusing.
 
 ## Simplicity First
 
@@ -162,7 +163,7 @@ Files in `.claude/rules/` auto-load via `paths:` frontmatter — path-scoped loa
 
 | Rule | Covers |
 |------|--------|
-| `design-principles.md` | Durable path selection: one-way-door classifier, public-contract trigger list, the agent protocol, coherence rule. Depth — post-launch contract evolution, the milestone addressing scheme (`M{phase}{letter}.{n}` — append, don't reinvent), the ADR bar: `.claude/references/design-principles-depth.md` |
+| `design-principles.md` | Durable path selection: one-way-door classifier, public-contract trigger list, the agent protocol, coherence rule. Depth — post-launch contract evolution, the milestone addressing scheme (`M{phase}{letter}.{n}` — append, don't reinvent), what it does NOT mean, the ADR bar: `.claude/references/design-principles-depth.md` |
 | `branching.md` | Branch prefix → PR label mapping, commit message style |
 | `sandboxing.md` | Bash invocation patterns: single commands, allowlisted pipelines, structured-output filtering, policy denials |
 | `agent-experience.md` | Required agent-experience report whenever you interact with MoneyBin's MCP server in a session |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,12 @@ disambiguates) and name the cost honestly ("more work for me" is not
 disqualifying). When audiences conflict (e.g. AX wants verbose envelopes,
 UX wants terse output), surface it and let the user pick.
 
+## Think Before Coding
+
+If multiple interpretations exist, present them — don't pick one silently. If
+a simpler approach exists, say so; push back when warranted. When something is
+unclear, stop and name what's confusing.
+
 ## Simplicity First
 
 Minimum code that solves the problem. No abstractions for single-use code.

--- a/docs/decisions/014-shared-ui-architecture.md
+++ b/docs/decisions/014-shared-ui-architecture.md
@@ -13,7 +13,7 @@ These could be built as two independent frontends. They share the same data, the
 
 The two surfaces genuinely differ in exactly one dimension: **how data crosses the wire.** The MCP App talks to its host over a postMessage / JSON-RPC bridge (`tools/call`); the Web UI talks to a FastAPI surface over HTTP. Everything above that boundary — components, view state, formatting, domain types — is identical.
 
-This is a pattern-establishing decision: every future visual surface (an in-app agent panel, a mobile view, an extension-contributed dashboard) inherits whatever shape we choose here. It meets the ADR bar in [`design-principles.md`](../../.claude/rules/design-principles.md): it establishes a pattern others inherit; the "why" (dual-surface reuse via a transport-agnostic core) is not recoverable from reading the code; and a future contributor could reasonably propose undoing it ("why not just fetch in the components?").
+This is a pattern-establishing decision: every future visual surface (an in-app agent panel, a mobile view, an extension-contributed dashboard) inherits whatever shape we choose here. It meets the ADR bar in [`design-principles-depth.md`](../../.claude/references/design-principles-depth.md): it establishes a pattern others inherit; the "why" (dual-surface reuse via a transport-agnostic core) is not recoverable from reading the code; and a future contributor could reasonably propose undoing it ("why not just fetch in the components?").
 
 ## Decision
 
@@ -70,5 +70,6 @@ Full design, diagrams, and testing strategy: [`ui-architecture.md`](../specs/ui-
 
 - [`ui-architecture.md`](../specs/ui-architecture.md) — the full architecture spec this ADR records the rationale for
 - [MCP Apps overview](https://modelcontextprotocol.io/extensions/apps/overview) · [spec announcement (2026-01-26)](https://blog.modelcontextprotocol.io/posts/2026-01-26-mcp-apps/)
-- [`design-principles.md`](../../.claude/rules/design-principles.md) — coherence ("one way to do each thing") and the ADR bar
+- [`design-principles.md`](../../.claude/rules/design-principles.md) — coherence ("one way to do each thing")
+- [`design-principles-depth.md`](../../.claude/references/design-principles-depth.md) — the ADR bar
 - [ADR-011](011-docs-site-framework.md) — prior frontend-tooling decision (docs site); same "Python-native, minimize second-toolchain friction" instinct applied where it fits

--- a/docs/decisions/015-transaction-identity-content-derived.md
+++ b/docs/decisions/015-transaction-identity-content-derived.md
@@ -49,7 +49,7 @@ immutability**, through a cheap append-only alias map.
 This is pattern-establishing: future canonical entities (securities, merchants)
 will inherit whichever identity model we choose here, and the "why" (the
 derive-from-raw vs. stable-public-id tension) is not recoverable from the code.
-It meets the ADR bar in [`design-principles.md`](../../.claude/rules/design-principles.md).
+It meets the ADR bar in [`design-principles-depth.md`](../../.claude/references/design-principles-depth.md).
 
 ## Decision
 

--- a/docs/specs/account-identity-resolution.md
+++ b/docs/specs/account-identity-resolution.md
@@ -481,7 +481,7 @@ Guard-2 free-text resolution):
   queues — matches, categorize, **account-links**, future — so a single "what needs my
   attention?" sweep can't silently miss the account-link backlog. Keep
   `moneybin transactions review` as a **deprecated CLI alias for one minor
-  release** (`design-principles.md` CLI/MCP evolution).
+  release** (`design-principles-depth.md` CLI/MCP evolution).
   `ReviewService`
   gains `account_links_pending` in its count.
 

--- a/docs/specs/categorization-source-model.md
+++ b/docs/specs/categorization-source-model.md
@@ -456,6 +456,6 @@ scenarios over synthetic ground truth (`make test-scenarios`), plus unit tests:
 - **ADR?** This establishes a category-source-model pattern later increments
   inherit (raw-as-assertion-store over a mutable candidate table; source/method
   split; method-based precedence enforced across runs). It sits near the ADR bar in
-  `design-principles.md`. Current call: capture rationale in this spec, no separate
+  `.claude/references/design-principles-depth.md`. Current call: capture rationale in this spec, no separate
   ADR (default "when in doubt, don't"); revisit if a contributor later proposes a
   mutable assertion store without this context.

--- a/docs/specs/connect-gsheet.md
+++ b/docs/specs/connect-gsheet.md
@@ -573,7 +573,7 @@ This spec co-ships a rename of the existing `sync-*` surface from `connect` to `
 
 **Scope.** User-facing surface only — CLI verb, MCP tool names, doc copy, error-message text. The `app.sync_connections` storage table name is unchanged ("connection" is the noun form of "link" — the records of established links).
 
-**Backwards compatibility.** Pre-launch, but `sync-plaid.md` is shipped (M1G Phase 1). Keep `sync connect` as a deprecated alias for one minor release with a deprecation warning. Remove on the next minor release. Same pattern for the MCP tool. Per `.claude/rules/design-principles.md` evolving-a-public-contract guidance.
+**Backwards compatibility.** Pre-launch, but `sync-plaid.md` is shipped (M1G Phase 1). Keep `sync connect` as a deprecated alias for one minor release with a deprecation warning. Remove on the next minor release. Same pattern for the MCP tool. Per `.claude/references/design-principles-depth.md` evolving-a-public-contract guidance.
 
 **Files affected by the rename** are enumerated in the Files to Modify table above. The rename lands as its own commits within the gsheet PR series (one commit for the rename, one for the alias-with-deprecation), so reviewers can read the rename diff independently.
 

--- a/docs/specs/investments-data-model.md
+++ b/docs/specs/investments-data-model.md
@@ -1008,7 +1008,8 @@ output schema, so this spec does not freeze a JSON response object.
 13. **Engine decisions confirmed 2026-07-04, no ADRs**: the cost-basis engine
     is a Python SQLMesh model (applies the `fct_balances_daily.py` precedent)
     and the ledger is a new fact table (applies ADR-001's dim/fact pattern) —
-    both recorded here and in the PR per `design-principles.md`'s ADR bar.
+    both recorded here and in the PR per the ADR bar in
+    `.claude/references/design-principles-depth.md`.
 14. **Four methods in v1 (FIFO, HIFO, specific-ID, average), LIFO on demand.**
     HIFO is a sort-key variant of the FIFO machinery with a real demand signal;
     average cost is 1099-B-motivated and implemented as a running pool (never

--- a/docs/specs/matching-nway-dedup.md
+++ b/docs/specs/matching-nway-dedup.md
@@ -55,7 +55,7 @@ N-way dedup is therefore predominantly a **matcher** problem: make the matcher e
 | Prep fold | Recursive-CTE transitive closure | Robust for any group topology; the two-pass breaks at 4-node chains |
 | Transfer interaction | Exclude all non-primary component members | Generalizes the current "lower side of the pair" exclusion to groups |
 
-This **applies** the existing dedup and medallion patterns rather than establishing a new one, so no ADR is warranted (per `.claude/rules/design-principles.md`).
+This **applies** the existing dedup and medallion patterns rather than establishing a new one, so no ADR is warranted (per the ADR bar in `.claude/references/design-principles-depth.md`).
 
 ## Requirements
 

--- a/docs/specs/multi-currency.md
+++ b/docs/specs/multi-currency.md
@@ -423,7 +423,8 @@ realized FX gain/loss on the conversion pairs.
    surface listed above is actually in scope.
 
    The original text here assumed the MCP-parameter rename needed the
-   ship-alongside-the-old-name-for-one-release protocol from `design-principles.md`. That
+   ship-alongside-the-old-name-for-one-release protocol from
+   `design-principles-depth.md`. That
    protocol is explicitly **post-launch only**; per that doc's own launch trigger
    (**M3H** hosted launch, or the first tagged release adopted by a non-author user —
    `design-principles.md` itself currently misstates this as "M3E," a separate stale

--- a/docs/specs/multi-currency.md
+++ b/docs/specs/multi-currency.md
@@ -424,11 +424,11 @@ realized FX gain/loss on the conversion pairs.
 
    The original text here assumed the MCP-parameter rename needed the
    ship-alongside-the-old-name-for-one-release protocol from
-   `design-principles-depth.md`. That
-   protocol is explicitly **post-launch only**; per that doc's own launch trigger
-   (**M3H** hosted launch, or the first tagged release adopted by a non-author user —
-   `design-principles.md` itself currently misstates this as "M3E," a separate stale
-   milestone-code reference worth fixing there independently of this spec), MoneyBin is
+   `design-principles-depth.md`. That protocol is explicitly **post-launch
+   only**; per the launch trigger in `design-principles.md` (**M3H** hosted
+   launch, or the first tagged release adopted by a non-author user — that rule
+   currently misstates this as "M3E," a separate stale milestone-code reference
+   worth fixing there independently of this spec), MoneyBin is
    still pre-launch — no tag has been cut and no non-author user has adopted the MCP
    contract yet. So the rename is a direct, one-time change: no shim, no follow-up removal
    PR. Implementation is scoped to M1K.1, not this spec pass — see Requirement 3.


### PR DESCRIPTION
## Summary

The repo's always-loaded agent instructions — `AGENTS.md` plus the four unscoped `.claude/rules/` files — had grown past the point where they pay for themselves. Frontier models reliably follow roughly 150–200 instructions, and a coding harness spends ~50 before any project rule loads; past that, rules don't just cost tokens, they get silently ignored. This trims the repo's always-loaded surface from 9,165 to 6,833 est. tokens (−25%) without deleting guidance: 149 lines of depth material move to `.claude/references/`, loaded on demand instead of every session.

It also closes a real gap the audit surfaced. `AGENTS.md` claimed `design-principles.md` held the "full protocol" for one-way-door decisions, but that file referenced "the protocol" three times without ever defining it — the only definition was the `AGENTS.md` paragraph itself. The protocol now lives in `design-principles.md`, where every pointer already led.

## Changes

- **Relocated, not deleted.** `design-principles.md` (232 → 143 lines) and `agent-experience.md` (90 → 49 lines) keep their triggers and always-on rules. Post-launch contract evolution, milestone addressing, the worked example, the ADR bar, and the AX report template move to two new files under `.claude/references/`. Verified line-by-line as zero content loss.
- **Deduplication in `AGENTS.md`** (191 → 162 lines): dropped the three-axis restatement of `design-principles.md`, the design-system non-negotiables (already carried by the `moneybin-design` skill and `design-system/readme.md`), and "Think Before Coding". The Rules Index was deliberately kept — it is the only way to discover a path-scoped rule *before* touching a file that would load it.
- **Citation repair.** Six references across `shipping.md`, two ADRs, and one spec pointed at `design-principles.md` for the ADR bar and the milestone scheme. Each now names the file that actually holds the content.

## Test plan

- [x] `pre-commit` passes on all changed files — `ruff check` skips, markdown-only diff
- [x] `uv run pytest tests/test_documentation_policy.py` — 2 passed
- [x] Every relative link in the two new `.claude/references/` files and the repointed ADRs resolves
- [ ] Verify no guidance was lost: each section removed from a rule file appears verbatim in its reference file
- [ ] Confirm the Rules Index row for `design-principles.md` names the depth file, so milestone addressing stays discoverable from the always-loaded surface
