### PR TITLE
Derive transforms.pending from every raw table the models read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   routing numbers stay masked (`****<last4>`). (#330)
 
 ### Fixed
+- **"Transforms up to date" now accounts for everything you can add, not just
+  accounts.** The staleness flag on `system_status` and `moneybin transform
+  status` watched three account tables out of the seventeen a refresh reads, so
+  a manually recorded transaction, a manually recorded investment trade, a
+  synced holding, and a fetched security price all landed while MoneyBin
+  reported nothing to refresh — the reports you then ran were built without
+  them. All seventeen are watched, compared against SQLMesh's own record of
+  when it last finished, and a raw table wired into a model but left out of
+  that set now fails the build rather than going unwatched. Manual entries also
+  close their import batch on success; a batch left open reads as a crashed
+  write to `import status` and to duplicate detection.
 - **`--profile` now logs like any other run.** Naming a profile explicitly —
   `moneybin -p work sync pull`, or `MONEYBIN_PROFILE=work` — wrote no log files
   at all: no `cli_*.log`, no `sqlmesh_*.log`. With no log file to hold them,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,7 +129,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   when it last finished, and a raw table wired into a model but left out of
   that set now fails the build rather than going unwatched. Manual entries also
   close their import batch on success; a batch left open reads as a crashed
-  write to `import status` and to duplicate detection.
+  write in `import history` and `import status`, with no completion time and no
+  row counts.
 - **`--profile` now logs like any other run.** Naming a profile explicitly —
   `moneybin -p work sync pull`, or `MONEYBIN_PROFILE=work` — wrote no log files
   at all: no `cli_*.log`, no `sqlmesh_*.log`. With no log file to hold them,

--- a/docs/specs/smart-import-transform.md
+++ b/docs/specs/smart-import-transform.md
@@ -11,7 +11,7 @@ Close the agent-driven ingest loop. An agent (Claude Code, Codex CLI, MCP client
 ## Background
 
 - **Originating finding:** After importing 5 OFX accounts, `core.dim_accounts` showed only 3 of the 5 — the materialized FULL dim hadn't been refreshed since the most recent imports. `core.fct_transactions` (a view) correctly showed all 5. No surface warning; the FK audit only runs on `sqlmesh run`.
-- **Existing primitive:** `core.dim_accounts.updated_at` is already set to `CURRENT_TIMESTAMP` at SQLMesh refresh time. Because the table is materialized FULL, every SQLMesh apply rewrites every row, so `MAX(updated_at)` approximates the last completed apply. Comparing that to `MAX(app.import_log.completed_at)` is the staleness heuristic — no SQLMesh-internal coupling required.
+- **Existing primitive:** every raw table already carries a landing stamp (`loaded_at`, `created_at`, or `extracted_at`), and SQLMesh already writes `finalized_ts` to `sqlmesh._environments` on every apply. Comparing the newest landing stamp against that apply stamp is the staleness heuristic. The original form compared `MAX(raw.import_log.completed_at)` against `MAX(core.dim_accounts.updated_at)`; PR #366 replaced it, because a dim-derived signal is blind to every source that does not write `dim_accounts` — manual entry among them.
 - **Related rules:** `.claude/rules/mcp.md` (thin tools over services, response envelope, sensitivity tiers), `.claude/rules/cli.md` (CLI is a first-class agent surface; `--output json` parity; non-interactive flag parity), `AGENTS.md` (`run_transforms()` lives in `ImportService` today; moves to the new `TransformService`).
 
 ## Requirements
@@ -23,7 +23,7 @@ Close the agent-driven ingest loop. An agent (Claude Code, Codex CLI, MCP client
 5. If the refresh itself fails after successful imports, raw rows stay durable; the envelope reports `transforms_applied=false` with a generic error message and an action hint to retry.
 6. `import_inbox_sync` internally builds the discovered-file list and calls the same batch path. New `refresh` parameter on the MCP tool and `--no-refresh` flag on the CLI.
 7. CLI command renamed to `moneybin import files PATHS...` (variadic). `--output json` parity for all transform commands and the renamed import command per `cli.md`.
-8. `system_status` adds a `transforms` block: `{"pending": bool, "last_apply_at": iso|None}`. Pending heuristic: `MAX(app.import_log.completed_at WHERE status='complete') > MAX(core.dim_accounts.updated_at)`. When pending, `actions` includes a hint to run `refresh_run`. No SQLMesh Context init on the `system_status` hot path.
+8. `system_status` adds a `transforms` block: `{"pending": bool, "last_apply_at": iso|None}`. Pending heuristic: the newest landing stamp across all 17 raw tables a SQLMesh model reads (`_RAW_LANDING_COLUMNS`, guarded set-equal against `raw_tables_read_by_models()`) is newer than `MAX(finalized_ts)` on the `prod` row of `sqlmesh._environments`. Rows belonging to a reverted or failed `raw.import_log` batch are excluded. When pending, `actions` includes a hint to run `refresh_run`. No SQLMesh Context init on the `system_status` hot path.
 9. A new `TransformService` owns SQLMesh interaction. `TransformService.apply()` replaces the prior inline transform call; source-priority seeding and `refresh_views` calls migrate with it. `ImportService` invokes the full refresh pipeline via `services.refresh.refresh(db)` at end-of-batch (PR #151), which calls `TransformService(db).apply()` along with matching and categorization steps. `ImportService.run_transforms()` is retained as a thin compatibility shim.
 10. A scenario test imports multiple files and asserts `MAX(dim_accounts.updated_at)` advances and all imported accounts appear in `accounts` — regression guard for the originating finding.
 11. Metrics: a new `IMPORT_BATCH_SIZE` histogram per `AGENTS.md` observability requirement. The existing `SQLMESH_RUN_DURATION_SECONDS` is reused; no per-pending gauge (derived signal, not state to scrape).
@@ -38,9 +38,9 @@ Close the agent-driven ingest loop. An agent (Claude Code, Codex CLI, MCP client
 
 No schema changes. The spec leans on three existing columns/tables:
 
-- `core.dim_accounts.updated_at` — already `CURRENT_TIMESTAMP` at SQLMesh refresh.
-- `app.import_log.completed_at` (with `status='complete'` filter) — already populated per import.
-- SQLMesh state tables — read by the refresh service via SQLMesh's Python API (Context), never on the `system_status` hot path.
+- Raw landing stamps — `loaded_at`, `created_at`, or `extracted_at`, one per raw table, already populated by each loader.
+- `raw.import_log` — `completed_at` (with `status='complete'`) drives `latest_import_at`; `status IN ('reverted','failed')` excludes abandoned batches from the landing scan.
+- `sqlmesh._environments.finalized_ts` — read by a direct `SELECT` on the `system_status` hot path. Context init stays off that path; it costs seconds and opens a second state connection.
 
 ## Implementation Plan
 
@@ -87,8 +87,8 @@ No schema changes. The spec leans on three existing columns/tables:
 | Auto-apply transforms at end-of-batch by default | Honors "data immediately query-ready" without paying latency per-file. Matches the finding's intent: the agent's mental model is the batch, not the file. |
 | Batch boundary = the list passed in one call | Multi-file batches pay one transform cost. Single-file calls still pay it (one-element list). Agents that want to defer pass `refresh=False`. |
 | Continue past per-file failures; apply for what succeeded | Matches existing inbox-sync tolerance. One corrupt statement shouldn't block 49 good ones. |
-| Use `core.dim_accounts.updated_at` for last-apply timestamp, not SQLMesh `_environments` | No SQLMesh-internal coupling; uses MoneyBin's own data; survives SQLMesh version changes; proves the apply happened rather than asserting a state record. |
-| Direct DuckDB query in `freshness()`, no SQLMesh Context init | `system_status` is `read_only=True` and called often for orientation. A Context init has side effects (writes state tables on first init) and multi-second latency. The freshness check is two cheap MAX queries. |
+| Use `core.dim_accounts.updated_at` for the `last_apply_at` field | Avoids SQLMesh-internal coupling on a display value and proves an apply rewrote rows rather than asserting a state record. Applies to that field only: PR #366 moved the `pending` comparison to `sqlmesh._environments.finalized_ts`, because a FULL-materialized dim advances only when accounts change, so it under-reports staleness for sources that touch no account. The two fields now read different clocks. |
+| Direct DuckDB query in `freshness()`, no SQLMesh Context init | `system_status` is `read_only=True` and called often for orientation. A Context init has side effects (writes state tables on first init) and multi-second latency. The freshness check is one 17-arm `UNION ALL` over raw landing columns plus one `SELECT` against `sqlmesh._environments` — index-free `MAX` scans on columns the loaders already write. |
 | Move `run_transforms()` from `ImportService` to `TransformService` | Logical home; keeps service boundaries clean. `ImportService` orchestrates; `TransformService` executes the SQLMesh-coupled work. |
 | Single PR, not three | PR2 (batch import) and PR3 (system_status signal) are only useful after PR1 (TransformService) lands. Splitting fragments review. Regression test verifies the integrated behavior. |
 
@@ -176,15 +176,17 @@ flowchart TD
     Agent -->|system_status| SS[system_status MCP tool]
     SS --> SSvc[SystemService.status]
     SSvc --> TSF[TransformService.freshness]
-    TSF -->|MAX updated_at| Core
-    TSF -->|MAX completed_at| ImpLog[(app.import_log)]
+    TSF -->|MAX updated_at for last_apply_at| Core
+    TSF -->|MAX landing stamp, 17 tables| RawL[(raw.* landing columns)]
+    TSF -->|exclude reverted/failed batches| ImpLog[(raw.import_log)]
+    TSF -->|MAX finalized_ts| SMState[(sqlmesh._environments)]
 ```
 
 ## Testing Strategy
 
 | Layer | Test file | Verifies |
 |---|---|---|
-| Unit | `test_services/test_transform_service.py` | `freshness()` returns correct pending/last_apply_at under controlled `dim_accounts.updated_at` and `import_log.completed_at`. Includes "dim_accounts schema missing" edge case. |
+| Unit | `test_services/test_transform_service.py` | `freshness()` returns correct pending/last_apply_at under controlled raw landing stamps and `sqlmesh._environments.finalized_ts`. Covers a missing raw table, a missing `import_log`, an unreadable SQLMesh state table, and set-equality of `_RAW_LANDING_COLUMNS` against `raw_tables_read_by_models()`. |
 | Integration | `test_services/test_transform_service.py` | SQLMesh apply against a real context increments `MAX(dim_accounts.updated_at)`. |
 | Service | `test_services/test_import_service.py` (extended) | `import_files([good, bad, good])` returns 2 imported + 1 failed, transforms ran once, partial failures don't block apply. `refresh=False` skips. Empty-success skips. Transform-fails-after-import path. |
 | CLI | `test_cli/test_import_files_cli.py` | Variadic `import files a b c`, `--no-refresh`, `--output json` envelope matches MCP. |

--- a/src/moneybin/services/investment_service.py
+++ b/src/moneybin/services/investment_service.py
@@ -1256,6 +1256,8 @@ class InvestmentService:
             actor=actor,
         )
 
+        from moneybin.loaders import import_log
+
         written: list[str] = []
         self._db.begin()
         try:
@@ -1275,8 +1277,6 @@ class InvestmentService:
             self._db.commit()
         except Exception:
             self._db.rollback()
-            from moneybin.loaders import import_log
-
             import_log.finalize_import(
                 self._db,
                 import_id,
@@ -1285,6 +1285,17 @@ class InvestmentService:
                 rows_imported=0,
             )
             raise
+
+        # Close the batch this path opened. Without it the row stays 'importing'
+        # forever, which find_existing_import cannot tell apart from a genuinely
+        # crashed write — the exact distinction that function exists to draw.
+        import_log.finalize_import(
+            self._db,
+            import_id,
+            status="complete",
+            rows_total=len(written),
+            rows_imported=len(written),
+        )
 
         for row in rows:
             INVESTMENT_EVENTS_RECORDED_TOTAL.labels(type=str(row["type"])).inc()
@@ -1320,6 +1331,8 @@ class InvestmentService:
             actor=actor,
         )
 
+        from moneybin.loaders import import_log
+
         written: list[str] = []
         self._db.begin()
         try:
@@ -1340,8 +1353,6 @@ class InvestmentService:
             self._db.commit()
         except Exception:
             self._db.rollback()
-            from moneybin.loaders import import_log
-
             import_log.finalize_import(
                 self._db,
                 import_id,
@@ -1350,6 +1361,15 @@ class InvestmentService:
                 rows_imported=0,
             )
             raise
+
+        # Close the batch this path opened — see :meth:`_write_rows`.
+        import_log.finalize_import(
+            self._db,
+            import_id,
+            status="complete",
+            rows_total=len(written),
+            rows_imported=len(written),
+        )
 
         for _account_id, rows in groups:
             for row in rows:

--- a/src/moneybin/services/investment_service.py
+++ b/src/moneybin/services/investment_service.py
@@ -1287,8 +1287,9 @@ class InvestmentService:
             raise
 
         # Close the batch this path opened. Without it the row stays 'importing'
-        # forever, which find_existing_import cannot tell apart from a genuinely
-        # crashed write — the exact distinction that function exists to draw.
+        # forever with a NULL completed_at and NULL row counts, which
+        # `moneybin import history` / `import_status` cannot tell apart from a
+        # genuinely crashed write.
         import_log.finalize_import(
             self._db,
             import_id,

--- a/src/moneybin/services/transaction_service.py
+++ b/src/moneybin/services/transaction_service.py
@@ -1193,8 +1193,9 @@ class TransactionService:
             raise
 
         # Close the batch this path opened. Without it the row stays 'importing'
-        # forever, which find_existing_import cannot tell apart from a genuinely
-        # crashed write — the exact distinction that function exists to draw.
+        # forever with a NULL completed_at and NULL row counts, which
+        # `moneybin import history` / `import_status` cannot tell apart from a
+        # genuinely crashed write.
         # Finalized here, before categorization: the raw rows are committed and
         # a later categorization failure explicitly leaves them in place.
         import_log.finalize_import(

--- a/src/moneybin/services/transaction_service.py
+++ b/src/moneybin/services/transaction_service.py
@@ -1110,6 +1110,8 @@ class TransactionService:
             actor=actor,
         )
 
+        from moneybin.loaders import import_log
+
         results: list[ManualEntryRawResult] = []
         self._db.begin()
         try:
@@ -1181,8 +1183,6 @@ class TransactionService:
             # blocks re-imports and shows up in `moneybin import history`.
             # Mirror the OFX path: mark the batch as failed before re-raising.
             self._db.rollback()
-            from moneybin.loaders import import_log
-
             import_log.finalize_import(
                 self._db,
                 import_id,
@@ -1191,6 +1191,19 @@ class TransactionService:
                 rows_imported=0,
             )
             raise
+
+        # Close the batch this path opened. Without it the row stays 'importing'
+        # forever, which find_existing_import cannot tell apart from a genuinely
+        # crashed write — the exact distinction that function exists to draw.
+        # Finalized here, before categorization: the raw rows are committed and
+        # a later categorization failure explicitly leaves them in place.
+        import_log.finalize_import(
+            self._db,
+            import_id,
+            status="complete",
+            rows_total=len(results),
+            rows_imported=len(results),
+        )
 
         # Attach user-supplied categories in one atomic txn AFTER the raw-write
         # commits. All-or-nothing: a failure on entry N rolls back entries

--- a/src/moneybin/services/transform_service.py
+++ b/src/moneybin/services/transform_service.py
@@ -91,9 +91,13 @@ def _build_raw_landing_scan(
         )
         arms.append(f'SELECT "{column}" AS landed_at, {batch} FROM raw."{table}"')
     union = "\n    UNION ALL\n    ".join(arms)
-    # The ::TIMESTAMPTZ cast reads each naive landing stamp in the session
-    # zone — the same zone DuckDB wrote it in — so the result is an absolute
-    # instant comparable to SQLMesh's UTC epoch stamp.
+    # The ::TIMESTAMPTZ cast resolves each naive landing stamp in the *reading*
+    # session's zone, which is the writing zone only while the profile stays on
+    # one machine. Carry the database across zones and these stamps skew against
+    # SQLMesh's absolute `finalized_ts` by the offset delta, which can strand
+    # `pending` true or briefly mask real staleness until the next apply
+    # re-anchors it. A naive value cannot yield its instant at read time, so the
+    # fix is storing the landing columns as TIMESTAMPTZ, not a different cast.
     if not filter_bad_imports:
         return f"""
             SELECT MAX(landed_at)::TIMESTAMPTZ FROM (

--- a/src/moneybin/services/transform_service.py
+++ b/src/moneybin/services/transform_service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
@@ -71,15 +72,20 @@ _RAW_IMPORT_SCOPED: frozenset[str] = frozenset({
 })
 
 
-def _build_raw_landing_scan() -> str:
+def _build_raw_landing_scan(
+    tables: Collection[str], *, filter_bad_imports: bool = True
+) -> str:
     """Compose the MAX-over-landing-times query from the declarations above.
 
-    Emitted once at import so the hot path runs a fixed string. Each arm
-    projects the table's landing column and its import batch (NULL where the
-    table has none) so one status filter covers every source.
+    The full-set form is emitted once at import so the hot path runs a fixed
+    string; ``_max_raw_landed_at`` rebuilds a narrowed one only when a table
+    is missing. Each arm projects the table's landing column and its import
+    batch (NULL where the table has none) so one status filter covers every
+    source.
     """
     arms: list[str] = []
-    for table, column in sorted(_RAW_LANDING_COLUMNS.items()):
+    for table in sorted(tables):
+        column = _RAW_LANDING_COLUMNS[table]
         batch = (
             "import_id" if table in _RAW_IMPORT_SCOPED else "NULL::VARCHAR AS import_id"
         )
@@ -88,6 +94,12 @@ def _build_raw_landing_scan() -> str:
     # The ::TIMESTAMPTZ cast reads each naive landing stamp in the session
     # zone — the same zone DuckDB wrote it in — so the result is an absolute
     # instant comparable to SQLMesh's UTC epoch stamp.
+    if not filter_bad_imports:
+        return f"""
+            SELECT MAX(landed_at)::TIMESTAMPTZ FROM (
+            {union}
+            ) AS candidates
+        """  # noqa: S608  # identifiers come from the module constants above
     return f"""
         WITH bad_imports AS (
             SELECT import_id FROM raw.import_log
@@ -101,7 +113,7 @@ def _build_raw_landing_scan() -> str:
     """  # noqa: S608  # identifiers come from the module constants above
 
 
-_RAW_LANDING_SCAN = _build_raw_landing_scan()
+_RAW_LANDING_SCAN = _build_raw_landing_scan(_RAW_LANDING_COLUMNS)
 
 
 @dataclass(frozen=True)
@@ -516,8 +528,27 @@ class TransformService:
         try:
             row = self._db.execute(_RAW_LANDING_SCAN).fetchone()
         except duckdb.CatalogException:
-            return None
+            # One absent table must not blind the scan to the other sixteen.
+            # Read-only opens never run `init_schemas`, so a raw table added
+            # by a newer release is genuinely missing until the next write —
+            # and returning None there reports "nothing pending" for every
+            # source, the exact fail-open this scan exists to close.
+            present, has_import_log = self._present_raw_landing_tables()
+            if not present:
+                return None
+            row = self._db.execute(
+                _build_raw_landing_scan(present, filter_bad_imports=has_import_log)
+            ).fetchone()
         return row[0] if row and row[0] is not None else None
+
+    def _present_raw_landing_tables(self) -> tuple[frozenset[str], bool]:
+        """Declared landing tables this catalog actually has, plus import_log."""
+        rows = self._db.execute(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_catalog = current_database() AND table_schema = 'raw'"
+        ).fetchall()
+        names = {str(row[0]) for row in rows}
+        return frozenset(names & set(_RAW_LANDING_COLUMNS)), "import_log" in names
 
     def _last_apply_finalized_at(self) -> datetime | None:
         """When SQLMesh last finished promoting the ``prod`` environment.
@@ -528,16 +559,26 @@ class TransformService:
         current catalog because an in-process ``memory.sqlmesh._environments``
         can otherwise satisfy it while the SELECT reads the persistent table —
         the catalog split ``_pin_cursor_to_moneybin`` exists to prevent.
+
+        SQLMesh owns this table's layout and migrates it across versions, so a
+        read failure is a real possibility on an un-migrated state schema. It
+        degrades to ``None`` rather than propagating: ``freshness()`` has no
+        catch of its own and is on the ``system_status`` path, and ``None``
+        means "no apply we can see", which reports pending rather than clean.
         """
-        exists = self._db.execute(
-            "SELECT 1 FROM information_schema.tables "
-            "WHERE table_catalog = current_database() "
-            "AND table_schema = 'sqlmesh' AND table_name = '_environments'"
-        ).fetchone()
-        if not exists:
+        try:
+            exists = self._db.execute(
+                "SELECT 1 FROM information_schema.tables "
+                "WHERE table_catalog = current_database() "
+                "AND table_schema = 'sqlmesh' AND table_name = '_environments'"
+            ).fetchone()
+            if not exists:
+                return None
+            row = self._db.execute(
+                "SELECT to_timestamp(MAX(finalized_ts) / 1000.0) "
+                "FROM sqlmesh._environments WHERE name = 'prod'"
+            ).fetchone()
+        except duckdb.Error:
+            logger.debug("SQLMesh apply-stamp read failed", exc_info=True)
             return None
-        row = self._db.execute(
-            "SELECT to_timestamp(MAX(finalized_ts) / 1000.0) "
-            "FROM sqlmesh._environments WHERE name = 'prod'"
-        ).fetchone()
         return row[0] if row and row[0] is not None else None

--- a/src/moneybin/services/transform_service.py
+++ b/src/moneybin/services/transform_service.py
@@ -23,6 +23,86 @@ from moneybin.tables import DIM_ACCOUNTS, IMPORT_LOG
 
 logger = logging.getLogger(__name__)
 
+# Every raw table a SQLMesh model reads, mapped to the column recording when
+# its rows landed in *this* database. Deliberately landing time, not
+# ``extracted_at``: OFX stamps ``extracted_at`` when parsing begins and Plaid
+# carries the provider's own sync time, both of which can predate an apply
+# that ran while the rows were still in flight — those rows would then read as
+# already-transformed forever. Landing time is written inside the write
+# transaction, which the single-writer lock orders strictly against an apply.
+#
+# `test_pending_scan_set_covers_every_raw_table_the_transforms_read` asserts
+# this key set equals `raw_tables_read_by_models()`, so a new raw table wired
+# into a model fails loudly here rather than going silently unwatched.
+_RAW_LANDING_COLUMNS: dict[str, str] = {
+    "ofx_accounts": "loaded_at",
+    "ofx_balances": "loaded_at",
+    "ofx_institutions": "loaded_at",
+    "ofx_transactions": "loaded_at",
+    "plaid_accounts": "loaded_at",
+    "plaid_balances": "loaded_at",
+    "plaid_investment_holding_lots": "loaded_at",
+    "plaid_investment_holdings": "loaded_at",
+    "plaid_investment_holdings_snapshots": "loaded_at",
+    "plaid_investment_transactions": "loaded_at",
+    "plaid_securities": "loaded_at",
+    "plaid_transactions": "loaded_at",
+    "security_prices": "loaded_at",
+    "tabular_accounts": "loaded_at",
+    "tabular_transactions": "loaded_at",
+    # The two manual-entry tables record their insert as `created_at` and have
+    # no `loaded_at` — same instant, different name.
+    "manual_investment_transactions": "created_at",
+    "manual_transactions": "created_at",
+}
+
+# Those of the above whose rows name the import batch that wrote them, so a
+# reverted or failed batch can be filtered back out. Sync and price-feed
+# tables open no `import_log` batch at all and are unconditionally counted.
+_RAW_IMPORT_SCOPED: frozenset[str] = frozenset({
+    "manual_investment_transactions",
+    "manual_transactions",
+    "ofx_accounts",
+    "ofx_balances",
+    "ofx_institutions",
+    "ofx_transactions",
+    "tabular_accounts",
+    "tabular_transactions",
+})
+
+
+def _build_raw_landing_scan() -> str:
+    """Compose the MAX-over-landing-times query from the declarations above.
+
+    Emitted once at import so the hot path runs a fixed string. Each arm
+    projects the table's landing column and its import batch (NULL where the
+    table has none) so one status filter covers every source.
+    """
+    arms: list[str] = []
+    for table, column in sorted(_RAW_LANDING_COLUMNS.items()):
+        batch = (
+            "import_id" if table in _RAW_IMPORT_SCOPED else "NULL::VARCHAR AS import_id"
+        )
+        arms.append(f'SELECT "{column}" AS landed_at, {batch} FROM raw."{table}"')
+    union = "\n    UNION ALL\n    ".join(arms)
+    # The ::TIMESTAMPTZ cast reads each naive landing stamp in the session
+    # zone — the same zone DuckDB wrote it in — so the result is an absolute
+    # instant comparable to SQLMesh's UTC epoch stamp.
+    return f"""
+        WITH bad_imports AS (
+            SELECT import_id FROM raw.import_log
+            WHERE status IN ('reverted', 'failed')
+        ), candidates AS (
+            {union}
+        )
+        SELECT MAX(landed_at)::TIMESTAMPTZ FROM candidates
+        WHERE import_id IS NULL
+           OR import_id NOT IN (SELECT import_id FROM bad_imports)
+    """  # noqa: S608  # identifiers come from the module constants above
+
+
+_RAW_LANDING_SCAN = _build_raw_landing_scan()
+
 
 @dataclass(frozen=True)
 class TransformFreshness:
@@ -222,23 +302,21 @@ class TransformService:
         * a registered SQLMesh model has no relation in the catalog — it was
           never built, which no timestamp comparison can detect because an
           unbuilt model has no timestamp; or
-        * a raw account row exists whose ``extracted_at`` is newer than
-          ``core.dim_accounts.extracted_at``.
+        * a raw row landed after the last SQLMesh apply finished.
 
-        The second check reads ``core.dim_accounts`` alone because it is the
-        only core model that projects a bare ``extracted_at`` — everything else
-        renames it (``source_extracted_at`` on ``fct_transactions``,
-        ``extracted_at AS updated_at`` on ``fct_security_prices``) or drops it.
-        Generalizing the comparison across models is therefore not possible
-        today, and would need care if it became so: models fed by independent
-        provider cadences could pin ``pending`` true permanently, which no
-        ``refresh_run`` could clear. The missing-model check above is the part
-        that does generalize. Both sides compare the same propagated data value
-        (Python-set when the loader parses the file, carried unchanged through
-        SQLMesh) — so the check stays immune to the DuckDB
-        ``CURRENT_TIMESTAMP`` transaction-start race that affects clock-derived
-        columns when autocommit writes and a longer SQLMesh apply transaction
-        interleave.
+        The second check scans every raw table a model reads
+        (:data:`_RAW_LANDING_COLUMNS`) against one global apply stamp —
+        SQLMesh's own ``finalized_ts``, read with a plain SELECT because a
+        ``Context`` costs seconds. One stamp rather than a per-model
+        comparison is what makes this safe to generalize: a global stamp
+        advances on every apply regardless of which model changed, so sources
+        on independent provider cadences cannot pin ``pending`` true in a way
+        no ``refresh_run`` can clear.
+
+        Both sides are absolute instants — the landing stamps cast through the
+        session zone DuckDB wrote them in, the apply stamp from epoch
+        milliseconds — so the comparison does not depend on either side's
+        wall-clock frame.
 
         ``last_apply_at`` (``dim_accounts.updated_at``) and
         ``latest_import_at`` (``import_log.completed_at``) remain
@@ -250,15 +328,15 @@ class TransformService:
         # looks like between `db init` and its first refresh. Reporting that as
         # pending would make the flag permanently true on a healthy first run.
         missing_models = () if presence.never_built else presence.missing
-        pending_extracted = self._max_unapplied_raw_extracted_at()
-        core_extracted = self._max_dim_accounts_extracted_at()
+        landed_at = self._max_raw_landed_at()
+        applied_at = self._last_apply_finalized_at()
 
-        if pending_extracted is None:
+        if landed_at is None:
             raw_ahead = False
-        elif core_extracted is None:
+        elif applied_at is None:
             raw_ahead = True
         else:
-            raw_ahead = pending_extracted > core_extracted
+            raw_ahead = landed_at > applied_at
 
         return TransformFreshness(
             pending=bool(missing_models) or raw_ahead,
@@ -399,19 +477,18 @@ class TransformService:
         return AuditResult(passed=passed, failed=failed, audits=audits)
 
     def _max_completed_import_at(self) -> datetime | None:
-        # Status filter is deliberately broader than
-        # SystemService._last_import_at (which restricts to status='complete').
-        # Here we want any non-aborted import to count as pending data the
-        # transforms haven't seen yet — including 'partial' (some rows landed
-        # but the batch errored) and 'importing' (an in-flight write that
-        # already produced rows). The system_status user-facing
-        # "last_import_at" should only show fully-complete imports; the
-        # transforms-pending freshness signal should fire as soon as any
-        # non-reverted raw row exists newer than the latest dim refresh.
+        # 'complete' and 'partial' are exactly the statuses that set
+        # completed_at, so the filter now matches the aggregate. The previous
+        # `NOT IN ('reverted', 'failed')` also admitted in-flight 'importing'
+        # batches to make them count as unseen data — but their completed_at
+        # is NULL until finalize, so MAX skipped every one of them, and this
+        # field drives no freshness decision anyway (see `freshness`).
+        # Deliberately broader than SystemService._last_import_at, which shows
+        # only fully-complete imports: a 'partial' batch did land rows.
         try:
             row = self._db.execute(
                 f"SELECT MAX(completed_at)::TIMESTAMP FROM {IMPORT_LOG.full_name} "
-                f"WHERE status NOT IN ('reverted', 'failed')"  # noqa: S608  # TableRef constant
+                f"WHERE status IN ('complete', 'partial')"  # noqa: S608  # TableRef constant
             ).fetchone()
         except duckdb.CatalogException:
             # CatalogException when raw.import_log not yet created (pre-first-import)
@@ -428,43 +505,39 @@ class TransformService:
             return None
         return row[0] if row and row[0] is not None else None
 
-    def _max_dim_accounts_extracted_at(self) -> datetime | None:
+    def _max_raw_landed_at(self) -> datetime | None:
+        """Latest landing time across every raw table the transforms read.
+
+        Excludes rows belonging to a reverted or failed import batch — a
+        revert deletes its raw rows, but a failed ingest can leave rows
+        behind, and those must not pin ``pending`` true forever. Tables that
+        open no ``import_log`` batch (sync, price feeds) always pass.
+        """
         try:
-            row = self._db.execute(
-                f"SELECT MAX(extracted_at) FROM {DIM_ACCOUNTS.full_name}"  # noqa: S608  # TableRef constant
-            ).fetchone()
+            row = self._db.execute(_RAW_LANDING_SCAN).fetchone()
         except duckdb.CatalogException:
             return None
         return row[0] if row and row[0] is not None else None
 
-    def _max_unapplied_raw_extracted_at(self) -> datetime | None:
-        """MAX(extracted_at) across raw account staging, excluding bad imports.
+    def _last_apply_finalized_at(self) -> datetime | None:
+        """When SQLMesh last finished promoting the ``prod`` environment.
 
-        Mirrors :meth:`_max_completed_import_at`'s status filter so a
-        partially-loaded failed batch (rows landed before the ingest
-        errored) doesn't permanently trigger pending=True. ``raw.plaid_accounts``
-        has no ``import_id`` column (Plaid sync doesn't use ``import_log``),
-        so its rows always pass the filter.
+        Reads the state table SQLMesh keeps inside the MoneyBin database
+        with a plain SELECT rather than a ``Context``, for the same reason
+        ``freshness()`` avoids one. The existence probe is scoped to the
+        current catalog because an in-process ``memory.sqlmesh._environments``
+        can otherwise satisfy it while the SELECT reads the persistent table —
+        the catalog split ``_pin_cursor_to_moneybin`` exists to prevent.
         """
-        try:
-            row = self._db.execute(
-                """
-                WITH bad_imports AS (
-                    SELECT import_id FROM raw.import_log
-                    WHERE status IN ('reverted', 'failed')
-                ), candidates AS (
-                    SELECT extracted_at, import_id FROM raw.ofx_accounts
-                    UNION ALL
-                    SELECT extracted_at, import_id FROM raw.tabular_accounts
-                    UNION ALL
-                    SELECT extracted_at, NULL::VARCHAR AS import_id
-                    FROM raw.plaid_accounts
-                )
-                SELECT MAX(extracted_at) FROM candidates
-                WHERE import_id IS NULL
-                   OR import_id NOT IN (SELECT import_id FROM bad_imports)
-                """
-            ).fetchone()
-        except duckdb.CatalogException:
+        exists = self._db.execute(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_catalog = current_database() "
+            "AND table_schema = 'sqlmesh' AND table_name = '_environments'"
+        ).fetchone()
+        if not exists:
             return None
+        row = self._db.execute(
+            "SELECT to_timestamp(MAX(finalized_ts) / 1000.0) "
+            "FROM sqlmesh._environments WHERE name = 'prod'"
+        ).fetchone()
         return row[0] if row and row[0] is not None else None

--- a/src/moneybin/services/transform_service.py
+++ b/src/moneybin/services/transform_service.py
@@ -324,15 +324,20 @@ class TransformService:
         (:data:`_RAW_LANDING_COLUMNS`) against one global apply stamp —
         SQLMesh's own ``finalized_ts``, read with a plain SELECT because a
         ``Context`` costs seconds. One stamp rather than a per-model
-        comparison is what makes this safe to generalize: a global stamp
-        advances on every apply regardless of which model changed, so sources
-        on independent provider cadences cannot pin ``pending`` true in a way
-        no ``refresh_run`` can clear.
+        comparison is what makes this safe to generalize: it advances however
+        the warehouse was rebuilt, so sources on independent provider cadences
+        cannot pin ``pending`` true in a way no ``refresh_run`` can clear.
 
-        Both sides are absolute instants — the landing stamps cast through the
-        session zone DuckDB wrote them in, the apply stamp from epoch
-        milliseconds — so the comparison does not depend on either side's
-        wall-clock frame.
+        Two known limits, both narrower than the fail-open they replaced:
+
+        * SQLMesh finalizes the environment on *every* promotion of ``prod``,
+          selective ones included, so ``transform seed`` and ``transform
+          restate --model`` advance the stamp without rebuilding the models
+          that consume a newly landed row.
+        * The landing stamps are naive and resolve through the *reading*
+          session's zone while the apply stamp is an absolute epoch, so the
+          comparison holds only while the profile is read in the zone that
+          wrote it.
 
         ``last_apply_at`` (``dim_accounts.updated_at``) and
         ``latest_import_at`` (``import_log.completed_at``) remain

--- a/src/moneybin/sqlmesh_registry.py
+++ b/src/moneybin/sqlmesh_registry.py
@@ -41,6 +41,11 @@ _PY_MODEL_NAME = re.compile(
     r"@model\(\s*[\"']([a-z_][a-z0-9_]*\.[a-z_][a-z0-9_]*)[\"']",
     re.IGNORECASE,
 )
+# Any `raw.<table>` reference anywhere in a model file. Deliberately not
+# anchored to FROM/JOIN: a prose mention that isn't really read only ever
+# *adds* a table, which fails the scan-set guard loudly and visibly. Missing
+# a real reference is the silent direction, so the pattern errs wide.
+_RAW_TABLE_REF = re.compile(r"\braw\.([a-z_][a-z0-9_]*)", re.IGNORECASE)
 
 
 @lru_cache(maxsize=1)
@@ -69,6 +74,26 @@ def registered_model_names() -> frozenset[str]:
             f"{len(unparsed)} SQLMesh model file(s) have an unreadable name "
             f"header and are excluded from the registered set: "
             f"{', '.join(sorted(unparsed))}"
+        )
+    return frozenset(names)
+
+
+@lru_cache(maxsize=1)
+def raw_tables_read_by_models() -> frozenset[str]:
+    """Bare ``raw`` table names any SQLMesh model reads.
+
+    This is the definition of "raw data a refresh would consume", and so of
+    which arrivals make the warehouse stale. Read from the project files for
+    the same reason as :func:`registered_model_names` — the caller is
+    ``system_status``, and a ``Context`` costs seconds.
+    """
+    names: set[str] = set()
+    for path in (
+        *sorted(_MODELS_DIR.rglob("*.sql")),
+        *sorted(_MODELS_DIR.rglob("*.py")),
+    ):
+        names.update(
+            m.group(1).lower() for m in _RAW_TABLE_REF.finditer(path.read_text())
         )
     return frozenset(names)
 

--- a/tests/moneybin/db_helpers.py
+++ b/tests/moneybin/db_helpers.py
@@ -6,9 +6,37 @@ need to INSERT test data directly require concrete tables, so we define
 minimal CREATE TABLE statements here.
 """
 
+from datetime import UTC, datetime
+
 import duckdb
 
 from moneybin.database import Database
+
+
+def record_sqlmesh_apply(db: Database, when: datetime) -> None:
+    """Stamp a finished SQLMesh apply at ``when``, read as UTC.
+
+    ``TransformService.freshness()`` decides ``pending`` by comparing raw
+    landing times against this stamp, so any fixture that means "the
+    warehouse has been refreshed" must write it — seeding ``core.dim_accounts``
+    no longer says that. Mirrors what a real plan finalize persists: one
+    ``prod`` row in the state schema SQLMesh keeps inside the MoneyBin
+    database, with ``finalized_ts`` in epoch milliseconds.
+
+    Callers pass a naive ``when`` and get UTC. Pin the session zone to UTC
+    too if the fixture's raw landing literals are naive, so both sides
+    describe the same instants on any machine.
+    """
+    db.execute("CREATE SCHEMA IF NOT EXISTS sqlmesh")
+    db.execute(
+        "CREATE TABLE IF NOT EXISTS sqlmesh._environments "
+        "(name VARCHAR, finalized_ts BIGINT)"
+    )
+    db.execute(
+        "INSERT INTO sqlmesh._environments (name, finalized_ts) VALUES ('prod', ?)",
+        [int(when.replace(tzinfo=UTC).timestamp() * 1000)],
+    )
+
 
 # ---------------------------------------------------------------------------
 # Core table DDL — keep in sync with the SQLMesh model output columns.

--- a/tests/moneybin/test_mcp/test_system_status_transforms.py
+++ b/tests/moneybin/test_mcp/test_system_status_transforms.py
@@ -3,20 +3,21 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from datetime import datetime
 
 import pytest
 
 from moneybin.database import get_database
 from moneybin.mcp.tools.system import system_status
+from tests.moneybin.db_helpers import record_sqlmesh_apply
 
 
 def _seed_pending_import(import_id: str = "IMP_PENDING_001") -> None:
-    """Insert raw account row + import_log strictly newer than template's dim.
+    """Insert a raw account row + import_log landing after any apply.
 
-    freshness() compares MAX(raw.X_accounts.extracted_at) to
-    MAX(core.dim_accounts.extracted_at); a bare import_log row no longer
-    triggers pending. Seed a raw.ofx_accounts row with a future
-    extracted_at so the new signal fires.
+    freshness() compares the newest raw landing time against SQLMesh's own
+    apply stamp; a bare import_log row does not trigger pending. Seed a
+    raw.ofx_accounts row with a far-future ``loaded_at`` so the signal fires.
     """
     with get_database(read_only=False) as db:
         db.execute(
@@ -34,11 +35,23 @@ def _seed_pending_import(import_id: str = "IMP_PENDING_001") -> None:
         db.execute(
             """
             INSERT INTO raw.ofx_accounts
-            (account_id, source_file, extracted_at, import_id)
-            VALUES (?, 'inline', TIMESTAMP '2099-01-01 00:00:00', ?)
+            (account_id, source_file, extracted_at, loaded_at, import_id)
+            VALUES (?, 'inline', TIMESTAMP '2099-01-01 00:00:00',
+                    TIMESTAMP '2099-01-01 00:00:00', ?)
             """,
             [f"ACC_{import_id}", import_id],
         )
+
+
+def _seed_apply_after_everything() -> None:
+    """Stamp a SQLMesh apply far enough ahead to cover the template's raw rows.
+
+    The shared MCP template DB carries raw rows whose landing times are its
+    own build time, and no SQLMesh state at all — which is genuinely pending.
+    A test asserting the settled state has to say an apply happened.
+    """
+    with get_database(read_only=False) as db:
+        record_sqlmesh_apply(db, datetime(2098, 1, 1))
 
 
 @pytest.mark.unit
@@ -69,8 +82,9 @@ async def test_pending_state_adds_action_hint(
 async def test_not_pending_omits_action_hint(
     mcp_db: object, declare_only_models: Callable[..., None]
 ) -> None:
-    """No pending imports → no refresh_run hint."""
+    """Nothing landed since the last apply → no refresh_run hint."""
     declare_only_models("core.dim_accounts")
+    _seed_apply_after_everything()
     env = system_status()
     parsed = env.to_dict()
     assert parsed["data"]["transforms"]["pending"] is False

--- a/tests/moneybin/test_services/test_investment_service.py
+++ b/tests/moneybin/test_services/test_investment_service.py
@@ -795,6 +795,90 @@ class TestRecordEventSigns:
 
 
 # ---------------------------------------------------------------------------
+# record_event / record_events — import-log finalization
+# ---------------------------------------------------------------------------
+
+
+def _manual_investment_import_rows(db: Database) -> list[Any]:
+    return db.conn.execute(
+        """
+        SELECT status, rows_total, rows_imported, completed_at
+          FROM raw.import_log
+         WHERE format_name = 'manual_investment_entry'
+        """  # noqa: S608  # test read, static SQL
+    ).fetchall()
+
+
+class TestManualInvestmentImportFinalization:
+    """The success path must close the batch it opened.
+
+    Both write paths allocate the batch as ``importing`` and call
+    ``finalize_import`` only from their ``except`` branch, so a *successful*
+    record leaves a permanently non-terminal batch — ``import_status`` reports
+    ``rows_imported: null`` and ``completed_at`` never gets a value.
+    """
+
+    def _svc(self, db: Database) -> InvestmentService:
+        _add_account(db)
+        _add_security(db, security_id="sec_1", name="Apple Inc.", ticker="AAPL")
+        return db_service(db)
+
+    def _buy(self, **overrides: Any) -> dict[str, Any]:
+        base: dict[str, Any] = {
+            "account_ref": "acct_brokerage",
+            "security_ref": "AAPL",
+            "type_": "buy",
+            "subtype": None,
+            "trade_date": date(2024, 1, 15),
+            "quantity": Decimal("10"),
+            "price": Decimal("150.00"),
+            "amount": Decimal("-1500.00"),
+            "fees": None,
+            "acquired": None,
+            "basis": None,
+            "event_group_id": None,
+            "currency_code": "USD",
+            "description": "buy aapl",
+        }
+        base.update(overrides)
+        return base
+
+    def test_record_event_finalizes_the_batch_on_the_success_path(
+        self, db: Database
+    ) -> None:
+        svc = self._svc(db)
+        ids = svc.record_event(**self._buy(), actor="cli", created_by="cli")
+        assert len(ids) == 1
+
+        rows = _manual_investment_import_rows(db)
+        assert len(rows) == 1
+        status, rows_total, rows_imported, completed_at = rows[0]
+        assert status == "complete"
+        assert rows_total == 1
+        assert rows_imported == 1
+        assert completed_at is not None
+
+    def test_record_events_finalizes_the_batch_on_the_success_path(
+        self, db: Database
+    ) -> None:
+        svc = self._svc(db)
+        result = svc.record_events(
+            [self._buy(), self._buy(quantity=Decimal("5"), amount=Decimal("-750.00"))],
+            actor="cli",
+            created_by="cli",
+        )
+        assert len(result.investment_transaction_ids) == 2
+
+        rows = _manual_investment_import_rows(db)
+        assert len(rows) == 1
+        status, rows_total, rows_imported, completed_at = rows[0]
+        assert status == "complete"
+        assert rows_total == 2
+        assert rows_imported == 2
+        assert completed_at is not None
+
+
+# ---------------------------------------------------------------------------
 # record_event — reinvest pairing (Req 6)
 # ---------------------------------------------------------------------------
 

--- a/tests/moneybin/test_services/test_system_service.py
+++ b/tests/moneybin/test_services/test_system_service.py
@@ -9,7 +9,7 @@ import pytest
 
 from moneybin.database import Database
 from moneybin.services.system_service import SystemService, SystemStatus
-from tests.moneybin.db_helpers import create_core_tables_raw
+from tests.moneybin.db_helpers import create_core_tables_raw, record_sqlmesh_apply
 
 _INSERT_TRANSACTIONS = """
     INSERT INTO core.fct_transactions (
@@ -177,14 +177,18 @@ def _seed_import_log(db: Database, completed_at: datetime) -> None:
 
 
 def _seed_raw_ofx_account(db: Database, extracted_at: datetime, import_id: str) -> None:
-    """Insert one raw.ofx_accounts row at the given extracted_at."""
+    """Insert one raw.ofx_accounts row landing at the given time.
+
+    ``extracted_at`` is supplied only because it is part of the primary key;
+    ``loaded_at`` is the column freshness reads.
+    """
     db.conn.execute(
         """
         INSERT INTO raw.ofx_accounts
-        (account_id, source_file, extracted_at, import_id)
-        VALUES ('ACC001', 'test.qfx', ?, ?)
+        (account_id, source_file, extracted_at, loaded_at, import_id)
+        VALUES ('ACC001', 'test.qfx', ?, ?, ?)
         """,
-        [extracted_at, import_id],
+        [extracted_at, extracted_at, import_id],
     )
 
 
@@ -205,14 +209,16 @@ def _insert_dim_account(
 
 
 @pytest.mark.unit
-def test_status_transforms_pending_when_raw_newer_than_dim(
+def test_status_transforms_pending_when_raw_landed_after_the_apply(
     db: Database, declare_only_models: Callable[..., None]
 ) -> None:
-    """transforms_pending is True when a raw account row postdates dim_accounts.extracted_at."""
+    """transforms_pending is True when a raw account row postdates the apply."""
     declare_only_models("core.dim_accounts")
+    db.execute("SET TimeZone = 'UTC'")
     create_core_tables_raw(db.conn)
     dim_updated = datetime(2026, 5, 10, 12, 0)
     _insert_dim_account(db, datetime(2025, 1, 1), dim_updated)
+    record_sqlmesh_apply(db, dim_updated)
     _seed_raw_ofx_account(db, datetime(2026, 5, 13, 18, 24), "import-1")
     _seed_import_log(db, datetime(2026, 5, 13, 18, 24))
 
@@ -225,13 +231,15 @@ def test_status_transforms_pending_when_raw_newer_than_dim(
 def test_status_transforms_not_pending_after_apply(
     db: Database, declare_only_models: Callable[..., None]
 ) -> None:
-    """transforms_pending is False when dim_accounts.extracted_at >= raw max extracted_at."""
+    """transforms_pending is False when the apply followed every raw row."""
     declare_only_models("core.dim_accounts")
+    db.execute("SET TimeZone = 'UTC'")
     create_core_tables_raw(db.conn)
     dim_updated = datetime(2026, 5, 13, 19, 0)
-    extracted = datetime(2026, 5, 13, 18, 24)
-    _insert_dim_account(db, extracted, dim_updated)
-    _seed_raw_ofx_account(db, extracted, "import-1")
+    landed = datetime(2026, 5, 13, 18, 24)
+    _insert_dim_account(db, landed, dim_updated)
+    record_sqlmesh_apply(db, dim_updated)
+    _seed_raw_ofx_account(db, landed, "import-1")
     _seed_import_log(db, datetime(2026, 5, 13, 18, 30))
 
     status = SystemService(db=db).status()

--- a/tests/moneybin/test_services/test_transaction_service.py
+++ b/tests/moneybin/test_services/test_transaction_service.py
@@ -1393,6 +1393,35 @@ class TestManualEntry:
         assert {r[1] for r in manual_rows} == {result.import_id}
 
     @pytest.mark.unit
+    def test_create_manual_batch_finalizes_the_batch_on_the_success_path(
+        self, transaction_db: Database
+    ) -> None:
+        """A committed manual batch must reach the terminal ``complete`` status.
+
+        ``finalize_import`` was reachable only from the ``except`` branch, so a
+        *successful* write left the batch at ``importing`` forever — which
+        ``find_existing_import`` cannot distinguish from a genuinely crashed
+        write, the exact distinction it exists to draw.
+        """
+        self._seed_account(transaction_db)
+        service = TransactionService(transaction_db)
+        result = service.create_manual_batch(
+            [self._entry(), self._entry(amount=Decimal("99.00"))], actor="cli"
+        )
+
+        row = transaction_db.conn.execute(
+            "SELECT status, rows_total, rows_imported, completed_at "
+            "FROM raw.import_log WHERE import_id = ?",
+            [result.import_id],
+        ).fetchone()
+        assert row is not None
+        status, rows_total, rows_imported, completed_at = row
+        assert status == "complete"
+        assert rows_total == 2
+        assert rows_imported == 2
+        assert completed_at is not None
+
+    @pytest.mark.unit
     def test_create_manual_batch_emits_one_manual_create_audit(
         self, transaction_db: Database
     ) -> None:

--- a/tests/moneybin/test_services/test_transform_service.py
+++ b/tests/moneybin/test_services/test_transform_service.py
@@ -237,6 +237,61 @@ def test_freshness_pending_when_a_price_row_lands_after_the_last_apply(
     assert TransformService(freshness_db).freshness().pending is True
 
 
+def test_freshness_still_sees_landings_when_a_declared_raw_table_is_absent(
+    freshness_db: Database, declare_only_models: Callable[..., None]
+) -> None:
+    """A missing raw table must not blind the scan to the other sixteen.
+
+    Read-only opens never run ``init_schemas``, so a raw table a newer release
+    added is genuinely absent until the next write. The whole-union scan raises
+    ``CatalogException`` there, and treating that as "no raw data" reports
+    "transforms up to date" for every source — the exact fail-open this scan
+    exists to close.
+    """
+    declare_only_models("core.dim_accounts")
+    record_sqlmesh_apply(freshness_db, _ts(2026, 5, 10, 12, 0))
+    freshness_db.execute("DROP TABLE raw.security_prices")
+    freshness_db.execute(
+        _INSERT_RAW_ACCOUNT,
+        ["a", _ts(2026, 5, 13, 18, 0), _ts(2026, 5, 13, 18, 24), "i1"],
+    )
+    freshness_db.execute(_INSERT_IMPORT, ["i1", "complete", _ts(2026, 5, 13, 18, 24)])
+
+    assert TransformService(freshness_db).freshness().pending is True
+
+
+def test_freshness_scans_landings_when_import_log_itself_is_absent(
+    freshness_db: Database, declare_only_models: Callable[..., None]
+) -> None:
+    """The bad-import filter is dropped, not the whole scan, without import_log."""
+    declare_only_models("core.dim_accounts")
+    record_sqlmesh_apply(freshness_db, _ts(2026, 5, 10, 12, 0))
+    freshness_db.execute(_INSERT_RAW_PRICE, [_ts(2026, 5, 13, 18, 24)])
+    freshness_db.execute("DROP TABLE raw.import_log")
+
+    assert TransformService(freshness_db).freshness().pending is True
+
+
+def test_freshness_reports_pending_when_the_sqlmesh_state_is_unreadable(
+    freshness_db: Database, declare_only_models: Callable[..., None]
+) -> None:
+    """A SQLMesh state table this release cannot read must not crash status.
+
+    SQLMesh owns ``sqlmesh._environments`` and migrates its layout across
+    versions. A read failure degrades to "no apply we can see" — pending — so
+    ``system_status`` keeps answering instead of raising a raw DuckDB error.
+    """
+    declare_only_models("core.dim_accounts")
+    freshness_db.execute("CREATE SCHEMA IF NOT EXISTS sqlmesh")
+    # No `finalized_ts` column: what an un-migrated / future state schema
+    # looks like to this release's SELECT.
+    freshness_db.execute("CREATE TABLE sqlmesh._environments (name VARCHAR)")
+    freshness_db.execute("INSERT INTO sqlmesh._environments VALUES ('prod')")
+    freshness_db.execute(_INSERT_RAW_PRICE, [_ts(2026, 5, 13, 18, 24)])
+
+    assert TransformService(freshness_db).freshness().pending is True
+
+
 def test_apply_returns_apply_result_shape(
     db: Database, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/moneybin/test_services/test_transform_service.py
+++ b/tests/moneybin/test_services/test_transform_service.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Generator
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
+from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
 
 from moneybin.database import Database
 from moneybin.services.transform_service import TransformService, TransformStatus
+from tests.moneybin.db_helpers import record_sqlmesh_apply
 
 # raw.import_log columns required by NOT NULL constraints. The table is
 # auto-created by Database() schema init; tests only need to provide
@@ -22,18 +24,27 @@ _INSERT_IMPORT = (
     "VALUES (?, '/tmp/f.csv', 'csv', 'test', '[]'::JSON, ?, ?)"
 )
 
-# raw.ofx_accounts NOT NULL columns. Tests only care about account_id,
-# extracted_at, and import_id; the rest are stubs.
+# raw.ofx_accounts NOT NULL columns. `loaded_at` is what freshness reads;
+# `extracted_at` is supplied only because it is part of the primary key.
 _INSERT_RAW_ACCOUNT = (
     "INSERT INTO raw.ofx_accounts "
-    "(account_id, source_file, extracted_at, import_id) "
-    "VALUES (?, '/tmp/f.ofx', ?, ?)"
+    "(account_id, source_file, extracted_at, loaded_at, import_id) "
+    "VALUES (?, '/tmp/f.ofx', ?, ?, ?)"
+)
+
+# raw.security_prices NOT NULL columns — a price feed row, which opens no
+# import_log batch at all.
+_INSERT_RAW_PRICE = (
+    "INSERT INTO raw.security_prices "
+    "(provider_security_key, price_date, quote_currency, source_type, "
+    "source_origin, close, price_basis, loaded_at) "
+    "VALUES ('AAPL', DATE '2026-05-13', 'USD', 'stooq', '', 190.00, 'raw', ?)"
 )
 
 
 def _ts(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
-    # Naive timestamp; mirrors raw.*_accounts.extracted_at and
-    # raw.import_log.completed_at (both TIMESTAMP).
+    # Naive timestamp; mirrors the raw landing columns and
+    # raw.import_log.completed_at (all TIMESTAMP).
     return datetime(year, month, day, hour, minute)
 
 
@@ -41,12 +52,15 @@ def _ts(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> date
 def freshness_db(db: Database) -> Database:
     """Empty DB with core.dim_accounts shimmed in (raw.* are auto-created).
 
-    The shimmed dim has both ``extracted_at`` (the propagated raw value
-    that drives the pending comparison) and ``updated_at`` (the SQLMesh
-    CURRENT_TIMESTAMP retained for the informational ``last_apply_at``
-    field). The session TZ is pinned to UTC so naive vs. tz-aware
-    inserts round-trip predictably through the ``updated_at::TIMESTAMP``
-    cast in :meth:`TransformService._max_dim_accounts_updated_at`.
+    The shimmed dim carries ``updated_at`` for the informational
+    ``last_apply_at`` field; ``extracted_at`` is retained because
+    ``dim_accounts`` really has it, not because freshness reads it. The
+    session TZ is pinned to UTC so the naive literals these tests write
+    into raw landing columns describe the same instants as
+    :func:`record_sqlmesh_apply`'s epoch stamp on any machine, and so naive vs.
+    tz-aware inserts round-trip predictably through the
+    ``updated_at::TIMESTAMP`` cast in
+    :meth:`TransformService._max_dim_accounts_updated_at`.
     """
     db.execute("SET TimeZone = 'UTC'")
     db.execute(
@@ -57,7 +71,7 @@ def freshness_db(db: Database) -> Database:
     return db
 
 
-def test_freshness_pending_when_raw_newer_than_dim(
+def test_freshness_pending_when_raw_landed_after_the_last_apply(
     freshness_db: Database, declare_only_models: Callable[..., None]
 ) -> None:
     declare_only_models("core.dim_accounts")
@@ -65,7 +79,11 @@ def test_freshness_pending_when_raw_newer_than_dim(
         "INSERT INTO core.dim_accounts VALUES ('a', ?, ?)",
         [_ts(2026, 5, 10, 12, 0), _ts(2026, 5, 10, 12, 0)],
     )
-    freshness_db.execute(_INSERT_RAW_ACCOUNT, ["a", _ts(2026, 5, 13, 18, 24), "i1"])
+    record_sqlmesh_apply(freshness_db, _ts(2026, 5, 10, 12, 0))
+    freshness_db.execute(
+        _INSERT_RAW_ACCOUNT,
+        ["a", _ts(2026, 5, 13, 18, 0), _ts(2026, 5, 13, 18, 24), "i1"],
+    )
     freshness_db.execute(_INSERT_IMPORT, ["i1", "complete", _ts(2026, 5, 13, 18, 24)])
     f = TransformService(freshness_db).freshness()
     assert f.pending is True
@@ -73,27 +91,33 @@ def test_freshness_pending_when_raw_newer_than_dim(
     assert f.latest_import_at == _ts(2026, 5, 13, 18, 24)
 
 
-def test_freshness_not_pending_when_dim_caught_up(
+def test_freshness_not_pending_when_the_apply_followed_every_raw_row(
     freshness_db: Database, declare_only_models: Callable[..., None]
 ) -> None:
     declare_only_models("core.dim_accounts")
-    extracted = _ts(2026, 5, 13, 18, 24)
+    landed = _ts(2026, 5, 13, 18, 24)
     freshness_db.execute(
         "INSERT INTO core.dim_accounts VALUES ('a', ?, ?)",
-        [extracted, _ts(2026, 5, 13, 19, 0)],
+        [landed, _ts(2026, 5, 13, 19, 0)],
     )
-    freshness_db.execute(_INSERT_RAW_ACCOUNT, ["a", extracted, "i1"])
+    record_sqlmesh_apply(freshness_db, _ts(2026, 5, 13, 19, 0))
+    freshness_db.execute(
+        _INSERT_RAW_ACCOUNT, ["a", _ts(2026, 5, 13, 18, 0), landed, "i1"]
+    )
     freshness_db.execute(_INSERT_IMPORT, ["i1", "complete", _ts(2026, 5, 13, 18, 30)])
     f = TransformService(freshness_db).freshness()
     assert f.pending is False
 
 
-def test_freshness_pending_when_dim_table_missing(
+def test_freshness_pending_when_no_apply_has_ever_run(
     db: Database, declare_only_models: Callable[..., None]
 ) -> None:
-    """Pre-first-transform: dim_accounts doesn't exist; pending if any raw rows."""
+    """Pre-first-transform: no SQLMesh state at all; pending if any raw rows."""
     declare_only_models("core.dim_accounts")
-    db.execute(_INSERT_RAW_ACCOUNT, ["a", _ts(2026, 5, 13, 18, 24), None])
+    db.execute(
+        _INSERT_RAW_ACCOUNT,
+        ["a", _ts(2026, 5, 13, 18, 0), _ts(2026, 5, 13, 18, 24), None],
+    )
     f = TransformService(db).freshness()
     assert f.pending is True
     assert f.last_apply_at is None
@@ -148,14 +172,17 @@ def test_freshness_filters_reverted_and_failed_imports(
 ) -> None:
     """Raw rows tied to reverted/failed imports must not count toward staleness."""
     declare_only_models("core.dim_accounts")
-    freshness_db.execute(
-        "INSERT INTO core.dim_accounts VALUES ('a', ?, ?)",
-        [_ts(2026, 5, 10, 12, 0), _ts(2026, 5, 10, 12, 0)],
-    )
+    record_sqlmesh_apply(freshness_db, _ts(2026, 5, 10, 12, 0))
     # Reverted revert deletes raw rows in production; failed imports may leave
     # partial raw rows. Both should be filtered by import_log status.
-    freshness_db.execute(_INSERT_RAW_ACCOUNT, ["a", _ts(2026, 5, 13, 18, 24), "i1"])
-    freshness_db.execute(_INSERT_RAW_ACCOUNT, ["b", _ts(2026, 5, 13, 18, 30), "i2"])
+    freshness_db.execute(
+        _INSERT_RAW_ACCOUNT,
+        ["a", _ts(2026, 5, 13, 18, 0), _ts(2026, 5, 13, 18, 24), "i1"],
+    )
+    freshness_db.execute(
+        _INSERT_RAW_ACCOUNT,
+        ["b", _ts(2026, 5, 13, 18, 0), _ts(2026, 5, 13, 18, 30), "i2"],
+    )
     freshness_db.execute(_INSERT_IMPORT, ["i1", "reverted", _ts(2026, 5, 13, 18, 24)])
     freshness_db.execute(_INSERT_IMPORT, ["i2", "failed", _ts(2026, 5, 13, 18, 30)])
     f = TransformService(freshness_db).freshness()
@@ -168,15 +195,46 @@ def test_freshness_counts_partial_imports(
 ) -> None:
     """Partial imports landed some rows; they count toward staleness."""
     declare_only_models("core.dim_accounts")
+    record_sqlmesh_apply(freshness_db, _ts(2026, 5, 10, 12, 0))
     freshness_db.execute(
-        "INSERT INTO core.dim_accounts VALUES ('a', ?, ?)",
-        [_ts(2026, 5, 10, 12, 0), _ts(2026, 5, 10, 12, 0)],
+        _INSERT_RAW_ACCOUNT,
+        ["a", _ts(2026, 5, 13, 18, 0), _ts(2026, 5, 13, 18, 24), "i1"],
     )
-    freshness_db.execute(_INSERT_RAW_ACCOUNT, ["a", _ts(2026, 5, 13, 18, 24), "i1"])
     freshness_db.execute(_INSERT_IMPORT, ["i1", "partial", _ts(2026, 5, 13, 18, 24)])
     f = TransformService(freshness_db).freshness()
     assert f.pending is True
     assert f.latest_import_at == _ts(2026, 5, 13, 18, 24)
+
+
+def test_latest_import_at_ignores_an_in_flight_batch(
+    freshness_db: Database, declare_only_models: Callable[..., None]
+) -> None:
+    """An unfinished import has no completion time and must not be reported.
+
+    Pins the behavior against the reading the old filter documented — that
+    an in-flight batch should count. It never could: `completed_at` is NULL
+    until finalize, so MAX skipped it while the filter claimed otherwise.
+    """
+    declare_only_models("core.dim_accounts")
+    freshness_db.execute(_INSERT_IMPORT, ["i1", "complete", _ts(2026, 5, 13, 18, 24)])
+    freshness_db.execute(_INSERT_IMPORT, ["i2", "importing", None])
+    f = TransformService(freshness_db).freshness()
+    assert f.latest_import_at == _ts(2026, 5, 13, 18, 24)
+
+
+def test_freshness_pending_when_a_price_row_lands_after_the_last_apply(
+    freshness_db: Database, declare_only_models: Callable[..., None]
+) -> None:
+    """A price feed writes no import_log batch — it must still count.
+
+    ``raw.security_prices`` feeds ``core.fct_security_prices`` and arrives
+    with no ``import_id`` at all, so a scan set built around the import
+    ledger would miss every price observation MoneyBin fetches.
+    """
+    declare_only_models("core.dim_accounts")
+    record_sqlmesh_apply(freshness_db, _ts(2026, 5, 10, 12, 0))
+    freshness_db.execute(_INSERT_RAW_PRICE, [_ts(2026, 5, 13, 18, 24)])
+    assert TransformService(freshness_db).freshness().pending is True
 
 
 def test_apply_returns_apply_result_shape(
@@ -589,12 +647,15 @@ def test_freshness_pending_and_named_when_a_registered_model_was_never_built(
     """
     # `core.dim_accounts` below is a registered model no `db init` creates, so
     # its presence is what marks this warehouse built rather than brand new.
-    extracted = _ts(2026, 5, 13, 18, 24)
+    landed = _ts(2026, 5, 13, 18, 24)
     freshness_db.execute(
         "INSERT INTO core.dim_accounts VALUES ('a', ?, ?)",
-        [extracted, _ts(2026, 5, 13, 19, 0)],
+        [landed, _ts(2026, 5, 13, 19, 0)],
     )
-    freshness_db.execute(_INSERT_RAW_ACCOUNT, ["a", extracted, "i1"])
+    record_sqlmesh_apply(freshness_db, _ts(2026, 5, 13, 19, 0))
+    freshness_db.execute(
+        _INSERT_RAW_ACCOUNT, ["a", _ts(2026, 5, 13, 18, 0), landed, "i1"]
+    )
     freshness_db.execute(_INSERT_IMPORT, ["i1", "complete", _ts(2026, 5, 13, 18, 30)])
 
     f = TransformService(freshness_db).freshness()
@@ -602,6 +663,147 @@ def test_freshness_pending_and_named_when_a_registered_model_was_never_built(
     assert f.pending is True
     assert "core.fct_transactions" in f.missing_models
     assert "core.dim_accounts" not in f.missing_models
+
+
+def _manual_entry_db(
+    db: Database, declare_only_models: Callable[..., None]
+) -> Database:
+    """A UTC-pinned DB with real core tables and one applied SQLMesh plan."""
+    from tests.moneybin.db_helpers import create_core_tables
+
+    db.execute("SET TimeZone = 'UTC'")
+    create_core_tables(db)
+    declare_only_models("core.dim_accounts")
+    record_sqlmesh_apply(db, _ts(2020, 1, 1))
+    return db
+
+
+def test_freshness_pending_after_a_manual_transaction_is_recorded(
+    db: Database, declare_only_models: Callable[..., None]
+) -> None:
+    """The 2026-07-26 finding: manual entry wrote rows no freshness check read.
+
+    Drives the real write path rather than inserting into
+    ``raw.manual_transactions`` directly — a hand-rolled row would still
+    pass if the service left the landing column unset.
+    """
+    from moneybin.services.transaction_service import TransactionService
+
+    manual_db = _manual_entry_db(db, declare_only_models)
+    manual_db.execute(
+        "INSERT INTO core.dim_accounts (account_id, account_type, source_type) "
+        "VALUES ('A1', 'checking', 'manual')"
+    )
+
+    TransactionService(manual_db).create_manual_batch(
+        [
+            {
+                "account_id": "A1",
+                "amount": Decimal("-12.34"),
+                "transaction_date": "2026-04-15",
+                "description": "Coffee Shop",
+            }
+        ],
+        actor="cli",
+    )
+
+    assert TransformService(manual_db).freshness().pending is True
+
+
+def test_freshness_pending_after_a_manual_investment_event_is_recorded(
+    db: Database, declare_only_models: Callable[..., None]
+) -> None:
+    """Same finding, the ``investments_record`` half of it."""
+    from moneybin.repositories.securities_repo import SecuritiesRepo
+    from moneybin.services.investment_service import InvestmentService
+
+    manual_db = _manual_entry_db(db, declare_only_models)
+    manual_db.execute(
+        "INSERT INTO core.dim_accounts "
+        "(account_id, account_type, institution_name, source_type) "
+        "VALUES ('acct_brokerage', 'investment', 'Fidelity', 'manual')"
+    )
+    SecuritiesRepo(manual_db).upsert(
+        security_id=None,
+        name="Apple Inc.",
+        ticker="AAPL",
+        security_type="equity",
+        actor="cli",
+    )
+
+    InvestmentService(manual_db).record_event(
+        account_ref="acct_brokerage",
+        security_ref="AAPL",
+        type_="buy",
+        subtype=None,
+        trade_date=date(2024, 1, 15),
+        quantity=Decimal("10"),
+        price=Decimal("150.00"),
+        amount=Decimal("-1500.00"),
+        fees=None,
+        acquired=None,
+        basis=None,
+        event_group_id=None,
+        currency_code="USD",
+        description="buy aapl",
+        actor="cli",
+        created_by="cli",
+    )
+
+    assert TransformService(manual_db).freshness().pending is True
+
+
+def test_pending_scan_set_covers_every_raw_table_the_transforms_read(
+    db: Database,
+) -> None:
+    """The scan set must equal the raw tables SQLMesh models actually read.
+
+    Set equality both ways, not a count and not a subset. A raw table wired
+    into a model but absent here is data whose arrival ``pending`` cannot
+    see — the exact defect this scan set was widened to fix — and one listed
+    here that no model reads is a table whose arrivals no refresh can clear.
+    """
+    from moneybin.services.transform_service import (
+        _RAW_LANDING_COLUMNS,  # pyright: ignore[reportPrivateUsage]  # the guarded list
+    )
+    from moneybin.sqlmesh_registry import raw_tables_read_by_models
+
+    assert set(_RAW_LANDING_COLUMNS) == set(raw_tables_read_by_models())
+
+
+def test_every_declared_landing_and_import_column_exists(db: Database) -> None:
+    """A declaration that no longer matches the schema must fail, not go quiet.
+
+    Both halves are silent when stale: a renamed landing column makes the
+    scan raise (caught and reported as "no raw data"), and an ``import_id``
+    that appears on a table declared without one leaves reverted rows
+    counting toward staleness forever.
+    """
+    from moneybin.services.transform_service import (
+        _RAW_IMPORT_SCOPED,  # pyright: ignore[reportPrivateUsage]  # the guarded list
+        _RAW_LANDING_COLUMNS,  # pyright: ignore[reportPrivateUsage]  # the guarded list
+    )
+
+    rows = db.execute(
+        "SELECT table_name, column_name FROM duckdb_columns() WHERE schema_name = 'raw'"
+    ).fetchall()
+    columns: dict[str, set[str]] = {}
+    for table, column in rows:
+        columns.setdefault(str(table), set()).add(str(column))
+
+    declared_landing = {
+        table: {column} for table, column in _RAW_LANDING_COLUMNS.items()
+    }
+    actual_landing = {
+        table: columns.get(table, set()) & {column}
+        for table, column in _RAW_LANDING_COLUMNS.items()
+    }
+    assert actual_landing == declared_landing
+
+    actual_import_scoped = {
+        table for table in _RAW_LANDING_COLUMNS if "import_id" in columns.get(table, ())
+    }
+    assert actual_import_scoped == _RAW_IMPORT_SCOPED
 
 
 @pytest.mark.fresh_db


### PR DESCRIPTION
Two defects found live during a Plaid Investments e2e pass, both instances of
the same thing: the manual-entry write path was not wired into the machinery
that reports on it.

## `transforms.pending` only watched account staging

The freshness flag on `system_status` and `moneybin transform status` compared
`raw.ofx_accounts` / `plaid_accounts` / `tabular_accounts` against
`core.dim_accounts.updated_at`. Rows landing in any other raw table — a
transaction import, a price feed, a manual entry — left the flag reading
"up to date" with a full refresh outstanding.

It now scans all 17 raw tables a SQLMesh model actually reads. Two details
that decided the shape:

- **Landing time, not `extracted_at`.** OFX stamps `extracted_at` when parsing
  begins and Plaid carries the provider's own sync time; both can predate an
  apply that ran while the rows were still in flight, which would make those
  rows read as already-transformed permanently. `loaded_at` (`created_at` on
  the two manual tables) is written inside the write transaction, which the
  single-writer lock orders strictly against an apply.
- **One timezone domain.** Naive DuckDB stamps, arrow-UTC ingest, and
  SQLMesh's UTC epoch-millisecond `finalized_ts` are three different frames,
  and a mismatch fails silent — reading fresh when stale. The comparison runs
  entirely in DuckDB's `TIMESTAMPTZ` domain so both sides are absolute
  instants.

The honest cost: the old check was immune to clock and timezone skew because
it compared a value to itself, propagated through SQLMesh. That immunity is
what buys coverage of 17 tables instead of 3.

A hand-maintained scan set can silently shrink, so a test asserts **set
equality** — never a count, never a subset — against the raw tables derived
live from the model files. A raw table wired into a model but absent from the
scan set fails the build.

Also fixes `_max_completed_import_at`, whose `NOT IN ('reverted', 'failed')`
filter admitted in-flight `'importing'` batches whose `completed_at` is NULL
until finalize, so `MAX` skipped every one of them anyway.

## Manual entries never closed their import batch

The success path opened an `import_log` batch and never called
`finalize_import`, leaving the row `'importing'` forever with a NULL
`completed_at` and NULL row counts — indistinguishable from a crashed write in
`moneybin import history` and `import_status`. Three call sites, all fixed.

## Review pass

`/code-review medium --fix` found a fail-open in the new scan and one unguarded
read; both are fixed in the second commit with three regression tests. A single
absent raw table had made the whole 17-table UNION return "no raw data", and
`_last_apply_finalized_at` read a SQLMesh-owned table with no exception handling.

## Verification

- Unit suite: 7595 passed, 4 skipped.
- The three slow integration scenarios that drive a **real** SQLMesh apply pass
  separately — `make test` excludes `slow`, and they are the only coverage
  proving a real apply writes a `finalized_ts` the plain SELECT reads.
- `make check`: ruff clean, pyright 0 errors.