### PR TITLE
Record the invisible-target lesson from the PRAGMA leak

### DIFF
--- a/.claude/references/guard-design.md
+++ b/.claude/references/guard-design.md
@@ -56,30 +56,37 @@ match the command word instead. (#346)
 
 **Matching the verb does not gate what the verb touches.** #346's "match the
 command word" bounds *which* statement runs; it says nothing about *what it
-reads*, and for a whole class of statements the target is invisible to the AST.
+reads*, and for a whole class of statements the target is invisible to the
+**generic table walk**, not to the AST itself. Take the leaked pragma:
 `PRAGMA storage_info('sqlmesh__core.core__dim_accounts__<hash>')` parses its
 target to a **string literal inside `exp.Anonymous`** — not an `exp.Table` — so
-`tables_outside_schemas` finds no table to refuse and the schema allowlist
-silently does not apply. `EXPLAIN` has the identical defect via `exp.Command`.
-The consequence was a cleartext CRITICAL leak: `storage_info`'s per-segment
-`Min:`/`Max:` stats returned an 8-character prefix of a stored 9-digit
-`routing_number` (ABA check digit makes the ninth arithmetically recoverable),
-in an envelope declaring `sensitivity: "low"` — so the audit trail recorded the
-wrong tier too. **No allowlist of verb names fixes an invisible target**, and
-re-parsing the payload to gate it is the #346 shape (classify a derived string
-while the engine executes the original). #360 dropped `PRAGMA` and `EXPLAIN`
-from the accepted prefixes outright instead; `sql_schema` already covered the
-legitimate introspection need, so the user-facing cost was near zero. Two rules
-carry forward. **Assert on `stats` content, not on the statement being
-refused**: a future stats-bearing pragma admitted by a name allowlist would
-reintroduce the leak while a refusal-shaped test stayed green
+`tables_outside_schemas`, which walks `find_all(exp.Table)`, finds no table to
+refuse and the schema allowlist silently does not apply. `EXPLAIN` has the
+identical defect via `exp.Command`. The consequence was a cleartext CRITICAL
+leak: `storage_info`'s per-segment `Min:`/`Max:` stats returned an 8-character
+prefix of a stored 9-digit `routing_number` (ABA check digit makes the ninth
+arithmetically recoverable), in an envelope declaring `sensitivity: "low"` — so
+the audit trail recorded the wrong tier too. **No allowlist of verb names fixes
+a target the table walk never visits.** A verb-specific reader could reach that
+literal — but gating on what it reads means re-parsing the payload, which is the
+#346 shape exactly (classify a derived string while the engine executes the
+original). #360 dropped `PRAGMA` and `EXPLAIN` from the accepted prefixes
+outright instead. **Price a removal on every surface the primitive backs**:
+`execute_sql_query` serves the MCP tool and `moneybin sql query` alike, and
+there is no CLI counterpart to `sql_schema` (`sql_query.py:373-376`). The cost
+was near zero on both, for two different reasons — MCP callers already had
+`sql_schema`, and CLI callers keep the `DESCRIBE`/`SHOW` the same change left
+admitted. Citing only the MCP replacement would have priced half the blast
+radius. Two rules carry forward. **Assert on `stats` content, not on the
+statement being refused**: a future stats-bearing pragma admitted by a name
+allowlist would reintroduce the leak while a refusal-shaped test stayed green
 (`test_metadata_path_never_returns_a_critical_value` pins the prefix, not the
 verdict). And **the same engine re-exposes a closed verb as a table function** —
 `SELECT * FROM pragma_storage_info(...)` clears a prefix gate on a literal
 `SELECT`. That one is closed, but not by the mechanism you would guess: sqlglot
 parses the call to an `exp.Table` whose `db` *and* `name` are both empty, so it
 takes the unqualified branch, matches no allowed schema, and fails closed. An
