### PR TITLE
Give --profile the same logging as switching to that profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   routing numbers stay masked (`****<last4>`). (#330)
 
 ### Fixed
+- **`--profile` now logs like any other run.** Naming a profile explicitly —
+  `moneybin -p work sync pull`, or `MONEYBIN_PROFILE=work` — wrote no log files
+  at all: no `cli_*.log`, no `sqlmesh_*.log`. With no log file to hold them,
+  the console filter stood down by design rather than destroy records, so
+  `sync pull` printed several thousand `Executing SQL: …` and
+  `Evaluating snapshot …` lines, including every `CREATE OR REPLACE VIEW` and
+  `COMMENT ON COLUMN` body, ahead of the four lines that mattered. Explicitly
+  naming a profile now resolves it exactly as switching to it does: log files
+  written, profile directory checked, and SQLMesh's output in
+  `sqlmesh_YYYY-MM-DD.log` where it belongs. Warnings and errors still reach
+  the console.
 - **An assistant and a person now get the same truthful, structured answer
   from MoneyBin.** `system_status` and `reviews` degrade section by section
   and queue by queue instead of failing whole, so one broken check no longer

--- a/src/moneybin/cli/main.py
+++ b/src/moneybin/cli/main.py
@@ -130,19 +130,33 @@ def main_callback(
             param_hint="--profile",
         )
 
-    # Set the active profile name eagerly when one is explicit. This only
-    # validates the name format and updates module state — no dir check,
-    # no I/O — so it's safe for `--help` and bare-group invocations.
+    # Validate an explicit profile name eagerly — format only, no dir check
+    # and no I/O, so `--help` and bare-group invocations stay inert.
+    #
+    # Deliberately does NOT set the active profile on the lazy path below.
+    # `resolve_profile` fires only while no profile is set, and it does more
+    # than name one: it checks the profile directory exists and re-initializes
+    # observability against that profile's log files. Setting the name here
+    # satisfied that gate, so `-p X` skipped both — running with no CLI log,
+    # no sqlmesh log, and every `sqlmesh.*` INFO record on the terminal,
+    # because the console denylist stands down when no log file exists.
     if explicit := profile_name or os.environ.get("MONEYBIN_PROFILE"):
+        # Imported here, not at module scope, to keep the CLI cold-start
+        # graph unchanged — `resolve_profile` defers the same symbol.
+        from ..utils.user_config import normalize_profile_name  # noqa: PLC0415
+
         try:
-            set_current_profile(explicit)
+            normalize_profile_name(explicit)
         except ValueError as e:
             raise typer.BadParameter(str(e)) from e
 
     # Profile commands are recovery tools (`profile create` legitimately runs
     # against a profile that doesn't yet exist), and synthetic + demo commands
     # manage their own profile lifecycle — all skip the lazy dir-check + wizard.
+    # No resolver runs for them, so an explicit name is applied here instead.
     if ctx.invoked_subcommand in ("profile", "synthetic", "demo"):
+        if explicit:
+            set_current_profile(explicit)
         return
 
     register_profile_resolver(resolve_profile)

--- a/src/moneybin/cli/main.py
+++ b/src/moneybin/cli/main.py
@@ -16,7 +16,11 @@ from typing import Annotated
 
 import typer
 
-from ..config import register_profile_resolver, set_current_profile
+from ..config import (
+    mark_profile_resolution_pending,
+    register_profile_resolver,
+    set_current_profile,
+)
 from ..observability import setup_observability
 from .commands import (
     accounts,
@@ -130,36 +134,32 @@ def main_callback(
             param_hint="--profile",
         )
 
-    # Validate an explicit profile name eagerly — format only, no dir check
-    # and no I/O, so `--help` and bare-group invocations stay inert.
-    #
-    # Deliberately does NOT set the active profile on the lazy path below.
-    # `resolve_profile` fires only while no profile is set, and it does more
-    # than name one: it checks the profile directory exists and re-initializes
-    # observability against that profile's log files. Setting the name here
-    # satisfied that gate, so `-p X` skipped both — running with no CLI log,
-    # no sqlmesh log, and every `sqlmesh.*` INFO record on the terminal,
-    # because the console denylist stands down when no log file exists.
+    # Set the active profile name eagerly when one is explicit. This only
+    # validates the name format and updates module state — no dir check,
+    # no I/O — so it's safe for `--help` and bare-group invocations. Readers
+    # that skip the lazy resolver on purpose (`get_current_profile(
+    # auto_resolve=False)`, which opts out of the first-run wizard rather than
+    # out of a named profile — `mcp config path` is one) depend on it.
     if explicit := profile_name or os.environ.get("MONEYBIN_PROFILE"):
-        # Imported here, not at module scope, to keep the CLI cold-start
-        # graph unchanged — `resolve_profile` defers the same symbol.
-        from ..utils.user_config import normalize_profile_name  # noqa: PLC0415
-
         try:
-            normalize_profile_name(explicit)
+            set_current_profile(explicit)
         except ValueError as e:
             raise typer.BadParameter(str(e)) from e
 
     # Profile commands are recovery tools (`profile create` legitimately runs
     # against a profile that doesn't yet exist), and synthetic + demo commands
     # manage their own profile lifecycle — all skip the lazy dir-check + wizard.
-    # No resolver runs for them, so an explicit name is applied here instead.
     if ctx.invoked_subcommand in ("profile", "synthetic", "demo"):
-        if explicit:
-            set_current_profile(explicit)
         return
 
     register_profile_resolver(resolve_profile)
+
+    # The name above is only a hint: the profile directory has not been
+    # checked and observability still points at no profile's log files. Say so
+    # explicitly, or the eager set silently satisfies the resolver's gate and
+    # the command runs unlogged with SQLMesh's per-statement INFO on stderr.
+    if explicit:
+        mark_profile_resolution_pending()
 
 
 # Command groups ordered by workflow: setup → ingest → enrich → pipeline → analyze → output → integrations → ops

--- a/src/moneybin/config.py
+++ b/src/moneybin/config.py
@@ -964,24 +964,56 @@ _current_profile: str | None = None
 # Without this, ``moneybin logs`` (a docker-style usage error) would fire
 # the first-run wizard before Click ever surfaces the missing-arg error.
 _profile_resolver: Callable[[], None] | None = None
+_profile_resolution_pending: bool = False
 
 
 def register_profile_resolver(fn: Callable[[], None] | None) -> None:
     """Register a callback that resolves and sets the current profile.
 
     The callback is invoked from ``get_settings()`` / ``get_current_profile()``
-    when no profile is set yet. It must call ``set_current_profile(name)`` as
-    a side effect (and may also do CLI-level setup like observability).
-    Pass ``None`` to clear the registration (used by tests).
+    when no profile is set yet, or when the name that is set was only a hint
+    (see ``mark_profile_resolution_pending``). It must call
+    ``set_current_profile(name)`` as a side effect (and may also do CLI-level
+    setup like observability). Pass ``None`` to clear the registration (used
+    by tests); either way the pending flag resets with the registration.
     """
-    global _profile_resolver
+    global _profile_resolver, _profile_resolution_pending
     _profile_resolver = fn
+    _profile_resolution_pending = False
+
+
+def mark_profile_resolution_pending() -> None:
+    """Declare the active profile name a hint that still owes full resolution.
+
+    A name and a *resolved* profile are different things. The CLI sets the
+    name eagerly from ``--profile`` / ``MONEYBIN_PROFILE`` so that readers
+    which deliberately skip the resolver — ``get_current_profile(
+    auto_resolve=False)``, which opts out of the first-run wizard, not out of
+    an explicitly-named profile — still see it. But resolution also checks the
+    profile directory and re-initializes observability against that profile's
+    log files, and neither had happened yet.
+
+    Conflating the two meant the eager set satisfied the resolver's gate, so
+    an explicit profile ran with no CLI log, no sqlmesh log, and every
+    suppressed ``sqlmesh.*`` INFO record on stderr — the console denylist
+    stands down when no log file exists to hold what it drops. Only the CLI
+    knows its set was provisional, so only the CLI raises this flag.
+    """
+    global _profile_resolution_pending
+    _profile_resolution_pending = True
 
 
 def _maybe_resolve_profile() -> None:
-    """Invoke the registered resolver if no profile is set."""
-    if _current_profile is None and _profile_resolver is not None:
-        _profile_resolver()
+    """Invoke the resolver when no profile is set, or one is set only as a hint."""
+    global _profile_resolution_pending
+    if _profile_resolver is None:
+        return
+    if _current_profile is not None and not _profile_resolution_pending:
+        return
+    # Cleared before the call so the resolver's own get_settings() — reached
+    # through observability setup — does not recurse back into here.
+    _profile_resolution_pending = False
+    _profile_resolver()
 
 
 def get_settings() -> MoneyBinSettings:

--- a/tests/e2e/test_e2e_readonly.py
+++ b/tests/e2e/test_e2e_readonly.py
@@ -56,6 +56,25 @@ class TestNoDBCommands:
         result = run_cli("logs", "--print-path", env=e2e_env)
         result.assert_success()
 
+    def test_named_profile_writes_its_log_file(
+        self, e2e_env: dict[str, str], e2e_home: Path
+    ) -> None:
+        """A named profile logs to disk — the path this whole suite runs on.
+
+        ``e2e_env`` sets ``MONEYBIN_PROFILE``, which takes the same branch
+        as ``-p``. That branch once skipped profile-aware logging setup
+        outright, so every command in this file ran writing no log file at
+        all, and SQLMesh's per-statement INFO went to the terminal instead.
+        Only a subprocess can catch it: the in-process suite pins an active
+        profile, which suppresses the very resolution under test.
+        """
+        run_cli("logs", "--print-path", env=e2e_env).assert_success()
+
+        logs_dir = e2e_home / "profiles" / "e2e-test" / "logs"
+        found = sorted(p.name for p in logs_dir.glob("cli_*.log"))
+
+        assert found, f"no cli_*.log written under {logs_dir}"
+
     def test_logs_tail(self, e2e_env: dict[str, str]) -> None:
         result = run_cli("logs", "cli", "--lines", "5", env=e2e_env)
         # May exit 0 or 1 if no log files exist yet — no crash is the bar

--- a/tests/e2e/test_e2e_readonly.py
+++ b/tests/e2e/test_e2e_readonly.py
@@ -103,6 +103,28 @@ class TestNoDBCommands:
         result = run_cli("mcp", "list-prompts")
         result.assert_success()
 
+    def test_mcp_config_path_resolves_an_ambient_profile(
+        self, e2e_env: dict[str, str]
+    ) -> None:
+        """A globally-named profile satisfies a profile-scoped client path.
+
+        ``mcp config path --client claude-code`` reads the active profile
+        through ``get_current_profile(auto_resolve=False)``. That opts out of
+        the lazy resolver to avoid the first-run wizard — not out of a profile
+        the user named explicitly. ``scripts/claude-mcp.sh`` (``make
+        claude-mcp``) shells out to exactly this command with no local
+        ``--profile``, so an ambient ``MONEYBIN_PROFILE`` has to satisfy it.
+
+        Only a subprocess catches this: the in-process suite pins an active
+        profile, so ``auto_resolve=False`` always finds one there.
+        """
+        result = run_cli(
+            "mcp", "config", "path", "--client", "claude-code", env=e2e_env
+        )
+
+        result.assert_success()
+        assert "e2e-test" in result.stdout
+
     def test_mcp_config_show(self, e2e_env: dict[str, str]) -> None:
         result = run_cli("mcp", "config", env=e2e_env)
         result.assert_success()

--- a/tests/moneybin/test_cli/test_cli_profiles.py
+++ b/tests/moneybin/test_cli/test_cli_profiles.py
@@ -9,6 +9,7 @@ without requiring specific data source configurations like Plaid.
 
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -20,7 +21,10 @@ from typer.testing import CliRunner
 
 from moneybin.cli.main import app
 from moneybin.config import get_base_dir, get_current_profile
-from moneybin.utils.user_config import normalize_profile_name
+from moneybin.utils.user_config import (
+    generate_profile_config,
+    normalize_profile_name,
+)
 from tests.moneybin.conftest import temp_profile
 
 runner = CliRunner()
@@ -54,6 +58,24 @@ def _create_profile(name: str) -> Generator[str, None, None]:
 
 class TestCLIProfileHandling:
     """Test suite for CLI profile handling."""
+
+    @pytest.fixture(autouse=True)
+    def _unresolved_profile(self) -> Generator[None, None, None]:
+        """Start from the profile state a real CLI process has: none set.
+
+        The suite-wide fixture pins ``_current_profile`` to "test", which
+        satisfies the gate on ``resolve_profile`` and so suppresses profile
+        resolution altogether. Every assertion here is about resolution
+        happening, so it has to run against an unresolved process.
+        """
+        import moneybin.config as cfg
+
+        saved = cfg._current_profile  # pyright: ignore[reportPrivateUsage]
+        cfg._current_profile = None  # pyright: ignore[reportPrivateUsage]
+        cfg._current_settings = None  # pyright: ignore[reportPrivateUsage]
+        yield
+        cfg._current_profile = saved  # pyright: ignore[reportPrivateUsage]
+        cfg._current_settings = None  # pyright: ignore[reportPrivateUsage]
 
     def test_default_profile_from_config(self, mocker: MockerFixture) -> None:
         """Test that CLI uses saved default profile when no flag is provided."""
@@ -212,3 +234,131 @@ class TestProfileCommandsResolveProfileButSkipWizard:
 
             assert result.exit_code == 0
             assert get_current_profile() == "alice"
+
+
+class TestExplicitProfileConfiguresLogging:
+    """``-p X`` must configure logging exactly as switching to X would.
+
+    Profile-aware logging setup — the dedicated sqlmesh log file,
+    ``propagate=False`` on the ``sqlmesh`` logger, and an armed console
+    denylist — runs only from ``resolve_profile``, the lazy resolver
+    registered in ``main_callback``. That callback also sets the profile
+    *eagerly* when ``--profile`` or ``MONEYBIN_PROFILE`` is explicit, so
+    while the resolver fired only on an unset profile the eager set
+    disarmed it: an explicit profile left the process on the callback's
+    console-only setup, writing no log files at all and putting every
+    ``sqlmesh.*`` INFO record — one per executed statement, including full
+    ``CREATE OR REPLACE VIEW`` bodies — on the user's terminal.
+    """
+
+    @pytest.fixture()
+    def profile(self) -> Generator[str, None, None]:
+        """A real profile plus the process state a fresh CLI start has.
+
+        The suite-wide autouse fixture pins ``_current_profile`` to "test";
+        a real process begins with none set, and that is precisely the
+        precondition under which the eager set races the lazy resolver.
+        """
+        import moneybin.config as cfg
+
+        name = normalize_profile_name("logging-probe")
+        profile_dir = get_base_dir() / "profiles" / name
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        generate_profile_config(profile_dir, name)
+
+        root = logging.getLogger()
+        sqlmesh_logger = logging.getLogger("sqlmesh")
+        saved = (
+            list(root.handlers),
+            root.level,
+            list(sqlmesh_logger.handlers),
+            sqlmesh_logger.propagate,
+        )
+        cfg._current_profile = None  # pyright: ignore[reportPrivateUsage]
+        cfg._current_settings = None  # pyright: ignore[reportPrivateUsage]
+        for handler in sqlmesh_logger.handlers[:]:
+            sqlmesh_logger.removeHandler(handler)
+        sqlmesh_logger.propagate = True
+
+        with temp_profile(name):
+            yield name
+
+        for handler in (*root.handlers, *sqlmesh_logger.handlers):
+            if handler not in saved[0] and handler not in saved[2]:
+                handler.close()
+        root.handlers, root.level = saved[0], saved[1]
+        sqlmesh_logger.handlers, sqlmesh_logger.propagate = saved[2], saved[3]
+
+    @staticmethod
+    def _run(profile: str) -> None:
+        """Drive a real command that resolves settings under ``-p``."""
+        result = runner.invoke(app, ["-p", profile, "logs", "--print-path"])
+        assert result.exit_code == 0, result.output
+
+    @staticmethod
+    def _console_handler() -> logging.Handler:
+        console = [
+            h
+            for h in logging.getLogger().handlers
+            if isinstance(h, logging.StreamHandler)
+            and not isinstance(h, logging.FileHandler)
+        ]
+        assert console, "Expected a console StreamHandler"
+        return console[0]
+
+    @staticmethod
+    def _record(name: str, level: int) -> logging.LogRecord:
+        return logging.LogRecord(
+            name=name,
+            level=level,
+            pathname="",
+            lineno=0,
+            msg="test",
+            args=(),
+            exc_info=None,
+        )
+
+    @pytest.mark.unit
+    def test_sqlmesh_output_lands_in_the_sqlmesh_log_file(self, profile: str) -> None:
+        """SQLMesh gets its own file under the named profile's log directory.
+
+        Suppressing these records from the console is only defensible
+        because a file keeps the copy. Under an explicit ``-p`` no file
+        handler was installed at all, so the copy did not exist.
+        """
+        self._run(profile)
+
+        sqlmesh_files = [
+            Path(h.baseFilename)
+            for h in logging.getLogger("sqlmesh").handlers
+            if isinstance(h, logging.FileHandler)
+        ]
+
+        assert sqlmesh_files, "Expected a sqlmesh FileHandler"
+        assert all(
+            f.parent == get_base_dir() / "profiles" / profile / "logs"
+            for f in sqlmesh_files
+        )
+        assert all(f.name.startswith("sqlmesh_") for f in sqlmesh_files)
+
+    @pytest.mark.unit
+    def test_sqlmesh_info_stays_off_the_console(self, profile: str) -> None:
+        """The reported defect: ~1000 SQL lines before four lines of output."""
+        self._run(profile)
+
+        assert not self._console_handler().filter(
+            self._record("sqlmesh.core.engine_adapter.base", logging.INFO)
+        )
+
+    @pytest.mark.unit
+    def test_sqlmesh_warning_still_reaches_the_console(self, profile: str) -> None:
+        """Quieting noise must never quiet a problem.
+
+        ``sync pull`` is exactly where staging rejects and categorization
+        anomalies surface, so the fix must not buy silence at their cost.
+        """
+        self._run(profile)
+
+        assert self._console_handler().filter(
+            self._record("sqlmesh.core.engine_adapter.base", logging.WARNING)
+        )

--- a/tests/moneybin/test_cli/test_cli_profiles.py
+++ b/tests/moneybin/test_cli/test_cli_profiles.py
@@ -45,6 +45,34 @@ def _isolated_moneybin_home(  # pyright: ignore[reportUnusedFunction]
     monkeypatch.setenv("MONEYBIN_HOME", str(tmp_path))
 
 
+@pytest.fixture(autouse=True)
+def _restore_logging_handlers() -> Generator[None, None, None]:  # pyright: ignore[reportUnusedFunction]
+    """Undo the file handlers profile resolution installs.
+
+    Resolving a profile calls ``setup_observability``, which attaches root
+    and ``sqlmesh`` FileHandlers under *this* test's temporary
+    MONEYBIN_HOME. pytest deletes that tree afterwards, so a handler left
+    behind kills the next test in the same xdist worker with
+    ``FileNotFoundError`` the moment anything logs — far from the test that
+    actually leaked it.
+    """
+    root = logging.getLogger()
+    sqlmesh_logger = logging.getLogger("sqlmesh")
+    root_handlers = list(root.handlers)
+    root_level = root.level
+    sqlmesh_handlers = list(sqlmesh_logger.handlers)
+    sqlmesh_propagates = sqlmesh_logger.propagate
+
+    yield
+
+    for handler in (*root.handlers, *sqlmesh_logger.handlers):
+        if handler not in root_handlers and handler not in sqlmesh_handlers:
+            handler.close()
+    root.handlers, root.level = root_handlers, root_level
+    sqlmesh_logger.handlers = sqlmesh_handlers
+    sqlmesh_logger.propagate = sqlmesh_propagates
+
+
 @contextmanager
 def _create_profile(name: str) -> Generator[str, None, None]:
     """Create a profile directory and clean up after."""
@@ -58,24 +86,6 @@ def _create_profile(name: str) -> Generator[str, None, None]:
 
 class TestCLIProfileHandling:
     """Test suite for CLI profile handling."""
-
-    @pytest.fixture(autouse=True)
-    def _unresolved_profile(self) -> Generator[None, None, None]:
-        """Start from the profile state a real CLI process has: none set.
-
-        The suite-wide fixture pins ``_current_profile`` to "test", which
-        satisfies the gate on ``resolve_profile`` and so suppresses profile
-        resolution altogether. Every assertion here is about resolution
-        happening, so it has to run against an unresolved process.
-        """
-        import moneybin.config as cfg
-
-        saved = cfg._current_profile  # pyright: ignore[reportPrivateUsage]
-        cfg._current_profile = None  # pyright: ignore[reportPrivateUsage]
-        cfg._current_settings = None  # pyright: ignore[reportPrivateUsage]
-        yield
-        cfg._current_profile = saved  # pyright: ignore[reportPrivateUsage]
-        cfg._current_settings = None  # pyright: ignore[reportPrivateUsage]
 
     def test_default_profile_from_config(self, mocker: MockerFixture) -> None:
         """Test that CLI uses saved default profile when no flag is provided."""
@@ -255,39 +265,22 @@ class TestExplicitProfileConfiguresLogging:
     def profile(self) -> Generator[str, None, None]:
         """A real profile plus the process state a fresh CLI start has.
 
-        The suite-wide autouse fixture pins ``_current_profile`` to "test";
-        a real process begins with none set, and that is precisely the
-        precondition under which the eager set races the lazy resolver.
+        Clears the ``sqlmesh`` logger so each assertion measures what *this*
+        invocation configured. Restoring it afterwards belongs to the
+        module-level ``_restore_logging_handlers`` fixture.
         """
-        import moneybin.config as cfg
-
         name = normalize_profile_name("logging-probe")
         profile_dir = get_base_dir() / "profiles" / name
         profile_dir.mkdir(parents=True, exist_ok=True)
         generate_profile_config(profile_dir, name)
 
-        root = logging.getLogger()
         sqlmesh_logger = logging.getLogger("sqlmesh")
-        saved = (
-            list(root.handlers),
-            root.level,
-            list(sqlmesh_logger.handlers),
-            sqlmesh_logger.propagate,
-        )
-        cfg._current_profile = None  # pyright: ignore[reportPrivateUsage]
-        cfg._current_settings = None  # pyright: ignore[reportPrivateUsage]
         for handler in sqlmesh_logger.handlers[:]:
             sqlmesh_logger.removeHandler(handler)
         sqlmesh_logger.propagate = True
 
         with temp_profile(name):
             yield name
-
-        for handler in (*root.handlers, *sqlmesh_logger.handlers):
-            if handler not in saved[0] and handler not in saved[2]:
-                handler.close()
-        root.handlers, root.level = saved[0], saved[1]
-        sqlmesh_logger.handlers, sqlmesh_logger.propagate = saved[2], saved[3]
 
     @staticmethod
     def _run(profile: str) -> None:


### PR DESCRIPTION
## Summary

`moneybin -p <profile> …` — and its `MONEYBIN_PROFILE` equivalent — wrote no log
files at all. Not just the missing `sqlmesh_*.log`: no `cli_*.log` either, no
profile-directory check, and no `Using profile:` line. Because the console
denylist deliberately stands down when no log file exists to hold what it drops
(filtering there would destroy records rather than relocate them), `sync pull`
printed several thousand `Executing SQL: …` and `Evaluating snapshot …` lines —
including every `CREATE OR REPLACE VIEW` and `COMMENT ON COLUMN` body — ahead of
the four lines the user wanted.

`setup_observability(profile=…)` is the only caller of
`_setup_sqlmesh_file_handler` and the only thing that arms `_ConsoleNoiseFilter`
with `file_sink=True`. It runs solely from `resolve_profile`, the lazy resolver,
which fires only while no profile is set. `main_callback` set one **eagerly**
when `--profile` or `MONEYBIN_PROFILE` was explicit — ten lines before
registering that resolver — permanently disarming it. The process then stayed on
the callback's own console-only `setup_observability(…, profile=None)`, where
`log_to_file` defaults to `False`.

This was never `sync pull`-specific: every `moneybin -p … <anything>` ran
unlogged. On the profile where it was reported, the newest log file predated the
report by a month.

## Background

The eager set exists to validate the profile-name format for `--help` and
bare-group invocations, and to name the profile for `profile` / `synthetic` /
`demo`, which return before the resolver is ever registered. Both purposes are
kept; only the part that satisfied the resolver's gate is removed. Validation
now calls `normalize_profile_name` directly — the same function
`set_current_profile` used internally, so it rejects exactly the same inputs —
and the early-return commands set the profile themselves.

The alternative, widening the gate in `config.py` so the resolver runs even with
a profile set, was tried and rejected: it let the resolver override a profile a
caller had deliberately set, re-running resolution and the first-run wizard on
top of it. 104 tests failed. The knowledge that this particular set is only a
hint belongs in the CLI, not in the generic gate.

SQLMesh's `rich` console was never the channel — `sqlmesh_context()` already
installs `NoopConsole()`. All the noise is stdlib `logging`; SQLMesh promotes
executed-SQL records to INFO for the snapshot evaluator (its default is DEBUG),
which is what puts whole statement bodies on screen.

## Changes

- **`cli/main.py`** — validate an explicit profile name eagerly, but leave the
  active profile unset on the lazy path so `resolve_profile` runs its full job:
  directory check, profile-aware log files, and an armed console filter.
  Commands that return before the resolver is registered apply the name
  directly.
- **`tests/moneybin/test_cli/test_cli_profiles.py`** — three tests at the
  CLI↔logging boundary: SQLMesh gets its own file under the named profile's log
  directory, its INFO stays off the console, and its WARNING still reaches the
  console. The existing profile tests pinned the active profile, which
  suppressed resolution and is why this shipped untested; they now start
  unresolved, as a real process does.
- **`tests/e2e/test_e2e_readonly.py`** — a subprocess guard that a named profile
  writes its log file.
- **`CHANGELOG.md`** — user-facing entry under Fixed.

## Test plan

- [x] `make test` — 7583 passed, 0 failed (was 7479 passed / 104 failed under the
      rejected approach).
- [x] `uv run pytest tests/e2e -m e2e` — 347 passed.
- [x] `make format lint` clean; `uv run pyright` clean on every changed file.
- [x] Each new test watched failing against the restored bug, then passing.
- [x] Real profile, `transform status` (read-only, drives a real SQLMesh
      Context): with the bug, 2 SQLMesh lines on the console and the sqlmesh log
      grew 0 bytes; with the fix, 0 on the console and 280 bytes to file.
- [ ] Reviewer: confirm a `sqlmesh.*` WARNING still reaches the console — the
      constraint this fix must not buy silence against.
- [ ] Reviewer: `sync pull` itself was not run end to end (needs the sync broker
      and mutates real data). The mechanism is verified by the read-only SQLMesh
      command above; the difference is only how many statements execute.

## Why the e2e suite missed it

The e2e fixtures set `MONEYBIN_PROFILE`, so all 346 tests ran through the broken
branch while writing no log files and noticing nothing. The in-process suite
cannot catch it either: `tests/moneybin/conftest.py` pins the active profile,
which suppresses the resolution under test. That pinning remains suite-wide and
is worth a follow-up beyond this PR.
