### PR TITLE
Ask before the CLI merges two accounts, and keep the prompt reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -421,10 +421,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   tax lots, and hand-set price marks that move, and waits for an answer. Pass
   `--yes` to answer in advance. `--standalone` is unchanged and never asks:
   keeping an account separate destroys nothing. Answering the prompt binds the
-  merge to the counts you read: the command re-derives them inside the write
-  transaction and refuses rather than committing a merge that grew while the
-  question was on screen. Declining prints `Cancelled — nothing was merged.` and
-  exits 0, matching every other confirm in the CLI (#385).
+  merge to what you read: inside the write transaction the command re-derives
+  both the counts it printed and the link rows the write actually repoints and
+  auto-rejects, and refuses rather than committing a merge that grew while the
+  question was on screen — including one that grew only in rows the printed
+  sentence has no words for, such as a sibling proposal a concurrent
+  `accounts links run` added. Declining prints `Cancelled — nothing was merged.`
+  and exits 0, matching every other confirm in the CLI (#385).
 - **A confirmation prompt no longer expires against the tool's timeout.** That
   cap exists to release a wedged database connection, and charging a person's
   reading time to it produced a dead end rather than a safeguard: at 30 seconds —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -412,6 +412,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   binding failure is what split the account in the first place.
 
 ### Changed
+- **`moneybin accounts links set --into` now shows what the merge moves and asks
+  before committing.** Accepting a link folds one account's whole history into
+  another, and no command splits it back apart — but this was the last accept
+  path that ran on a single unprompted invocation, while the same decision driven
+  through `identity_links_decide` had prompted since M1. The command now prints
+  the same sentence the MCP prompt shows, counting the accounts, transactions,
+  tax lots, and hand-set price marks that move, and waits for an answer. Pass
+  `--yes` to answer in advance. `--standalone` is unchanged and never asks:
+  keeping an account separate destroys nothing.
+- **A confirmation prompt no longer expires against the tool's timeout.** That
+  cap exists to release a wedged database connection, and charging a person's
+  reading time to it produced a dead end rather than a safeguard: at 30 seconds —
+  the default for 10 of the 16 operations that ask — the prompt was cancelled and
+  the answer came back `timed_out` with no token to retry with, so there was no
+  way to finish the operation at all. The cap now pauses while a prompt is on
+  screen and resumes with its remaining budget. Prompts get their own 120-second
+  window (`MONEYBIN_MCP__ELICITATION_WAIT_SECONDS`), after which the operation
+  degrades to the token path it already had for clients that cannot prompt —
+  still gated, still finishable. An unanswered export-redaction prompt refuses
+  instead, rather than falling back to a policy nobody chose.
 - **Breaking:** **Every import now stops before it merges a file into an
   account you already
   have.** Previously only CSV/Excel stopped to ask; OFX and PDF resolved and
@@ -671,6 +691,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   will see `import_confirm` move band.
 
 ### Fixed
+- **Undoing a decision puts it back in the review queue, and the queue count now
+  says so.** `system audit undo` restores a link decision to pending, but the
+  counter that reports how many decisions await review was refreshed only by the
+  accept and reject paths — so a reversed accept left the queue re-filled and the
+  count reading zero. The count is the prompt to go look at the queue, so
+  under-reporting it is the one direction nothing else signals.
 - **A saved PDF recipe that misreads a masked account number now repairs
   itself (#380).** Recipes saved before the anchor fix in #371 read
   `Account Number: XXXX XXXX XXXX 1234` as the bare mask, producing an account

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -422,12 +422,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `--yes` to answer in advance. `--standalone` is unchanged and never asks:
   keeping an account separate destroys nothing. Answering the prompt binds the
   merge to what you read: inside the write transaction the command re-derives
-  both the counts it printed and the link rows the write actually repoints and
-  auto-rejects, and refuses rather than committing a merge that grew while the
-  question was on screen — including one that grew only in rows the printed
-  sentence has no words for, such as a sibling proposal a concurrent
-  `accounts links run` added. Declining prints `Cancelled — nothing was merged.`
-  and exits 0, matching every other confirm in the CLI (#385).
+  both the counts it printed and the exact link and decision rows the write
+  will repoint and settle, and refuses rather than committing a merge that
+  changed while the question was on screen. That covers changes the printed
+  sentence has no words for — a sibling proposal a concurrent
+  `accounts links run` added — and changes no count can express, such as one
+  pending sibling being resolved elsewhere while another arrives. Declining
+  prints `Cancelled — nothing was merged.` and exits 0, matching every other
+  confirm in the CLI (#385).
+- **`identity_links_decide`'s merge confirmation now binds to the same exact
+  rows.** The approval token digested the two account ids and a set of counts,
+  so a same-count change between the prompt and the commit verified cleanly.
+  It now carries the link and decision ids as well, through the `resolved_ids`
+  field the grant already covers. Tokens issued before this change no longer
+  verify — re-run the decision to get a current one (#385).
 - **A confirmation prompt no longer expires against the tool's timeout.** That
   cap exists to release a wedged database connection, and charging a person's
   reading time to it produced a dead end rather than a safeguard: at 30 seconds —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -420,7 +420,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the same sentence the MCP prompt shows, counting the accounts, transactions,
   tax lots, and hand-set price marks that move, and waits for an answer. Pass
   `--yes` to answer in advance. `--standalone` is unchanged and never asks:
-  keeping an account separate destroys nothing.
+  keeping an account separate destroys nothing. Answering the prompt binds the
+  merge to the counts you read: the command re-derives them inside the write
+  transaction and refuses rather than committing a merge that grew while the
+  question was on screen. Declining prints `Cancelled — nothing was merged.` and
+  exits 0, matching every other confirm in the CLI (#385).
 - **A confirmation prompt no longer expires against the tool's timeout.** That
   cap exists to release a wedged database connection, and charging a person's
   reading time to it produced a dead end rather than a safeguard: at 30 seconds —

--- a/docs/reference/account-matching.md
+++ b/docs/reference/account-matching.md
@@ -191,7 +191,8 @@ When the same account arrives from a second source and only matches *weakly*
 
 ```bash
 moneybin accounts links pending                    # see proposals: provisional account, candidate, signal, last4
-moneybin accounts links set <decision_id> --into <account_id>   # accept the merge
+moneybin accounts links set <decision_id> --into <account_id>   # accept the merge (asks first)
+moneybin accounts links set <decision_id> --into <account_id> --yes  # answer the prompt in advance
 moneybin accounts links set <decision_id> --standalone           # keep it as its own account
 moneybin accounts links run                        # re-scan existing accounts for twins
 ```

--- a/docs/specs/account-identity-resolution.md
+++ b/docs/specs/account-identity-resolution.md
@@ -490,7 +490,7 @@ Guard-2 free-text resolution):
 | Operation | CLI | MCP |
 |---|---|---|
 | List pending link proposals (grouped by provisional account) | `accounts links pending` | `reviews(kind="account_links", status="pending")` |
-| Resolve one — **merge** into a candidate, or keep **standalone** | `accounts links set <id> --into <account_id>` / `--standalone` | Accept with `identity_links_decide(decisions=[{"kind":"account_link","decision_id":"<id>","decision":"accept","target_id":"<account_id>"}])`; reject omits `target_id`. An accepted merge is gated by MCP elicitation; reject decisions do not prompt. |
+| Resolve one — **merge** into a candidate, or keep **standalone** | `accounts links set <id> --into <account_id>` / `--standalone` | Accept with `identity_links_decide(decisions=[{"kind":"account_link","decision_id":"<id>","decision":"accept","target_id":"<account_id>"}])`; reject omits `target_id`. An accepted merge is gated on both surfaces — MCP elicits, the CLI prints what moves and asks (`--yes` answers in advance). Reject decisions do not prompt on either. |
 | Reverse a prior decision | `accounts links undo <id>` | Find the operation with `system_audit(view="history", limit=50)`, optionally inspect it with `system_audit(view="detail", operation_id=...)`, then call `system_audit_undo(operation_id=...)`. |
 | Decision history | `accounts links history` | `reviews(kind="account_links", status="history")` |
 | Run resolution over unlinked accounts (backfill) | `accounts links run` | `refresh_run(steps=["identity"])` |

--- a/docs/specs/mcp-tool-timeouts.md
+++ b/docs/specs/mcp-tool-timeouts.md
@@ -41,7 +41,10 @@ Related code: `src/moneybin/mcp/` (tool registration and dispatch), `src/moneybi
    DuckDB connection across its prompt; verify that still holds before adding a
    confirm to a tool that opens one first. The human wait has its own separate
    bound (below), after which the call degrades to the opaque-token path rather
-   than failing.
+   than failing. Every bounded wait increments
+   `moneybin_mcp_elicitations_total{site,outcome}` — both `answered` and
+   `timeout`, because a miss count without the answers it is a fraction of
+   cannot say whether the configured window is long enough.
 
 ## Data Model
 

--- a/docs/specs/mcp-tool-timeouts.md
+++ b/docs/specs/mcp-tool-timeouts.md
@@ -30,12 +30,25 @@ Related code: `src/moneybin/mcp/` (tool registration and dispatch), `src/moneybi
    `gsheet_connect`, `gsheet_disconnect`, `sync_disconnect`,
    `identity_links_decide`, `import_confirm`, and `import_revert`.
 7. Tools that already complete in well under the cap are unchanged in behavior; the timeout is invisible on the happy path.
+8. **The cap bounds machine work, not human deliberation.** Time a call spends
+   waiting on a confirmation prompt is excluded from it: the deadline pauses for
+   the wait and resumes with its remaining budget intact
+   (`decorator.excluded_from_tool_deadline`). Charging a human's reading time to
+   a cap whose purpose is releasing a wedged DuckDB connection produced only a
+   dead end — the elicitation was cancelled at the cap and the caller received
+   `INFRA_TIMED_OUT` with no confirmation token, so there was no way to finish
+   the operation. The exclusion is safe because no confirm-gated tool holds a
+   DuckDB connection across its prompt; verify that still holds before adding a
+   confirm to a tool that opens one first. The human wait has its own separate
+   bound (below), after which the call degrades to the opaque-token path rather
+   than failing.
 
 ## Data Model
 
-No schema changes. One new configuration field:
+No schema changes. Two configuration fields:
 
 - `MoneyBinSettings.mcp.tool_timeout_seconds: float = 30.0` (env: `MONEYBIN_MCP__TOOL_TIMEOUT_SECONDS`). Validated to be `>=` the write-lock wait (`config.DEFAULT_WRITE_LOCK_MAX_WAIT_SECONDS`, the `get_database` `max_wait` default). A shorter cap would let a timed-out write tool's uncancellable thread-pool worker acquire the lock and commit after the caller already received the timeout envelope; requiring `timeout >= wait` guarantees the worker has stopped queuing by the time the caller gives up. See [`database-writer-coordination.md`](database-writer-coordination.md).
+- `MoneyBinSettings.mcp.elicitation_wait_seconds: float = 120.0` (env: `MONEYBIN_MCP__ELICITATION_WAIT_SECONDS`). How long a confirmation prompt waits for a human before the call gives up on the prompt. Deliberately not derived from `tool_timeout_seconds`: 10 of the 16 confirm sites run at the 30-second default, which is not a human-scale answer window, and raising those caps to suit a human would also hand a genuinely hung statement the same longer leash.
 
 ## Implementation Plan
 

--- a/docs/specs/moneybin-cli.md
+++ b/docs/specs/moneybin-cli.md
@@ -234,9 +234,11 @@ moneybin [--profile NAME] [--verbose] <command> [--output text|json] [--quiet] [
 |       +-- pending [--output json] [--quiet]
 |       |         List provisional accounts + candidate merge proposals; each candidate
 |       |         shows decision_id, candidate_account_id, display name, confidence, signal.
-|       +-- set <decision_id> --into <account_id> | --standalone
+|       +-- set <decision_id> --into <account_id> | --standalone [--yes]
 |       |         Merge the provisional into the candidate (--into) or keep as standalone
 |       |         (--standalone). The two flags are mutually exclusive; omitting both exits 2.
+|       |         A merge prints what it moves and asks before committing; --yes answers
+|       |         in advance. Standalone is never gated.
 |       +-- history [--limit N] [--output json] [--quiet]
 |       |         Recent decisions (all statuses), newest first.
 |       +-- run [--output json]

--- a/src/moneybin/cli/commands/accounts/links.py
+++ b/src/moneybin/cli/commands/accounts/links.py
@@ -14,9 +14,11 @@ from typing import TYPE_CHECKING
 
 import typer
 
+from moneybin import error_codes
 from moneybin.cli.output import OutputFormat, output_option, quiet_option
 from moneybin.cli.utils import handle_cli_errors
 from moneybin.database import get_database
+from moneybin.errors import UserError
 from moneybin.privacy.payloads.accounts import (
     AccountLinksHistoryPayload,
     AccountLinksPendingPayload,
@@ -24,11 +26,15 @@ from moneybin.privacy.payloads.accounts import (
 )
 from moneybin.protocol.envelope import build_envelope
 from moneybin.services.account_links_service import (
+    AccountLinkAcceptImpact,
     AccountLinksService,
 )
 from moneybin.services.identity_confirmation import identity_confirm_message
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from moneybin.database import Database
     from moneybin.services.review_decisions_service import IdentityDecisionPlan
 
 app = typer.Typer(
@@ -141,11 +147,15 @@ def links_set(
     target_account_id: str | None = into if not standalone else None
 
     with handle_cli_errors():
+        approved: dict[str, int] | None = None
         if target_account_id is not None and not yes:
-            _confirm_merge(decision_id, target_account_id)
+            approved = _confirm_merge(decision_id, target_account_id)
         with get_database(read_only=False) as db:
             AccountLinksService(db, actor="cli").set(
-                decision_id, target_account_id=target_account_id, decided_by="user"
+                decision_id,
+                target_account_id=target_account_id,
+                decided_by="user",
+                verify_accept=_drift_check(db, decision_id, approved),
             )
 
     action = (
@@ -156,8 +166,10 @@ def links_set(
     logger.info(f"✅ Decision {decision_id[:12]}... → {action}")
 
 
-def _merge_preview(decision_id: str, target_account_id: str) -> IdentityDecisionPlan:
-    """Resolve the merge read-only, the way MCP previews the same decision."""
+def _plan_merge(
+    db: Database, decision_id: str, target_account_id: str
+) -> IdentityDecisionPlan:
+    """Resolve the merge against ``db``, the way MCP plans the same decision."""
     # Deferred: the identity contracts and decision service are not worth loading
     # on every CLI invocation to gate one subcommand.
     from moneybin.mcp.write_contracts import (  # noqa: PLC0415 — keep off the cold-start path
@@ -167,7 +179,7 @@ def _merge_preview(decision_id: str, target_account_id: str) -> IdentityDecision
         ReviewDecisionsService,
     )
 
-    with get_database(read_only=True) as db:
+    try:
         return ReviewDecisionsService(db, actor="cli").plan_identity([
             AccountLinkDecisionRequest(
                 kind="account_link",
@@ -176,26 +188,108 @@ def _merge_preview(decision_id: str, target_account_id: str) -> IdentityDecision
                 target_id=target_account_id,
             )
         ])
+    except UserError as exc:
+        raise _preflight_reason(exc) from exc
 
 
-def _confirm_merge(decision_id: str, target_account_id: str) -> None:
-    """Show what the merge moves and require a yes before anything commits.
+def _merge_preview(decision_id: str, target_account_id: str) -> IdentityDecisionPlan:
+    """Resolve the merge read-only, the way MCP previews the same decision."""
+    with get_database(read_only=True) as db:
+        return _plan_merge(db, decision_id, target_account_id)
+
+
+def _drift_check(
+    db: Database, decision_id: str, approved: dict[str, int] | None
+) -> Callable[[AccountLinkAcceptImpact], None] | None:
+    """Refuse the write if the merge stopped matching the sentence the operator read.
+
+    The prompt reads on its own read-only connection and closes it, so the plan
+    shown and the plan committed are two separate reads with a human in between
+    — long enough for a concurrent import or sync to widen the merge. The
+    service calls this back inside its write transaction immediately before the
+    first mutation, which is the only place the comparison is worth anything;
+    ``mcp/tools/accounts.py`` verifies its own grant through the same hook.
+
+    ``None`` when nothing was approved: ``--yes`` and ``--standalone`` have no
+    displayed radius to hold the commit to, and inventing one would refuse a
+    write on a comparison the operator never saw.
+    """
+    if approved is None:
+        return None
+
+    def verify(impact: AccountLinkAcceptImpact) -> None:
+        # Re-plans rather than reading impact.blast_radius: that one counts link
+        # rows, while the sentence the operator answered counts transactions and
+        # accounts. Only the plan's own arithmetic can contradict what was shown.
+        current = _plan_merge(db, decision_id, impact.candidate_account_id).blast_radius
+        if current != approved:
+            raise UserError(
+                "This merge changed while the confirmation was open, so nothing "
+                "was written. Re-run the command to see what it moves now.",
+                code=error_codes.MUTATION_CONSTRAINT_VIOLATION,
+            )
+
+    return verify
+
+
+#: The per-decision codes ``plan_identity`` can attach, mapped to themselves.
+#: The lookup is what keeps the unwrapped code declared: ``--output json`` puts
+#: it in the envelope an agent reads, and a code assembled from a dict is
+#: invisible to the literal scan that proves every wire code was declared. An
+#: unrecognized value degrades to the batch code rather than reaching the wire
+#: unannounced.
+_PREFLIGHT_CODES = {
+    code: code
+    for code in (
+        error_codes.MUTATION_INVALID_INPUT,
+        error_codes.MUTATION_NOT_FOUND,
+        error_codes.MUTATION_CONSTRAINT_VIOLATION,
+        error_codes.MUTATION_NOTHING_TO_DO,
+    )
+}
+
+
+def _preflight_reason(exc: UserError) -> UserError:
+    """Unwrap a one-decision preflight failure back into its own message.
+
+    ``plan_identity`` batches per-decision reasons into ``details["errors"]``,
+    which the MCP envelope carries but the CLI's text mode never prints — it
+    shows ``message`` and ``hint`` only. A mistyped decision id would otherwise
+    read "Identity decision preflight failed." and nothing else, where the
+    ungated command used to name the id it could not find. One request can
+    produce at most one reason, so surface it directly.
+    """
+    errors: list[dict[str, object]] = (exc.details or {}).get("errors") or []
+    if len(errors) != 1:
+        return exc
+    (error,) = errors
+    return UserError(
+        str(error["reason"]),
+        code=_PREFLIGHT_CODES.get(str(error["code"]), exc.code),
+    )
+
+
+def _confirm_merge(decision_id: str, target_account_id: str) -> dict[str, int] | None:
+    """Show what the merge moves, require a yes, and return what was approved.
 
     Renders the same sentence the MCP elicitation shows, from the same preflight,
     because the decision does not change with the surface driving it: an accepted
     link folds one account's whole history into another and no command splits it
     back apart. This was the last accept path that committed unasked.
 
-    A plan that turns out not to be destructive — the decision is already
-    accepted, so nothing moves — passes through silently rather than asking about
-    a merge that will not happen.
+    Returns the blast radius the operator actually read, so the write can hold
+    itself to it. A plan that turns out not to be destructive — the decision is
+    already accepted, so nothing moves — returns ``None`` and asks nothing.
     """
     plan = _merge_preview(decision_id, target_account_id)
     if not plan.destructive:
-        return
-    typer.echo(identity_confirm_message(plan.blast_radius), err=True)
+        return None
+    approved = plan.blast_radius
+    typer.echo(identity_confirm_message(approved), err=True)
     if not typer.confirm("Merge these accounts?", default=False, err=True):
-        raise typer.Abort()
+        typer.echo("Cancelled — nothing was merged.", err=True)
+        raise typer.Exit(0)
+    return approved
 
 
 @app.command("history")

--- a/src/moneybin/cli/commands/accounts/links.py
+++ b/src/moneybin/cli/commands/accounts/links.py
@@ -10,6 +10,7 @@ deferred to the M1L audit-undo consumer.
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 import typer
 
@@ -25,6 +26,10 @@ from moneybin.protocol.envelope import build_envelope
 from moneybin.services.account_links_service import (
     AccountLinksService,
 )
+from moneybin.services.identity_confirmation import identity_confirm_message
+
+if TYPE_CHECKING:
+    from moneybin.services.review_decisions_service import IdentityDecisionPlan
 
 app = typer.Typer(
     help="Review and manage account-link binding decisions",
@@ -104,6 +109,12 @@ def links_set(
         "--standalone",
         help="Standalone-reject: keep the provisional account as its own canonical entity",
     ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip the merge confirmation prompt (--into only; --standalone never asks)",
+    ),
 ) -> None:
     """Accept (merge) or standalone-reject a pending account-link decision.
 
@@ -111,8 +122,13 @@ def links_set(
       --into <candidate_account_id>   merge the provisional into the candidate
       --standalone                    reject all candidates; provisional stays standalone
 
+    A merge shows what it moves and asks before committing; pass --yes to answer
+    it in advance. Rejecting is never gated — the provisional account stays where
+    it is.
+
     Examples:
       accounts links set dec001 --into ACC002
+      accounts links set dec001 --into ACC002 --yes
       accounts links set dec001 --standalone
     """
     if into is not None and standalone:
@@ -125,6 +141,8 @@ def links_set(
     target_account_id: str | None = into if not standalone else None
 
     with handle_cli_errors():
+        if target_account_id is not None and not yes:
+            _confirm_merge(decision_id, target_account_id)
         with get_database(read_only=False) as db:
             AccountLinksService(db, actor="cli").set(
                 decision_id, target_account_id=target_account_id, decided_by="user"
@@ -136,6 +154,48 @@ def links_set(
         else "standalone (rejected)"
     )
     logger.info(f"✅ Decision {decision_id[:12]}... → {action}")
+
+
+def _merge_preview(decision_id: str, target_account_id: str) -> IdentityDecisionPlan:
+    """Resolve the merge read-only, the way MCP previews the same decision."""
+    # Deferred: the identity contracts and decision service are not worth loading
+    # on every CLI invocation to gate one subcommand.
+    from moneybin.mcp.write_contracts import (  # noqa: PLC0415 — keep off the cold-start path
+        AccountLinkDecisionRequest,
+    )
+    from moneybin.services.review_decisions_service import (  # noqa: PLC0415 — keep off the cold-start path
+        ReviewDecisionsService,
+    )
+
+    with get_database(read_only=True) as db:
+        return ReviewDecisionsService(db, actor="cli").plan_identity([
+            AccountLinkDecisionRequest(
+                kind="account_link",
+                decision_id=decision_id,
+                decision="accept",
+                target_id=target_account_id,
+            )
+        ])
+
+
+def _confirm_merge(decision_id: str, target_account_id: str) -> None:
+    """Show what the merge moves and require a yes before anything commits.
+
+    Renders the same sentence the MCP elicitation shows, from the same preflight,
+    because the decision does not change with the surface driving it: an accepted
+    link folds one account's whole history into another and no command splits it
+    back apart. This was the last accept path that committed unasked.
+
+    A plan that turns out not to be destructive — the decision is already
+    accepted, so nothing moves — passes through silently rather than asking about
+    a merge that will not happen.
+    """
+    plan = _merge_preview(decision_id, target_account_id)
+    if not plan.destructive:
+        return
+    typer.echo(identity_confirm_message(plan.blast_radius), err=True)
+    if not typer.confirm("Merge these accounts?", default=False, err=True):
+        raise typer.Abort()
 
 
 @app.command("history")

--- a/src/moneybin/cli/commands/accounts/links.py
+++ b/src/moneybin/cli/commands/accounts/links.py
@@ -10,6 +10,7 @@ deferred to the M1L audit-undo consumer.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import typer
@@ -147,7 +148,7 @@ def links_set(
     target_account_id: str | None = into if not standalone else None
 
     with handle_cli_errors():
-        approved: dict[str, int] | None = None
+        approved: _ApprovedMerge | None = None
         if target_account_id is not None and not yes:
             approved = _confirm_merge(decision_id, target_account_id)
         with get_database(read_only=False) as db:
@@ -192,14 +193,44 @@ def _plan_merge(
         raise _preflight_reason(exc) from exc
 
 
-def _merge_preview(decision_id: str, target_account_id: str) -> IdentityDecisionPlan:
-    """Resolve the merge read-only, the way MCP previews the same decision."""
+@dataclass(frozen=True)
+class _ApprovedMerge:
+    """The two radii the operator's yes was bound to.
+
+    Neither one covers the other, which is why both travel together.
+    ``sentence`` is what the prompt printed — accounts, transactions, merchants
+    — and moves when a concurrent import brings new history into either side.
+    ``rows`` is what the write physically touches: the ``account_links`` it
+    repoints and the ``account_link_decisions`` it accepts and auto-rejects.
+    A concurrent ``accounts links run`` proposes one more candidate for the same
+    provisional and moves only the second, so a comparison holding just the
+    sentence would commit a merge that silently rejects a decision nobody read.
+    """
+
+    sentence: dict[str, int]
+    rows: dict[str, int]
+
+
+def _merge_preview(decision_id: str, target_account_id: str) -> _ApprovedMerge | None:
+    """Resolve both radii read-only, the way MCP previews the same decision.
+
+    ``None`` when the accept changes nothing — a decision already settled onto
+    this same candidate. The destructive check has to come first: ``accept_impact``
+    refuses a non-pending decision, so asking it about that legitimate re-run
+    would raise where the command should simply pass through.
+    """
     with get_database(read_only=True) as db:
-        return _plan_merge(db, decision_id, target_account_id)
+        plan = _plan_merge(db, decision_id, target_account_id)
+        if not plan.destructive:
+            return None
+        impact = AccountLinksService(db, actor="cli").accept_impact(
+            decision_id, target_account_id=target_account_id
+        )
+    return _ApprovedMerge(sentence=plan.blast_radius, rows=impact.blast_radius)
 
 
 def _drift_check(
-    db: Database, decision_id: str, approved: dict[str, int] | None
+    db: Database, decision_id: str, approved: _ApprovedMerge | None
 ) -> Callable[[AccountLinkAcceptImpact], None] | None:
     """Refuse the write if the merge stopped matching the sentence the operator read.
 
@@ -218,11 +249,13 @@ def _drift_check(
         return None
 
     def verify(impact: AccountLinkAcceptImpact) -> None:
-        # Re-plans rather than reading impact.blast_radius: that one counts link
-        # rows, while the sentence the operator answered counts transactions and
-        # accounts. Only the plan's own arithmetic can contradict what was shown.
+        # Both radii, because a merge can grow in either one alone. Re-planning
+        # catches history that arrived on either account; ``impact`` — which the
+        # service already recomputed on this transaction's own read — catches the
+        # links this write repoints and the sibling decisions it auto-rejects,
+        # none of which the plan's arithmetic counts.
         current = _plan_merge(db, decision_id, impact.candidate_account_id).blast_radius
-        if current != approved:
+        if current != approved.sentence or impact.blast_radius != approved.rows:
             raise UserError(
                 "This merge changed while the confirmation was open, so nothing "
                 "was written. Re-run the command to see what it moves now.",
@@ -269,7 +302,7 @@ def _preflight_reason(exc: UserError) -> UserError:
     )
 
 
-def _confirm_merge(decision_id: str, target_account_id: str) -> dict[str, int] | None:
+def _confirm_merge(decision_id: str, target_account_id: str) -> _ApprovedMerge | None:
     """Show what the merge moves, require a yes, and return what was approved.
 
     Renders the same sentence the MCP elicitation shows, from the same preflight,
@@ -277,15 +310,14 @@ def _confirm_merge(decision_id: str, target_account_id: str) -> dict[str, int] |
     link folds one account's whole history into another and no command splits it
     back apart. This was the last accept path that committed unasked.
 
-    Returns the blast radius the operator actually read, so the write can hold
-    itself to it. A plan that turns out not to be destructive — the decision is
-    already accepted, so nothing moves — returns ``None`` and asks nothing.
+    Returns both radii the operator's yes was bound to, so the write can hold
+    itself to them. A merge that turns out to move nothing — the decision is
+    already settled — returns ``None`` and asks nothing.
     """
-    plan = _merge_preview(decision_id, target_account_id)
-    if not plan.destructive:
+    approved = _merge_preview(decision_id, target_account_id)
+    if approved is None:
         return None
-    approved = plan.blast_radius
-    typer.echo(identity_confirm_message(approved), err=True)
+    typer.echo(identity_confirm_message(approved.sentence), err=True)
     if not typer.confirm("Merge these accounts?", default=False, err=True):
         typer.echo("Cancelled — nothing was merged.", err=True)
         raise typer.Exit(0)

--- a/src/moneybin/cli/commands/accounts/links.py
+++ b/src/moneybin/cli/commands/accounts/links.py
@@ -195,20 +195,25 @@ def _plan_merge(
 
 @dataclass(frozen=True)
 class _ApprovedMerge:
-    """The two radii the operator's yes was bound to.
+    """Everything the operator's yes was bound to.
 
-    Neither one covers the other, which is why both travel together.
     ``sentence`` is what the prompt printed — accounts, transactions, merchants
     — and moves when a concurrent import brings new history into either side.
-    ``rows`` is what the write physically touches: the ``account_links`` it
-    repoints and the ``account_link_decisions`` it accepts and auto-rejects.
-    A concurrent ``accounts links run`` proposes one more candidate for the same
-    provisional and moves only the second, so a comparison holding just the
-    sentence would commit a merge that silently rejects a decision nobody read.
+    ``links`` and ``decisions`` are the rows the write physically touches: the
+    ``account_links`` it repoints and the ``account_link_decisions`` it accepts
+    and auto-rejects. Neither half covers the other. A concurrent
+    ``accounts links run`` proposes one more candidate for the same provisional
+    and moves only the rows, so holding just the sentence would commit a merge
+    that silently rejects a decision nobody read.
+
+    The rows are identities rather than counts because a swap keeps every count
+    intact: one pending sibling resolved elsewhere while another arrives leaves
+    the same number of decisions in play and still changes which one dies.
     """
 
     sentence: dict[str, int]
-    rows: dict[str, int]
+    links: tuple[str, ...]
+    decisions: tuple[str, ...]
 
 
 def _merge_preview(decision_id: str, target_account_id: str) -> _ApprovedMerge | None:
@@ -226,7 +231,11 @@ def _merge_preview(decision_id: str, target_account_id: str) -> _ApprovedMerge |
         impact = AccountLinksService(db, actor="cli").accept_impact(
             decision_id, target_account_id=target_account_id
         )
-    return _ApprovedMerge(sentence=plan.blast_radius, rows=impact.blast_radius)
+    return _ApprovedMerge(
+        sentence=plan.blast_radius,
+        links=impact.link_ids,
+        decisions=impact.decision_ids,
+    )
 
 
 def _drift_check(
@@ -249,17 +258,26 @@ def _drift_check(
         return None
 
     def verify(impact: AccountLinkAcceptImpact) -> None:
-        # Both radii, because a merge can grow in either one alone. Re-planning
+        # Both halves, because a merge can move in either one alone. Re-planning
         # catches history that arrived on either account; ``impact`` — which the
-        # service already recomputed on this transaction's own read — catches the
-        # links this write repoints and the sibling decisions it auto-rejects,
+        # service already recomputed on this transaction's own read — names the
+        # exact links this write repoints and the exact decisions it settles,
         # none of which the plan's arithmetic counts.
         current = _plan_merge(db, decision_id, impact.candidate_account_id).blast_radius
-        if current != approved.sentence or impact.blast_radius != approved.rows:
+        if (
+            current != approved.sentence
+            or impact.link_ids != approved.links
+            or impact.decision_ids != approved.decisions
+        ):
             raise UserError(
                 "This merge changed while the confirmation was open, so nothing "
                 "was written. Re-run the command to see what it moves now.",
-                code=error_codes.MUTATION_CONSTRAINT_VIOLATION,
+                # Not MUTATION_CONSTRAINT_VIOLATION, which this file already uses
+                # for a structurally invalid decision. A stale approval is the
+                # retriable failure, and an agent reading --output json has to
+                # tell the two apart; import_cmd.py's delete_saved_format raises
+                # this same code from the same preview → confirm → verify shape.
+                code=error_codes.MUTATION_CONFIRMATION_MISMATCH,
             )
 
     return verify

--- a/src/moneybin/config.py
+++ b/src/moneybin/config.py
@@ -237,6 +237,7 @@ DEFAULT_WRITE_LOCK_MAX_WAIT_SECONDS: float = 10.0
 MIN_CONFIRMATION_TTL_SECONDS: int = 30
 DEFAULT_CONFIRMATION_TTL_SECONDS: int = 300
 MAX_CONFIRMATION_TTL_SECONDS: int = 900
+DEFAULT_ELICITATION_WAIT_SECONDS: float = 120.0
 
 
 class MCPConfig(BaseModel):
@@ -266,6 +267,16 @@ class MCPConfig(BaseModel):
             "list[X] / Sequence[X] / tuple[X, ...]. Exceeding returns a "
             "ResponseEnvelope.error with code='too_many_items'. Parallels max_rows "
             "for read responses. See docs/specs/moneybin-mcp.md §Collection size cap."
+        ),
+    )
+    elicitation_wait_seconds: float = Field(
+        default=DEFAULT_ELICITATION_WAIT_SECONDS,
+        gt=0.0,
+        description=(
+            "How long a destructive-operation confirmation prompt waits for a "
+            "human before degrading to the opaque-token path. Excluded from "
+            "tool_timeout_seconds, which bounds machine work only — no DuckDB "
+            "connection is held across the prompt."
         ),
     )
     confirmation_ttl_seconds: int = Field(

--- a/src/moneybin/mcp/confirmation.py
+++ b/src/moneybin/mcp/confirmation.py
@@ -238,7 +238,8 @@ async def grant_confirmation_or_raise(
                 response_description=(
                     "Select true only after reviewing the exact operation."
                 ),
-            )
+            ),
+            site="confirmation_grant",
         )
         # result is None only when nobody answered in time; fall through to the
         # opaque-token path so the caller keeps a way to finish, not a dead end.

--- a/src/moneybin/mcp/confirmation.py
+++ b/src/moneybin/mcp/confirmation.py
@@ -22,7 +22,7 @@ from moneybin.config import (
     get_settings,
 )
 from moneybin.errors import UserError
-from moneybin.mcp.elicitation import supports_elicitation
+from moneybin.mcp.elicitation import elicit_bounded, supports_elicitation
 
 if TYPE_CHECKING:
     from fastmcp.server.context import Context
@@ -230,17 +230,22 @@ async def grant_confirmation_or_raise(
     ctx = _active_context()
     if ctx is not None and supports_elicitation(ctx):
         expected_digest = _binding_digest(binding)
-        result = await ctx.elicit(
-            message,
-            response_type=bool,
-            response_title="Confirm high-impact operation",
-            response_description=(
-                "Select true only after reviewing the exact operation."
-            ),
+        result = await elicit_bounded(
+            ctx.elicit(
+                message,
+                response_type=bool,
+                response_title="Confirm high-impact operation",
+                response_description=(
+                    "Select true only after reviewing the exact operation."
+                ),
+            )
         )
-        if isinstance(result, AcceptedElicitation) and result.data is True:
-            return ConfirmationGrant(expected_digest)
-        raise _confirmation_declined()
+        # result is None only when nobody answered in time; fall through to the
+        # opaque-token path so the caller keeps a way to finish, not a dead end.
+        if result is not None:
+            if isinstance(result, AcceptedElicitation) and result.data is True:
+                return ConfirmationGrant(expected_digest)
+            raise _confirmation_declined()
 
     token = broker.issue(binding, now=_utcnow())
     raise _confirmation_required(

--- a/src/moneybin/mcp/decorator.py
+++ b/src/moneybin/mcp/decorator.py
@@ -95,6 +95,36 @@ def _get_timeout_seconds() -> float:
     return get_settings().mcp.tool_timeout_seconds
 
 
+_active_tool_timeout: ContextVar[asyncio.Timeout | None] = ContextVar(
+    "_active_tool_timeout", default=None
+)
+
+
+@contextmanager
+def excluded_from_tool_deadline() -> Generator[None]:
+    """Stop the tool's wall-clock cap while the call waits on a human.
+
+    The cap bounds machine work — a DuckDB statement that will not finish, an
+    HTTP call that hangs — so that a timed-out tool's connection can be reset.
+    A human reading a confirmation prompt is not machine work, and no
+    confirm-gated tool holds a connection across its prompt, so charging their
+    deliberation to that budget only produces a dead end at the cap. The
+    deadline resumes with its remaining machine budget intact.
+    """
+    cm = _active_tool_timeout.get()
+    deadline = cm.when() if cm is not None else None
+    if cm is None or deadline is None:
+        yield
+        return
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    cm.reschedule(None)
+    try:
+        yield
+    finally:
+        cm.reschedule(deadline + (loop.time() - started))
+
+
 def _get_max_items() -> int | None:
     """Read the configured collection cap. Indirected for test monkeypatching."""
     from moneybin.config import get_settings
@@ -598,10 +628,20 @@ def mcp_tool(
                 try:
                     with operation(), request_lifetime_scope(request_lifetime):
                         async with cm:
-                            if is_coro:
-                                result = await fn(*args, **kwargs)
-                            else:
-                                result = await asyncio.to_thread(fn, *args, **kwargs)
+                            # Published so a confirmation prompt can stop the
+                            # cap while it waits on a human; set inside the
+                            # `async with` because reschedule() requires an
+                            # entered Timeout.
+                            timeout_token = _active_tool_timeout.set(cm)
+                            try:
+                                if is_coro:
+                                    result = await fn(*args, **kwargs)
+                                else:
+                                    result = await asyncio.to_thread(
+                                        fn, *args, **kwargs
+                                    )
+                            finally:
+                                _active_tool_timeout.reset(timeout_token)
                 finally:
                     _call_conn_holder.reset(holder_token)
             except TimeoutError as exc:

--- a/src/moneybin/mcp/decorator.py
+++ b/src/moneybin/mcp/decorator.py
@@ -118,7 +118,15 @@ def excluded_from_tool_deadline() -> Generator[None]:
         return
     loop = asyncio.get_running_loop()
     started = loop.time()
-    cm.reschedule(None)
+    try:
+        cm.reschedule(None)
+    except RuntimeError:
+        # The cap fired in the instant between reading its deadline and pausing
+        # it; asyncio refuses to reschedule an expiring Timeout. The task is
+        # already being cancelled, so let the timed_out envelope stand rather
+        # than replacing it with an unclassified RuntimeError.
+        yield
+        return
     try:
         yield
     finally:

--- a/src/moneybin/mcp/elicitation.py
+++ b/src/moneybin/mcp/elicitation.py
@@ -14,6 +14,7 @@ from moneybin import error_codes
 from moneybin.config import DEFAULT_ELICITATION_WAIT_SECONDS, get_settings
 from moneybin.errors import UserError
 from moneybin.mcp.decorator import excluded_from_tool_deadline
+from moneybin.metrics.registry import MCP_ELICITATIONS_TOTAL
 
 if TYPE_CHECKING:
     from fastmcp.server.context import Context
@@ -34,7 +35,7 @@ def elicitation_wait_seconds() -> float:
         return DEFAULT_ELICITATION_WAIT_SECONDS
 
 
-async def elicit_bounded[T](elicitation: Awaitable[T]) -> T | None:
+async def elicit_bounded[T](elicitation: Awaitable[T], *, site: str) -> T | None:
     """Await one elicitation, bounded by the human-answer budget.
 
     Takes the ``ctx.elicit(...)`` coroutine itself so the caller keeps its
@@ -43,12 +44,22 @@ async def elicit_bounded[T](elicitation: Awaitable[T]) -> T | None:
     path instead of inheriting a default. The tool's wall-clock cap is paused
     for the wait; see ``excluded_from_tool_deadline`` for why a human's
     deliberation is not machine work.
+
+    ``site`` labels the counter. It is required rather than defaulted because
+    every call site degrades differently — token, refusal, setup envelope — and
+    one unlabelled bucket would hide which of them the misses came from.
     """
     try:
         with excluded_from_tool_deadline():
-            return await asyncio.wait_for(elicitation, elicitation_wait_seconds())
+            result = await asyncio.wait_for(elicitation, elicitation_wait_seconds())
     except TimeoutError:
+        MCP_ELICITATIONS_TOTAL.labels(site=site, outcome="timeout").inc()
         return None
+    # Deliberately not a `finally`: a transport failure or a cancelled call is
+    # neither an answer nor an expired window, and folding it into either label
+    # would corrupt the ratio the counter exists to report.
+    MCP_ELICITATIONS_TOTAL.labels(site=site, outcome="answered").inc()
+    return result
 
 
 def _confirmation_unavailable(
@@ -107,7 +118,8 @@ async def confirm_or_raise(
             response_description=(
                 "Select true only after reviewing the inference and affected data."
             ),
-        )
+        ),
+        site="confirm_or_raise",
     )
     if result is None:
         raise _confirmation_unavailable(

--- a/src/moneybin/mcp/elicitation.py
+++ b/src/moneybin/mcp/elicitation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Awaitable
 from typing import TYPE_CHECKING
 
 from fastmcp.server.dependencies import get_context
@@ -9,7 +11,9 @@ from fastmcp.server.elicitation import AcceptedElicitation
 from mcp.types import ClientCapabilities, ElicitationCapability
 
 from moneybin import error_codes
+from moneybin.config import DEFAULT_ELICITATION_WAIT_SECONDS, get_settings
 from moneybin.errors import UserError
+from moneybin.mcp.decorator import excluded_from_tool_deadline
 
 if TYPE_CHECKING:
     from fastmcp.server.context import Context
@@ -20,6 +24,31 @@ def supports_elicitation(ctx: Context) -> bool:
     return ctx.session.check_client_capability(
         ClientCapabilities(elicitation=ElicitationCapability())
     )
+
+
+def elicitation_wait_seconds() -> float:
+    """Read the configured human-answer budget. Indirected for monkeypatching."""
+    try:
+        return get_settings().mcp.elicitation_wait_seconds
+    except RuntimeError:
+        return DEFAULT_ELICITATION_WAIT_SECONDS
+
+
+async def elicit_bounded[T](elicitation: Awaitable[T]) -> T | None:
+    """Await one elicitation, bounded by the human-answer budget.
+
+    Takes the ``ctx.elicit(...)`` coroutine itself so the caller keeps its
+    precise result type. Returns ``None`` — never a real elicitation result —
+    when nobody answered in time, so every caller must choose its own degraded
+    path instead of inheriting a default. The tool's wall-clock cap is paused
+    for the wait; see ``excluded_from_tool_deadline`` for why a human's
+    deliberation is not machine work.
+    """
+    try:
+        with excluded_from_tool_deadline():
+            return await asyncio.wait_for(elicitation, elicitation_wait_seconds())
+    except TimeoutError:
+        return None
 
 
 def _confirmation_unavailable(
@@ -70,14 +99,25 @@ async def confirm_or_raise(
             reason="client_unsupported",
             detail="this client cannot prompt you (no elicitation)",
         )
-    result = await ctx.elicit(
-        message,
-        response_type=bool,
-        response_title="Confirm inferred financial behavior",
-        response_description=(
-            "Select true only after reviewing the inference and affected data."
-        ),
+    result = await elicit_bounded(
+        ctx.elicit(
+            message,
+            response_type=bool,
+            response_title="Confirm inferred financial behavior",
+            response_description=(
+                "Select true only after reviewing the inference and affected data."
+            ),
+        )
     )
+    if result is None:
+        raise _confirmation_unavailable(
+            subject=subject,
+            unchanged=unchanged,
+            cli_equivalent=cli_equivalent,
+            details=details,
+            reason="timeout",
+            detail="nobody answered the prompt in time",
+        )
     if not (isinstance(result, AcceptedElicitation) and result.data is True):
         raise _confirmation_unavailable(
             subject=subject,

--- a/src/moneybin/mcp/first_run.py
+++ b/src/moneybin/mcp/first_run.py
@@ -24,7 +24,7 @@ from fastmcp.tools import ToolResult
 from moneybin import error_codes
 from moneybin.config import set_current_profile
 from moneybin.errors import UserError
-from moneybin.mcp.elicitation import supports_elicitation
+from moneybin.mcp.elicitation import elicit_bounded, supports_elicitation
 from moneybin.observability import setup_observability
 from moneybin.protocol.envelope import build_error_envelope
 from moneybin.services.profile_service import ProfileExistsError, ProfileService
@@ -111,7 +111,9 @@ async def _elicit_profile_name(ctx: Context) -> str | None:
                 "Please enter a name like 'brandon'."
             )
         )
-        result = await ctx.elicit(message, response_type=str)
+        # None covers both a declined answer and one that never arrived; the
+        # caller returns the setup-required envelope either way.
+        result = await elicit_bounded(ctx.elicit(message, response_type=str))
         if not isinstance(result, AcceptedElicitation):
             return None
         try:

--- a/src/moneybin/mcp/first_run.py
+++ b/src/moneybin/mcp/first_run.py
@@ -100,7 +100,7 @@ async def _elicit_profile_name(ctx: Context) -> str | None:
     """Elicit a valid profile name, retrying once on an invalid answer.
 
     Returns the raw accepted name (un-normalized) or None if the user
-    declined/cancelled or gave two invalid answers.
+    declined/cancelled, never answered, or gave two invalid answers.
     """
     for attempt in range(2):
         message = (
@@ -113,7 +113,9 @@ async def _elicit_profile_name(ctx: Context) -> str | None:
         )
         # None covers both a declined answer and one that never arrived; the
         # caller returns the setup-required envelope either way.
-        result = await elicit_bounded(ctx.elicit(message, response_type=str))
+        result = await elicit_bounded(
+            ctx.elicit(message, response_type=str), site="first_run_profile"
+        )
         if not isinstance(result, AcceptedElicitation):
             return None
         try:

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -510,7 +510,10 @@ class _AccountMergeProposal:
     candidate_display_name: str
     confidence: float | None
     signal: str | None
-    blast_radius: dict[str, int]
+    #: The whole impact, not a flattened blast radius: the grant issued here has
+    #: to digest the same row identities the commit-time verify recomputes, so
+    #: dropping them at this boundary would make every account grant unverifiable.
+    impact: AccountLinkAcceptImpact
 
 
 def _load_pending_account_proposal(decision_id: str) -> _AccountMergeProposal:
@@ -533,7 +536,7 @@ def _load_pending_account_proposal(decision_id: str) -> _AccountMergeProposal:
                         candidate_display_name=candidate.candidate_display_name,
                         confidence=candidate.confidence,
                         signal=candidate.signal,
-                        blast_radius=impact.blast_radius,
+                        impact=impact,
                     )
     raise UserError(
         f"No pending account-link decision '{decision_id}'.",
@@ -546,10 +549,16 @@ def _account_link_binding(
     *,
     decision_id: str,
     target_account_id: str,
-    provisional_account_id: str,
-    blast_radius: dict[str, int],
+    impact: AccountLinkAcceptImpact,
 ) -> ConfirmationBinding:
-    """Bind approval to one exact live account merge."""
+    """Bind approval to one exact live account merge.
+
+    ``resolved_ids`` carries the link and decision rows, not only the two
+    accounts, because ``blast_radius`` is counts: a pending sibling resolved
+    elsewhere while another arrives leaves every count intact and still changes
+    which decision the commit auto-rejects. Naming the rows makes that swap
+    fail the digest instead of passing it.
+    """
     return ConfirmationBinding(
         arguments={
             "decision_id": decision_id,
@@ -557,14 +566,16 @@ def _account_link_binding(
             "target_account_id": target_account_id,
         },
         resolved_ids=(
-            provisional_account_id,
+            impact.provisional_account_id,
             target_account_id,
+            *impact.link_ids,
+            *impact.decision_ids,
         ),
         actor="mcp",
         profile=get_settings().profile,
         authorization_context="local-profile",
         operation_kind="account_identity_merge",
-        blast_radius=blast_radius,
+        blast_radius=impact.blast_radius,
     )
 
 
@@ -608,8 +619,7 @@ def _apply_account_accept(
             _account_link_binding(
                 decision_id=decision_id,
                 target_account_id=target_account_id,
-                provisional_account_id=impact.provisional_account_id,
-                blast_radius=impact.blast_radius,
+                impact=impact,
             )
         )
 
@@ -720,8 +730,7 @@ async def accounts_links_set(
             binding = _account_link_binding(
                 decision_id=decision_id,
                 target_account_id=target_account_id,
-                provisional_account_id=proposal.provisional_account_id,
-                blast_radius=proposal.blast_radius,
+                impact=proposal.impact,
             )
             message = _account_confirm_message(proposal)
         else:

--- a/src/moneybin/mcp/tools/exports.py
+++ b/src/moneybin/mcp/tools/exports.py
@@ -252,7 +252,8 @@ async def _select_redaction_mode(explicit: RedactionMode | None) -> RedactionMod
             response_description=(
                 "Choose redacted (the safe default) or explicitly choose unredacted."
             ),
-        )
+        ),
+        site="export_redaction",
     )
     if result is None:
         # Refuse rather than assume "redacted": the choice is the user's, and a

--- a/src/moneybin/mcp/tools/exports.py
+++ b/src/moneybin/mcp/tools/exports.py
@@ -31,7 +31,7 @@ from moneybin.mcp.confirmation import (
     grant_confirmation_or_raise,
 )
 from moneybin.mcp.decorator import mcp_tool
-from moneybin.mcp.elicitation import supports_elicitation
+from moneybin.mcp.elicitation import elicit_bounded, supports_elicitation
 from moneybin.privacy.taxonomy import DataClass
 from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
 from moneybin.repositories.export_destinations_repo import ExportDestinationsRepo
@@ -244,14 +244,20 @@ async def _select_redaction_mode(explicit: RedactionMode | None) -> RedactionMod
         raise _redaction_refusal("no_session") from exc
     if not supports_elicitation(ctx):
         raise _redaction_refusal("client_unsupported")
-    result = await ctx.elicit(
-        "Choose the redaction policy for this export run.",
-        response_type=["redacted", "unredacted"],
-        response_title="Export redaction mode",
-        response_description=(
-            "Choose redacted (the safe default) or explicitly choose unredacted."
-        ),
+    result = await elicit_bounded(
+        ctx.elicit(
+            "Choose the redaction policy for this export run.",
+            response_type=["redacted", "unredacted"],
+            response_title="Export redaction mode",
+            response_description=(
+                "Choose redacted (the safe default) or explicitly choose unredacted."
+            ),
+        )
     )
+    if result is None:
+        # Refuse rather than assume "redacted": the choice is the user's, and a
+        # silent default here is the inference this prompt exists to prevent.
+        raise _redaction_refusal("timeout")
     if not isinstance(result, AcceptedElicitation):
         raise _redaction_refusal("declined")
     if result.data not in {"redacted", "unredacted"}:

--- a/src/moneybin/mcp/tools/reviews.py
+++ b/src/moneybin/mcp/tools/reviews.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Mapping
 from dataclasses import replace
 from decimal import Decimal
 from functools import cmp_to_key
@@ -100,11 +99,11 @@ from moneybin.protocol.pagination import (
 from moneybin.services.account_links_service import AccountLinksService
 from moneybin.services.auto_rule_service import AutoRuleService
 from moneybin.services.categorization import CategorizationService
+from moneybin.services.identity_confirmation import identity_confirm_message
 from moneybin.services.matching_service import MatchingService
 from moneybin.services.merchant_links_service import MerchantLinksService
 from moneybin.services.mutation_context import current_operation_id
 from moneybin.services.review_decisions_service import (
-    IDENTITY_BLAST_RADIUS_CATEGORIES,
     IdentityDecisionPlan,
     ReviewDecisionsService,
 )
@@ -1070,47 +1069,6 @@ def reviews_decide_coarse(
     )
 
 
-#: How each blast-radius category is named in the prompt a human ratifies.
-#:
-#: Presentation, so it lives here rather than beside the category constant in the
-#: service — but it must stay in step with it, which
-#: ``test_every_blast_radius_category_has_a_prompt_label`` asserts by set
-#: equality. A category counted in the digest but absent from this map would be
-#: bound into the approval and left out of the sentence explaining it.
-IDENTITY_BLAST_RADIUS_LABELS: dict[str, tuple[str, str]] = {
-    "accounts": ("account", "accounts"),
-    "merchants": ("merchant", "merchants"),
-    "securities": ("security", "securities"),
-    "transactions": ("transaction", "transactions"),
-    "lots": ("tax lot", "tax lots"),
-    "price_marks": ("price mark you set by hand", "price marks you set by hand"),
-}
-
-
-def _identity_confirm_message(blast_radius: Mapping[str, int]) -> str:
-    """Prompt text naming what this batch moves, and how much of it.
-
-    The elicitation shows this string and nothing else — the binding's counts are
-    a digest the human never reads — so a category missing from here is a
-    mutation nobody was told about. Zero-count categories are omitted rather than
-    listed as zeros: a bind that touches one security should not read as a batch
-    reaching into accounts and merchants it never opens.
-    """
-    moved = [
-        f"{count} {IDENTITY_BLAST_RADIUS_LABELS[key][0 if count == 1 else 1]}"
-        for key in IDENTITY_BLAST_RADIUS_CATEGORIES
-        if (count := blast_radius.get(key, 0))
-    ]
-    return (
-        "Confirm this complete identity-decision batch. Accepted links can merge "
-        "account histories, merchant attribution, or security lots — including "
-        "any price marks you set by hand, which move onto the survivor — or bind "
-        "a price-feed symbol without merging anything; every decision in the "
-        "ordered batch will commit together.\n\n"
-        f"This batch touches: {', '.join(moved) if moved else 'no rows'}."
-    )
-
-
 def _identity_binding(
     decisions: list[IdentityDecisionRequest],
     plan: IdentityDecisionPlan,
@@ -1127,12 +1085,6 @@ def _identity_binding(
         for value in (item.request.decision_id, item.source_id, item.target_id):
             if value not in resolved_ids:
                 resolved_ids.append(value)
-    blast_radius = {
-        key: len({
-            entity_id for item in plan.items for entity_id in item.affected_ids[key]
-        })
-        for key in IDENTITY_BLAST_RADIUS_CATEGORIES
-    }
     return ConfirmationBinding(
         arguments=arguments,
         resolved_ids=tuple(resolved_ids),
@@ -1140,7 +1092,7 @@ def _identity_binding(
         profile=get_settings().profile,
         authorization_context="local-profile",
         operation_kind="identity_links_decide",
-        blast_radius=blast_radius,
+        blast_radius=plan.blast_radius,
     )
 
 
@@ -1197,7 +1149,7 @@ async def identity_links_decide_coarse(
     if plan.destructive:
         grant = await grant_confirmation_or_raise(
             binding=binding if confirmation_token is None else None,
-            message=_identity_confirm_message(binding.blast_radius),
+            message=identity_confirm_message(binding.blast_radius),
             confirmation_token=confirmation_token,
         )
     live = await asyncio.to_thread(

--- a/src/moneybin/metrics/registry.py
+++ b/src/moneybin/metrics/registry.py
@@ -169,6 +169,20 @@ TABULAR_SIGN_GATE_TOTAL = Counter(
     ["outcome"],  # values: "proposed", "confirmed", "overridden"
 )
 
+# ── MCP elicitation ──────────────────────────────────────────────────────────
+
+# Every confirm prompt gives the human a bounded window and degrades when it
+# closes unanswered — to an opaque token, a structured refusal, or a setup
+# envelope depending on the site. Both outcomes are counted because a timeout
+# count alone has no denominator: one miss means something different against
+# three prompts than against three thousand, and the configured window is a
+# guess until that ratio is observable.
+MCP_ELICITATIONS_TOTAL = Counter(
+    "moneybin_mcp_elicitations_total",
+    "Bounded MCP elicitation waits by call site and outcome.",
+    ("site", "outcome"),  # outcome: "answered" | "timeout"
+)
+
 # ── Smart import confirmation ────────────────────────────────────────────────
 
 IMPORT_CONFIRMATIONS_TOTAL = Counter(

--- a/src/moneybin/repositories/account_link_decisions_repo.py
+++ b/src/moneybin/repositories/account_link_decisions_repo.py
@@ -63,6 +63,14 @@ class AccountLinkDecisionsRepo(BaseRepo):
     table_ref = ACCOUNT_LINK_DECISIONS
     pk_columns = ("decision_id",)
 
+    def refresh_pending_gauge(self) -> None:
+        """Re-read the account-link queue depth after an undo restored rows to it."""
+        from moneybin.services.account_resolver import (  # noqa: PLC0415 — repo→service import must stay lazy
+            refresh_account_link_pending_gauge,
+        )
+
+        refresh_account_link_pending_gauge(self._db)
+
     def _fetch_row(self, decision_id: str) -> dict[str, Any] | None:
         return self._fetch_one(
             ACCOUNT_LINK_DECISIONS,

--- a/src/moneybin/repositories/base.py
+++ b/src/moneybin/repositories/base.py
@@ -240,6 +240,18 @@ class BaseRepo:
                 out[key] = value
         return out
 
+    def refresh_pending_gauge(self) -> None:
+        """Re-read any review-queue gauge this table feeds. No-op by default.
+
+        Undo reverses through repos rather than the services that own a queue, so
+        the refreshers those services run on every accept and reject do not fire
+        on the way back. A repo whose table backs a pending gauge overrides this;
+        ``UndoService`` calls it once per touched repo after the undo commits.
+        Declaring it here rather than mapping tables to refreshers in the undo
+        consumer keeps the knowledge in the repo that owns the table, the way
+        ``undo_dispatch`` already resolves repos by their own metadata.
+        """
+
     def undo_event(
         self,
         event: AuditEvent,

--- a/src/moneybin/repositories/merchant_link_decisions_repo.py
+++ b/src/moneybin/repositories/merchant_link_decisions_repo.py
@@ -66,6 +66,14 @@ class MerchantLinkDecisionsRepo(BaseRepo):
     table_ref: ClassVar[TableRef] = MERCHANT_LINK_DECISIONS
     pk_columns: ClassVar[tuple[str, ...]] = ("decision_id",)
 
+    def refresh_pending_gauge(self) -> None:
+        """Re-read the merchant-link queue depth after an undo restored rows to it."""
+        from moneybin.services.merchant_resolver import (  # noqa: PLC0415 — repo→service import must stay lazy
+            refresh_merchant_link_pending_gauge,
+        )
+
+        refresh_merchant_link_pending_gauge(self._db)
+
     def _fetch_row(self, decision_id: str) -> dict[str, Any] | None:
         return self._fetch_one(
             MERCHANT_LINK_DECISIONS,

--- a/src/moneybin/repositories/security_link_decisions_repo.py
+++ b/src/moneybin/repositories/security_link_decisions_repo.py
@@ -67,6 +67,14 @@ class SecurityLinkDecisionsRepo(BaseRepo):
     table_ref: ClassVar[TableRef] = SECURITY_LINK_DECISIONS
     pk_columns: ClassVar[tuple[str, ...]] = ("decision_id",)
 
+    def refresh_pending_gauge(self) -> None:
+        """Re-read the security-link queue depth after an undo restored rows to it."""
+        from moneybin.services.security_resolver import (  # noqa: PLC0415 — repo→service import must stay lazy
+            refresh_security_link_pending_gauge,
+        )
+
+        refresh_security_link_pending_gauge(self._db)
+
     def _fetch_row(self, decision_id: str) -> dict[str, Any] | None:
         return self._fetch_one(
             SECURITY_LINK_DECISIONS,

--- a/src/moneybin/services/account_links_service.py
+++ b/src/moneybin/services/account_links_service.py
@@ -36,11 +36,21 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class AccountLinkAcceptImpact:
-    """Stable identities and physical rows touched by an account merge."""
+    """Stable identities and physical rows touched by an account merge.
+
+    ``link_ids`` and ``decision_ids`` carry the rows themselves, not just how
+    many there are, because a confirmation bound to counts cannot see a swap:
+    one pending sibling resolved elsewhere while another arrives for the same
+    provisional leaves every count intact and still changes which decision the
+    write auto-rejects. Both are sorted so the comparison and the MCP grant
+    digest are stable — the queries below carry no ORDER BY of their own.
+    """
 
     provisional_account_id: str
     candidate_account_id: str
     blast_radius: dict[str, int]
+    link_ids: tuple[str, ...]
+    decision_ids: tuple[str, ...]
 
 
 def _resolve_display_name(db: Database, account_id: str) -> str:
@@ -179,37 +189,45 @@ class AccountLinksService:
         provisional_id = str(decision["provisional_account_id"])
         links = self._db.execute(
             f"""
-            SELECT ref_kind FROM {ACCOUNT_LINKS.full_name}
+            SELECT link_id, ref_kind FROM {ACCOUNT_LINKS.full_name}
             WHERE account_id = ? AND status = 'accepted'
             """,  # noqa: S608  # TableRef constant + parameterized value
             [provisional_id],
         ).fetchall()
-        if not any(ref_kind == "source_native" for (ref_kind,) in links):
+        if not any(ref_kind == "source_native" for _, ref_kind in links):
             raise UserError(
                 f"Cannot apply merge for decision {decision_id!r}: the "
                 "provisional account has no source_native mapping to re-point "
                 "onto the candidate.",
                 code=error_codes.MUTATION_CONSTRAINT_VIOLATION,
             )
-        sibling_count_row = self._db.execute(
+        sibling_rows = self._db.execute(
             f"""
-            SELECT COUNT(*) FROM {ACCOUNT_LINK_DECISIONS.full_name}
+            SELECT decision_id FROM {ACCOUNT_LINK_DECISIONS.full_name}
             WHERE (provisional_account_id = ? OR candidate_account_id = ?)
               AND decision_id != ?
               AND status = 'pending'
               AND reversed_at IS NULL
             """,  # noqa: S608  # TableRef constant + parameterized values
             [provisional_id, provisional_id, decision_id],
-        ).fetchone()
-        sibling_count = int(sibling_count_row[0]) if sibling_count_row else 0
+        ).fetchall()
+        # Mirrors set()'s own two queries exactly: every accepted link is
+        # repointed, and the named decision plus every pending sibling changes
+        # status. Sorted because neither query orders its rows.
+        link_ids = tuple(sorted(str(link_id) for link_id, _ in links))
+        decision_ids = tuple(
+            sorted([decision_id, *(str(sid) for (sid,) in sibling_rows)])
+        )
         return AccountLinkAcceptImpact(
             provisional_account_id=provisional_id,
             candidate_account_id=str(decision["candidate_account_id"]),
             blast_radius={
                 "accounts": 2,
-                "account_links": len(links),
-                "account_link_decisions": 1 + sibling_count,
+                "account_links": len(link_ids),
+                "account_link_decisions": len(decision_ids),
             },
+            link_ids=link_ids,
+            decision_ids=decision_ids,
         )
 
     # ------------------------------------------------------------------

--- a/src/moneybin/services/identity_confirmation.py
+++ b/src/moneybin/services/identity_confirmation.py
@@ -1,0 +1,74 @@
+"""The sentence a human ratifies before an identity batch commits.
+
+Sibling of ``import_confirmation``: the prose a confirm gate shows lives beside
+the domain it describes rather than inside one surface, so the MCP elicitation
+and the CLI prompt cannot drift into describing the same merge two different
+ways. The MCP tool wrapper is where it used to live, which put the CLI a copy
+away from a sentence it needs to render identically.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+#: Every blast-radius category an identity confirmation reports, named once.
+#:
+#: The confirm binding indexes ``affected_ids`` by exactly this set, so the two
+#: lists have to agree: a preparer that omits a key raises at confirmation time,
+#: and a category added to a preparer but not here is a mutation the prompt
+#: silently drops. ``price_marks`` was the second kind — the merge moved every
+#: override while the prompt counted only the first five.
+#:
+#: It lives beside the labels rather than in the decision service so that
+#: rendering the sentence costs an importer nothing but this module: a CLI that
+#: only needs to print a confirmation should not load the repositories and
+#: sibling services that applying one requires.
+IDENTITY_BLAST_RADIUS_CATEGORIES = (
+    "accounts",
+    "merchants",
+    "securities",
+    "transactions",
+    "lots",
+    "price_marks",
+)
+
+#: How each blast-radius category is named in the prompt a human ratifies.
+#:
+#: Deliberately a second list beside ``IDENTITY_BLAST_RADIUS_CATEGORIES`` rather
+#: than a field on it: the categories index the digest an approval binds to, and
+#: these name those categories in the sentence a human reads. The two must agree,
+#: which ``test_every_blast_radius_category_has_a_prompt_label`` asserts by set
+#: equality. A category counted in the digest but absent from this map would be
+#: bound into the approval and left out of the sentence explaining it.
+IDENTITY_BLAST_RADIUS_LABELS: dict[str, tuple[str, str]] = {
+    "accounts": ("account", "accounts"),
+    "merchants": ("merchant", "merchants"),
+    "securities": ("security", "securities"),
+    "transactions": ("transaction", "transactions"),
+    "lots": ("tax lot", "tax lots"),
+    "price_marks": ("price mark you set by hand", "price marks you set by hand"),
+}
+
+
+def identity_confirm_message(blast_radius: Mapping[str, int]) -> str:
+    """Prompt text naming what this batch moves, and how much of it.
+
+    The elicitation shows this string and nothing else — the binding's counts are
+    a digest the human never reads — so a category missing from here is a
+    mutation nobody was told about. Zero-count categories are omitted rather than
+    listed as zeros: a bind that touches one security should not read as a batch
+    reaching into accounts and merchants it never opens.
+    """
+    moved = [
+        f"{count} {IDENTITY_BLAST_RADIUS_LABELS[key][0 if count == 1 else 1]}"
+        for key in IDENTITY_BLAST_RADIUS_CATEGORIES
+        if (count := blast_radius.get(key, 0))
+    ]
+    return (
+        "Confirm this complete identity-decision batch. Accepted links can merge "
+        "account histories, merchant attribution, or security lots — including "
+        "any price marks you set by hand, which move onto the survivor — or bind "
+        "a price-feed symbol without merging anything; every decision in the "
+        "ordered batch will commit together.\n\n"
+        f"This batch touches: {', '.join(moved) if moved else 'no rows'}."
+    )

--- a/src/moneybin/services/review_decisions_service.py
+++ b/src/moneybin/services/review_decisions_service.py
@@ -31,6 +31,7 @@ from moneybin.repositories.match_decisions_repo import MatchDecisionsRepo
 from moneybin.services._text import build_match_inputs
 from moneybin.services.account_links_service import AccountLinksService
 from moneybin.services.categorization import CategorizationService
+from moneybin.services.identity_confirmation import IDENTITY_BLAST_RADIUS_CATEGORIES
 from moneybin.services.merchant_links_service import MerchantLinksService
 from moneybin.services.security_links_service import SecurityLinksService
 from moneybin.tables import (
@@ -75,23 +76,6 @@ class OrdinaryDecisionPlanItem:
     merchant_group_key: tuple[str, str, str | None] | None = None
 
 
-#: Every blast-radius category an identity confirmation reports, named once.
-#:
-#: The confirm binding indexes ``affected_ids`` by exactly this set, so the two
-#: lists have to agree: a preparer that omits a key raises at confirmation time,
-#: and a category added to a preparer but not here is a mutation the prompt
-#: silently drops. ``price_marks`` was the second kind — the merge moved every
-#: override while the prompt counted only the first five.
-IDENTITY_BLAST_RADIUS_CATEGORIES = (
-    "accounts",
-    "merchants",
-    "securities",
-    "transactions",
-    "lots",
-    "price_marks",
-)
-
-
 @dataclass(frozen=True, slots=True)
 class IdentityDecisionPlanItem:
     """One resolved identity target with exact persisted before-state."""
@@ -123,6 +107,22 @@ class IdentityDecisionPlan:
         return any(
             item.changed and item.request.decision == "accept" for item in self.items
         )
+
+    @property
+    def blast_radius(self) -> dict[str, int]:
+        """Distinct entities this batch touches, per category.
+
+        Lives on the plan rather than in either surface because two of them read
+        it for the same decision: the MCP binding digests it, and the CLI prompt
+        renders it. A second copy of the de-duplication would let one surface
+        confirm a different size than the other commits.
+        """
+        return {
+            key: len({
+                entity_id for item in self.items for entity_id in item.affected_ids[key]
+            })
+            for key in IDENTITY_BLAST_RADIUS_CATEGORIES
+        }
 
 
 def _json_safe(value: Any) -> JsonValue:

--- a/src/moneybin/services/undo_service.py
+++ b/src/moneybin/services/undo_service.py
@@ -246,9 +246,18 @@ class UndoService:
                 code=error_codes.RECOVERY_NO_PATH,
             )
         # After the commit, never inside it: a gauge set from uncommitted rows
-        # would survive a rollback that discarded them.
+        # would survive a rollback that discarded them. And never fatal: the
+        # undo is already durable, so a failed telemetry read must not report a
+        # committed reversal as an error the caller would retry.
         for repo in touched.values():
-            repo.refresh_pending_gauge()
+            try:
+                repo.refresh_pending_gauge()
+            except Exception:  # noqa: BLE001 — telemetry never fails a committed undo
+                logger.warning(
+                    f"⚠️ Could not refresh the review-queue gauge for "
+                    f"{type(repo).__name__} after undo {operation_id}; the count "
+                    "will correct itself on the next decision."
+                )
         tables = sorted({e.target_table for e in undone if e.target_table})
         audit_undo_total.labels(outcome="success").inc()
         audit_undo_rows_reversed_total.inc(len(undone))

--- a/src/moneybin/services/undo_service.py
+++ b/src/moneybin/services/undo_service.py
@@ -26,6 +26,7 @@ from moneybin.metrics.registry import (
     audit_undo_rows_reversed_total,
     audit_undo_total,
 )
+from moneybin.repositories.base import BaseRepo
 from moneybin.services.audit_service import AuditEvent, AuditService
 from moneybin.services.mutation_context import operation
 from moneybin.services.undo_dispatch import is_registered, repo_for
@@ -209,6 +210,7 @@ class UndoService:
             self._db.begin()
             try:
                 undone: list[AuditEvent] = []
+                touched: dict[str, BaseRepo] = {}
                 for event in reversed(row_events):
                     repo = repo_for(
                         event.target_schema or "",
@@ -216,6 +218,7 @@ class UndoService:
                         self._db,
                         audit=self._audit,
                     )
+                    touched.setdefault(type(repo).__name__, repo)
                     inverse = repo.undo_event(event, actor=actor, in_outer_txn=True)
                     if inverse is not None:
                         undone.append(inverse)
@@ -242,6 +245,10 @@ class UndoService:
                 "(all captured rows show before == after).",
                 code=error_codes.RECOVERY_NO_PATH,
             )
+        # After the commit, never inside it: a gauge set from uncommitted rows
+        # would survive a rollback that discarded them.
+        for repo in touched.values():
+            repo.refresh_pending_gauge()
         tables = sorted({e.target_table for e in undone if e.target_table})
         audit_undo_total.labels(outcome="success").inc()
         audit_undo_rows_reversed_total.inc(len(undone))

--- a/tests/moneybin/test_cli/test_accounts_links.py
+++ b/tests/moneybin/test_cli/test_accounts_links.py
@@ -12,6 +12,11 @@ from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
 
 from moneybin.cli.commands.accounts.links import app
+from moneybin.mcp.write_contracts import AccountLinkDecisionRequest
+from moneybin.services.review_decisions_service import (
+    IdentityDecisionPlan,
+    IdentityDecisionPlanItem,
+)
 
 runner = CliRunner()
 
@@ -44,6 +49,45 @@ def _make_pending_group(
     group.provisional_display_name = provisional_name
     group.candidates = [candidate]
     return group
+
+
+def _merge_plan(
+    *,
+    provisional_id: str = "PROV1",
+    candidate_id: str = "CAND001",
+    decision_id: str = "dec001",
+    transactions: tuple[str, ...] = ("t1",),
+) -> IdentityDecisionPlan:
+    """A one-item plan shaped exactly like ``_prepare_account`` builds for an accept.
+
+    Built from the real dataclasses rather than a MagicMock so the prompt under
+    test renders through the same ``blast_radius`` arithmetic the MCP binding
+    uses — a mock would report whatever count the assertion asked for. The
+    ``accounts`` pair mirrors the preparer, which counts both sides of a merge.
+    """
+    item = IdentityDecisionPlanItem(
+        request=AccountLinkDecisionRequest(
+            kind="account_link",
+            decision_id=decision_id,
+            decision="accept",
+            target_id=candidate_id,
+        ),
+        changed=True,
+        status="accepted",
+        source_id=provisional_id,
+        target_id=candidate_id,
+        group_key=("account", provisional_id),
+        before_state=None,
+        affected_ids={
+            "accounts": (provisional_id, candidate_id),
+            "merchants": (),
+            "securities": (),
+            "transactions": transactions,
+            "lots": (),
+            "price_marks": (),
+        },
+    )
+    return IdentityDecisionPlan(items=(item,))
 
 
 # ---------------------------------------------------------------------------
@@ -161,10 +205,14 @@ class TestLinksSet:
         mock_set: MagicMock,
         mock_get_db: MagicMock,
     ) -> None:
-        """--into <account_id> passes target_account_id to service."""
+        """--into <account_id> passes target_account_id to service.
+
+        Carries --yes because a merge is gated: the flag is the non-interactive
+        half of that gate, not an unrelated convenience.
+        """
         mock_get_db.return_value.__enter__.return_value = MagicMock()
 
-        result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"])
+        result = runner.invoke(app, ["set", "dec001", "--into", "CAND001", "--yes"])
         assert result.exit_code == 0
         mock_set.assert_called_once_with(
             "dec001", target_account_id="CAND001", decided_by="user"
@@ -185,6 +233,99 @@ class TestLinksSet:
         mock_set.assert_called_once_with(
             "dec001", target_account_id=None, decided_by="user"
         )
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.cli.commands.accounts.links._merge_preview")
+    @patch("moneybin.services.account_links_service.AccountLinksService.set")
+    def test_set_into_declined_at_the_prompt_writes_nothing(
+        self,
+        mock_set: MagicMock,
+        mock_preview: MagicMock,
+        mock_get_db: MagicMock,
+    ) -> None:
+        """A merge the operator declines must not reach the service.
+
+        `accounts links set --into` was the one accept path with no gate on any
+        surface: MCP elicits, the import gate asks, and this command merged one
+        account's whole history into another on a single unprompted invocation.
+        """
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_preview.return_value = _merge_plan()
+
+        result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"], input="n\n")
+
+        assert result.exit_code != 0
+        mock_set.assert_not_called()
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.cli.commands.accounts.links._merge_preview")
+    @patch("moneybin.services.account_links_service.AccountLinksService.set")
+    def test_set_into_prompt_names_what_the_merge_moves(
+        self,
+        mock_set: MagicMock,
+        mock_preview: MagicMock,
+        mock_get_db: MagicMock,
+    ) -> None:
+        """The operator reads the same sentence the MCP elicitation shows.
+
+        A bare "Are you sure?" would satisfy the gate above while telling the
+        reader nothing about the size of what moves, which is the only fact that
+        makes the answer more than a coin flip.
+        """
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_preview.return_value = _merge_plan(transactions=("t1", "t2", "t3"))
+
+        result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"], input="y\n")
+
+        assert result.exit_code == 0
+        assert "3 transactions" in result.output
+        assert "2 accounts" in result.output
+        mock_set.assert_called_once()
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.cli.commands.accounts.links._merge_preview")
+    @patch("moneybin.services.account_links_service.AccountLinksService.set")
+    def test_set_standalone_is_not_gated(
+        self,
+        mock_set: MagicMock,
+        mock_preview: MagicMock,
+        mock_get_db: MagicMock,
+    ) -> None:
+        """Keeping an account standalone destroys nothing, so it never asks.
+
+        Matches the MCP rule exactly — `IdentityDecisionPlan.destructive` is true
+        only for a changed accept — so the gate cannot drift into confirming a
+        rejection on one surface and not the other.
+        """
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+
+        result = runner.invoke(app, ["set", "dec001", "--standalone"])
+
+        assert result.exit_code == 0
+        mock_preview.assert_not_called()
+        mock_set.assert_called_once()
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.cli.commands.accounts.links._merge_preview")
+    @patch("moneybin.services.account_links_service.AccountLinksService.set")
+    def test_set_into_with_yes_never_reaches_the_prompt(
+        self,
+        mock_set: MagicMock,
+        mock_preview: MagicMock,
+        mock_get_db: MagicMock,
+    ) -> None:
+        """--yes is the whole gate, preflight included.
+
+        Asserting the preview never runs is what proves the flag short-circuits
+        rather than answering a prompt that still cost a read.
+        """
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+
+        result = runner.invoke(app, ["set", "dec001", "--into", "CAND001", "--yes"])
+
+        assert result.exit_code == 0
+        mock_preview.assert_not_called()
+        mock_set.assert_called_once()
 
     def test_set_requires_into_or_standalone(self) -> None:
         """Invoking set without --into or --standalone exits 2."""

--- a/tests/moneybin/test_cli/test_accounts_links.py
+++ b/tests/moneybin/test_cli/test_accounts_links.py
@@ -7,13 +7,21 @@ service layer and test argument parsing, exit codes, and output shape.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
 
 from moneybin import error_codes
-from moneybin.cli.commands.accounts.links import app
+from moneybin.cli.commands.accounts.links import (
+    # Both are module-private on purpose — nothing outside the command should
+    # build an approval or resolve a preview — so the tests that cover them
+    # reach in rather than widening the surface to make them reachable.
+    _ApprovedMerge,  # pyright: ignore[reportPrivateUsage]
+    _merge_preview,  # pyright: ignore[reportPrivateUsage]
+    app,
+)
 from moneybin.errors import UserError
 from moneybin.mcp.write_contracts import AccountLinkDecisionRequest
 from moneybin.services.account_links_service import AccountLinkAcceptImpact
@@ -61,6 +69,7 @@ def _merge_plan(
     candidate_id: str = "CAND001",
     decision_id: str = "dec001",
     transactions: tuple[str, ...] = ("t1",),
+    changed: bool = True,
 ) -> IdentityDecisionPlan:
     """A one-item plan shaped exactly like ``_prepare_account`` builds for an accept.
 
@@ -76,7 +85,7 @@ def _merge_plan(
             decision="accept",
             target_id=candidate_id,
         ),
-        changed=True,
+        changed=changed,
         status="accepted",
         source_id=provisional_id,
         target_id=candidate_id,
@@ -94,28 +103,59 @@ def _merge_plan(
     return IdentityDecisionPlan(items=(item,))
 
 
-def _commit_running_verifier(*_args: object, **kwargs: object) -> None:
+def _approved_merge(
+    *,
+    transactions: tuple[str, ...] = ("t1",),
+    account_links: int = 1,
+    account_link_decisions: int = 1,
+) -> _ApprovedMerge:
+    """What ``_merge_preview`` hands the prompt: both radii the yes is bound to.
+
+    Built from the real plan arithmetic on the sentence side so the rendered
+    prompt and the drift comparison read the same numbers a live preview would
+    produce, and from literal row counts on the other because those come from
+    ``accept_impact``'s own ``COUNT(*)``, not from the plan.
+    """
+    return _ApprovedMerge(
+        sentence=_merge_plan(transactions=transactions).blast_radius,
+        rows={
+            "accounts": 2,
+            "account_links": account_links,
+            "account_link_decisions": account_link_decisions,
+        },
+    )
+
+
+def _commit_running_verifier(
+    *, account_links: int = 1, account_link_decisions: int = 1
+) -> Callable[..., None]:
     """Stand in for ``AccountLinksService.set``, running the verifier it is given.
 
     The real service calls ``verify_accept`` inside its write transaction just
-    before the first mutation. Asserting the callback is present is half the
-    point: a CLI that stopped passing one would otherwise still pass every
-    drift assertion below by never checking anything.
+    before the first mutation, handing it the impact it recomputed there.
+    Asserting the callback is present is half the point: a CLI that stopped
+    passing one would otherwise still pass every drift assertion below by never
+    checking anything. The row counts are parameters so a test can hand the
+    verifier an impact that grew since the prompt without touching the plan.
     """
-    verify = kwargs.get("verify_accept")
-    assert verify is not None, "the merge write must carry a verifier"
-    assert callable(verify)
-    verify(
-        AccountLinkAcceptImpact(
-            provisional_account_id="PROV1",
-            candidate_account_id="CAND001",
-            blast_radius={
-                "accounts": 2,
-                "account_links": 1,
-                "account_link_decisions": 1,
-            },
+
+    def _set(*_args: object, **kwargs: object) -> None:
+        verify = kwargs.get("verify_accept")
+        assert verify is not None, "the merge write must carry a verifier"
+        assert callable(verify)
+        verify(
+            AccountLinkAcceptImpact(
+                provisional_account_id="PROV1",
+                candidate_account_id="CAND001",
+                blast_radius={
+                    "accounts": 2,
+                    "account_links": account_links,
+                    "account_link_decisions": account_link_decisions,
+                },
+            )
         )
-    )
+
+    return _set
 
 
 # ---------------------------------------------------------------------------
@@ -286,7 +326,7 @@ class TestLinksSet:
         account's whole history into another on a single unprompted invocation.
         """
         mock_get_db.return_value.__enter__.return_value = MagicMock()
-        mock_preview.return_value = _merge_plan()
+        mock_preview.return_value = _approved_merge()
 
         result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"], input="n\n")
 
@@ -312,7 +352,7 @@ class TestLinksSet:
         makes the answer more than a coin flip.
         """
         mock_get_db.return_value.__enter__.return_value = MagicMock()
-        mock_preview.return_value = _merge_plan(transactions=("t1", "t2", "t3"))
+        mock_preview.return_value = _approved_merge(transactions=("t1", "t2", "t3"))
 
         result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"], input="y\n")
 
@@ -364,9 +404,9 @@ class TestLinksSet:
         verifier refuses a batch that no longer matches the sentence shown.
         """
         mock_get_db.return_value.__enter__.return_value = MagicMock()
-        mock_preview.return_value = _merge_plan(transactions=("t1",))
+        mock_preview.return_value = _approved_merge(transactions=("t1",))
         mock_plan.return_value = _merge_plan(transactions=("t1", "t2", "t3"))
-        mock_set.side_effect = _commit_running_verifier
+        mock_set.side_effect = _commit_running_verifier()
 
         result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"], input="y\n")
 
@@ -393,14 +433,96 @@ class TestLinksSet:
         refused everything would look correct.
         """
         mock_get_db.return_value.__enter__.return_value = MagicMock()
-        mock_preview.return_value = _merge_plan(transactions=("t1",))
+        mock_preview.return_value = _approved_merge(transactions=("t1",))
         mock_plan.return_value = _merge_plan(transactions=("t1",))
-        mock_set.side_effect = _commit_running_verifier
+        mock_set.side_effect = _commit_running_verifier()
 
         result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"], input="y\n")
 
         assert result.exit_code == 0
         mock_set.assert_called_once()
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.cli.commands.accounts.links._plan_merge")
+    @patch("moneybin.cli.commands.accounts.links._merge_preview")
+    @patch("moneybin.services.account_links_service.AccountLinksService.set")
+    def test_set_into_aborts_when_a_sibling_decision_arrived_between_prompt_and_commit(
+        self,
+        mock_set: MagicMock,
+        mock_preview: MagicMock,
+        mock_plan: MagicMock,
+        mock_get_db: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Drift the displayed sentence cannot express must still stop the write.
+
+        The plan's radius counts accounts and transactions; the write also
+        repoints every accepted link and auto-rejects every pending sibling
+        decision. A concurrent `accounts links run` proposes one more candidate
+        for the same provisional — no new account, no new transaction — so the
+        sentence is word-for-word what the operator read while the commit now
+        rejects a decision they never saw. Only the impact radius moves here,
+        which is why comparing the plan alone cannot catch it.
+        """
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_preview.return_value = _approved_merge(account_link_decisions=1)
+        mock_plan.return_value = _merge_plan(transactions=("t1",))
+        mock_set.side_effect = _commit_running_verifier(account_link_decisions=2)
+
+        result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"], input="y\n")
+
+        assert result.exit_code != 0
+        assert "changed while the confirmation was open" in caplog.text
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.cli.commands.accounts.links._plan_merge")
+    def test_merge_preview_asks_nothing_when_the_merge_moves_nothing(
+        self,
+        mock_plan: MagicMock,
+        mock_get_db: MagicMock,
+    ) -> None:
+        """Re-running an already-settled decision has no sentence and no radius.
+
+        `IdentityDecisionPlan.destructive` is false when the accept changes
+        nothing, and `accept_impact` refuses that same decision as non-pending —
+        so the destructive check has to come first or the legitimate re-run
+        raises instead of passing through. Returning None is what lets the
+        command skip the prompt and commit with no radius to hold itself to.
+        """
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_plan.return_value = _merge_plan(changed=False)
+
+        assert _merge_preview("dec001", "CAND001") is None
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.cli.commands.accounts.links._merge_preview")
+    @patch("moneybin.services.account_links_service.AccountLinksService.set")
+    def test_set_into_commits_unprompted_when_the_merge_moves_nothing(
+        self,
+        mock_set: MagicMock,
+        mock_preview: MagicMock,
+        mock_get_db: MagicMock,
+    ) -> None:
+        """A preview that moves nothing reaches the service without asking.
+
+        No stdin is supplied on purpose: a prompt appearing here would read EOF
+        and abort, so the passing exit code is itself the evidence that nothing
+        was asked. `verify_accept` is None because there is no approved radius —
+        inventing one would refuse a write on a comparison never shown.
+        """
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_preview.return_value = None
+
+        result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"])
+
+        assert result.exit_code == 0
+        assert "Merge these accounts?" not in result.output
+        mock_set.assert_called_once_with(
+            "dec001",
+            target_account_id="CAND001",
+            decided_by="user",
+            verify_accept=None,
+        )
 
     @patch("moneybin.cli.commands.accounts.links.get_database")
     @patch(
@@ -507,7 +629,7 @@ class TestLinksSet:
         place to leave the reader guessing whether anything moved.
         """
         mock_get_db.return_value.__enter__.return_value = MagicMock()
-        mock_preview.return_value = _merge_plan()
+        mock_preview.return_value = _approved_merge()
 
         result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"], input="n\n")
 

--- a/tests/moneybin/test_cli/test_accounts_links.py
+++ b/tests/moneybin/test_cli/test_accounts_links.py
@@ -9,10 +9,14 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
 from typer.testing import CliRunner
 
+from moneybin import error_codes
 from moneybin.cli.commands.accounts.links import app
+from moneybin.errors import UserError
 from moneybin.mcp.write_contracts import AccountLinkDecisionRequest
+from moneybin.services.account_links_service import AccountLinkAcceptImpact
 from moneybin.services.review_decisions_service import (
     IdentityDecisionPlan,
     IdentityDecisionPlanItem,
@@ -88,6 +92,30 @@ def _merge_plan(
         },
     )
     return IdentityDecisionPlan(items=(item,))
+
+
+def _commit_running_verifier(*_args: object, **kwargs: object) -> None:
+    """Stand in for ``AccountLinksService.set``, running the verifier it is given.
+
+    The real service calls ``verify_accept`` inside its write transaction just
+    before the first mutation. Asserting the callback is present is half the
+    point: a CLI that stopped passing one would otherwise still pass every
+    drift assertion below by never checking anything.
+    """
+    verify = kwargs.get("verify_accept")
+    assert verify is not None, "the merge write must carry a verifier"
+    assert callable(verify)
+    verify(
+        AccountLinkAcceptImpact(
+            provisional_account_id="PROV1",
+            candidate_account_id="CAND001",
+            blast_radius={
+                "accounts": 2,
+                "account_links": 1,
+                "account_link_decisions": 1,
+            },
+        )
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -214,8 +242,13 @@ class TestLinksSet:
 
         result = runner.invoke(app, ["set", "dec001", "--into", "CAND001", "--yes"])
         assert result.exit_code == 0
+        # verify_accept=None: --yes displayed no radius, so there is nothing for
+        # the write to hold itself to.
         mock_set.assert_called_once_with(
-            "dec001", target_account_id="CAND001", decided_by="user"
+            "dec001",
+            target_account_id="CAND001",
+            decided_by="user",
+            verify_accept=None,
         )
 
     @patch("moneybin.cli.commands.accounts.links.get_database")
@@ -231,7 +264,10 @@ class TestLinksSet:
         result = runner.invoke(app, ["set", "dec001", "--standalone"])
         assert result.exit_code == 0
         mock_set.assert_called_once_with(
-            "dec001", target_account_id=None, decided_by="user"
+            "dec001",
+            target_account_id=None,
+            decided_by="user",
+            verify_accept=None,
         )
 
     @patch("moneybin.cli.commands.accounts.links.get_database")
@@ -254,7 +290,10 @@ class TestLinksSet:
 
         result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"], input="n\n")
 
-        assert result.exit_code != 0
+        # Exit 0: the project's code table reserves non-zero for runtime and
+        # usage errors, and a declined prompt is the operator's choice carried
+        # out, not a failure. Matches every sibling decline site.
+        assert result.exit_code == 0
         mock_set.assert_not_called()
 
     @patch("moneybin.cli.commands.accounts.links.get_database")
@@ -304,6 +343,176 @@ class TestLinksSet:
         assert result.exit_code == 0
         mock_preview.assert_not_called()
         mock_set.assert_called_once()
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.cli.commands.accounts.links._plan_merge")
+    @patch("moneybin.cli.commands.accounts.links._merge_preview")
+    @patch("moneybin.services.account_links_service.AccountLinksService.set")
+    def test_set_into_aborts_when_the_merge_grew_between_prompt_and_commit(
+        self,
+        mock_set: MagicMock,
+        mock_preview: MagicMock,
+        mock_plan: MagicMock,
+        mock_get_db: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """What the operator approved must still be what commits.
+
+        The prompt reads on one connection and the write opens another, so a
+        concurrent import can grow the merge while the operator is reading. The
+        service re-derives the plan inside the write transaction and this
+        verifier refuses a batch that no longer matches the sentence shown.
+        """
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_preview.return_value = _merge_plan(transactions=("t1",))
+        mock_plan.return_value = _merge_plan(transactions=("t1", "t2", "t3"))
+        mock_set.side_effect = _commit_running_verifier
+
+        result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"], input="y\n")
+
+        # The refusal reaches the operator through the error logger, not the
+        # Click result stream, so assert on the record that actually carries it.
+        assert result.exit_code != 0
+        assert "changed while the confirmation was open" in caplog.text
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.cli.commands.accounts.links._plan_merge")
+    @patch("moneybin.cli.commands.accounts.links._merge_preview")
+    @patch("moneybin.services.account_links_service.AccountLinksService.set")
+    def test_set_into_commits_when_the_merge_is_unchanged(
+        self,
+        mock_set: MagicMock,
+        mock_preview: MagicMock,
+        mock_plan: MagicMock,
+        mock_get_db: MagicMock,
+    ) -> None:
+        """The guard must not refuse the ordinary case it wraps.
+
+        Paired with the drift test above so neither passes for the other's
+        reason: identical counts have to reach the service, or a verifier that
+        refused everything would look correct.
+        """
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_preview.return_value = _merge_plan(transactions=("t1",))
+        mock_plan.return_value = _merge_plan(transactions=("t1",))
+        mock_set.side_effect = _commit_running_verifier
+
+        result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"], input="y\n")
+
+        assert result.exit_code == 0
+        mock_set.assert_called_once()
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch(
+        "moneybin.services.review_decisions_service.ReviewDecisionsService.plan_identity"
+    )
+    @patch("moneybin.services.account_links_service.AccountLinksService.set")
+    def test_set_into_names_why_the_preflight_refused(
+        self,
+        mock_set: MagicMock,
+        mock_plan_identity: MagicMock,
+        mock_get_db: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A mistyped id keeps naming itself once the gate reads it first.
+
+        ``plan_identity`` batches per-decision reasons into ``details["errors"]``,
+        which the MCP envelope carries and the CLI's text mode never prints. One
+        request can only fail for one reason, so surfacing it beats the generic
+        batch message the operator would otherwise get — worse than the ungated
+        command gave, and only on the path that asks.
+        """
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_plan_identity.side_effect = UserError(
+            "Identity decision preflight failed.",
+            code=error_codes.MUTATION_INVALID_INPUT,
+            details={
+                "errors": [
+                    {
+                        "reason": "No account-link decision found for id 'typo'.",
+                        "code": error_codes.MUTATION_NOT_FOUND,
+                    }
+                ]
+            },
+        )
+
+        result = runner.invoke(app, ["set", "typo", "--into", "CAND001"], input="y\n")
+
+        assert result.exit_code != 0
+        assert "No account-link decision found for id 'typo'." in caplog.text
+        mock_set.assert_not_called()
+
+    def test_preflight_reason_keeps_the_specific_code(self) -> None:
+        """The unwrapped code is the decision's own, not the batch's.
+
+        ``--output json`` puts it in the envelope an agent branches on, so
+        collapsing a missing id to the batch's ``invalid_input`` would cost the
+        one distinction worth having on a typo.
+        """
+        from moneybin.cli.commands.accounts.links import (
+            _preflight_reason,  # pyright: ignore[reportPrivateUsage]  # the unwrapping is the unit under test
+        )
+
+        unwrapped = _preflight_reason(
+            UserError(
+                "Identity decision preflight failed.",
+                code=error_codes.MUTATION_INVALID_INPUT,
+                details={
+                    "errors": [
+                        {"reason": "gone", "code": error_codes.MUTATION_NOT_FOUND}
+                    ]
+                },
+            )
+        )
+
+        assert unwrapped.code == error_codes.MUTATION_NOT_FOUND
+
+    def test_preflight_reason_refuses_an_undeclared_code(self) -> None:
+        """An unrecognized upstream code degrades instead of reaching the wire.
+
+        Every wire code is proven declared by a scan of source literals, which
+        cannot see through a dict. The lookup is what keeps that proof true if
+        the preflight ever grows a code this command has not been taught.
+        """
+        from moneybin.cli.commands.accounts.links import (
+            _preflight_reason,  # pyright: ignore[reportPrivateUsage]  # the unwrapping is the unit under test
+        )
+
+        unwrapped = _preflight_reason(
+            UserError(
+                "Identity decision preflight failed.",
+                code=error_codes.MUTATION_INVALID_INPUT,
+                details={
+                    "errors": [{"reason": "novel", "code": "invented_at_runtime"}]
+                },
+            )
+        )
+
+        assert unwrapped.message == "novel"
+        assert unwrapped.code == error_codes.MUTATION_INVALID_INPUT
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.cli.commands.accounts.links._merge_preview")
+    @patch("moneybin.services.account_links_service.AccountLinksService.set")
+    def test_set_into_declined_says_nothing_was_merged(
+        self,
+        mock_set: MagicMock,
+        mock_preview: MagicMock,
+        mock_get_db: MagicMock,
+    ) -> None:
+        """A decline states the outcome instead of Click's bare ``Aborted!``.
+
+        Every other confirm-then-decline site in the CLI prints its own line
+        (`transactions notes`, `sync`, `db kill`); a merge decision is the last
+        place to leave the reader guessing whether anything moved.
+        """
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_preview.return_value = _merge_plan()
+
+        result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"], input="n\n")
+
+        assert "nothing was merged" in result.output.lower()
+        mock_set.assert_not_called()
 
     @patch("moneybin.cli.commands.accounts.links.get_database")
     @patch("moneybin.cli.commands.accounts.links._merge_preview")

--- a/tests/moneybin/test_cli/test_accounts_links.py
+++ b/tests/moneybin/test_cli/test_accounts_links.py
@@ -19,6 +19,7 @@ from moneybin.cli.commands.accounts.links import (
     # build an approval or resolve a preview — so the tests that cover them
     # reach in rather than widening the surface to make them reachable.
     _ApprovedMerge,  # pyright: ignore[reportPrivateUsage]
+    _drift_check,  # pyright: ignore[reportPrivateUsage]
     _merge_preview,  # pyright: ignore[reportPrivateUsage]
     app,
 )
@@ -103,31 +104,54 @@ def _merge_plan(
     return IdentityDecisionPlan(items=(item,))
 
 
+def _accept_impact(
+    *,
+    links: tuple[str, ...] = ("L1",),
+    decisions: tuple[str, ...] = ("dec001",),
+) -> AccountLinkAcceptImpact:
+    """The impact the service recomputes inside its own write transaction.
+
+    Counts are derived from the identity tuples rather than passed separately,
+    so a fixture cannot describe a row set whose size disagrees with itself —
+    which is precisely the same-count swap these tests exist to catch.
+    """
+    return AccountLinkAcceptImpact(
+        provisional_account_id="PROV1",
+        candidate_account_id="CAND001",
+        blast_radius={
+            "accounts": 2,
+            "account_links": len(links),
+            "account_link_decisions": len(decisions),
+        },
+        link_ids=links,
+        decision_ids=decisions,
+    )
+
+
 def _approved_merge(
     *,
     transactions: tuple[str, ...] = ("t1",),
-    account_links: int = 1,
-    account_link_decisions: int = 1,
+    links: tuple[str, ...] = ("L1",),
+    decisions: tuple[str, ...] = ("dec001",),
 ) -> _ApprovedMerge:
-    """What ``_merge_preview`` hands the prompt: both radii the yes is bound to.
+    """What ``_merge_preview`` hands the prompt: everything the yes is bound to.
 
     Built from the real plan arithmetic on the sentence side so the rendered
     prompt and the drift comparison read the same numbers a live preview would
-    produce, and from literal row counts on the other because those come from
-    ``accept_impact``'s own ``COUNT(*)``, not from the plan.
+    produce, and from row identities on the other because that is what
+    ``accept_impact`` returns.
     """
     return _ApprovedMerge(
         sentence=_merge_plan(transactions=transactions).blast_radius,
-        rows={
-            "accounts": 2,
-            "account_links": account_links,
-            "account_link_decisions": account_link_decisions,
-        },
+        links=links,
+        decisions=decisions,
     )
 
 
 def _commit_running_verifier(
-    *, account_links: int = 1, account_link_decisions: int = 1
+    *,
+    links: tuple[str, ...] = ("L1",),
+    decisions: tuple[str, ...] = ("dec001",),
 ) -> Callable[..., None]:
     """Stand in for ``AccountLinksService.set``, running the verifier it is given.
 
@@ -135,25 +159,15 @@ def _commit_running_verifier(
     before the first mutation, handing it the impact it recomputed there.
     Asserting the callback is present is half the point: a CLI that stopped
     passing one would otherwise still pass every drift assertion below by never
-    checking anything. The row counts are parameters so a test can hand the
-    verifier an impact that grew since the prompt without touching the plan.
+    checking anything. The row identities are parameters so a test can hand the
+    verifier rows that moved since the prompt without touching the plan.
     """
 
     def _set(*_args: object, **kwargs: object) -> None:
         verify = kwargs.get("verify_accept")
         assert verify is not None, "the merge write must carry a verifier"
         assert callable(verify)
-        verify(
-            AccountLinkAcceptImpact(
-                provisional_account_id="PROV1",
-                candidate_account_id="CAND001",
-                blast_radius={
-                    "accounts": 2,
-                    "account_links": account_links,
-                    "account_link_decisions": account_link_decisions,
-                },
-            )
-        )
+        verify(_accept_impact(links=links, decisions=decisions))
 
     return _set
 
@@ -465,14 +479,60 @@ class TestLinksSet:
         which is why comparing the plan alone cannot catch it.
         """
         mock_get_db.return_value.__enter__.return_value = MagicMock()
-        mock_preview.return_value = _approved_merge(account_link_decisions=1)
+        mock_preview.return_value = _approved_merge(decisions=("dec001",))
         mock_plan.return_value = _merge_plan(transactions=("t1",))
-        mock_set.side_effect = _commit_running_verifier(account_link_decisions=2)
+        mock_set.side_effect = _commit_running_verifier(decisions=("dec001", "dec002"))
 
         result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"], input="y\n")
 
         assert result.exit_code != 0
         assert "changed while the confirmation was open" in caplog.text
+
+    @patch("moneybin.cli.commands.accounts.links._plan_merge")
+    def test_drift_refusal_carries_the_retriable_confirmation_code(
+        self, mock_plan: MagicMock
+    ) -> None:
+        """A stale approval and an invalid decision are different failures.
+
+        Both reach an agent through the same `--output json` envelope, where the
+        code is the only machine-readable half — one is safely retriable and the
+        other is not. Asserting the message text alone is exactly how the generic
+        constraint-violation code sat here unnoticed, so this asserts the code.
+        The plan is pinned unchanged so only the row comparison can refuse.
+        """
+        mock_plan.return_value = _merge_plan(transactions=("t1",))
+        verify = _drift_check(MagicMock(), "dec001", _approved_merge(links=("L1",)))
+        assert verify is not None
+
+        with pytest.raises(UserError) as excinfo:
+            verify(_accept_impact(links=("L1", "L2")))
+
+        assert excinfo.value.code == error_codes.MUTATION_CONFIRMATION_MISMATCH
+
+    @patch("moneybin.cli.commands.accounts.links._plan_merge")
+    def test_drift_refusal_catches_a_swap_that_leaves_every_count_intact(
+        self, mock_plan: MagicMock
+    ) -> None:
+        """One sibling resolved elsewhere while another arrives must still refuse.
+
+        Every count is identical across the swap — same accounts, same
+        transactions, one accepted link, two pending decisions — so a comparison
+        made of counts cannot see it, and the write would auto-reject a decision
+        that did not exist when the operator answered. Only comparing the row
+        identities themselves catches it.
+        """
+        mock_plan.return_value = _merge_plan(transactions=("t1",))
+        approved = _approved_merge(decisions=("dec001", "dec002"))
+        verify = _drift_check(MagicMock(), "dec001", approved)
+        assert verify is not None
+
+        swapped = _accept_impact(decisions=("dec001", "dec003"))
+        assert swapped.blast_radius["account_link_decisions"] == len(approved.decisions)
+
+        with pytest.raises(UserError) as excinfo:
+            verify(swapped)
+
+        assert excinfo.value.code == error_codes.MUTATION_CONFIRMATION_MISMATCH
 
     @patch("moneybin.cli.commands.accounts.links.get_database")
     @patch("moneybin.cli.commands.accounts.links._plan_merge")

--- a/tests/moneybin/test_config.py
+++ b/tests/moneybin/test_config.py
@@ -75,6 +75,27 @@ def test_mcp_max_items_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.unit
+def test_mcp_elicitation_wait_default() -> None:
+    """The default is read from the constant, not restated as a literal."""
+    from moneybin.config import DEFAULT_ELICITATION_WAIT_SECONDS
+
+    assert MCPConfig().elicitation_wait_seconds == DEFAULT_ELICITATION_WAIT_SECONDS
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("wait_seconds", [0.0, -1.0])
+def test_mcp_elicitation_wait_must_be_positive(wait_seconds: float) -> None:
+    """A non-positive window makes every confirmation prompt un-answerable.
+
+    The bound is business logic, not decoration: at zero the wait expires before
+    a human can read the prompt, so every destructive gate silently degrades to
+    the opaque-token path and the human never sees the question.
+    """
+    with pytest.raises(ValueError):
+        MCPConfig(elicitation_wait_seconds=wait_seconds)
+
+
+@pytest.mark.unit
 def test_mcp_confirmation_ttl_default() -> None:
     assert MCPConfig().confirmation_ttl_seconds == 300
 

--- a/tests/moneybin/test_mcp/test_confirmation.py
+++ b/tests/moneybin/test_mcp/test_confirmation.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -20,6 +22,9 @@ from moneybin.mcp.confirmation import (
     ConfirmationGrant,
     grant_confirmation_or_raise,
 )
+from moneybin.mcp.decorator import mcp_tool
+from moneybin.mcp.privacy import Sensitivity
+from moneybin.protocol.envelope import ResponseEnvelope, SummaryMeta
 
 NOW = datetime(2026, 7, 18, 12, 0, tzinfo=UTC)
 
@@ -383,6 +388,134 @@ async def test_declined_or_cancelled_elicitation_refuses_confirmation(
 
     assert raised.value.code == error_codes.MUTATION_CONFIRMATION_DECLINED
     assert raised.value.details == {"reason": "declined"}
+
+
+@pytest.mark.asyncio
+async def test_unanswered_elicitation_degrades_to_a_usable_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A prompt nobody answers must leave a working token, not a dead end."""
+
+    async def answers_too_late(
+        *_args: object, **_kwargs: object
+    ) -> AcceptedElicitation[bool]:
+        await asyncio.sleep(1.0)
+        return AcceptedElicitation(data=True)
+
+    ctx = MagicMock()
+    ctx.elicit = AsyncMock(side_effect=answers_too_late)
+    monkeypatch.setattr("moneybin.mcp.confirmation._active_context", lambda: ctx)
+    monkeypatch.setattr(
+        "moneybin.mcp.confirmation.supports_elicitation", _supports_elicitation
+    )
+    monkeypatch.setattr(
+        "moneybin.mcp.elicitation.elicitation_wait_seconds", lambda: 0.05
+    )
+    broker = ConfirmationBroker(ttl_seconds=300)
+
+    with pytest.raises(UserError) as raised:
+        await grant_confirmation_or_raise(
+            binding=BINDING,
+            message="Merge the PDF-derived account into the OFX account?",
+            confirmation_token=None,
+            broker=broker,
+        )
+
+    assert raised.value.code == error_codes.MUTATION_CONFIRMATION_REQUIRED
+    details = raised.value.details or {}
+    # A token that cannot be redeemed is still a dead end — redeem it.
+    grant = broker.consume(details["confirmation_token"], now=datetime.now(UTC))
+    grant.verify(BINDING)
+
+
+@pytest.mark.asyncio
+async def test_human_thinking_time_does_not_count_against_the_tool_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cap bounds machine work; a human reading a prompt is not machine work."""
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 0.3)
+    monkeypatch.setattr(
+        "moneybin.mcp.decorator.interrupt_and_reset_database", MagicMock()
+    )
+
+    async def answers_after_thinking(
+        *_args: object, **_kwargs: object
+    ) -> AcceptedElicitation[bool]:
+        await asyncio.sleep(0.5)  # deliberately longer than the 0.3s cap
+        return AcceptedElicitation(data=True)
+
+    ctx = MagicMock()
+    ctx.elicit = AsyncMock(side_effect=answers_after_thinking)
+    monkeypatch.setattr("moneybin.mcp.confirmation._active_context", lambda: ctx)
+    monkeypatch.setattr(
+        "moneybin.mcp.confirmation.supports_elicitation", _supports_elicitation
+    )
+    monkeypatch.setattr(
+        "moneybin.mcp.elicitation.elicitation_wait_seconds", lambda: 5.0
+    )
+
+    @mcp_tool(dynamic_classification=True, maximum_sensitivity=Sensitivity.HIGH)
+    async def merge_tool() -> ResponseEnvelope[Any]:
+        await grant_confirmation_or_raise(
+            binding=BINDING,
+            message="Merge the PDF-derived account into the OFX account?",
+            confirmation_token=None,
+            broker=ConfirmationBroker(ttl_seconds=300),
+        )
+        return ResponseEnvelope(
+            summary=SummaryMeta(total_count=0, returned_count=0), data=[]
+        )
+
+    result = await merge_tool()
+
+    assert result.error is None, (
+        f"cap fired while the human was reading: {result.error}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_cap_resumes_after_the_human_answers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Excluding the prompt must not leave the rest of the tool unbounded."""
+    monkeypatch.setattr("moneybin.mcp.decorator._get_timeout_seconds", lambda: 0.3)
+    monkeypatch.setattr(
+        "moneybin.mcp.decorator.interrupt_and_reset_database", MagicMock()
+    )
+
+    async def answers_after_thinking(
+        *_args: object, **_kwargs: object
+    ) -> AcceptedElicitation[bool]:
+        await asyncio.sleep(0.4)
+        return AcceptedElicitation(data=True)
+
+    ctx = MagicMock()
+    ctx.elicit = AsyncMock(side_effect=answers_after_thinking)
+    monkeypatch.setattr("moneybin.mcp.confirmation._active_context", lambda: ctx)
+    monkeypatch.setattr(
+        "moneybin.mcp.confirmation.supports_elicitation", _supports_elicitation
+    )
+    monkeypatch.setattr(
+        "moneybin.mcp.elicitation.elicitation_wait_seconds", lambda: 5.0
+    )
+
+    @mcp_tool(dynamic_classification=True, maximum_sensitivity=Sensitivity.HIGH)
+    async def merge_tool() -> ResponseEnvelope[Any]:
+        await grant_confirmation_or_raise(
+            binding=BINDING,
+            message="Merge the PDF-derived account into the OFX account?",
+            confirmation_token=None,
+            broker=ConfirmationBroker(ttl_seconds=300),
+        )
+        await asyncio.sleep(0.5)  # machine work, past the 0.3s cap on its own
+        return ResponseEnvelope(
+            summary=SummaryMeta(total_count=0, returned_count=0), data=[]
+        )
+
+    result = await merge_tool()
+
+    assert result.error is not None, "machine work after the prompt went unbounded"
+    assert result.error.code == error_codes.INFRA_TIMED_OUT
 
 
 @pytest.mark.asyncio

--- a/tests/moneybin/test_mcp/test_elicitation.py
+++ b/tests/moneybin/test_mcp/test_elicitation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -42,6 +43,47 @@ async def test_confirm_or_raise_requires_explicit_true(
         "file_path": "statement.csv",
         "reason": "declined",
     }
+
+
+@pytest.mark.asyncio
+async def test_confirm_or_raise_reports_an_unanswered_prompt_as_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nobody answering is not the same as somebody declining."""
+
+    async def answers_too_late(
+        *_args: object, **_kwargs: object
+    ) -> AcceptedElicitation[bool]:
+        await asyncio.sleep(1.0)
+        return AcceptedElicitation(data=True)
+
+    ctx = MagicMock()
+    ctx.elicit = AsyncMock(side_effect=answers_too_late)
+    monkeypatch.setattr("moneybin.mcp.elicitation.get_context", lambda: ctx)
+    monkeypatch.setattr(
+        "moneybin.mcp.elicitation.supports_elicitation",
+        _supports_elicitation,
+    )
+    monkeypatch.setattr(
+        "moneybin.mcp.elicitation.elicitation_wait_seconds", lambda: 0.05
+    )
+
+    with pytest.raises(UserError) as raised:
+        await confirm_or_raise(
+            "Invert every amount?",
+            subject="This sign inversion",
+            unchanged="the import remains pending",
+            cli_equivalent="moneybin import confirm statement.csv --confirm-sign",
+            details={"file_path": "statement.csv"},
+        )
+
+    assert raised.value.code == error_codes.MUTATION_CONFIRMATION_REQUIRED
+    assert raised.value.details == {
+        "file_path": "statement.csv",
+        "reason": "timeout",
+    }
+    # The refusal must still carry a way to finish the job.
+    assert "moneybin import confirm" in (raised.value.hint or "")
 
 
 @pytest.mark.asyncio

--- a/tests/moneybin/test_mcp/test_elicitation.py
+++ b/tests/moneybin/test_mcp/test_elicitation.py
@@ -86,6 +86,81 @@ async def test_confirm_or_raise_reports_an_unanswered_prompt_as_timeout(
     assert "moneybin import confirm" in (raised.value.hint or "")
 
 
+def _elicitation_count(site: str, outcome: str) -> float:
+    from moneybin.metrics.registry import MCP_ELICITATIONS_TOTAL
+
+    counter = MCP_ELICITATIONS_TOTAL.labels(site=site, outcome=outcome)
+    return counter._value.get()  # type: ignore[reportPrivateUsage] — prometheus internals
+
+
+@pytest.mark.asyncio
+async def test_an_unanswered_prompt_is_counted_against_its_site(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The 120s budget is a guess until the misses are countable.
+
+    Without this the degrade path is invisible: a human who never answers looks
+    identical to a client that never supported prompting, and there is no way
+    to tell after shipping whether the window is long enough.
+    """
+
+    async def answers_too_late(
+        *_args: object, **_kwargs: object
+    ) -> AcceptedElicitation[bool]:
+        await asyncio.sleep(1.0)
+        return AcceptedElicitation(data=True)
+
+    ctx = MagicMock()
+    ctx.elicit = AsyncMock(side_effect=answers_too_late)
+    monkeypatch.setattr("moneybin.mcp.elicitation.get_context", lambda: ctx)
+    monkeypatch.setattr(
+        "moneybin.mcp.elicitation.supports_elicitation", _supports_elicitation
+    )
+    monkeypatch.setattr(
+        "moneybin.mcp.elicitation.elicitation_wait_seconds", lambda: 0.05
+    )
+    before = _elicitation_count("confirm_or_raise", "timeout")
+
+    with pytest.raises(UserError):
+        await confirm_or_raise(
+            "Invert every amount?",
+            subject="This sign inversion",
+            unchanged="the import remains pending",
+            cli_equivalent="moneybin import confirm statement.csv --confirm-sign",
+            details={"file_path": "statement.csv"},
+        )
+
+    assert _elicitation_count("confirm_or_raise", "timeout") == before + 1
+
+
+@pytest.mark.asyncio
+async def test_an_answered_prompt_is_counted_against_the_same_site(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Timeouts only mean something next to the answers they are a fraction of.
+
+    Counting misses alone gives a numerator with no denominator — one timeout
+    reads the same whether it followed three prompts or three thousand.
+    """
+    ctx = MagicMock()
+    ctx.elicit = AsyncMock(return_value=AcceptedElicitation(data=True))
+    monkeypatch.setattr("moneybin.mcp.elicitation.get_context", lambda: ctx)
+    monkeypatch.setattr(
+        "moneybin.mcp.elicitation.supports_elicitation", _supports_elicitation
+    )
+    before = _elicitation_count("confirm_or_raise", "answered")
+
+    await confirm_or_raise(
+        "Invert every amount?",
+        subject="This sign inversion",
+        unchanged="the import remains pending",
+        cli_equivalent="moneybin import confirm statement.csv --confirm-sign",
+        details={"file_path": "statement.csv"},
+    )
+
+    assert _elicitation_count("confirm_or_raise", "answered") == before + 1
+
+
 @pytest.mark.asyncio
 async def test_confirm_or_raise_uses_explicit_boolean_schema(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/moneybin/test_mcp/test_exports.py
+++ b/tests/moneybin/test_mcp/test_exports.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from typing import Any
@@ -339,6 +340,44 @@ async def test_export_run_refuses_nonaccepted_or_invalid_redaction_choice(
         )
 
     assert _structured(response)["error"]["details"]["reason"] == reason
+    run.assert_not_called()
+
+
+async def test_export_run_refuses_when_nobody_answers_the_redaction_prompt(
+    mcp_db: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unanswered prompt must refuse, never silently pick a redaction mode."""
+    from moneybin.exports.service import ExportService
+    from moneybin.mcp.tools import exports as exports_mcp
+
+    async def answers_too_late(
+        *_args: object, **_kwargs: object
+    ) -> AcceptedElicitation[str]:
+        # Deliberately the unsafe answer: a late reply must not slip through.
+        await asyncio.sleep(1.0)
+        return AcceptedElicitation(data="unredacted")
+
+    ctx = MagicMock()
+    ctx.elicit = AsyncMock(side_effect=answers_too_late)
+    monkeypatch.setattr(
+        "moneybin.mcp.elicitation.elicitation_wait_seconds", lambda: 0.05
+    )
+    with (
+        patch.object(exports_mcp, "get_context", return_value=ctx),
+        patch.object(exports_mcp, "supports_elicitation", return_value=True),
+        patch.object(ExportService, "run") as run,
+    ):
+        response = await call_tool_raw(
+            isolated_server(exports_mcp.register_export_tools),
+            "export_run",
+            {
+                "subject": {"kind": "bundle"},
+                "destination": {"kind": "local", "name": "exports"},
+            },
+        )
+
+    assert _structured(response)["error"]["details"]["reason"] == "timeout"
     run.assert_not_called()
 
 

--- a/tests/moneybin/test_mcp/test_first_run_setup.py
+++ b/tests/moneybin/test_mcp/test_first_run_setup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -124,6 +125,38 @@ async def test_setup_envelope_on_decline() -> None:
     ctx = _fake_ctx(
         supports_elicit=True,
         elicit_result=DeclinedElicitation(),
+    )
+
+    with patch("moneybin.mcp.first_run._bootstrap_profile") as boot:
+        result = await mw.on_call_tool(_fake_mw_context(ctx), call_next)
+
+    boot.assert_not_called()
+    call_next.assert_not_called()
+    assert isinstance(result, ToolResult)
+    assert result.structured_content is not None
+    assert (
+        result.structured_content["error"]["code"] == error_codes.INFRA_SETUP_REQUIRED
+    )
+
+
+@pytest.mark.asyncio
+async def test_setup_envelope_when_nobody_answers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unanswered setup prompt returns the envelope instead of hanging."""
+    mw = FirstRunSetupMiddleware()
+    call_next = AsyncMock()
+
+    async def answers_too_late(
+        *_args: object, **_kwargs: object
+    ) -> AcceptedElicitation[str]:
+        await asyncio.sleep(1.0)
+        return AcceptedElicitation(data="brandon")
+
+    ctx = _fake_ctx(supports_elicit=True)
+    ctx.elicit = AsyncMock(side_effect=answers_too_late)
+    monkeypatch.setattr(
+        "moneybin.mcp.elicitation.elicitation_wait_seconds", lambda: 0.05
     )
 
     with patch("moneybin.mcp.first_run._bootstrap_profile") as boot:

--- a/tests/moneybin/test_mcp/test_review.py
+++ b/tests/moneybin/test_mcp/test_review.py
@@ -18,9 +18,7 @@ from moneybin import error_codes
 from moneybin.database import get_database
 from moneybin.mcp.tools import reviews as reviews_module
 from moneybin.mcp.tools.reviews import (
-    IDENTITY_BLAST_RADIUS_LABELS,
     _identity_binding,  # pyright: ignore[reportPrivateUsage]
-    _identity_confirm_message,  # pyright: ignore[reportPrivateUsage]  # prompt under test
     identity_links_decide_coarse,
     register_review_coarse_reads,
     register_review_coarse_writes,
@@ -53,9 +51,9 @@ from moneybin.services.auto_rule_service import (
     AutoRuleService,
 )
 from moneybin.services.categorization import CategorizationService
+from moneybin.services.identity_confirmation import IDENTITY_BLAST_RADIUS_CATEGORIES
 from moneybin.services.merchant_links_service import MerchantLinksService
 from moneybin.services.review_decisions_service import (
-    IDENTITY_BLAST_RADIUS_CATEGORIES,
     IdentityDecisionPlan,
     IdentityDecisionPlanItem,
     ReviewDecisionsService,
@@ -2529,59 +2527,3 @@ def test_an_identity_merge_still_claims_the_rows_it_re_points() -> None:
     (item,) = plan.items
     assert item.affected_ids["transactions"] == ("txn-radius-merge",)
     assert item.affected_ids["lots"] == ("lot-radius-merge",)
-
-
-def test_every_blast_radius_category_has_a_prompt_label() -> None:
-    """Set equality, because a missing label is silent in the direction that matters.
-
-    ``_identity_confirm_message`` reports only the categories it can name. A
-    category added to ``IDENTITY_BLAST_RADIUS_CATEGORIES`` without a label here
-    would be counted in the digest the approval binds to and then omitted from
-    the sentence the human reads — which is the same failure as counting five
-    categories while moving six, one layer further out.
-    """
-    assert set(IDENTITY_BLAST_RADIUS_LABELS) == set(IDENTITY_BLAST_RADIUS_CATEGORIES)
-
-
-def test_the_identity_prompt_counts_every_category_it_moves() -> None:
-    """The registered description promises the prompt counts what it moves.
-
-    Until now it did not: the counts lived only in the confirmation digest, which
-    the human never sees, while the elicited text was fixed prose naming
-    "security lots" and nothing else. A merge could move a user's hand-set
-    valuations onto another instrument with no sentence anywhere saying so.
-    """
-    message = _identity_confirm_message({
-        "accounts": 0,
-        "merchants": 0,
-        "securities": 2,
-        "transactions": 7,
-        "lots": 3,
-        "price_marks": 4,
-    })
-
-    assert "4 price marks you set by hand" in message
-    assert "7 transactions" in message
-    assert "3 tax lots" in message
-    assert "2 securities" in message
-
-
-def test_the_identity_prompt_omits_categories_it_does_not_touch() -> None:
-    """A radius padded with zeros reads as a bigger blast than it is.
-
-    Paired with the test above: listing every category unconditionally satisfies
-    that one, and would tell a user binding a price feed that the batch touches
-    accounts and merchants it never opens.
-    """
-    message = _identity_confirm_message({
-        "accounts": 0,
-        "merchants": 0,
-        "securities": 1,
-        "transactions": 0,
-        "lots": 0,
-        "price_marks": 0,
-    })
-
-    assert "1 security" in message
-    assert "account" not in message.split("This batch touches:")[-1]
-    assert "tax lot" not in message.split("This batch touches:")[-1]

--- a/tests/moneybin/test_services/test_account_links_service.py
+++ b/tests/moneybin/test_services/test_account_links_service.py
@@ -317,6 +317,34 @@ def test_accept_impact_counts_every_row_the_merge_will_mutate(
     }
 
 
+def test_accept_impact_names_every_row_the_merge_will_mutate(
+    seeded: AccountLinksService, db: Database
+) -> None:
+    """Counts cannot describe a swap, so the impact carries the ids themselves.
+
+    One pending sibling resolved elsewhere while another arrives for the same
+    provisional leaves ``account_link_decisions`` unchanged and still changes
+    which decision the commit auto-rejects. Both confirmation surfaces bind to
+    these tuples, so the counts must be a projection of them rather than a
+    separate read that could disagree.
+    """
+    _insert_decision(
+        db,
+        decision_id="qp_dec000001",
+        provisional_account_id=_PROV2,
+        candidate_account_id=_PROV1,
+    )
+
+    impact = seeded.accept_impact(_DEC1, target_account_id=_CAND_A)
+
+    assert _DEC1 in impact.decision_ids
+    assert "qp_dec000001" in impact.decision_ids
+    assert impact.decision_ids == tuple(sorted(impact.decision_ids))
+    assert impact.link_ids == tuple(sorted(impact.link_ids))
+    assert impact.blast_radius["account_link_decisions"] == len(impact.decision_ids)
+    assert impact.blast_radius["account_links"] == len(impact.link_ids)
+
+
 def test_accept_verifier_receives_live_impact_and_failure_rolls_back(
     seeded: AccountLinksService, db: Database
 ) -> None:

--- a/tests/moneybin/test_services/test_identity_confirmation.py
+++ b/tests/moneybin/test_services/test_identity_confirmation.py
@@ -1,0 +1,65 @@
+"""Tests for the sentence a human ratifies before an identity batch commits."""
+
+from __future__ import annotations
+
+from moneybin.services.identity_confirmation import (
+    IDENTITY_BLAST_RADIUS_CATEGORIES,
+    IDENTITY_BLAST_RADIUS_LABELS,
+    identity_confirm_message,
+)
+
+
+def test_every_blast_radius_category_has_a_prompt_label() -> None:
+    """Set equality, because a missing label is silent in the direction that matters.
+
+    ``identity_confirm_message`` reports only the categories it can name. A
+    category added to ``IDENTITY_BLAST_RADIUS_CATEGORIES`` without a label here
+    would be counted in the digest the approval binds to and then omitted from
+    the sentence the human reads — which is the same failure as counting five
+    categories while moving six, one layer further out.
+    """
+    assert set(IDENTITY_BLAST_RADIUS_LABELS) == set(IDENTITY_BLAST_RADIUS_CATEGORIES)
+
+
+def test_the_identity_prompt_counts_every_category_it_moves() -> None:
+    """The registered description promises the prompt counts what it moves.
+
+    Until now it did not: the counts lived only in the confirmation digest, which
+    the human never sees, while the elicited text was fixed prose naming
+    "security lots" and nothing else. A merge could move a user's hand-set
+    valuations onto another instrument with no sentence anywhere saying so.
+    """
+    message = identity_confirm_message({
+        "accounts": 0,
+        "merchants": 0,
+        "securities": 2,
+        "transactions": 7,
+        "lots": 3,
+        "price_marks": 4,
+    })
+
+    assert "4 price marks you set by hand" in message
+    assert "7 transactions" in message
+    assert "3 tax lots" in message
+    assert "2 securities" in message
+
+
+def test_the_identity_prompt_omits_categories_it_does_not_touch() -> None:
+    """A radius padded with zeros reads as a bigger blast than it is.
+
+    Paired with the test above: listing every category unconditionally satisfies
+    that one, and would tell a user binding a price feed that the batch touches
+    accounts and merchants it never opens.
+    """
+    message = identity_confirm_message({
+        "accounts": 0,
+        "merchants": 0,
+        "securities": 1,
+        "transactions": 0,
+        "lots": 0,
+        "price_marks": 0,
+    })
+
+    assert "1 security" in message
+    assert "account" not in message.split("This batch touches:")[-1]
+    assert "tax lot" not in message.split("This batch touches:")[-1]

--- a/tests/moneybin/test_services/test_undo_service.py
+++ b/tests/moneybin/test_services/test_undo_service.py
@@ -15,11 +15,69 @@ import pytest
 from moneybin import error_codes
 from moneybin.database import Database
 from moneybin.errors import UserError
+from moneybin.metrics.registry import ACCOUNT_LINK_REVIEW_PENDING
+from moneybin.repositories.account_link_decisions_repo import AccountLinkDecisionsRepo
+from moneybin.repositories.account_links_repo import AccountLinksRepo
+from moneybin.repositories.base import BaseRepo
 from moneybin.repositories.transaction_notes_repo import TransactionNotesRepo
 from moneybin.repositories.transaction_tags_repo import TransactionTagsRepo
+from moneybin.services.account_links_service import AccountLinksService
+from moneybin.services.account_resolver import refresh_account_link_pending_gauge
 from moneybin.services.audit_service import AuditService
 from moneybin.services.mutation_context import operation
 from moneybin.services.undo_service import UndoService
+from tests.moneybin.db_helpers import create_core_tables
+
+
+def _pending_gauge() -> int:
+    """Read the live account-link pending gauge value."""
+    return int(ACCOUNT_LINK_REVIEW_PENDING._value.get())  # type: ignore[reportPrivateUsage] — testing prometheus internals
+
+
+def _insert_dim_account(db: Database, account_id: str, display_name: str) -> None:
+    db.execute(
+        "INSERT INTO core.dim_accounts (account_id, display_name, source_type) "
+        "VALUES (?, ?, ?)",
+        [account_id, display_name, "csv"],
+    )
+
+
+def _insert_pending_decision(
+    db: Database, decision_id: str, provisional: str, candidate: str
+) -> None:
+    AccountLinkDecisionsRepo(db).insert(
+        decision_id=decision_id,
+        provisional_account_id=provisional,
+        candidate_account_id=candidate,
+        confidence_score=0.9,
+        match_signals={"signal": "institution_last4", "value": "***"},
+        decided_by="auto",
+        actor="system",
+        status="pending",
+    )
+
+
+def _insert_source_native_link(db: Database, account_id: str) -> None:
+    """The mapping ``set`` re-points onto the candidate; a merge refuses without one."""
+    AccountLinksRepo(db).insert(
+        link_id=f"link_{account_id}",
+        account_id=account_id,
+        ref_kind="source_native",
+        ref_value=f"ref_{account_id}",
+        source_type="csv",
+        source_origin="bank_a",
+        decided_by="auto",
+        actor="system",
+        status="accepted",
+    )
+
+
+def _decision_status(db: Database, decision_id: str) -> str | None:
+    row = db.execute(
+        "SELECT status FROM app.account_link_decisions WHERE decision_id = ?",
+        [decision_id],
+    ).fetchone()
+    return row[0] if row else None
 
 
 def _note_and_tag_op(db: Database) -> str:
@@ -525,6 +583,62 @@ class TestGet:
             )
         detail = UndoService(db).get(op)
         assert detail.can_undo is False
+
+
+class TestUndoRefreshesPendingGauges:
+    """Undoing a decision puts it back in the queue; the gauge must say so."""
+
+    def test_undo_of_an_accepted_link_restores_the_pending_gauge(
+        self, db: Database
+    ) -> None:
+        """The queue re-fills on undo and the gauge has to follow it back up.
+
+        Every accept/reject path refreshes ``ACCOUNT_LINK_REVIEW_PENDING`` from a
+        live count, but undo reverses through repos rather than the link service,
+        so none of those refreshers ran on the way back. The proposal returned to
+        ``pending`` while the gauge still read the post-accept value — and an
+        under-reported review queue is the direction nothing else signals, since
+        the operator's prompt to go look at it is the gauge.
+        """
+        create_core_tables(db)  # materializes core.dim_accounts
+        _insert_dim_account(db, "prov1", "Provisional")
+        _insert_dim_account(db, "cand1", "Candidate")
+        _insert_source_native_link(db, "prov1")
+        _insert_pending_decision(db, "dec1", "prov1", "cand1")
+        refresh_account_link_pending_gauge(db)
+        assert _pending_gauge() == 1
+
+        with operation() as op:
+            AccountLinksService(db, actor="cli").set(
+                "dec1", target_account_id="cand1", decided_by="user"
+            )
+        assert _pending_gauge() == 0
+
+        UndoService(db).undo(op, actor="cli")
+
+        assert _decision_status(db, "dec1") == "pending"
+        assert _pending_gauge() == 1
+
+    def test_every_touched_repo_is_refreshed_once(
+        self, db: Database, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Once per distinct repo — not once per row, and not only the last one.
+
+        A two-table operation is the case the account-link test above cannot
+        see: it has one repo, so a call site that refreshed only the final repo,
+        or re-refreshed per audit row, would pass it either way. The note+tag
+        operation writes two rows through two repos.
+        """
+        refreshed: list[str] = []
+
+        def _record(repo: BaseRepo) -> None:
+            refreshed.append(type(repo).__name__)
+
+        monkeypatch.setattr(BaseRepo, "refresh_pending_gauge", _record)
+
+        UndoService(db).undo(_note_and_tag_op(db), actor="cli")
+
+        assert sorted(refreshed) == ["TransactionNotesRepo", "TransactionTagsRepo"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Two gaps in the same confirmation gate, plus the coherence work that made one sentence serve both surfaces.

**The CLI merged without asking.** `identity_links_decide` has gated every changed identity accept since M1, but `moneybin accounts links set --into` committed the same merge on a single unprompted invocation — the last accept path with no gate on any surface. It now prints the same sentence the MCP prompt shows, counting the accounts, transactions, tax lots, and hand-set price marks that move, and takes `--yes` for non-interactive parity. `--standalone` stays ungated: keeping an account separate destroys nothing, matching `IdentityDecisionPlan.destructive` exactly so the two surfaces cannot drift on which decisions ask.

**The gate was unreachable in one direction.** A confirmation prompt was bounded by the tool's wall-clock cap — which exists to release a wedged DuckDB connection. At the 30-second default that 10 of the 16 confirm sites run at, the prompt was cancelled and the caller received `INFRA_TIMED_OUT` with **no token issued**, so there was no way to finish the operation at all. The cap now pauses while a prompt is on screen and resumes with its remaining machine budget; prompts get their own 120-second window (`MONEYBIN_MCP__ELICITATION_WAIT_SECONDS`), after which the call degrades to the opaque-token path that clients without elicitation already use — still gated, still finishable.

Excluding the wait is safe because none of the 16 confirm sites holds a DuckDB connection across its prompt; that precondition is written into `mcp-tool-timeouts.md` so a future confirm on a connection-holding tool has to re-check it.

## Scope note

The fix landed at all four `ctx.elicit` sites, not just the one that prompted it — the import merge confirm, the first-run setup prompt, and the export redaction prompt carried the identical defect, and leaving three copies is what the coherence rule forbids. The export site is the sharpest: its RED test showed a *late* answer of `"unredacted"` sailing through and exporting unmasked data. It now refuses rather than inheriting a policy nobody chose.

## Also

- `_identity_confirm_message` and its labels move out of the MCP tool layer into `services/identity_confirmation.py`, so both surfaces render one text; the blast-radius arithmetic moves onto `IdentityDecisionPlan` so neither surface can count it differently.
- `system audit undo` restores a link decision to pending, but the review-queue gauges were refreshed only by the accept and reject paths — undo reverses through repos, so a reversed accept left the queue re-filled and the count reading zero. `BaseRepo.refresh_pending_gauge` is now a hook the three link-decision repos implement and `UndoService` calls once per touched repo after the commit, rather than a table→refresher map in the undo consumer.

## Correcting an earlier claim

An agent-experience note recorded that this tool "absorbs a 704-transaction account with no confirm gate." That is wrong on both counts, and the history says so: the gate landed in `24cf28f7` (2026-07-20) and the blast-radius-counted prompt in `5f54c72c` (2026-08-02), three weeks and six days respectively before the session that filed it. The observation "executed on the first call, no token round trip" leaves one path — the client declared elicitation support, so the gate took its `ctx.elicit` branch and that prompt was answered in-band without its text reaching the human. The real defect is a confirm that exists, renders the right sentence, and is consumed before the person it was written for sees it.

## Verification

`make check test` — **8,784 passed, 4 skipped**. The count was hand-derived before the run: 8,778 after the elicit work, +4 CLI gate tests, +2 undo tests, and the message-builder relocation moved 3 tests without adding any.

Both new undo tests were mutation-probed against a "refresh only the last repo" variant and both fail under it.

## Not done here

- Ledger-overlap evidence on link proposals, the checkable confirm sentence, and re-running the matcher after an accepted link are the next two PRs in this series.