-empty *schema* alone would not have done it — the empty **name** is what finds
+empty **schema** alone would not have done it — the empty **name** is what finds
 nothing to resolve. (#360)
 
 **Applying an existing guard to a second path means guarding a tree the first

--- a/.claude/references/guard-design.md
+++ b/.claude/references/guard-design.md
@@ -54,6 +54,46 @@ nodes: sqlglot lowers `EXPLAIN` to the same `exp.Command` it uses for syntax it
 cannot parse, so allowlisting that node wholesale reopens what you just closed —
 match the command word instead. (#346)
 
+**Matching the verb does not gate what the verb touches.** #346's "match the
+command word" bounds *which* statement runs; it says nothing about *what it
+reads*, and for a whole class of statements the target is invisible to the AST.
+`PRAGMA storage_info('sqlmesh__core.core__dim_accounts__<hash>')` parses its
+target to a **string literal inside `exp.Anonymous`** — not an `exp.Table` — so
+`tables_outside_schemas` finds no table to refuse and the schema allowlist
+silently does not apply. `EXPLAIN` has the identical defect via `exp.Command`.
+The consequence was a cleartext CRITICAL leak: `storage_info`'s per-segment
+`Min:`/`Max:` stats returned an 8-character prefix of a stored 9-digit
+`routing_number` (ABA check digit makes the ninth arithmetically recoverable),
+in an envelope declaring `sensitivity: "low"` — so the audit trail recorded the
+wrong tier too. **No allowlist of verb names fixes an invisible target**, and
+re-parsing the payload to gate it is the #346 shape (classify a derived string
+while the engine executes the original). #360 dropped `PRAGMA` and `EXPLAIN`
+from the accepted prefixes outright instead; `sql_schema` already covered the
+legitimate introspection need, so the user-facing cost was near zero. Two
+follow-ons worth carrying: a regression test here must assert on **`stats`
+content**, not on the statement being refused — a future stats-bearing pragma
+admitted by a name allowlist reintroduces this silently; and the same engine
+often re-exposes the closed verb as a **table function**
+(`SELECT * FROM pragma_storage_info(...)`), which clears a prefix gate on a
+literal `SELECT`. That one is bounded only because an unqualified function
+resolves to an empty schema name and the allowlist fails closed on it — verify
+that, don't assume it. (#360)
+
+**Applying an existing guard to a second path means guarding a tree the first
+path had already normalized.** The false *refusals* land in the shape the
+original path silently repaired. Extending `tables_outside_schemas` to
+`sql_query`'s metadata branch produced two, both caught in review: `DESCRIBE
+CORE.dim_accounts` was refused because the data path lowercases via
+`expand_star` while the metadata path passes the raw parse tree, and `SHOW
+TABLES FROM core` was refused because sqlglot parses that schema into a Table
+node's *name* slot rather than its `db` slot. The test-design consequence is
+sharp: **a fixture on a DENIED schema cannot catch either** — `RAW` is refused
+whatever its case, so the assertion passes for the wrong reason. Only an
+**allowed** schema in non-canonical case isolates the guard. When you re-apply a
+guard at a new call site, enumerate the normalizations the original site
+performed upstream of it, and write the fixture where a false refusal would be
+*visible*. (#360)
+
 **Enumerate the exposed set, never the declared set.** A guard that iterates the
 registry you are trusting can never reveal what you failed to declare. Widening
 `sql_query`'s gate to the whole `reports` schema shipped a masking hole: the

--- a/.claude/references/guard-design.md
+++ b/.claude/references/guard-design.md
@@ -69,15 +69,18 @@ wrong tier too. **No allowlist of verb names fixes an invisible target**, and
 re-parsing the payload to gate it is the #346 shape (classify a derived string
 while the engine executes the original). #360 dropped `PRAGMA` and `EXPLAIN`
 from the accepted prefixes outright instead; `sql_schema` already covered the
-legitimate introspection need, so the user-facing cost was near zero. Two
-follow-ons worth carrying: a regression test here must assert on **`stats`
-content**, not on the statement being refused — a future stats-bearing pragma
-admitted by a name allowlist reintroduces this silently; and the same engine
-often re-exposes the closed verb as a **table function**
-(`SELECT * FROM pragma_storage_info(...)`), which clears a prefix gate on a
-literal `SELECT`. That one is bounded only because an unqualified function
-resolves to an empty schema name and the allowlist fails closed on it — verify
-that, don't assume it. (#360)
+legitimate introspection need, so the user-facing cost was near zero. Two rules
+carry forward. **Assert on `stats` content, not on the statement being
+refused**: a future stats-bearing pragma admitted by a name allowlist would
+reintroduce the leak while a refusal-shaped test stayed green
+(`test_metadata_path_never_returns_a_critical_value` pins the prefix, not the
+verdict). And **the same engine re-exposes a closed verb as a table function** —
+`SELECT * FROM pragma_storage_info(...)` clears a prefix gate on a literal
+`SELECT`. That one is closed, but not by the mechanism you would guess: sqlglot
+parses the call to an `exp.Table` whose `db` *and* `name` are both empty, so it
+takes the unqualified branch, matches no allowed schema, and fails closed. An
+empty *schema* alone would not have done it — the empty **name** is what finds
+nothing to resolve. (#360)
 
 **Applying an existing guard to a second path means guarding a tree the first
 path had already normalized.** The false *refusals* land in the shape the


### PR DESCRIPTION
## Summary

Adds two guard-design lessons from #360's `PRAGMA storage_info` leak to
`.claude/references/guard-design.md` — the reference `.claude/rules/testing.md`
routes agents to before they write or change a guard.

- **Matching the verb does not gate what the verb touches.** #346's "match the
  command word" bounds *which* statement runs, not *what it reads*. A pragma's
  target is a string literal inside `exp.Anonymous`, and an `EXPLAIN`'s payload
  stays unparsed inside `exp.Command` — so `tables_outside_schemas` finds no
  table and the schema allowlist silently does not apply. That returned an
  8-of-9-digit cleartext prefix of a stored `routing_number` in an envelope
  declaring `sensitivity: "low"`, so the audit trail recorded the wrong tier
  too. No allowlist of verb *names* fixes an invisible target.
- **Re-applying a guard at a second call site guards a tree the first site had
  already normalized.** The false *refusals* land in the shape the original path
  silently repaired (`DESCRIBE CORE.dim_accounts`, `SHOW TABLES FROM core`), and
  a fixture on a DENIED schema cannot catch either — it passes for the wrong
  reason. Only an *allowed* schema in non-canonical case isolates the guard.

The second commit replaces the first draft's unverified hedge about
table-function re-exposure (`SELECT * FROM pragma_storage_info(...)`) with the
checked result. It is closed, but not by the guessed mechanism: sqlglot yields
an `exp.Table` whose `db` **and** `name` are both empty, so it takes the
unqualified branch and matches no allowed schema. An empty schema alone would
not have closed it — that distinction is the difference between a guard that
holds and one that holds by accident.

## Test plan

- [x] `uv run pytest tests/test_documentation_policy.py` — 2 passed, exit 0 (the
      layer covering `.claude/**` content policy)
- [x] Table-function claim checked against the live guard rather than asserted:
      `tables_outside_schemas` returns a non-empty refusal list for
      `pragma_storage_info('core.dim_accounts')`,
      `pragma_storage_info('raw.leaky')`, `pragma_table_info('raw.leaky')`, and
      `duckdb_columns()`
- [ ] Reviewers: confirm `test_metadata_path_never_returns_a_critical_value`
      asserts on `stats` *content* (the 8-char prefix), not on the statement
      being refused — the doc now cites it as pinning that rule

Docs-only. No runtime code paths touched.

## Related

Refs #360, #346
