### PR TITLE
Codify four session learnings into the rules

### DIFF
--- a/.claude/rules/branching.md
+++ b/.claude/rules/branching.md
@@ -8,6 +8,19 @@ description: "Branch prefix → PR label mapping, commit message style"
 
 `{type}/{kebab-case-summary}` — e.g., `feat/add-oauth-support`, `fix/null-pointer-auth`, `deps/bump-typer`.
 
+## Branch names are a public surface
+
+A branch name reaches origin, every PR URL, the reflog, and CI logs — all
+public. Never build one from real account data: an institution plus a last four
+is a linked pair, and a rename does not recall it. One such branch had to be
+force-deleted from origin with its history rewritten, and the worktree
+directory kept the name afterward.
+
+Name the defect, not the account — `fix/cross-source-dedup-remediation`, never
+`fix/<bank>-<last-four>-…`. The same applies to worktree directory names, which
+the native mechanism derives from the branch. This rule file is public too:
+describe the shape, never paste the offending name as an example.
+
 ## Type → Label Mapping
 
 Every branch must use one of these prefixes. The corresponding GitHub label is applied to the PR.

--- a/.claude/rules/sandboxing.md
+++ b/.claude/rules/sandboxing.md
@@ -79,7 +79,7 @@ The sandbox is a guard, not an obstacle. Default to fixing the policy, not bypas
 
 ## Known cases — don't re-derive these
 
-Each of these has already cost a debugging detour. The first four are failures that **look** like they need a bypass and do not.
+Each of these has already cost a debugging detour. The first five are failures that **look** like they need a bypass and do not.
 
 | Case | What actually happens | What to do |
 |---|---|---|
@@ -87,6 +87,7 @@ Each of these has already cost a debugging detour. The first four are failures t
 | `gh run view --log-failed` | Works in-sandbox — the `gh` cache path is allowlisted. | Read CI failure logs directly; no bypass. |
 | Bare `git push` after the sandbox blocked the `-u` write | Reports success and **no-ops**. | Push `HEAD:<branch>` explicitly, then verify `origin/<branch>` actually moved. |
 | `git branch -m` on a fresh branch → `could not lock config file .git/config` | The ref rename **succeeded**; only the (nonexistent) upstream-config write failed. | Confirm with `git symbolic-ref HEAD` and `git worktree list`. Don't retry unsandboxed. |
+| `moneybin demo` / `accounts links run` → `PasswordSetError: Can't store password on keychain: (-60008)` | The keychain **write** is denied. Reads are unaffected and `moneybin db backup` completes normally (34.5 MB written), so only commands that store a secret fail. | Not an allowlist problem. For `demo`, supply the in-memory keyring: `PYTHON_KEYRING_BACKEND=tests.e2e.memory_keyring.MemoryKeyring PYTHONPATH="$PWD" uv run moneybin demo …`. For `accounts links run`, go via MCP — the server holds its own keyring session. |
 | Compound bash — several `&&`/`;` statements or subshells | Defeats the static analyzer and prompts even when every component is allowlisted. | One statement per call, or move the logic into a single `python3` / `uv run python` helper. |
 | Bare `uv run sqlmesh -p … format` | Forks a worker pool the encrypted-DB design disallows. | `make format-sql` (sets `MAX_FORK_WORKERS=1`). |
 | Reading repos under `~/Workspace/` other than `moneybin*` (sibling clones, external projects) | Outside the read allowlist. | Genuine one-off bypass — quote the denied path first. |

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -198,6 +198,39 @@ guard may have silently started catching them. Pick fixture values that fail
 exactly one condition: a *long* pattern with a huge blast radius tests breadth;
 a *short* pattern with a tiny blast radius tests specificity.
 
+## A Fixture That Never Reaches the Predicate Proves Nothing
+
+The sibling failure of the section above: not two guards catching one fixture,
+but *zero* guards executing. A green result from a check whose predicate never
+ran is indistinguishable from a green result from a check that passed.
+
+`duplicate_account_overlap` narrows with `GROUP BY institution_slug HAVING
+COUNT(*) > 1`. The `basic` demo persona holds two accounts at two *different*
+institutions, so `contested_accounts` was empty, the invariant returned no
+rows, and the check reported green with its detection logic never evaluated.
+Re-running with `--persona family --years 3` produced two Chase accounts and
+2,886 transactions, and the same green meant something.
+
+**How to apply.** Before trusting a green invariant or scenario, prove the
+input reached the predicate: count the rows satisfying the *narrowing* clause —
+the `WHERE`, the `HAVING`, the join — and hand-derive that it is non-zero.
+
+## Fixture Dates Expire When the Code Filters on Now
+
+A test that pins absolute fixture dates against code filtering on a wall-clock
+window stops testing anything once the window moves past them — and the failure
+surfaces months later, attributed to whatever change was in flight that day.
+
+`test_spending_service` pinned transactions in 2026-03 and 2026-04 against
+`by_category`, which filters `transaction_year_month >= CURRENT_DATE - INTERVAL
+n months`. On 2026-08-02 two tests failed for a reason unrelated to any code
+change in that session.
+
+**How to apply.** When the code under test filters relative to `CURRENT_DATE`,
+`now()`, or `today()`, derive fixture dates from the same clock or freeze it —
+never write an absolute literal on the far side of a moving window. Check the
+model or service for `CURRENT_DATE` / `INTERVAL` before pinning a date.
+
 ## Guard Design — How Guards Have Failed Here Before
 
 The failure modes above are one family. [`.claude/references/guard-design.md`](../references/guard-design.md)


### PR DESCRIPTION
Four rules earned during the cross-source dedup remediation (#377). Each one
cost a debugging detour or produced a false green that survived a full review
round.

### `.claude/rules/branching.md` — branch names are a public surface

A branch name reaches origin, every PR URL, the reflog, and CI logs. An
institution plus a last four in one is a linked pair that a rename does not
recall — the branch behind #377 had to be force-deleted from origin with its
history rewritten. The section describes the shape rather than pasting the
offending name, because this rule file is public too.

### `.claude/rules/sandboxing.md` — one new known case

The keychain **write** deny: `moneybin demo` and `accounts links run` fail with
`PasswordSetError: (-60008)` while reads and `db backup` complete normally. It
reads like an allowlist problem and is not. Records the in-memory-keyring route
for `demo` and the MCP route for `accounts links run`.

### `.claude/rules/testing.md` — two fixture failure modes

**A fixture that never reaches the predicate proves nothing.** The sibling of
the existing "trips two guards" section: not two guards catching one fixture,
but zero guards executing. A doctor invariant reported green against a persona
whose two accounts sat at two different institutions, so its `HAVING COUNT(*) >
1` never matched and the detection logic never ran.

**Fixture dates expire when the code filters on now.** Absolute date literals
pinned against a `CURRENT_DATE - INTERVAL n months` filter stop testing
anything once the window moves past them, and the failure surfaces months later
attributed to whatever change was in flight.

### Verification

Markdown-only diff, so the covering gate is the markdown layer rather than the
Python suite: `pre-commit run --files` on all three paths passes. No `.py`,
SQL, or config files touched.