### PR TITLE
Judge an account merge on its ledgers, not on a constant

### DIFF
--- a/.claude/rules/mcp.md
+++ b/.claude/rules/mcp.md
@@ -31,7 +31,12 @@ MCP Tools / CLI  →  Privacy Middleware  →  Service Layer  →  DuckDB
 2. **Privacy by architecture.** MoneyBin uses four sensitivity tiers (`low`,
    `medium`, `high`, `critical`). Static tools derive their maximum tier from
    the typed response payload; projection-varying tools opt into dynamic
-   classification and declare a maximum. Critical-field masking is wired;
+   classification and declare a maximum. A tool that shows the caller
+   classified data *outside* that payload — in practice, the text of a
+   confirmation elicitation — declares it with `discloses=Tier.X`, which is
+   folded in as a floor (it raises the derived tier, never lowers it). Without
+   it, a prompt rendering transaction dates through a tool whose response holds
+   only record ids audits as `low`. Critical-field masking is wired;
    **global consent enforcement is deferred**. Do not claim or depend on an
    automatic consent gate or degraded response until that gate ships.
 3. **Batch-first, composable.** Each tool is called once per turn with a complete result. Collection operations accept lists, not single items.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -466,7 +466,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   account with no known last four still reaches the name rung, since vetoing
   there would drop a proposal nothing else surfaces. At the same institution the
   pair re-surfaces under `institution_reissue`, which is the signal a reissued
-  card actually carries, so the proposal is retyped rather than lost (#387).
+  card actually carries, so the proposal is retyped rather than lost. That
+  retype is offered alongside any other name match rather than only when there
+  is none, so an unrelated account that happens to share the name and states no
+  last four cannot stand in for the reissue and hide it (#387).
 - **`moneybin accounts links set --into` now shows what the merge moves and asks
   before committing.** Accepting a link folds one account's whole history into
   another, and no command splits it back apart — but this was the last accept

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,7 +426,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   that predates a feed's download window reports `no shared period` rather than
   a zero that would read as evidence against a correct merge. The group header
   also states how many transactions the merge would move, so deciding no longer
-  costs a second command (#387).
+  costs a second command (#387). Two rows count as the same transaction only
+  when they agree on currency as well as amount: at a multi-currency
+  institution a USD 10.00 row and a EUR 10.00 row are different money, and
+  without that a USD checking account and a EUR savings account proposed
+  together by their name could read as a perfect twin. Silence is not
+  disagreement — two ledgers that never stated a currency still match each
+  other, since refusing them would switch the evidence off for every account
+  whose source never reported one (#387).
 - **One merge now reads the same way wherever it is proposed.** The CLI prompt,
   `accounts_links_set`, and `identity_links_decide` each described the same
   decision differently, and the worst of the three named both accounts by their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -446,7 +446,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   side by what *differs* between them (which source reported it, how much
   history it holds, the period it covers, its subtype, its currency), states
   which account is absorbed and which survives, carries the overlap evidence,
-  and names `system_audit_undo` as the reversal. When the surviving account has
+  and names the reversal in the syntax of the surface you are reading it on —
+  `moneybin system audit undo <operation_id>` at the CLI,
+  `system_audit_undo(operation_id=...)` over MCP. It is the one clause that
+  differs between the two, because a recovery command is worth nothing unless it
+  runs where it is read. When the surviving account has
   no transactions of its own — a malformed placeholder offered as the survivor,
   which the live queue produced — the prompt says so and tells you to check the
   direction before accepting. The closing paragraph now describes only the link

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -447,7 +447,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   which the live queue produced — the prompt says so and tells you to check the
   direction before accepting. The closing paragraph now describes only the link
   kinds the batch actually contains, so a card-to-card merge is no longer warned
-  about security tax lots and hand-set price marks it never touches (#387).
+  about security tax lots and hand-set price marks it never touches. An account
+  that arrived over `moneybin sync` is described by that channel rather than by
+  the provider the sync server happens to speak to, which is an implementation
+  detail behind the server and not something a confirmation prompt should
+  name (#387).
 - **A name match no longer proposes a merge across two different stated last
   fours.** Two accounts that agree on a fuzzy name and *disagree* on a last four
   they both state are evidence of two different accounts, not one; the name rung

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -412,6 +412,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   binding failure is what split the account in the first place.
 
 ### Changed
+- **The account-link queue now shows how much of the ledger already matches,
+  instead of a confidence score that never moved.** Every proposal in
+  `accounts links pending` carried `0.5` or `0.4` — a constant picked by which
+  signal fired, not a measurement of anything about your accounts — so the one
+  number offered for the decision could not tell a certain merge from a doubtful
+  one. Each candidate now reports how many of the provisional account's
+  transactions already appear in the candidate's ledger, matched on amount
+  within a few days to absorb the gap between a statement's transaction date and
+  a feed's posting date. Against a real duplicated card that reads `345 of 346`;
+  against an unrelated account at the same institution, `0 of 346`. The
+  comparison is scoped to the period both accounts cover, so a statement archive
+  that predates a feed's download window reports `no shared period` rather than
+  a zero that would read as evidence against a correct merge. The group header
+  also states how many transactions the merge would move, so deciding no longer
+  costs a second command.
+- **One merge now reads the same way wherever it is proposed.** The CLI prompt,
+  `accounts_links_set`, and `identity_links_decide` each described the same
+  decision differently, and the worst of the three named both accounts by their
+  display label — identical text on both sides in exactly the split-account case
+  the feature exists to fix. All three now render one sentence that names each
+  side by what *differs* between them (which source reported it, how much
+  history it holds, the period it covers, its subtype, its currency), states
+  which account is absorbed and which survives, carries the overlap evidence,
+  and names `system_audit_undo` as the reversal. When the surviving account has
+  no transactions of its own — a malformed placeholder offered as the survivor,
+  which the live queue produced — the prompt says so and tells you to check the
+  direction before accepting. The closing paragraph now describes only the link
+  kinds the batch actually contains, so a card-to-card merge is no longer warned
+  about security tax lots and hand-set price marks it never touches.
+- **A name match no longer proposes a merge across two different stated last
+  fours.** Two accounts that agree on a fuzzy name and *disagree* on a last four
+  they both state are evidence of two different accounts, not one; the name rung
+  proposed them anyway. It now skips that pair. Silence is not disagreement — an
+  account with no known last four still reaches the name rung, since vetoing
+  there would drop a proposal nothing else surfaces. At the same institution the
+  pair re-surfaces under `institution_reissue`, which is the signal a reissued
+  card actually carries, so the proposal is retyped rather than lost.
 - **`moneybin accounts links set --into` now shows what the merge moves and asks
   before committing.** Accepting a link folds one account's whole history into
   another, and no command splits it back apart — but this was the last accept
@@ -701,6 +738,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   so the tool's declared ceiling has to admit the critical tier for the
   masking middleware to apply. Hosts that gate tools on declared sensitivity
   will see `import_confirm` move band.
+
+### Removed
+- **`confidence` no longer appears in the account-link review payloads.** The
+  `Conf` column is gone from `accounts links pending` and `accounts links
+  history`, and the `confidence` field is gone from their `--output json`
+  envelopes and from `reviews(kind="account_links")`. It reported a constant
+  chosen by which signal fired, so anything reading it was reading the signal
+  name in a less legible form — `signal` still carries that, and
+  `overlap_matched` / `overlap_comparable` now carry the measurement it looked
+  like it was making. The `app.account_link_decisions.confidence_score` column
+  is unchanged: it is what was recorded when the proposal was written, and the
+  audit trail keeps it.
 
 ### Fixed
 - **Undoing a decision puts it back in the review queue, and the queue count now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -452,6 +452,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the provider the sync server happens to speak to, which is an implementation
   detail behind the server and not something a confirmation prompt should
   name (#387).
+- **`identity_links_decide` now reports `sensitivity: "medium"`.** Its response
+  still carries only record ids and counts, but its merge prompt shows
+  transaction dates and the account labels you wrote, and the privacy audit
+  event recorded the response's tier rather than what you were shown. A tool
+  that renders classified data in a confirmation prompt now declares that tier
+  alongside the one derived from its response, and the higher of the two wins
+  (#387).
 - **A name match no longer proposes a merge across two different stated last
   fours.** Two accounts that agree on a fuzzy name and *disagree* on a last four
   they both state are evidence of two different accounts, not one; the name rung

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,7 +426,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   that predates a feed's download window reports `no shared period` rather than
   a zero that would read as evidence against a correct merge. The group header
   also states how many transactions the merge would move, so deciding no longer
-  costs a second command.
+  costs a second command (#387).
 - **One merge now reads the same way wherever it is proposed.** The CLI prompt,
   `accounts_links_set`, and `identity_links_decide` each described the same
   decision differently, and the worst of the three named both accounts by their
@@ -440,7 +440,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   which the live queue produced — the prompt says so and tells you to check the
   direction before accepting. The closing paragraph now describes only the link
   kinds the batch actually contains, so a card-to-card merge is no longer warned
-  about security tax lots and hand-set price marks it never touches.
+  about security tax lots and hand-set price marks it never touches (#387).
 - **A name match no longer proposes a merge across two different stated last
   fours.** Two accounts that agree on a fuzzy name and *disagree* on a last four
   they both state are evidence of two different accounts, not one; the name rung
@@ -448,7 +448,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   account with no known last four still reaches the name rung, since vetoing
   there would drop a proposal nothing else surfaces. At the same institution the
   pair re-surfaces under `institution_reissue`, which is the signal a reissued
-  card actually carries, so the proposal is retyped rather than lost.
+  card actually carries, so the proposal is retyped rather than lost (#387).
 - **`moneybin accounts links set --into` now shows what the merge moves and asks
   before committing.** Accepting a link folds one account's whole history into
   another, and no command splits it back apart — but this was the last accept
@@ -749,7 +749,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `overlap_matched` / `overlap_comparable` now carry the measurement it looked
   like it was making. The `app.account_link_decisions.confidence_score` column
   is unchanged: it is what was recorded when the proposal was written, and the
-  audit trail keeps it.
+  audit trail keeps it (#387).
 
 ### Fixed
 - **Undoing a decision puts it back in the review queue, and the queue count now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -433,7 +433,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   together by their name could read as a perfect twin. Silence is not
   disagreement — two ledgers that never stated a currency still match each
   other, since refusing them would switch the evidence off for every account
-  whose source never reported one (#387).
+  whose source never reported one. The veto reads the currency and not its
+  spelling: a spreadsheet column holding `usd` names the same money as a
+  statement's `USD`, padding and letter case included, and a currency column
+  left blank on domestic rows counts as unstated rather than as a currency of
+  its own (#387).
 - **One merge now reads the same way wherever it is proposed.** The CLI prompt,
   `accounts_links_set`, and `identity_links_decide` each described the same
   decision differently, and the worst of the three named both accounts by their

--- a/docs/specs/account-identity-resolution.md
+++ b/docs/specs/account-identity-resolution.md
@@ -1,6 +1,6 @@
 # Cross-Source Account Identity Resolution
 
-> Last updated: 2026-07-09
+> Last updated: 2026-08-10
 > Status: implemented (architecture M1S.1–.6 + the capture/bind-first
 > corrections M1S.7–.9, all shipped — see [§Decision 8](#decision-8--capture-mutable-labels-and-the-exporter-axis-m1s7-live-test-reconciliation));
 > the full-scale live re-validation this spec was written to unblock (5-account
@@ -334,7 +334,15 @@ signal reliability:
    definition, so signal 1 cannot fire; and on the PDF path `account_name` is a
    per-file filename alias, so signal 2 misses too. Requiring a last-four on both
    sides, and requiring them to differ, keeps it the reissue shape rather than a
-   general "any account at this institution" list. It is on for `resolve()` and
+   general "any account at this institution" list. The same disagreement is a
+   **veto** one rung up: the fuzzy-name pass skips any pair where both sides
+   state a last four and the two differ, because a name match across a stated
+   contradiction is evidence of two *different* accounts. Silence is not
+   disagreement — an account with no known last four still reaches the name
+   rung, since vetoing there would drop a proposal nothing else surfaces. Where
+   the pair also shares an institution the reissue signal re-surfaces it under
+   the signal a replacement card actually carries, so the veto retypes the
+   proposal rather than discarding it. It is on for `resolve()` and
    its `propose()` preview, which must agree, and off for `propose_existing()`
    backfill, where every account is already known-distinct and pairwise proposals
    would be noise:
@@ -503,6 +511,30 @@ Guard-2 free-text resolution):
   auto-rejecting siblings; `decision="reject"` forbids `target_id`. The envelope,
   sensitivity tier (low — `ref_value` masked/omitted), and `actions[]` follow
   `mcp.md`.
+- **What a queue row carries — measured overlap, not a stored score.** Each
+  candidate reports the **ledger overlap**: how many of the provisional
+  account's transactions already appear in the candidate's, matched on equal
+  amount within a ±3-day posting-lag window (`services/ledger_overlap.py`).
+  Exact date+amount alone is not the right predicate — a statement carries the
+  transaction date and an OFX feed the posting date, which scores a true twin at
+  roughly a quarter of its rows. Each group states how many transactions an
+  accepted merge would move, so the magnitude and the evidence are both present
+  at browse time rather than only inside the confirm.
+  Three properties are load-bearing:
+  - **Keyed on two account ids, not a decision id.** The matcher excludes
+    same-`account_id` pairs, so the overlap cannot be computed *after* the merge
+    it justifies; and the two-id shape leaves the probe reachable for
+    `system doctor`'s `duplicate_account_overlap` pairs, which carry no proposal.
+  - **Scoped to the comparable period.** The denominator counts only the
+    provisional's transactions falling inside the candidate's own span, widened
+    by the lag. Otherwise a statement archive predating a feed's download window
+    renders as "0 of 400", which reads as evidence *against* a correct merge. A
+    probe with no comparable period says so; it never renders as `0 of 0`.
+  - **`confidence_score` is not a review surface.** Its value is fixed per
+    signal (0.5 `institution_last4`, 0.4 `name`, 0.3 `institution_reissue`), so
+    it restates `signal` in a less legible form; no input moves it. The column
+    remains as the audit record of what was written when the proposal was
+    created, and is no longer projected onto either surface.
 - **Status lifecycle.** `account_links`: `accepted` (live) / `reversed` (undone).
   `account_link_decisions`: `pending` (awaiting review) → `accepted` (merged onto
   the named candidate) / `rejected` (declined pairing — not re-proposed) /
@@ -958,7 +990,19 @@ Per [`observability.md`](observability.md), mirror the `DEDUP_*` family
 - `ACCOUNT_LINK_OUTCOMES_TOTAL` — Counter, labels
   `result ∈ {adopted_strong, minted_new, pending_review, merged, rejected}`.
 - `ACCOUNT_LINK_REVIEW_PENDING` — Gauge, current pending-decision count.
-- `ACCOUNT_LINK_CONFIDENCE` — Histogram of resolution confidence.
+- `ACCOUNT_LINK_CONFIDENCE` — Histogram of resolution confidence. Records the
+  score written with a proposal, which is where that number is still meaningful;
+  it is deliberately not the review surfaces' evidence (Decision 5).
+
+**Known gap — the ledger-overlap probe is unmetered.** A deployment where every
+probe returns "no comparable period" has an evidence surface that renders
+nothing useful, and no instrument would say so. The measurement runs on the
+read-only browse and confirm paths, and `flush_metrics()` deliberately skips a
+session that opened no write connection, so an observation emitted there is
+accumulated in-process and discarded at exit — recorded nowhere, while looking
+instrumented in the source. Wire it from a path that already writes
+(`accounts links run`, the identity refresh step) if the ratio's distribution
+ever needs watching.
 
 ## Testing
 

--- a/docs/specs/account-identity-resolution.md
+++ b/docs/specs/account-identity-resolution.md
@@ -1053,6 +1053,18 @@ means a transported-but-undigested field on a primitive every destructive tool
 shares. That blast radius is why this lands as its own change rather than
 half-done on one surface.
 
+**The merge prompt is what makes `identity_links_decide` a medium-tier tool.**
+Its response payload carries record ids, a status, and counts — all `low`. The
+elicitation carries each ledger's first and last transaction dates and the
+account labels the user wrote, which the tier table puts at `medium`. Static
+classification walks only the payload, so the tool declares the difference with
+`discloses=Tier.MEDIUM` and the decorator folds it in as a floor. Without it the
+privacy audit event would record `low` for a call that showed the caller
+medium-tier data, and a future consent gate would admit the call on the wrong
+tier. `accounts_links_set` renders the same evidence and needs no declaration:
+it is an unregistered internal callback with no caller, so its prompt reaches
+nobody. Registering it means declaring the tier in the same change.
+
 ## Testing
 
 - **Unit** (`tests/moneybin/`): `AccountResolver` ladder — strong/remembered ref

--- a/docs/specs/account-identity-resolution.md
+++ b/docs/specs/account-identity-resolution.md
@@ -343,7 +343,15 @@ signal reliability:
    the pair also shares an institution, the veto **retypes** rather than
    discards: that exact pair re-emerges under `institution_reissue`, the signal
    a replacement card actually carries. The retype runs on every path, because
-   it is bounded by what the name matcher already matched. That is distinct from
+   it is bounded by what the name matcher already matched — and it runs
+   *unconditionally*, beside the name pass rather than only when that pass came
+   up empty. The two read disjoint halves of the same rows: the veto keeps the
+   pairs whose last fours agree or are silent, the retype keeps the ones that
+   disagree. Gating the retype on an empty name pass therefore let an unrelated
+   account that shared the name and stated no last four populate the list and
+   hide the genuine reissue behind it — the coincidental-namesake case the
+   retype exists for. Both are weak signals bound for the same review queue, so
+   both surface and the human picks. That is distinct from
    the unconditional same-institution *sweep*, which surfaces every account whose
    last four differs whether or not any signal fired: the sweep is on for
    `resolve()` and its `propose()` preview, which must agree, and off for

--- a/docs/specs/account-identity-resolution.md
+++ b/docs/specs/account-identity-resolution.md
@@ -530,6 +530,16 @@ Guard-2 free-text resolution):
     by the lag. Otherwise a statement archive predating a feed's download window
     renders as "0 of 400", which reads as evidence *against* a correct merge. A
     probe with no comparable period says so; it never renders as `0 of 0`.
+  - **Amount-equal means same currency.** A nominal amount is not a sum of
+    money until a currency names it, and `fct_transactions.currency_code`
+    exists precisely because two accounts can differ on it. Without the
+    predicate a multi-currency institution's USD checking and EUR savings —
+    a pair the name rung will happily propose — measure as a perfect twin. The
+    comparison is NULL-safe on purpose: only a *stated* disagreement vetoes a
+    match, because a plain `=` would score every pair of unknown-currency
+    ledgers at zero and switch the evidence off silently for exactly the
+    accounts whose sources never reported one. The same asymmetry the name
+    rung's last-four veto uses — silence is not disagreement.
   - **`confidence_score` is not a review surface.** Its value is fixed per
     signal (0.5 `institution_last4`, 0.4 `name`, 0.3 `institution_reissue`), so
     it restates `signal` in a less legible form; no input moves it. The column
@@ -1003,6 +1013,21 @@ accumulated in-process and discarded at exit — recorded nowhere, while looking
 instrumented in the source. Wire it from a path that already writes
 (`accounts links run`, the identity refresh step) if the ratio's distribution
 ever needs watching.
+
+**Known gap — the empty-survivor warning is not re-verified at commit.** The
+merge sentence appends "the surviving account has no transactions of its own —
+check the direction before accepting" when `facts.survivor.transactions == 0`,
+which is the cheap tell for a reversed proposal. Neither confirm path holds the
+commit to it: the CLI's `_drift_check` compares the blast radius and the link
+and decision row identities, and the MCP grant digests resolved ids and blast
+radius. A second accept landing while the prompt is open can absorb the
+survivor's own history elsewhere, so the warning that should have fired never
+does. The ledger *ratio* is deliberately unbound for the opposite reason — a
+concurrent import can only strengthen it, and binding it would refuse a correct
+merge — which makes the fix an **asymmetric** check rather than another field
+in the digest: refuse when the survivor became empty, never when it stopped
+being empty. Both surfaces have to gain it together, and on MCP it must survive
+the opaque-token round trip where the proposal is never reloaded.
 
 ## Testing
 

--- a/docs/specs/account-identity-resolution.md
+++ b/docs/specs/account-identity-resolution.md
@@ -1008,30 +1008,45 @@ Per [`observability.md`](observability.md), mirror the `DEDUP_*` family
   score written with a proposal, which is where that number is still meaningful;
   it is deliberately not the review surfaces' evidence (Decision 5).
 
-**Known gap — the ledger-overlap probe is unmetered.** A deployment where every
-probe returns "no comparable period" has an evidence surface that renders
-nothing useful, and no instrument would say so. The measurement runs on the
-read-only browse and confirm paths, and `flush_metrics()` deliberately skips a
-session that opened no write connection, so an observation emitted there is
-accumulated in-process and discarded at exit — recorded nowhere, while looking
-instrumented in the source. Wire it from a path that already writes
-(`accounts links run`, the identity refresh step) if the ratio's distribution
-ever needs watching.
+- `ACCOUNT_LINK_OVERLAP_PROBES_TOTAL` — Counter,
+  `result ∈ {measurable, unmeasurable}`, incremented inside
+  `probe_ledger_overlap` so no call site can forget it. A deployment where
+  schema or source drift makes every probe return "no comparable period" has an
+  evidence surface that renders prose and no number, and nothing else on any
+  surface changes when that happens. `unmeasurable` climbing while `measurable`
+  stays flat is the alarm. Note the flush boundary: the probe runs on the
+  read-only browse and confirm paths, and `flush_metrics()` skips a session that
+  opened no write connection, so a browse-only session's counts are accumulated
+  in-process and discarded at exit. The confirm path that precedes a merge does
+  open a write connection, which is the path where the signal has to survive.
 
-**Known gap — the empty-survivor warning is not re-verified at commit.** The
-merge sentence appends "the surviving account has no transactions of its own —
-check the direction before accepting" when `facts.survivor.transactions == 0`,
-which is the cheap tell for a reversed proposal. Neither confirm path holds the
-commit to it: the CLI's `_drift_check` compares the blast radius and the link
-and decision row identities, and the MCP grant digests resolved ids and blast
-radius. A second accept landing while the prompt is open can absorb the
-survivor's own history elsewhere, so the warning that should have fired never
-does. The ledger *ratio* is deliberately unbound for the opposite reason — a
-concurrent import can only strengthen it, and binding it would refuse a correct
-merge — which makes the fix an **asymmetric** check rather than another field
-in the digest: refuse when the survivor became empty, never when it stopped
-being empty. Both surfaces have to gain it together, and on MCP it must survive
-the opaque-token round trip where the proposal is never reloaded.
+**Known gap — the displayed ledger evidence is not re-verified at commit.** The
+merge sentence renders two facts that neither confirm path holds the commit to.
+The CLI's `_drift_check` compares the blast radius and the link and decision row
+identities; the MCP grant digests resolved ids and blast radius.
+
+- **The empty-survivor warning.** "The surviving account has no transactions of
+  its own — check the direction before accepting" appends when
+  `facts.survivor.transactions == 0`, the cheap tell for a reversed proposal. A
+  second accept landing while the prompt is open can absorb the survivor's own
+  history elsewhere, so the warning that should have fired never does.
+- **The overlap ratio.** The probe's comparison window is `MIN`/`MAX` over the
+  *survivor's* dates, so one survivor-side row arriving outside it widens the
+  window and admits absorbed rows that match nothing: `matched` holds while
+  `comparable` grows. A ratified "40 of 40" can commit as "40 of 400" with the
+  sentence unchanged. `test_a_wider_survivor_span_pulls_more_rows_into_comparable`
+  pins the mechanism.
+
+Both want the same missing check, and it is **asymmetric** rather than another
+field in the digest: refuse when the evidence got worse, never when it got
+better — a survivor that gained its first transactions, or an import that
+strengthened the overlap, are both harmless and a digest would refuse them. Both
+surfaces have to gain it together, and on MCP it must survive the opaque-token
+round trip where the proposal is never reloaded — `ConfirmationBinding` is
+frozen and hashed over every field, so carrying the approved baseline there
+means a transported-but-undigested field on a primitive every destructive tool
+shares. That blast radius is why this lands as its own change rather than
+half-done on one surface.
 
 ## Testing
 

--- a/docs/specs/account-identity-resolution.md
+++ b/docs/specs/account-identity-resolution.md
@@ -517,7 +517,11 @@ Guard-2 free-text resolution):
   amount within a ±3-day posting-lag window (`services/ledger_overlap.py`).
   Exact date+amount alone is not the right predicate — a statement carries the
   transaction date and an OFX feed the posting date, which scores a true twin at
-  roughly a quarter of its rows. Each group states how many transactions an
+  roughly a quarter of its rows. That window is a calibration rather than a
+  preference, so it is a module constant and not `matching.date_window_days`
+  (which `system doctor`'s `duplicate_account_overlap` does reuse): the control
+  result that makes the ratio discriminating was measured at this width, and a
+  user who widened it would get a larger number that means less. Each group states how many transactions an
   accepted merge would move, so the magnitude and the evidence are both present
   at browse time rather than only inside the confirm.
   Three properties are load-bearing:

--- a/docs/specs/account-identity-resolution.md
+++ b/docs/specs/account-identity-resolution.md
@@ -556,7 +556,14 @@ Guard-2 free-text resolution):
     match, because a plain `=` would score every pair of unknown-currency
     ledgers at zero and switch the evidence off silently for exactly the
     accounts whose sources never reported one. The same asymmetry the name
-    rung's last-four veto uses — silence is not disagreement.
+    rung's last-four veto uses — silence is not disagreement. Both sides are
+    folded to a bare upper-case code before comparing, so the veto fires on the
+    currency rather than on its spelling: the tabular extractor copies
+    `currency` out of the source cell verbatim while OFX and Plaid carry ISO
+    codes, which puts `usd` opposite `USD` in precisely the cross-source pair
+    this probe is asked to judge. A blank cell reads as unstated for the same
+    reason silence does — a statement that fills its currency column only on
+    foreign rows leaves the domestic ones empty, not NULL.
   - **`confidence_score` is not a review surface.** Its value is fixed per
     signal (0.5 `institution_last4`, 0.4 `name`, 0.3 `institution_reissue`), so
     it restates `signal` in a less legible form; no input moves it. The column

--- a/docs/specs/account-identity-resolution.md
+++ b/docs/specs/account-identity-resolution.md
@@ -340,12 +340,17 @@ signal reliability:
    contradiction is evidence of two *different* accounts. Silence is not
    disagreement — an account with no known last four still reaches the name
    rung, since vetoing there would drop a proposal nothing else surfaces. Where
-   the pair also shares an institution the reissue signal re-surfaces it under
-   the signal a replacement card actually carries, so the veto retypes the
-   proposal rather than discarding it. It is on for `resolve()` and
-   its `propose()` preview, which must agree, and off for `propose_existing()`
-   backfill, where every account is already known-distinct and pairwise proposals
-   would be noise:
+   the pair also shares an institution, the veto **retypes** rather than
+   discards: that exact pair re-emerges under `institution_reissue`, the signal
+   a replacement card actually carries. The retype runs on every path, because
+   it is bounded by what the name matcher already matched. That is distinct from
+   the unconditional same-institution *sweep*, which surfaces every account whose
+   last four differs whether or not any signal fired: the sweep is on for
+   `resolve()` and its `propose()` preview, which must agree, and off for
+   `propose_existing()` backfill, where it would propose every same-issuer card
+   against every other. Keeping the two separate is what lets backfill see a
+   vetoed duplicate without drowning in pairwise noise — conflating them made a
+   duplicate the backfill queue used to surface silently invisible:
    - **0 candidates** → done: a new standalone account. Its `last_four` /
      institution / name (captured per Decision 7) become candidate signals for
      *future* imports.

--- a/docs/specs/mcp-architecture.md
+++ b/docs/specs/mcp-architecture.md
@@ -433,6 +433,15 @@ maximum sensitivity from the data classes on their typed response payload.
 Tools whose projection varies by request declare `dynamic_classification=True`,
 classify the returned payload, and advertise a `maximum_sensitivity` ceiling.
 
+Both paths read the response. A tool that shows the caller classified data
+somewhere else — today, only the text of a confirmation elicitation — declares
+that tier with `discloses=Tier.X` on a static tool, and the decorator folds it
+in as a floor: it raises the derived tier and never lowers it, so it cannot
+argue a `critical` payload out of masking. `identity_links_decide` is the one
+tool that carries it: its response holds record ids and counts, while its merge
+prompt renders each ledger's first and last transaction dates and the account
+labels the user chose.
+
 Classification and critical-field masking are current behavior. The consent
 ledger is current, but **global consent enforcement is deferred**; the
 consented/not-consented columns below describe the target gate, not current

--- a/docs/specs/moneybin-cli.md
+++ b/docs/specs/moneybin-cli.md
@@ -232,8 +232,9 @@ moneybin [--profile NAME] [--verbose] <command> [--output text|json] [--quiet] [
 |   |   +-- history --account ID [--from DATE] [--to DATE]
 |   +-- links                      -- Review and manage account-link binding decisions
 |       +-- pending [--output json] [--quiet]
-|       |         List provisional accounts + candidate merge proposals; each candidate
-|       |         shows decision_id, candidate_account_id, display name, confidence, signal.
+|       |         List provisional accounts + candidate merge proposals; each group states
+|       |         how many transactions the merge would move, and each candidate shows
+|       |         decision_id, candidate_account_id, display name, ledger overlap, signal.
 |       +-- set <decision_id> --into <account_id> | --standalone [--yes]
 |       |         Merge the provisional into the candidate (--into) or keep as standalone
 |       |         (--standalone). The two flags are mutually exclusive; omitting both exits 2.

--- a/docs/specs/moneybin-mcp.md
+++ b/docs/specs/moneybin-mcp.md
@@ -74,7 +74,7 @@ safety family without duplicating FastMCP's drifting JSON schema.
 | `transactions_categorize_rules_set` | `confirmation_token`, `rules` | Rule target state | Confirmed write / maximum low |
 | `reviews` | `cursor`, `kind`, `limit`, `status` | Pending/history queues, including current blast-radius evidence for pending `kind='auto_rules'` rows | Read / dynamic / maximum high / queue-derived |
 | `reviews_decide` | `decisions` | Resolve ordinary or auto-rule review items; `kind='auto_rule'` carries proposal-scoped `allow_broad` | Confirmed write / maximum low |
-| `identity_links_decide` | `confirmation_token`, `decisions` | Resolve identity links | Confirmed write / maximum low |
+| `identity_links_decide` | `confirmation_token`, `decisions` | Resolve identity links | Confirmed write / maximum medium (prompt-disclosed) |
 | `taxonomy` | `cursor`, `include_inactive`, `limit`, `query`, `view` | Read taxonomy projections | Read / dynamic / maximum medium / view-derived |
 | `taxonomy_set` | `confirmation_token`, `items` | Taxonomy target state | Audited write / maximum low |
 | `import_files` | `account_bindings`, `force`, `paths`, `refresh` | Import files | Audited workflow / maximum critical / file-derived |

--- a/src/moneybin/cli/commands/accounts/links.py
+++ b/src/moneybin/cli/commands/accounts/links.py
@@ -227,6 +227,19 @@ class _ApprovedMerge:
     accept — the write touches the absorbed account's rows, which ``sentence``
     already counts — so binding them would refuse a correct merge because a
     concurrent import made the evidence for it *stronger*.
+
+    **Known accepted gap.** That argument holds for the ratio, which can only
+    move in the safe direction, but not for the empty-survivor warning
+    ("the surviving account has no transactions of its own — check the
+    direction") that the same ledger size drives. A second accept landing
+    between prompt and commit can absorb the survivor's own history elsewhere
+    and leave it an empty placeholder, so a warning that should have fired
+    never does and nothing re-checks it. Closing it means re-verifying one
+    asymmetric condition — refuse when the survivor became empty, never when it
+    stopped being empty — on this path *and* on the MCP grant, whose binding is
+    a symmetric digest and would need a second, non-digest check to express the
+    asymmetry. Both halves land together or the two surfaces disagree about
+    what a confirmation covers; tracked rather than half-done here.
     """
 
     sentence: dict[str, int]

--- a/src/moneybin/cli/commands/accounts/links.py
+++ b/src/moneybin/cli/commands/accounts/links.py
@@ -31,6 +31,7 @@ from moneybin.services.account_links_service import (
     AccountLinksService,
 )
 from moneybin.services.identity_confirmation import identity_confirm_message
+from moneybin.services.ledger_overlap import LedgerOverlap
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -83,22 +84,33 @@ def links_pending(
         typer.echo(
             f"\n── provisional {group.provisional_account_id} "
             f"({group.provisional_display_name or '-'}) "
+            f"— {group.transactions:,} transactions move "
             f"— {len(group.candidates)} candidate(s) ──"
         )
         typer.echo(
             f"  {'Decision ID':<14} {'Candidate ID':<14} {'Signal':<20} "
-            f"{'Conf':>5}  {'Display Name'}"
+            f"{'Ledger overlap':>16}  {'Display Name'}"
         )
         for c in group.candidates:
-            conf_str = f"{c.confidence:.2f}" if c.confidence is not None else "  -  "
             typer.echo(
                 f"  {c.decision_id[:12]:<14} "
                 f"{c.candidate_account_id[:12]:<14} "
                 f"{c.signal:<20} "
-                f"{conf_str:>5}  "
+                f"{_overlap_cell(c.overlap):>16}  "
                 f"{c.candidate_display_name or '-'}"
             )
     typer.echo()
+
+
+def _overlap_cell(overlap: LedgerOverlap) -> str:
+    """One cell of measured evidence, or an honest dash when there is none.
+
+    "0 of 0" would read as two ledgers with nothing in common — evidence against
+    the merge — where no comparable period means the probe could not look.
+    """
+    if not overlap.measurable:
+        return "no shared period"
+    return f"{overlap.matched:,} of {overlap.comparable:,}"
 
 
 @app.command("set")
@@ -209,6 +221,12 @@ class _ApprovedMerge:
     The rows are identities rather than counts because a swap keeps every count
     intact: one pending sibling resolved elsewhere while another arrives leaves
     the same number of decisions in play and still changes which one dies.
+
+    The surviving account's own ledger size and the overlap ratio are rendered in
+    the prompt but deliberately not held here. Neither is a consequence of the
+    accept — the write touches the absorbed account's rows, which ``sentence``
+    already counts — so binding them would refuse a correct merge because a
+    concurrent import made the evidence for it *stronger*.
     """
 
     sentence: dict[str, int]
@@ -216,8 +234,10 @@ class _ApprovedMerge:
     decisions: tuple[str, ...]
 
 
-def _merge_preview(decision_id: str, target_account_id: str) -> _ApprovedMerge | None:
-    """Resolve both radii read-only, the way MCP previews the same decision.
+def _merge_preview(
+    decision_id: str, target_account_id: str
+) -> tuple[_ApprovedMerge, str] | None:
+    """Resolve both radii and the prompt text read-only, the way MCP previews it.
 
     ``None`` when the accept changes nothing — a decision already settled onto
     this same candidate. The destructive check has to come first: ``accept_impact``
@@ -228,13 +248,19 @@ def _merge_preview(decision_id: str, target_account_id: str) -> _ApprovedMerge |
         plan = _plan_merge(db, decision_id, target_account_id)
         if not plan.destructive:
             return None
-        impact = AccountLinksService(db, actor="cli").accept_impact(
-            decision_id, target_account_id=target_account_id
+        service = AccountLinksService(db, actor="cli")
+        impact = service.accept_impact(decision_id, target_account_id=target_account_id)
+        facts = service.merge_facts(
+            absorbed_account_id=impact.provisional_account_id,
+            survivor_account_id=target_account_id,
         )
-    return _ApprovedMerge(
+    approved = _ApprovedMerge(
         sentence=plan.blast_radius,
         links=impact.link_ids,
         decisions=impact.decision_ids,
+    )
+    return approved, identity_confirm_message(
+        plan.blast_radius, merges=[facts], kinds=["account_link"]
     )
 
 
@@ -332,10 +358,11 @@ def _confirm_merge(decision_id: str, target_account_id: str) -> _ApprovedMerge |
     itself to them. A merge that turns out to move nothing — the decision is
     already settled — returns ``None`` and asks nothing.
     """
-    approved = _merge_preview(decision_id, target_account_id)
-    if approved is None:
+    preview = _merge_preview(decision_id, target_account_id)
+    if preview is None:
         return None
-    typer.echo(identity_confirm_message(approved.sentence), err=True)
+    approved, message = preview
+    typer.echo(message, err=True)
     if not typer.confirm("Merge these accounts?", default=False, err=True):
         typer.echo("Cancelled — nothing was merged.", err=True)
         raise typer.Exit(0)
@@ -372,19 +399,17 @@ def links_history(
 
     typer.echo(
         f"\n{'Decision ID':<14} {'Provisional':<14} {'Candidate':<14} "
-        f"{'Status':<10} {'Decided By':<10} {'Signal':<20} {'Conf':>5}"
+        f"{'Status':<10} {'Decided By':<10} {'Signal':<20}"
     )
-    typer.echo("-" * 90)
+    typer.echo("-" * 84)
     for d in payload.decisions:
-        conf_str = f"{d.confidence:.2f}" if d.confidence is not None else "  -  "
         typer.echo(
             f"{d.decision_id[:12]:<14} "
             f"{d.provisional_account_id[:12]:<14} "
             f"{d.candidate_account_id[:12]:<14} "
             f"{d.status:<10} "
             f"{d.decided_by:<10} "
-            f"{d.signal:<20} "
-            f"{conf_str:>5}"
+            f"{d.signal:<20}"
         )
     typer.echo()
 

--- a/src/moneybin/cli/commands/accounts/links.py
+++ b/src/moneybin/cli/commands/accounts/links.py
@@ -54,7 +54,7 @@ def links_pending(
     """List pending account-link decisions, grouped by provisional account.
 
     Shows provisional accounts with candidate merge proposals. Each group
-    lists the candidate decision_id, account_id, display name, confidence,
+    lists the candidate decision_id, account_id, display name, ledger overlap,
     and match signal. Use `accounts links set` to decide each group.
     """
     with handle_cli_errors():

--- a/src/moneybin/cli/commands/accounts/links.py
+++ b/src/moneybin/cli/commands/accounts/links.py
@@ -222,24 +222,33 @@ class _ApprovedMerge:
     intact: one pending sibling resolved elsewhere while another arrives leaves
     the same number of decisions in play and still changes which one dies.
 
-    The surviving account's own ledger size and the overlap ratio are rendered in
-    the prompt but deliberately not held here. Neither is a consequence of the
-    accept — the write touches the absorbed account's rows, which ``sentence``
-    already counts — so binding them would refuse a correct merge because a
-    concurrent import made the evidence for it *stronger*.
+    The surviving account's own ledger size and the overlap ratio are rendered
+    in the prompt but deliberately not held here. Neither is a consequence of
+    the accept — the write touches the absorbed account's rows, which
+    ``sentence`` already counts — and holding them by equality would refuse a
+    correct merge whenever a concurrent import moved either one harmlessly.
 
-    **Known accepted gap.** That argument holds for the ratio, which can only
-    move in the safe direction, but not for the empty-survivor warning
-    ("the surviving account has no transactions of its own — check the
-    direction") that the same ledger size drives. A second accept landing
-    between prompt and commit can absorb the survivor's own history elsewhere
-    and leave it an empty placeholder, so a warning that should have fired
-    never does and nothing re-checks it. Closing it means re-verifying one
-    asymmetric condition — refuse when the survivor became empty, never when it
-    stopped being empty — on this path *and* on the MCP grant, whose binding is
-    a symmetric digest and would need a second, non-digest check to express the
-    asymmetry. Both halves land together or the two surfaces disagree about
-    what a confirmation covers; tracked rather than half-done here.
+    **Known accepted gap**, in both of them. Equality is the wrong test, but no
+    test at all is not the right one, because each can also move the *unsafe*
+    way between prompt and commit:
+
+    - The empty-survivor warning ("the surviving account has no transactions of
+      its own — check the direction"): a second accept can absorb the survivor's
+      own history elsewhere and leave it an empty placeholder, so a warning that
+      should have fired never does.
+    - The overlap ratio: the probe's comparison window is ``MIN``/``MAX`` over
+      the *survivor's* dates, so one survivor-side row arriving outside it
+      widens the window and admits absorbed rows that match nothing. A ratified
+      "40 of 40" commits as "40 of 400" with the sentence unchanged. Pinned by
+      ``test_a_wider_survivor_span_pulls_more_rows_into_comparable``.
+
+    Both want the same missing mechanism: re-verify asymmetrically inside the
+    write transaction — refuse when the evidence got worse, never when it got
+    better — on this path *and* on the MCP grant, whose binding is a frozen
+    symmetric digest and would need a transported-but-undigested baseline to
+    express the asymmetry. That is a change to a primitive every destructive
+    MCP tool shares, so both halves land together in their own change or the
+    two surfaces disagree about what a confirmation covers.
     """
 
     sentence: dict[str, int]

--- a/src/moneybin/cli/commands/accounts/links.py
+++ b/src/moneybin/cli/commands/accounts/links.py
@@ -282,7 +282,7 @@ def _merge_preview(
         decisions=impact.decision_ids,
     )
     return approved, identity_confirm_message(
-        plan.blast_radius, merges=[facts], kinds=["account_link"]
+        plan.blast_radius, surface="cli", merges=[facts], kinds=["account_link"]
     )
 
 

--- a/src/moneybin/mcp/decorator.py
+++ b/src/moneybin/mcp/decorator.py
@@ -49,6 +49,7 @@ from moneybin.privacy.introspection import (
 )
 from moneybin.privacy.log import build_tool_call_event, write_privacy_event
 from moneybin.privacy.redaction import has_active_transform, redact_typed
+from moneybin.privacy.taxonomy import Tier
 from moneybin.protocol.envelope import ResponseEnvelope, build_error_envelope
 from moneybin.services.mutation_context import operation
 from moneybin.services.request_lifetime import RequestLifetime, request_lifetime_scope
@@ -394,6 +395,7 @@ def mcp_tool(
     max_items: int | None | _UnsetType = _UNSET,
     dynamic_classification: bool = False,
     maximum_sensitivity: Sensitivity | None = None,
+    discloses: Tier | None = None,
     timeout_seconds: float | _UnsetType = _UNSET,
 ) -> Callable[..., Any]:
     """Mark a function as an MCP tool. Sensitivity is derived from the return type.
@@ -432,6 +434,14 @@ def mcp_tool(
             This is a declared contract for documentation and admission review;
             it does not replace the tool's per-call classification. Static tools
             derive their maximum from their typed response and must not set it.
+        discloses: Tier this tool shows the caller *outside* its typed response —
+            in practice, the text of a confirmation elicitation. The derived tier
+            walks the payload, so a prompt rendering transaction dates or a
+            user's own account label discloses MEDIUM through a tool whose
+            response carries only record ids. Declared here, that tier is folded
+            in as a floor: it can raise the tool's sensitivity, never lower it,
+            so it cannot be used to talk a CRITICAL payload out of being masked.
+            Omit it unless the tool renders classified content in a prompt.
         timeout_seconds: Per-tool override for ``MCPConfig.tool_timeout_seconds``.
             Sentinel ``_UNSET`` inherits from settings. Use this for tools whose
             natural runtime exceeds the default cap (e.g. interactive OAuth
@@ -447,6 +457,11 @@ def mcp_tool(
     if not dynamic_classification and maximum_sensitivity is not None:
         raise ValueError(
             "maximum_sensitivity is only valid with dynamic_classification=True"
+        )
+    if dynamic_classification and discloses is not None:
+        raise ValueError(
+            "discloses is only valid for a static tool; a dynamic tool already "
+            "sets its own per-call sensitivity"
         )
 
     def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
@@ -493,6 +508,11 @@ def mcp_tool(
                 tier = derive_tier(payload_type_arg)
             except PrivacyContractError as exc:
                 raise PrivacyContractError(f"{fn.__name__}: {exc}") from exc
+            # A floor, never an answer: max() keeps a CRITICAL payload CRITICAL
+            # even when the prompt is declared MEDIUM. Tier is an IntEnum for
+            # exactly this.
+            if discloses is not None:
+                tier = max(tier, discloses)
             sensitivity = tier_to_sensitivity(tier)
             classes_for_log = [
                 c.value for c in sorted(extract_data_classes(payload_type_arg))

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -109,6 +109,10 @@ from moneybin.services.entity_reference import (
     MissingEntity,
     resolve_entity_reference,
 )
+from moneybin.services.identity_confirmation import (
+    AccountMergeFacts,
+    identity_confirm_message,
+)
 from moneybin.services.mutation_context import current_operation_id
 
 # ─── Read tools (entity) ──────────────────────────────────────────────────
@@ -508,12 +512,15 @@ class _AccountMergeProposal:
     provisional_display_name: str
     candidate_account_id: str
     candidate_display_name: str
-    confidence: float | None
     signal: str | None
     #: The whole impact, not a flattened blast radius: the grant issued here has
     #: to digest the same row identities the commit-time verify recomputes, so
     #: dropping them at this boundary would make every account grant unverifiable.
     impact: AccountLinkAcceptImpact
+    #: Both ledgers and the overlap between them — what the prompt describes.
+    #: Read on the same connection as the impact so the sentence and the grant
+    #: describe one state rather than two reads with a gap between them.
+    facts: AccountMergeFacts
 
 
 def _load_pending_account_proposal(decision_id: str) -> _AccountMergeProposal:
@@ -534,9 +541,12 @@ def _load_pending_account_proposal(decision_id: str) -> _AccountMergeProposal:
                         provisional_display_name=group.provisional_display_name,
                         candidate_account_id=candidate.candidate_account_id,
                         candidate_display_name=candidate.candidate_display_name,
-                        confidence=candidate.confidence,
                         signal=candidate.signal,
                         impact=impact,
+                        facts=service.merge_facts(
+                            absorbed_account_id=group.provisional_account_id,
+                            survivor_account_id=candidate.candidate_account_id,
+                        ),
                     )
     raise UserError(
         f"No pending account-link decision '{decision_id}'.",
@@ -582,27 +592,27 @@ def _account_link_binding(
 def _account_confirm_message(p: _AccountMergeProposal) -> str:
     """Prompt text a human reads before two accounts' histories are fused.
 
-    Names BOTH accounts and the weak signal the resolver fired on — the human
-    cannot judge the merge without seeing what merges into what, and why the
-    resolver refused to decide on its own.
+    Delegates the merge itself to the shared renderer so this tool, the identity
+    batch, and the CLI describe one decision in one wording. The three used to
+    diverge, and this one was the worst of them: it named both accounts by
+    display label — identical on a split account — and quoted a "confidence"
+    that was a per-signal constant.
+
+    What stays local is what only this tool knows: which weak signal proposed
+    the pair, and that its own reject path is the alternative.
     """
-    confidence = "unscored" if p.confidence is None else f"{p.confidence:.2f}"
+    merge = identity_confirm_message(
+        {"accounts": 2, "transactions": p.facts.absorbed.transactions},
+        merges=[p.facts],
+        kinds=["account_link"],
+    )
     return (
-        "Confirm an account merge (this fuses two accounts' transaction "
-        "histories and balances).\n\n"
-        f"MERGE AWAY — provisional, account_id {p.provisional_account_id}:\n"
-        f"  name {p.provisional_display_name or '(none)'}\n\n"
-        f"INTO — survivor, account_id {p.candidate_account_id}:\n"
-        f"  name {p.candidate_display_name or '(none)'}\n\n"
-        f"Proposed on: signal {p.signal or 'unspecified'}, confidence "
-        f"{confidence}. The resolver proposes a merge ONLY when it cannot bind "
-        "on its own — this is an ambiguous match, not a certain one.\n\n"
-        "Accepting re-points every accepted source reference from the "
-        "provisional onto the survivor, so both accounts' transactions and "
-        "balances become one account, and every other pending proposal touching "
-        "the provisional is rejected. If these are not the same real-world "
-        "account, the merged history and net worth will be wrong. Reversible "
-        "via system_audit_undo(operation_id).\n\n"
+        f"{merge}\n\n"
+        f"Proposed on the {p.signal or 'unspecified'} signal. The resolver "
+        "proposes a merge ONLY when it cannot bind on its own — this is an "
+        "ambiguous match, not a certain one. If these are not the same "
+        "real-world account, the merged history and net worth will be wrong; "
+        "action='reject' keeps them separate.\n\n"
         "Accept this merge?"
     )
 

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -476,9 +476,13 @@ def accounts_links_pending() -> ResponseEnvelope[AccountLinksPendingPayload]:
     imported but not yet confirmed as a canonical entity) and its candidate
     existing accounts that may represent the same real-world account.
 
-    For each candidate: decision_id, candidate_account_id, display name,
-    confidence score, and the matching signal that fired (institution_last4,
-    name, or institution_reissue — same bank, last four changed). ref_value
+    For each candidate: decision_id, candidate_account_id, display name, the
+    matching signal that fired (institution_last4, name, or
+    institution_reissue — same bank, last four changed), and measured ledger
+    evidence — overlap_matched of overlap_comparable transactions already held
+    by both accounts over the period they share. overlap_comparable of 0 means
+    the two ledgers share no comparable period, not that they disagree. Each
+    group also carries how many transactions the merge would move. ref_value
     (the raw native reference, which can be a full account number) is never
     included.
 
@@ -568,6 +572,14 @@ def _account_link_binding(
     elsewhere while another arrives leaves every count intact and still changes
     which decision the commit auto-rejects. Naming the rows makes that swap
     fail the digest instead of passing it.
+
+    **Known accepted gap**, shared with the CLI's ``_ApprovedMerge``: the
+    ledger facts the prompt renders are not bound here, so a survivor emptied
+    by another accept between the grant and the commit loses its
+    check-the-direction warning without anything refusing the write. A digest
+    is symmetric and would also refuse the harmless direction — a survivor that
+    *gained* its first transactions — so closing this needs an explicit
+    asymmetric check beside the digest rather than another field inside it.
     """
     return ConfirmationBinding(
         arguments={

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -576,12 +576,20 @@ def _account_link_binding(
     fail the digest instead of passing it.
 
     **Known accepted gap**, shared with the CLI's ``_ApprovedMerge``: the
-    ledger facts the prompt renders are not bound here, so a survivor emptied
-    by another accept between the grant and the commit loses its
-    check-the-direction warning without anything refusing the write. A digest
-    is symmetric and would also refuse the harmless direction — a survivor that
-    *gained* its first transactions — so closing this needs an explicit
-    asymmetric check beside the digest rather than another field inside it.
+    ledger facts the prompt renders are not bound here, so two things can
+    change between the grant and the commit without anything refusing the
+    write. A survivor emptied by another accept loses its check-the-direction
+    warning; and the overlap ratio can worsen on its own, because the probe's
+    window is bounded by the *survivor's* dates and one row arriving outside it
+    admits absorbed rows that match nothing.
+
+    A digest is symmetric and would also refuse the harmless directions — a
+    survivor that gained its first transactions, an import that strengthened
+    the evidence — so closing this needs an asymmetric check beside the digest
+    rather than another field inside it. This binding is frozen and hashed over
+    every field, so carrying the approved baseline across the opaque-token
+    round trip means a transported-but-undigested field on
+    ``ConfirmationBinding`` itself, which every destructive tool shares.
     """
     return ConfirmationBinding(
         arguments={

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -509,13 +509,17 @@ def accounts_links_pending() -> ResponseEnvelope[AccountLinksPendingPayload]:
 
 @dataclass(frozen=True, slots=True)
 class _AccountMergeProposal:
-    """One pending account-merge decision, flattened for the confirmation prompt."""
+    """One pending account-merge decision, flattened for the confirmation prompt.
+
+    No display names: the shared renderer names each side by what *differs*
+    between the two ledgers, precisely because a split account renders the same
+    label on both sides. Carrying them here as well would offer a second, worse
+    way to describe the same account.
+    """
 
     decision_id: str
     provisional_account_id: str
-    provisional_display_name: str
     candidate_account_id: str
-    candidate_display_name: str
     signal: str | None
     #: The whole impact, not a flattened blast radius: the grant issued here has
     #: to digest the same row identities the commit-time verify recomputes, so
@@ -542,9 +546,7 @@ def _load_pending_account_proposal(decision_id: str) -> _AccountMergeProposal:
                     return _AccountMergeProposal(
                         decision_id=decision_id,
                         provisional_account_id=group.provisional_account_id,
-                        provisional_display_name=group.provisional_display_name,
                         candidate_account_id=candidate.candidate_account_id,
-                        candidate_display_name=candidate.candidate_display_name,
                         signal=candidate.signal,
                         impact=impact,
                         facts=service.merge_facts(

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -625,6 +625,7 @@ def _account_confirm_message(p: _AccountMergeProposal) -> str:
     """
     merge = identity_confirm_message(
         {"accounts": 2, "transactions": p.facts.absorbed.transactions},
+        surface="mcp",
         merges=[p.facts],
         kinds=["account_link"],
     )

--- a/src/moneybin/mcp/tools/reviews.py
+++ b/src/moneybin/mcp/tools/reviews.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from decimal import Decimal
 from functools import cmp_to_key
 from typing import Annotated, Any, Literal, cast
@@ -99,7 +99,10 @@ from moneybin.protocol.pagination import (
 from moneybin.services.account_links_service import AccountLinksService
 from moneybin.services.auto_rule_service import AutoRuleService
 from moneybin.services.categorization import CategorizationService
-from moneybin.services.identity_confirmation import identity_confirm_message
+from moneybin.services.identity_confirmation import (
+    AccountMergeFacts,
+    identity_confirm_message,
+)
 from moneybin.services.matching_service import MatchingService
 from moneybin.services.merchant_links_service import MerchantLinksService
 from moneybin.services.mutation_context import current_operation_id
@@ -1096,12 +1099,42 @@ def _identity_binding(
     )
 
 
+@dataclass(frozen=True)
+class _IdentityPreview:
+    """A planned identity batch plus everything its prompt needs to describe it.
+
+    The facts are gathered here, on the preview's own read-only connection,
+    rather than on the plan: ``plan_identity`` also runs inside the write
+    transaction to re-verify the grant, and the prompt is long gone by then.
+    """
+
+    plan: IdentityDecisionPlan
+    merges: tuple[AccountMergeFacts, ...]
+    kinds: tuple[str, ...]
+
+
 def _preview_identity_decisions(
     decisions: list[IdentityDecisionRequest],
-) -> IdentityDecisionPlan:
+) -> _IdentityPreview:
     """Resolve one identity batch on a read-only connection."""
     with get_database(read_only=True) as db:
-        return ReviewDecisionsService(db, actor="mcp").plan_identity(decisions)
+        plan = ReviewDecisionsService(db, actor="mcp").plan_identity(decisions)
+        accepts = [
+            item
+            for item in plan.items
+            if item.changed and item.request.decision == "accept"
+        ]
+        links = AccountLinksService(db, actor="mcp")
+        merges = tuple(
+            links.merge_facts(
+                absorbed_account_id=item.source_id,
+                survivor_account_id=item.target_id,
+            )
+            for item in accepts
+            if item.request.kind == "account_link"
+        )
+        kinds = tuple(sorted({item.request.kind for item in accepts}))
+    return _IdentityPreview(plan=plan, merges=merges, kinds=kinds)
 
 
 def _apply_identity_decisions(
@@ -1133,7 +1166,8 @@ async def identity_links_decide_coarse(
     confirmation_token: str | None = None,
 ) -> ResponseEnvelope[IdentityLinksDecidePayload]:
     """Atomically accept or reject account, merchant, and security identity links."""
-    plan = await asyncio.to_thread(_preview_identity_decisions, decisions)
+    preview = await asyncio.to_thread(_preview_identity_decisions, decisions)
+    plan = preview.plan
     binding = _identity_binding(decisions, plan)
     if confirmation_token is not None and not plan.destructive:
         raise UserError(
@@ -1149,7 +1183,11 @@ async def identity_links_decide_coarse(
     if plan.destructive:
         grant = await grant_confirmation_or_raise(
             binding=binding if confirmation_token is None else None,
-            message=identity_confirm_message(binding.blast_radius),
+            message=identity_confirm_message(
+                binding.blast_radius,
+                merges=preview.merges,
+                kinds=preview.kinds,
+            ),
             confirmation_token=confirmation_token,
         )
     live = await asyncio.to_thread(

--- a/src/moneybin/mcp/tools/reviews.py
+++ b/src/moneybin/mcp/tools/reviews.py
@@ -87,6 +87,7 @@ from moneybin.privacy.payloads.reviews import (
 )
 from moneybin.privacy.payloads.transactions import MatchHistoryRow, MatchPendingRow
 from moneybin.privacy.redaction import redact_typed
+from moneybin.privacy.taxonomy import Tier
 from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
 from moneybin.protocol.pagination import (
     KeysetPosition,
@@ -1160,7 +1161,17 @@ def _apply_identity_decisions(
         return service.apply_identity(decisions, verify=verify)
 
 
-@mcp_tool(read_only=False, destructive=True, idempotent=True, timeout_seconds=180.0)
+@mcp_tool(
+    read_only=False,
+    destructive=True,
+    idempotent=True,
+    timeout_seconds=180.0,
+    # The response carries record ids and counts; the elicitation carries each
+    # ledger's first and last transaction dates and the user's own account
+    # labels. Only the payload is walked, so without this the audit event would
+    # record `low` for a call that put MEDIUM data in front of the caller.
+    discloses=Tier.MEDIUM,
+)
 async def identity_links_decide_coarse(
     decisions: list[IdentityDecisionRequest],
     confirmation_token: str | None = None,

--- a/src/moneybin/mcp/tools/reviews.py
+++ b/src/moneybin/mcp/tools/reviews.py
@@ -1196,6 +1196,7 @@ async def identity_links_decide_coarse(
             binding=binding if confirmation_token is None else None,
             message=identity_confirm_message(
                 binding.blast_radius,
+                surface="mcp",
                 merges=preview.merges,
                 kinds=preview.kinds,
             ),

--- a/src/moneybin/metrics/registry.py
+++ b/src/moneybin/metrics/registry.py
@@ -480,6 +480,16 @@ ACCOUNT_LINK_CONFIDENCE = Histogram(
     "Resolution confidence for account-link candidate proposals.",
 )
 
+ACCOUNT_LINK_OVERLAP_PROBES_TOTAL = Counter(
+    "moneybin_account_link_overlap_probes_total",
+    "Ledger-overlap probes behind an account-merge proposal, by whether the two "
+    "ledgers shared a period the probe could compare at all. Alarm when "
+    "'unmeasurable' climbs while 'measurable' stays flat: schema or source drift "
+    "can silently reduce every merge prompt to prose with no evidence in it, and "
+    "no surface renders differently when that happens.",
+    ["result"],
+)
+
 DUPLICATE_ACCOUNT_PAIRS = Gauge(
     "moneybin_duplicate_account_pairs",
     "Account pairs at one institution whose transactions mirror each other — "

--- a/src/moneybin/privacy/payloads/accounts.py
+++ b/src/moneybin/privacy/payloads/accounts.py
@@ -246,8 +246,13 @@ class AccountSettingsPayload:
 class LinkCandidateRow:
     """One candidate merge proposal in an account-links pending review group.
 
-    Carries only opaque ids + account labels + match signal/confidence.
-    ref_value (which can be a full account number) is never surfaced here.
+    Carries only opaque ids + account labels + the match signal and the measured
+    ledger overlap. ref_value (which can be a full account number) is never
+    surfaced here.
+
+    No confidence field: the resolver's number was a per-signal constant no input
+    could move, and a reviewer reading it as a score was reading a label.
+    ``overlap_matched`` / ``overlap_comparable`` replace it with a measurement.
     """
 
     decision_id: Annotated[str, DataClass.RECORD_ID]
@@ -256,9 +261,15 @@ class LinkCandidateRow:
     # else (taxonomy.py / AccountSummary / AccountDetail); a user/auto label can
     # embed identifying text, so it must not be under-classified to LOW here.
     candidate_display_name: Annotated[str, DataClass.USER_NOTE]
-    confidence: Annotated[float | None, DataClass.AGGREGATE]
     # "institution_last4", "name", or "institution_reissue"
     signal: Annotated[str, DataClass.TXN_TYPE]
+    #: Transactions of the provisional account that also appear in this
+    #: candidate's ledger, out of those in a period both ledgers cover. Both are
+    #: 0 when the two share no comparable period, which is absence of evidence
+    #: rather than evidence of absence — ``overlap_comparable == 0`` is the only
+    #: way to tell the two apart, so neither may be dropped from the surface.
+    overlap_matched: Annotated[int, DataClass.AGGREGATE]
+    overlap_comparable: Annotated[int, DataClass.AGGREGATE]
 
     @classmethod
     def from_candidate(cls, c: PendingLinkCandidate) -> LinkCandidateRow:
@@ -267,8 +278,9 @@ class LinkCandidateRow:
             decision_id=c.decision_id,
             candidate_account_id=c.candidate_account_id,
             candidate_display_name=c.candidate_display_name,
-            confidence=float(c.confidence) if c.confidence is not None else None,
             signal=c.signal,
+            overlap_matched=c.overlap.matched,
+            overlap_comparable=c.overlap.comparable,
         )
 
 
@@ -280,6 +292,9 @@ class LinkPendingGroup:
     # USER_NOTE (MEDIUM) — see LinkCandidateRow.candidate_display_name.
     provisional_display_name: Annotated[str, DataClass.USER_NOTE]
     candidates: list[LinkCandidateRow]
+    #: How much history an accept moves. Browse-time magnitude: the reviewer
+    #: chooses which proposals are worth opening before any confirm gate runs.
+    transactions: Annotated[int, DataClass.AGGREGATE] = 0
 
     @classmethod
     def from_domain(cls, g: PendingLinkGroup) -> LinkPendingGroup:
@@ -288,6 +303,7 @@ class LinkPendingGroup:
             provisional_account_id=g.provisional_account_id,
             provisional_display_name=g.provisional_display_name,
             candidates=[LinkCandidateRow.from_candidate(c) for c in g.candidates],
+            transactions=g.transactions,
         )
 
 
@@ -323,7 +339,13 @@ class AccountLinksSetPayload:
 
 @dataclass(frozen=True, slots=True)
 class LinkHistoryRow:
-    """One past account-link decision (accounts_links_history result)."""
+    """One past account-link decision (accounts_links_history result).
+
+    No confidence field, for the same reason as ``LinkCandidateRow``:
+    ``app.account_link_decisions.confidence_score`` still records the constant
+    the resolver stamped, but replaying a number nothing could move tells a
+    reader the decision was scored when it was only labelled.
+    """
 
     decision_id: Annotated[str, DataClass.RECORD_ID]
     provisional_account_id: Annotated[str, DataClass.RECORD_ID]
@@ -331,7 +353,6 @@ class LinkHistoryRow:
     status: Annotated[str, DataClass.TXN_TYPE]
     decided_by: Annotated[str, DataClass.TXN_TYPE]
     decided_at: Annotated[str | None, DataClass.TIMESTAMP_OBSERVABILITY]
-    confidence: Annotated[float | None, DataClass.AGGREGATE]
     signal: Annotated[str, DataClass.TXN_TYPE]
 
     @classmethod
@@ -345,11 +366,6 @@ class LinkHistoryRow:
             decided_by=r["decided_by"],
             decided_at=(
                 str(r["decided_at"]) if r.get("decided_at") is not None else None
-            ),
-            confidence=(
-                float(r["confidence_score"])
-                if r.get("confidence_score") is not None
-                else None
             ),
             signal=signal_from_match_signals(r.get("match_signals")),
         )

--- a/src/moneybin/services/account_links_service.py
+++ b/src/moneybin/services/account_links_service.py
@@ -28,7 +28,17 @@ from moneybin.services.account_resolution_types import (
     PendingLinkCandidate,
     PendingLinkGroup,
 )
-from moneybin.tables import ACCOUNT_LINK_DECISIONS, ACCOUNT_LINKS, DIM_ACCOUNTS
+from moneybin.services.identity_confirmation import (
+    AccountLedgerFacts,
+    AccountMergeFacts,
+)
+from moneybin.services.ledger_overlap import probe_ledger_overlap
+from moneybin.tables import (
+    ACCOUNT_LINK_DECISIONS,
+    ACCOUNT_LINKS,
+    DIM_ACCOUNTS,
+    FCT_TRANSACTIONS,
+)
 from moneybin.utils.parsing import signal_from_match_signals
 
 logger = logging.getLogger(__name__)
@@ -139,9 +149,13 @@ class AccountLinksService:
                     candidate_display_name=_resolve_display_name(
                         self._db, d["candidate_account_id"]
                     ),
-                    confidence=d["confidence_score"],
                     # match_signals is already decoded by list_pending(); cast for pyright.
                     signal=signal_from_match_signals(d["match_signals"]),
+                    overlap=probe_ledger_overlap(
+                        self._db,
+                        account_id=provisional_id,
+                        against_account_id=d["candidate_account_id"],
+                    ),
                 )
                 for d in decisions
             )
@@ -150,9 +164,96 @@ class AccountLinksService:
                     provisional_account_id=provisional_id,
                     provisional_display_name=prov_display,
                     candidates=candidates,
+                    transactions=self._ledger_size(provisional_id),
                 )
             )
         return result
+
+    def _ledger_size(self, account_id: str) -> int:
+        """How many transactions the account holds; 0 when core is not materialized."""
+        try:
+            row = self._db.execute(
+                f"SELECT COUNT(*) FROM {FCT_TRANSACTIONS.full_name} "  # noqa: S608  # TableRef constant + parameterized value
+                "WHERE account_id = ?",
+                [account_id],
+            ).fetchone()
+        except duckdb.CatalogException:
+            return 0
+        return int(row[0]) if row else 0
+
+    def ledger_facts(self, account_id: str) -> AccountLedgerFacts:
+        """Describe one account in the terms that tell it apart from its twin.
+
+        Never the masked last four: the institution+last-four signal fires
+        *because* the two sides carry the same one, so a description keyed to it
+        renders both halves of a split account identically.
+        """
+        subtype: str | None = None
+        currency: str | None = None
+        try:
+            row = self._db.execute(
+                f"""
+                SELECT account_subtype, account_type, currency_code
+                FROM {DIM_ACCOUNTS.full_name} WHERE account_id = ?
+                """,  # noqa: S608  # TableRef constant + parameterized value
+                [account_id],
+            ).fetchone()
+        except duckdb.CatalogException:
+            row = None
+        if row is not None:
+            # Subtype before type, the way dim_accounts derives its own
+            # display_name: "checking" reads to a human where the canonical
+            # "depository" does not.
+            subtype = str(row[0]) if row[0] else (str(row[1]) if row[1] else None)
+            currency = str(row[2]) if row[2] else None
+        try:
+            ledger = self._db.execute(
+                f"""
+                SELECT
+                    COUNT(*),
+                    MIN(transaction_date),
+                    MAX(transaction_date),
+                    LIST(DISTINCT source_type)
+                FROM {FCT_TRANSACTIONS.full_name} WHERE account_id = ?
+                """,  # noqa: S608  # TableRef constant + parameterized value
+                [account_id],
+            ).fetchone()
+        except duckdb.CatalogException:
+            ledger = None
+        count, first_date, last_date, sources = ledger or (0, None, None, None)
+        source_list: list[Any] = list(sources) if sources else []
+        return AccountLedgerFacts(
+            account_id=account_id,
+            display_name=_resolve_display_name(self._db, account_id),
+            # Sorted because LIST() carries no order of its own, and the label it
+            # feeds is compared against the other side's.
+            source_types=tuple(sorted(str(s) for s in source_list if s)),
+            subtype=subtype,
+            currency_code=currency,
+            transactions=int(count),
+            first_date=first_date,
+            last_date=last_date,
+        )
+
+    def merge_facts(
+        self, *, absorbed_account_id: str, survivor_account_id: str
+    ) -> AccountMergeFacts:
+        """Everything the merge prompt renders: both sides plus the ledger evidence.
+
+        Keyed on two account ids rather than a decision id so the CLI prompt, the
+        single-decision MCP tool, and the identity batch all reach the same
+        sentence through one call — three renderings of one merge was the
+        coherence failure this replaces.
+        """
+        return AccountMergeFacts(
+            absorbed=self.ledger_facts(absorbed_account_id),
+            survivor=self.ledger_facts(survivor_account_id),
+            overlap=probe_ledger_overlap(
+                self._db,
+                account_id=absorbed_account_id,
+                against_account_id=survivor_account_id,
+            ),
+        )
 
     def history(self, *, limit: int | None = 50) -> list[dict[str, Any]]:
         """All decisions (any status) newest-first by ``decided_at``. Read-only.

--- a/src/moneybin/services/account_resolution_types.py
+++ b/src/moneybin/services/account_resolution_types.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TypedDict
 
+from moneybin.services.ledger_overlap import LedgerOverlap
+
 
 class AccountCandidateDict(TypedDict):
     """Serialized shape of one ``AccountCandidate`` carried across the envelope."""
@@ -196,23 +198,39 @@ class ResolvedAccount:
 
 @dataclass(frozen=True)
 class PendingLinkCandidate:
-    """One candidate merge proposal within a pending-review group."""
+    """One candidate merge proposal within a pending-review group.
+
+    Carries no confidence number. ``_weak_signal_candidates`` hardcoded 0.5 for
+    the last-four signal and 0.4 for the name signal under the comment
+    "confidence is informational only"; nothing accumulated evidence and nothing
+    thresholded on it, so no input could ever move either one. Rendering a
+    constant as a score invited a reviewer to read it as one. ``overlap`` is what
+    replaces it — a measurement of the two ledgers that actually varies with the
+    accounts in front of the reviewer.
+    """
 
     decision_id: str
     candidate_account_id: str
     candidate_display_name: str
-    confidence: float | None
     # "institution_last4" | "name" | "institution_reissue" — only these three.
     # Narrower than _Candidate.signal: this reads persisted decision rows, and
     # the single insert site passes fallback=False, so the gate's last-resort
     # pick-list ("institution" / "fallback") is never written to review.
     signal: str
+    overlap: LedgerOverlap
 
 
 @dataclass(frozen=True)
 class PendingLinkGroup:
-    """One provisional account awaiting review + its candidate proposals."""
+    """One provisional account awaiting review + its candidate proposals.
+
+    ``transactions`` is the magnitude at browse time. It sat only in the confirm
+    binding before, computed inside the decide call, so a reviewer chose which
+    proposals were worth opening while nothing had yet told them how much history
+    each one moves.
+    """
 
     provisional_account_id: str
     provisional_display_name: str
     candidates: tuple[PendingLinkCandidate, ...]
+    transactions: int = 0

--- a/src/moneybin/services/account_resolver.py
+++ b/src/moneybin/services/account_resolver.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 
 import logging
 import uuid
+from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Any
 
 import duckdb
 
@@ -129,6 +131,60 @@ class _Candidate:
     signal: str
     value: str
     confidence: float
+
+
+def _retyped_reissue_candidates(
+    src: SourceAccount, name_rows: Sequence[Any]
+) -> list[_Candidate]:
+    """Name matches the last-four veto discarded, relabelled as what they are.
+
+    The veto is right to refuse calling a match across a stated last-four
+    disagreement a ``name`` match — that is evidence of a *different* account.
+    But refusing the label is not the same as refusing the pair, and the two got
+    conflated: ``propose_existing`` runs with ``reissue=False``, so on the
+    backfill path a vetoed pair had nothing to fall through to and a duplicate
+    the queue used to surface went silently invisible.
+
+    Runs on every path, unlike ``_reissue_candidates``, because the two answer
+    different questions. That one sweeps *every* same-institution account whose
+    last four differs, which in an established book is the pairwise cross
+    product — noise, which is why backfill keeps it off. This one is bounded by
+    what the name matcher actually matched, so it stays the reissue shape: same
+    institution, same name, a last four that changed.
+
+    Same-institution only. "Checking" at two different banks with two different
+    last fours is a common word, not a reissued card, and retyping that would
+    reintroduce the evidence-free merge proposal the veto exists to prevent.
+    """
+    target_inst = _institution_key(src.institution) if src.institution else None
+    if not target_inst:
+        return []
+    vetoed = [
+        {"account_id": str(row[0]), "account_name": str(row[1] or "")}
+        for row in name_rows
+        if _last_fours_disagree(src.last_four, row[2])
+        and row[3]
+        and _institution_key(str(row[3])) == target_inst
+    ]
+    if not vetoed:
+        return []
+    result = match_account(src.account_name, existing_accounts=vetoed)
+    # match_account returns an exact slug hit via .account_id and fuzzy hits via
+    # .candidates — the same split the name rung above reads, for the same reason.
+    matched = (
+        [result.account_id]
+        if result.matched and result.account_id
+        else [c["account_id"] for c in result.candidates if c["account_id"]]
+    )
+    return [
+        _Candidate(
+            account_id=str(account_id),
+            signal="institution_reissue",
+            value=target_inst,
+            confidence=0.3,
+        )
+        for account_id in matched
+    ][:_FALLBACK_CANDIDATE_CAP]
 
 
 class AccountResolver:
@@ -700,8 +756,10 @@ class AccountResolver:
         disagreement is not weaker evidence than the last-four signal — it is
         evidence of a *different* account, and letting it score merely lower put
         a checking account and a savings account in one merge proposal. When the
-        two also share an institution, ``reissue`` re-surfaces the pair under the
-        signal that is actually true.
+        two also share an institution, ``_retyped_reissue_candidates`` re-surfaces
+        that exact pair under the signal that is actually true — on every path,
+        because the ``reissue`` sweep below is off for backfill and a vetoed pair
+        would otherwise have nothing to fall through to.
 
         ``reissue`` (arriving source accounts only): when neither signal clears,
         surface same-institution accounts whose last-four differs — see
@@ -750,13 +808,15 @@ class AccountResolver:
                 )
             if out:
                 return out
+            name_rows = self._db.execute(
+                f"SELECT account_id, display_name, last_four, institution_slug "  # noqa: S608  # TableRef + parameterized values
+                f"FROM {DIM_ACCOUNTS.full_name} WHERE account_id != ? "
+                "ORDER BY account_id",
+                [exclude_account_id],
+            ).fetchall()
             existing = [
                 {"account_id": str(r[0]), "account_name": str(r[1] or "")}
-                for r in self._db.execute(
-                    f"SELECT account_id, display_name, last_four "  # noqa: S608  # TableRef + parameterized values
-                    f"FROM {DIM_ACCOUNTS.full_name} WHERE account_id != ?",
-                    [exclude_account_id],
-                ).fetchall()
+                for r in name_rows
                 if not _last_fours_disagree(src.last_four, r[2])
             ]
             result = match_account(src.account_name, existing_accounts=existing)
@@ -783,6 +843,8 @@ class AccountResolver:
                     for c in result.candidates
                     if c["account_id"]
                 )
+            if not out:
+                out = _retyped_reissue_candidates(src, name_rows)
             if not out and reissue:
                 out = self._reissue_candidates(src, exclude_account_id)
             if not out and fallback:

--- a/src/moneybin/services/account_resolver.py
+++ b/src/moneybin/services/account_resolver.py
@@ -93,7 +93,7 @@ def _institution_key(institution: str | None) -> str | None:
 
 
 def _last_fours_disagree(
-    source_last_four: str | None, candidate_last_four: object
+    source_last_four: str | None, candidate_last_four: str | None
 ) -> bool:
     """Whether two accounts state last fours that positively contradict each other.
 
@@ -104,7 +104,7 @@ def _last_fours_disagree(
     return bool(
         source_last_four
         and candidate_last_four
-        and str(candidate_last_four) != source_last_four
+        and candidate_last_four != source_last_four
     )
 
 
@@ -145,12 +145,15 @@ def _retyped_reissue_candidates(
     backfill path a vetoed pair had nothing to fall through to and a duplicate
     the queue used to surface went silently invisible.
 
-    Runs on every path, unlike ``_reissue_candidates``, because the two answer
-    different questions. That one sweeps *every* same-institution account whose
-    last four differs, which in an established book is the pairwise cross
-    product — noise, which is why backfill keeps it off. This one is bounded by
-    what the name matcher actually matched, so it stays the reissue shape: same
-    institution, same name, a last four that changed.
+    Runs on every path and unconditionally, unlike ``_reissue_candidates``,
+    because the two answer different questions. That one sweeps *every*
+    same-institution account whose last four differs, which in an established
+    book is the pairwise cross product — noise, which is why backfill keeps it
+    off and why it stays a last-resort fallback. This one is bounded by what the
+    name matcher actually matched, so it stays the reissue shape (same
+    institution, same name, a last four that changed) and is cheap enough to
+    always ask. It reads only rows the veto discarded, so it can never duplicate
+    a candidate the name pass already returned.
 
     Same-institution only. "Checking" at two different banks with two different
     last fours is a common word, not a reissued card, and retyping that would
@@ -759,7 +762,10 @@ class AccountResolver:
         two also share an institution, ``_retyped_reissue_candidates`` re-surfaces
         that exact pair under the signal that is actually true — on every path,
         because the ``reissue`` sweep below is off for backfill and a vetoed pair
-        would otherwise have nothing to fall through to.
+        would otherwise have nothing to fall through to. It runs *beside* the
+        name pass rather than only when that pass came up empty: the two read
+        disjoint halves of the same rows, so gating it let an unrelated namesake
+        carrying no last four hide a genuine reissue.
 
         ``reissue`` (arriving source accounts only): when neither signal clears,
         surface same-institution accounts whose last-four differs — see
@@ -843,8 +849,13 @@ class AccountResolver:
                     for c in result.candidates
                     if c["account_id"]
                 )
-            if not out:
-                out = _retyped_reissue_candidates(src, name_rows)
+            # Beside the name pass, not after it. The two read disjoint halves of
+            # name_rows — the veto keeps agreeing/absent last fours, this keeps
+            # the disagreeing ones — so a coincidental namesake with no last four
+            # would otherwise populate `out` and suppress the reissue it has
+            # nothing to do with. Both are weak signals headed for the same
+            # review queue; picking between them is the human's call.
+            out.extend(_retyped_reissue_candidates(src, name_rows))
             if not out and reissue:
                 out = self._reissue_candidates(src, exclude_account_id)
             if not out and fallback:

--- a/src/moneybin/services/account_resolver.py
+++ b/src/moneybin/services/account_resolver.py
@@ -90,6 +90,22 @@ def _institution_key(institution: str | None) -> str | None:
     return slugify(slug_for_institution_name(institution) or institution) or None
 
 
+def _last_fours_disagree(
+    source_last_four: str | None, candidate_last_four: object
+) -> bool:
+    """Whether two accounts state last fours that positively contradict each other.
+
+    Requires BOTH sides to state one. Silence is not disagreement: an account
+    with no known last four is a different gap, and vetoing on it would drop a
+    proposal that nothing else surfaces rather than retype it.
+    """
+    return bool(
+        source_last_four
+        and candidate_last_four
+        and str(candidate_last_four) != source_last_four
+    )
+
+
 # Cap on the fallback pick-list (existing accounts surfaced for the human to pick
 # from when no real signal cleared). Bounds an otherwise-unbounded "list all
 # accounts" so a large book doesn't dump everything; a personal-finance user
@@ -679,6 +695,14 @@ class AccountResolver:
         Each is a review proposal, never an auto-merge. Returns no candidates if
         core.dim_accounts is not yet materialized (first import before any transform).
 
+        The name rung skips any account whose last four positively contradicts
+        the source's (``_last_fours_disagree``). A name match across a stated
+        disagreement is not weaker evidence than the last-four signal — it is
+        evidence of a *different* account, and letting it score merely lower put
+        a checking account and a savings account in one merge proposal. When the
+        two also share an institution, ``reissue`` re-surfaces the pair under the
+        signal that is actually true.
+
         ``reissue`` (arriving source accounts only): when neither signal clears,
         surface same-institution accounts whose last-four differs — see
         ``_reissue_candidates``. On for ``resolve()`` and its ``propose()``
@@ -729,10 +753,11 @@ class AccountResolver:
             existing = [
                 {"account_id": str(r[0]), "account_name": str(r[1] or "")}
                 for r in self._db.execute(
-                    f"SELECT account_id, display_name FROM {DIM_ACCOUNTS.full_name} "  # noqa: S608  # TableRef + parameterized values
-                    "WHERE account_id != ?",
+                    f"SELECT account_id, display_name, last_four "  # noqa: S608  # TableRef + parameterized values
+                    f"FROM {DIM_ACCOUNTS.full_name} WHERE account_id != ?",
                     [exclude_account_id],
                 ).fetchall()
+                if not _last_fours_disagree(src.last_four, r[2])
             ]
             result = match_account(src.account_name, existing_accounts=existing)
             if result.matched and result.account_id:

--- a/src/moneybin/services/identity_confirmation.py
+++ b/src/moneybin/services/identity_confirmation.py
@@ -61,6 +61,24 @@ IDENTITY_BLAST_RADIUS_LABELS: dict[str, tuple[str, str]] = {
     "price_marks": ("price mark you set by hand", "price marks you set by hand"),
 }
 
+#: How each surface spells the command that reverses a committed merge.
+#:
+#: The one clause in this prompt that must differ by surface, and the exception
+#: that proves the rest of the module: the sentence is shared so two surfaces
+#: cannot describe one merge differently, but a recovery instruction is worth
+#: nothing unless it runs where it is read. A CLI user told to call
+#: ``system_audit_undo(operation_id=...)`` has no way to run it, and this prompt
+#: accompanies a destructive merge — the one moment the recovery path has to be
+#: reachable without a second lookup.
+#:
+#: ``surface`` is a required argument rather than a defaulted one so a third
+#: surface has to answer this question instead of silently inheriting whichever
+#: spelling happened to be the default.
+UNDO_COMMANDS: dict[str, str] = {
+    "cli": "moneybin system audit undo <operation_id>",
+    "mcp": "system_audit_undo(operation_id=...)",
+}
+
 #: What an accepted link of each kind does, in the user's terms.
 #:
 #: Rendered only for the kinds a batch actually contains. The single paragraph
@@ -207,7 +225,7 @@ def _evidence_line(overlap: LedgerOverlap) -> str:
     )
 
 
-def _account_merge_block(merge: AccountMergeFacts) -> str:
+def _account_merge_block(merge: AccountMergeFacts, undo_command: str) -> str:
     """The question, the evidence, and what the answer does — in that order."""
     absorbed, survivor = merge.absorbed, merge.survivor
     lines = [
@@ -218,8 +236,7 @@ def _account_merge_block(merge: AccountMergeFacts) -> str:
         "",
         f"The absorbed account {absorbed.account_id} is folded into "
         f"{survivor.account_id}: its transactions move onto that account's "
-        "history and nothing is deleted. Reverse with "
-        "system_audit_undo(operation_id=...).",
+        f"history and nothing is deleted. Reverse with {undo_command}.",
     ]
     if survivor.transactions == 0:
         # The reversed proposal is the expensive failure on this path: the live
@@ -251,6 +268,7 @@ def _batch_paragraph(kinds: Collection[str], *, accounts_described: bool) -> str
 def identity_confirm_message(
     blast_radius: Mapping[str, int],
     *,
+    surface: str,
     merges: Sequence[AccountMergeFacts] = (),
     kinds: Collection[str] = (),
 ) -> str:
@@ -268,13 +286,17 @@ def identity_confirm_message(
     batch actually accepts, so the closing paragraph describes those and not the
     other two. Both default to empty, which reproduces the counts-only prompt for
     a caller that has neither.
+
+    ``surface`` keys ``UNDO_COMMANDS`` — the only clause that varies by caller,
+    because the reversal has to be runnable where the sentence is read.
     """
+    undo_command = UNDO_COMMANDS[surface]
     moved = [
         f"{count} {IDENTITY_BLAST_RADIUS_LABELS[key][0 if count == 1 else 1]}"
         for key in IDENTITY_BLAST_RADIUS_CATEGORIES
         if (count := blast_radius.get(key, 0))
     ]
-    blocks = [_account_merge_block(merge) for merge in merges]
+    blocks = [_account_merge_block(merge, undo_command) for merge in merges]
     blocks.append(_batch_paragraph(kinds, accounts_described=bool(merges)))
     blocks.append(f"This batch touches: {', '.join(moved) if moved else 'no rows'}.")
     return "\n\n".join(blocks)

--- a/src/moneybin/services/identity_confirmation.py
+++ b/src/moneybin/services/identity_confirmation.py
@@ -127,9 +127,25 @@ class AccountMergeFacts:
     )
 
 
+#: Source types that arrive through the mediated sync server.
+#:
+#: ``source_type`` records the provider slug the server happens to speak, and
+#: the client's contract is that those providers are implementation details
+#: hidden behind it (AGENTS.md, "Sync server is opaque"). This sentence is read
+#: by a human in the CLI and by an agent over MCP, so the label names the
+#: channel the user knows — ``moneybin sync pull`` — never the vendor. A format
+#: like OFX or a store like GSheet is the user's own and stays named.
+_MEDIATED_SYNC_SOURCES = frozenset({"plaid"})
+_SYNC_SOURCE_LABEL = "SYNC"
+
+
 def _source_label(facts: AccountLedgerFacts) -> str | None:
     """Uppercased source origins — "PDF", "OFX", "PDF+OFX" — or None when unknown."""
-    return "+".join(s.upper() for s in facts.source_types) or None
+    labels = dict.fromkeys(
+        _SYNC_SOURCE_LABEL if source in _MEDIATED_SYNC_SOURCES else source.upper()
+        for source in facts.source_types
+    )
+    return "+".join(labels) or None
 
 
 def _side_label(side: AccountLedgerFacts, other: AccountLedgerFacts) -> str:

--- a/src/moneybin/services/identity_confirmation.py
+++ b/src/moneybin/services/identity_confirmation.py
@@ -5,11 +5,23 @@ the domain it describes rather than inside one surface, so the MCP elicitation
 and the CLI prompt cannot drift into describing the same merge two different
 ways. The MCP tool wrapper is where it used to live, which put the CLI a copy
 away from a sentence it needs to render identically.
+
+Presentation only: everything here takes already-resolved values and returns a
+string. Gathering the facts costs a database read, which is why
+``AccountLinksService.merge_facts`` owns that half — a caller that only needs to
+*print* a confirmation should not load the repositories and sibling services that
+applying one requires. The one import below that reaches outside this module is
+``LedgerOverlap``, a value type; duplicating it here to preserve a purity claim
+would let the rendered evidence disagree with the probe that measured it.
 """
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import date
+
+from moneybin.services.ledger_overlap import LedgerOverlap
 
 #: Every blast-radius category an identity confirmation reports, named once.
 #:
@@ -49,8 +61,183 @@ IDENTITY_BLAST_RADIUS_LABELS: dict[str, tuple[str, str]] = {
     "price_marks": ("price mark you set by hand", "price marks you set by hand"),
 }
 
+#: What an accepted link of each kind does, in the user's terms.
+#:
+#: Rendered only for the kinds a batch actually contains. The single paragraph
+#: this replaces enumerated all three unconditionally, so a card-to-card account
+#: link was told about security tax lots and hand-set price marks — consequences
+#: that do not apply to the decision in hand, in the one place a human is
+#: deciding whether the risk is acceptable.
+_KIND_CLAUSES: dict[str, str] = {
+    "account_link": (
+        "move one account's whole transaction history onto the surviving account"
+    ),
+    "merchant_link": "merge merchant attribution onto the surviving merchant",
+    "security_link": (
+        "merge security tax lots, manual events, and any price marks you set by "
+        "hand onto the surviving instrument, or bind a price-feed symbol without "
+        "merging anything"
+    ),
+}
 
-def identity_confirm_message(blast_radius: Mapping[str, int]) -> str:
+#: Fallback paragraph for a caller that names no kinds — every kind, as before.
+_EVERY_KIND_PARAGRAPH = (
+    "Confirm this complete identity-decision batch. Accepted links can merge "
+    "account histories, merchant attribution, or security lots — including any "
+    "price marks you set by hand, which move onto the survivor — or bind a "
+    "price-feed symbol without merging anything; every decision in the ordered "
+    "batch will commit together."
+)
+
+_BATCH_TAIL = "Every decision in this batch commits together."
+
+
+@dataclass(frozen=True)
+class AccountLedgerFacts:
+    """One account, described by the things that distinguish it from its twin.
+
+    Deliberately not built around the masked last four. Two accounts proposed
+    for a merge routinely carry the *same* one — that is what the institution
+    plus last-four signal fires on — so a description keyed to it renders both
+    sides identically in exactly the case a human most needs them apart. What
+    differs is the source that reported each one, how much history it holds,
+    the period it covers, its subtype, and its currency.
+    """
+
+    account_id: str
+    display_name: str = ""
+    source_types: tuple[str, ...] = ()
+    subtype: str | None = None
+    currency_code: str | None = None
+    transactions: int = 0
+    first_date: date | None = None
+    last_date: date | None = None
+
+
+@dataclass(frozen=True)
+class AccountMergeFacts:
+    """One proposed account merge, with the direction and the evidence for it."""
+
+    absorbed: AccountLedgerFacts
+    survivor: AccountLedgerFacts
+    overlap: LedgerOverlap = field(
+        default_factory=lambda: LedgerOverlap(
+            comparable=0, matched=0, window_start=None, window_end=None
+        )
+    )
+
+
+def _source_label(facts: AccountLedgerFacts) -> str | None:
+    """Uppercased source origins — "PDF", "OFX", "PDF+OFX" — or None when unknown."""
+    return "+".join(s.upper() for s in facts.source_types) or None
+
+
+def _side_label(side: AccountLedgerFacts, other: AccountLedgerFacts) -> str:
+    """Name one side of the merge by the first thing that tells it from the other.
+
+    Falls through to a bare "the account" rather than reaching for the last
+    four: the ids in the parenthetical already make the two descriptions
+    distinguishable, and a shared last four would make them identical again.
+    """
+    if side.display_name and side.display_name != other.display_name:
+        return side.display_name
+    source = _source_label(side)
+    if source and source != _source_label(other):
+        return f"the {source}-derived account"
+    return "the account"
+
+
+def _side_traits(side: AccountLedgerFacts, other: AccountLedgerFacts) -> list[str]:
+    """The magnitude, the period, and whatever else separates the two sides."""
+    traits = [f"{side.transactions:,} transactions"]
+    if side.first_date and side.last_date:
+        traits.append(f"{side.first_date.isoformat()} → {side.last_date.isoformat()}")
+    if side.subtype != other.subtype:
+        traits.append(side.subtype or "no subtype")
+    if side.currency_code != other.currency_code:
+        traits.append(side.currency_code or "no currency")
+    return traits
+
+
+def _side_phrase(side: AccountLedgerFacts, other: AccountLedgerFacts) -> str:
+    return (
+        f"{_side_label(side, other)} "
+        f"({side.account_id}; {', '.join(_side_traits(side, other))})"
+    )
+
+
+def _evidence_line(overlap: LedgerOverlap) -> str:
+    """State how much of the absorbed ledger the survivor already holds.
+
+    An unmeasurable probe says so in words. Rendering it as "0 of 0" would read
+    as a merge with nothing in common, which is evidence against — the opposite
+    of what no comparable period means.
+    """
+    if not overlap.measurable:
+        return (
+            "The two ledgers share no comparable period, so there is no overlap "
+            "evidence either way."
+        )
+    window = ""
+    if overlap.window_start and overlap.window_end:
+        window = (
+            f" over {overlap.window_start.isoformat()} → "
+            f"{overlap.window_end.isoformat()}"
+        )
+    return (
+        f"{overlap.matched:,} of {overlap.comparable:,} of the absorbed "
+        f"account's transactions{window} already appear in the surviving "
+        "account's ledger."
+    )
+
+
+def _account_merge_block(merge: AccountMergeFacts) -> str:
+    """The question, the evidence, and what the answer does — in that order."""
+    absorbed, survivor = merge.absorbed, merge.survivor
+    lines = [
+        f"Merge {_side_phrase(absorbed, survivor)} "
+        f"into {_side_phrase(survivor, absorbed)}?",
+        "",
+        _evidence_line(merge.overlap),
+        "",
+        f"The absorbed account {absorbed.account_id} is folded into "
+        f"{survivor.account_id}: its transactions move onto that account's "
+        "history and nothing is deleted. Reverse with "
+        "system_audit_undo(operation_id=...).",
+    ]
+    if survivor.transactions == 0:
+        # The reversed proposal is the expensive failure on this path: the live
+        # queue offered a malformed placeholder as the survivor, where accepting
+        # would have made it canonical. An empty surviving ledger is the one
+        # cheap, legible tell for it.
+        lines.append(
+            "The surviving account has no transactions of its own — check the "
+            "direction before accepting."
+        )
+    return "\n".join(lines)
+
+
+def _batch_paragraph(kinds: Collection[str], *, accounts_described: bool) -> str:
+    """Name what the batch's remaining accepted links do, and nothing else."""
+    if not kinds:
+        return _EVERY_KIND_PARAGRAPH
+    remaining = [
+        kind
+        for kind in ("account_link", "merchant_link", "security_link")
+        if kind in kinds and not (kind == "account_link" and accounts_described)
+    ]
+    if not remaining:
+        return _BATCH_TAIL
+    clauses = "; ".join(_KIND_CLAUSES[kind] for kind in remaining)
+    return f"Accepted links {clauses}. {_BATCH_TAIL}"
+
+
+def identity_confirm_message(
+    blast_radius: Mapping[str, int],
+    *,
+    merges: Sequence[AccountMergeFacts] = (),
+    kinds: Collection[str] = (),
+) -> str:
     """Prompt text naming what this batch moves, and how much of it.
 
     The elicitation shows this string and nothing else — the binding's counts are
@@ -58,17 +245,20 @@ def identity_confirm_message(blast_radius: Mapping[str, int]) -> str:
     mutation nobody was told about. Zero-count categories are omitted rather than
     listed as zeros: a bind that touches one security should not read as a batch
     reaching into accounts and merchants it never opens.
+
+    ``merges`` renders one clause-by-clause block per account merge in the batch:
+    which account is absorbed, which survives, how much history moves, and how
+    much of it the survivor already holds. ``kinds`` names the link kinds the
+    batch actually accepts, so the closing paragraph describes those and not the
+    other two. Both default to empty, which reproduces the counts-only prompt for
+    a caller that has neither.
     """
     moved = [
         f"{count} {IDENTITY_BLAST_RADIUS_LABELS[key][0 if count == 1 else 1]}"
         for key in IDENTITY_BLAST_RADIUS_CATEGORIES
         if (count := blast_radius.get(key, 0))
     ]
-    return (
-        "Confirm this complete identity-decision batch. Accepted links can merge "
-        "account histories, merchant attribution, or security lots — including "
-        "any price marks you set by hand, which move onto the survivor — or bind "
-        "a price-feed symbol without merging anything; every decision in the "
-        "ordered batch will commit together.\n\n"
-        f"This batch touches: {', '.join(moved) if moved else 'no rows'}."
-    )
+    blocks = [_account_merge_block(merge) for merge in merges]
+    blocks.append(_batch_paragraph(kinds, accounts_described=bool(merges)))
+    blocks.append(f"This batch touches: {', '.join(moved) if moved else 'no rows'}.")
+    return "\n\n".join(blocks)

--- a/src/moneybin/services/ledger_overlap.py
+++ b/src/moneybin/services/ledger_overlap.py
@@ -25,6 +25,7 @@ from datetime import date
 import duckdb
 
 from moneybin.database import Database
+from moneybin.metrics.registry import ACCOUNT_LINK_OVERLAP_PROBES_TOTAL
 from moneybin.tables import FCT_TRANSACTIONS
 
 logger = logging.getLogger(__name__)
@@ -166,9 +167,16 @@ def probe_ledger_overlap(
         logger.debug("core.fct_transactions unavailable; ledger overlap unmeasurable")
         row = None
     comparable, matched, start, end = row or _EMPTY_WINDOW_ROW
-    return LedgerOverlap(
+    overlap = LedgerOverlap(
         comparable=int(comparable),
         matched=int(matched),
         window_start=start,
         window_end=end,
     )
+    # Counted here rather than at the two call sites so a third one cannot forget:
+    # the failure this instruments is every probe going unmeasurable at once, and
+    # a counter that misses one caller cannot distinguish that from a quiet week.
+    ACCOUNT_LINK_OVERLAP_PROBES_TOTAL.labels(
+        result="measurable" if overlap.measurable else "unmeasurable"
+    ).inc()
+    return overlap

--- a/src/moneybin/services/ledger_overlap.py
+++ b/src/moneybin/services/ledger_overlap.py
@@ -112,6 +112,15 @@ def probe_ledger_overlap(
     of money until a currency names it, so a USD row and a EUR row are never
     the same transaction however equal they look.
 
+    Both sides are folded to a bare upper-case code first, because the veto has
+    to fire on the currency and not on its spelling. Tabular ``currency`` is a
+    pass-through extractor field copied out of the source cell verbatim, while
+    OFX and Plaid carry ISO codes — so the cross-source pair this probe exists
+    to judge is exactly where ``usd`` meets ``USD``. ``NULLIF(…, '')`` extends
+    the same reading to a blank cell, which a statement produces whenever it
+    fills its currency column only on foreign rows: an empty string is silence,
+    and silence already means unstated here.
+
     Returns an unmeasurable overlap — rather than raising — when ``core`` is not
     yet materialized, which is a first import before any transform.
     """
@@ -147,7 +156,9 @@ def probe_ledger_overlap(
                     FROM comparable AS c
                     JOIN against AS a
                       ON a.amount = c.amount
-                     AND a.currency_code IS NOT DISTINCT FROM c.currency_code
+                     AND NULLIF(UPPER(TRIM(a.currency_code)), '')
+                         IS NOT DISTINCT FROM
+                         NULLIF(UPPER(TRIM(c.currency_code)), '')
                      AND ABS(DATE_DIFF('day', a.transaction_date, c.transaction_date))
                          <= CAST(? AS INTEGER)
                     GROUP BY c.transaction_id

--- a/src/moneybin/services/ledger_overlap.py
+++ b/src/moneybin/services/ledger_overlap.py
@@ -36,6 +36,19 @@ logger = logging.getLogger(__name__)
 #: pair, amount within ±3 days matched 345 of 346 rows against the true twin and
 #: 0 of 346 against each of two controls; requiring an exact date collapsed that
 #: to 23%. The window is what makes the probe discriminate rather than the amount.
+#:
+#: Deliberately **not** ``settings.matching.date_window_days`` (default 5), which
+#: `system doctor`'s ``duplicate_account_overlap`` does reuse for a similar-looking
+#: job. Two reasons, and they are about what the number is for rather than what it
+#: measures. It is a calibration, not a preference: the 0-of-346 control result is
+#: the whole claim that this ratio discriminates, and it was measured at this
+#: width — a user who widens the window gets a higher number that means less,
+#: with nothing on the surface saying so. And the two call sites carry different
+#: consequences: doctor's window tunes what an audit *flags*, while this one
+#: supplies the evidence a human ratifies an irreversible whole-ledger merge on.
+#: Callers that genuinely need another width pass ``window_days``; consolidating
+#: the two would require re-running the twin-and-controls measurement at the
+#: shared width first, which is the part that cannot be assumed.
 DEFAULT_POSTING_LAG_DAYS = 3
 
 _EMPTY_WINDOW_ROW = (0, 0, None, None)

--- a/src/moneybin/services/ledger_overlap.py
+++ b/src/moneybin/services/ledger_overlap.py
@@ -1,0 +1,145 @@
+"""Ledger-overlap probe: do two accounts already hold the same transactions?
+
+An account-link proposal fires on an identifier — an institution plus a masked
+last four, or a name that slugifies the same way. None of that is evidence about
+the *ledgers*, and the reviewer ratifying a whole-account merge has no other way
+to tell a genuine cross-source twin from two distinct accounts that happen to
+share a signal. The discriminating evidence is already in ``core`` and was never
+consulted.
+
+Deliberately keyed on **two account ids** rather than a decision id. The
+matcher cannot answer this question — ``matching/scoring.py`` blocks candidate
+pairs on the same ``account_id``, so it can only compute overlap after the merge
+that overlap is meant to justify. Keeping the probe's signature free of the
+review queue also leaves it reachable for a pair that has no proposal at all,
+which is the shape ``system doctor``'s ``duplicate_account_overlap`` audit
+detects and currently has no merge path for.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date
+
+import duckdb
+
+from moneybin.database import Database
+from moneybin.tables import FCT_TRANSACTIONS
+
+logger = logging.getLogger(__name__)
+
+#: Days of posting lag tolerated before two rows stop being the same transaction.
+#:
+#: A statement carries the transaction date and a feed the posting date, so the
+#: same purchase is dated differently by each source. Measured on a live twin
+#: pair, amount within ±3 days matched 345 of 346 rows against the true twin and
+#: 0 of 346 against each of two controls; requiring an exact date collapsed that
+#: to 23%. The window is what makes the probe discriminate rather than the amount.
+DEFAULT_POSTING_LAG_DAYS = 3
+
+_EMPTY_WINDOW_ROW = (0, 0, None, None)
+
+
+@dataclass(frozen=True)
+class LedgerOverlap:
+    """How much of one account's ledger the other account already holds.
+
+    ``comparable`` counts only the rows that *could* match — those inside the
+    period the other ledger covers. Rows outside it are excluded rather than
+    counted as misses: a statement archive predating a feed's download window
+    would otherwise render as "0 of 400 match", which reads as evidence against
+    a correct merge when it is only evidence the other account was not there yet.
+
+    ``comparable == 0`` therefore means *no comparable period*, not *no overlap*.
+    The two must stay distinguishable to a reader — one is absence of evidence
+    and the other is evidence of absence — which is what ``measurable`` names.
+    """
+
+    comparable: int
+    matched: int
+    window_start: date | None
+    window_end: date | None
+
+    @property
+    def measurable(self) -> bool:
+        """Whether the two ledgers share a period this probe could compare at all."""
+        return self.comparable > 0
+
+
+def probe_ledger_overlap(
+    db: Database,
+    *,
+    account_id: str,
+    against_account_id: str,
+    window_days: int = DEFAULT_POSTING_LAG_DAYS,
+) -> LedgerOverlap:
+    """Count how many of ``account_id``'s transactions ``against_account_id`` holds.
+
+    Directional on purpose: the question a merge asks is what happens to the
+    absorbed account's history, so ``account_id`` is the ledger being probed and
+    ``against_account_id`` is the one it is checked against. Reversing them
+    answers a different question and yields a different ratio.
+
+    Matching is amount-equal within ``window_days``, by existence rather than by
+    a one-to-one assignment: a repeated amount inside the window can be answered
+    by the same counterpart twice, which can only inflate the ratio. The controls
+    measured 0 of 346 even so, and a genuine assignment costs a join this read
+    does not need to be worth showing.
+
+    Returns an unmeasurable overlap — rather than raising — when ``core`` is not
+    yet materialized, which is a first import before any transform.
+    """
+    try:
+        row = db.execute(
+            f"""
+            WITH against AS (
+                SELECT transaction_date, amount
+                FROM {FCT_TRANSACTIONS.full_name}
+                WHERE account_id = ?
+            ),
+            span AS (
+                SELECT MIN(transaction_date) AS lo, MAX(transaction_date) AS hi
+                FROM against
+            ),
+            comparable AS (
+                SELECT probe.transaction_id, probe.transaction_date, probe.amount
+                FROM {FCT_TRANSACTIONS.full_name} AS probe, span
+                WHERE probe.account_id = ?
+                  AND span.lo IS NOT NULL
+                  AND probe.transaction_date
+                      BETWEEN span.lo - CAST(? AS INTEGER)
+                          AND span.hi + CAST(? AS INTEGER)
+            )
+            SELECT
+                (SELECT COUNT(*) FROM comparable),
+                (SELECT COUNT(*) FROM (
+                    SELECT c.transaction_id
+                    FROM comparable AS c
+                    JOIN against AS a
+                      ON a.amount = c.amount
+                     AND ABS(DATE_DIFF('day', a.transaction_date, c.transaction_date))
+                         <= CAST(? AS INTEGER)
+                    GROUP BY c.transaction_id
+                )),
+                (SELECT MIN(transaction_date) FROM comparable),
+                (SELECT MAX(transaction_date) FROM comparable)
+            """,  # noqa: S608  # TableRef constants + parameterized values
+            [
+                against_account_id,
+                account_id,
+                window_days,
+                window_days,
+                window_days,
+            ],
+        ).fetchone()
+    except duckdb.CatalogException:
+        logger.debug("core.fct_transactions unavailable; ledger overlap unmeasurable")
+        row = None
+    comparable, matched, start, end = row or _EMPTY_WINDOW_ROW
+    return LedgerOverlap(
+        comparable=int(comparable),
+        matched=int(matched),
+        window_start=start,
+        window_end=end,
+    )

--- a/src/moneybin/services/ledger_overlap.py
+++ b/src/moneybin/services/ledger_overlap.py
@@ -81,11 +81,22 @@ def probe_ledger_overlap(
     ``against_account_id`` is the one it is checked against. Reversing them
     answers a different question and yields a different ratio.
 
-    Matching is amount-equal within ``window_days``, by existence rather than by
-    a one-to-one assignment: a repeated amount inside the window can be answered
-    by the same counterpart twice, which can only inflate the ratio. The controls
-    measured 0 of 346 even so, and a genuine assignment costs a join this read
-    does not need to be worth showing.
+    Matching is amount-equal *in the same currency* within ``window_days``, by
+    existence rather than by a one-to-one assignment: a repeated amount inside
+    the window can be answered by the same counterpart twice, which can only
+    inflate the ratio. The controls measured 0 of 346 even so, and a genuine
+    assignment costs a join this read does not need to be worth showing.
+
+    The currency comparison is NULL-safe, which is a deliberate asymmetry: only
+    a *stated* disagreement vetoes a match. ``currency_code`` is nullable — it
+    is the transaction's own captured currency, else the one inherited from
+    ``dim_accounts`` — so a plain ``=`` would score every pair of
+    unknown-currency ledgers at zero overlap and turn a genuine twin's evidence
+    off silently. Treating NULL as a value rather than a wildcard costs a true
+    twin its evidence only where one source states a currency and the other
+    does not, and refuses the case that matters: a nominal amount is not a sum
+    of money until a currency names it, so a USD row and a EUR row are never
+    the same transaction however equal they look.
 
     Returns an unmeasurable overlap — rather than raising — when ``core`` is not
     yet materialized, which is a first import before any transform.
@@ -94,7 +105,7 @@ def probe_ledger_overlap(
         row = db.execute(
             f"""
             WITH against AS (
-                SELECT transaction_date, amount
+                SELECT transaction_date, amount, currency_code
                 FROM {FCT_TRANSACTIONS.full_name}
                 WHERE account_id = ?
             ),
@@ -103,7 +114,11 @@ def probe_ledger_overlap(
                 FROM against
             ),
             comparable AS (
-                SELECT probe.transaction_id, probe.transaction_date, probe.amount
+                SELECT
+                    probe.transaction_id,
+                    probe.transaction_date,
+                    probe.amount,
+                    probe.currency_code
                 FROM {FCT_TRANSACTIONS.full_name} AS probe, span
                 WHERE probe.account_id = ?
                   AND span.lo IS NOT NULL
@@ -118,6 +133,7 @@ def probe_ledger_overlap(
                     FROM comparable AS c
                     JOIN against AS a
                       ON a.amount = c.amount
+                     AND a.currency_code IS NOT DISTINCT FROM c.currency_code
                      AND ABS(DATE_DIFF('day', a.transaction_date, c.transaction_date))
                          <= CAST(? AS INTEGER)
                     GROUP BY c.transaction_id

--- a/tests/moneybin/test_cli/test_accounts_links.py
+++ b/tests/moneybin/test_cli/test_accounts_links.py
@@ -251,6 +251,55 @@ class TestLinksPending:
     @patch("moneybin.cli.commands.accounts.links.get_database")
     @patch("moneybin.services.account_links_service.AccountLinksService.pending")
     @patch("moneybin.services.account_links_service.AccountLinksService.count_pending")
+    def test_pending_states_the_evidence_and_the_magnitude(
+        self,
+        mock_count: MagicMock,
+        mock_pending: MagicMock,
+        mock_get_db: MagicMock,
+    ) -> None:
+        """Browsing has to answer "is this the same account" and "how much moves".
+
+        The queue previously showed a confidence constant no input could move,
+        so both questions cost a separate command. The candidate row now carries
+        the measured overlap and the group header the size of the merge.
+        """
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_pending.return_value = [_make_pending_group(transactions=346)]
+        mock_count.return_value = 1
+
+        result = runner.invoke(app, ["pending"])
+        assert result.exit_code == 0
+        assert "345 of 346" in result.output
+        assert "346 transactions move" in result.output
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.pending")
+    @patch("moneybin.services.account_links_service.AccountLinksService.count_pending")
+    def test_pending_says_no_shared_period_rather_than_zero_of_zero(
+        self,
+        mock_count: MagicMock,
+        mock_pending: MagicMock,
+        mock_get_db: MagicMock,
+    ) -> None:
+        """An unmeasurable probe must not render as evidence against the merge."""
+        mock_get_db.return_value.__enter__.return_value = MagicMock()
+        mock_pending.return_value = [
+            _make_pending_group(
+                overlap=LedgerOverlap(
+                    comparable=0, matched=0, window_start=None, window_end=None
+                )
+            )
+        ]
+        mock_count.return_value = 1
+
+        result = runner.invoke(app, ["pending"])
+        assert result.exit_code == 0
+        assert "0 of 0" not in result.output
+        assert "no shared period" in result.output
+
+    @patch("moneybin.cli.commands.accounts.links.get_database")
+    @patch("moneybin.services.account_links_service.AccountLinksService.pending")
+    @patch("moneybin.services.account_links_service.AccountLinksService.count_pending")
     def test_pending_json_output_shape(
         self,
         mock_count: MagicMock,
@@ -279,6 +328,12 @@ class TestLinksPending:
         assert len(groups[0]["candidates"]) == 1
         assert groups[0]["candidates"][0]["decision_id"] == "dec_j"
         assert "n_pending" in parsed["data"]
+        # The JSON consumer gets the same two answers the table does: an agent
+        # that had to re-derive them would be reading the ledger itself.
+        assert groups[0]["transactions"] == 346
+        assert groups[0]["candidates"][0]["overlap_matched"] == 345
+        assert groups[0]["candidates"][0]["overlap_comparable"] == 346
+        assert "confidence" not in groups[0]["candidates"][0]
 
     @patch("moneybin.cli.commands.accounts.links.get_database")
     @patch("moneybin.services.account_links_service.AccountLinksService.pending")

--- a/tests/moneybin/test_cli/test_accounts_links.py
+++ b/tests/moneybin/test_cli/test_accounts_links.py
@@ -917,6 +917,12 @@ class TestLinksHistory:
         assert len(decisions) == 1
         assert decisions[0]["decision_id"] == "dh001"
         assert decisions[0]["signal"] == "name"
+        # The service row above still carries confidence_score — it stays an
+        # audit column on app.account_link_decisions. The public envelope is
+        # what dropped it, so the row reaching the renderer is exactly the
+        # fixture that would catch it leaking back through.
+        assert "confidence" not in decisions[0]
+        assert "confidence_score" not in decisions[0]
 
     @patch("moneybin.cli.commands.accounts.links.get_database")
     @patch("moneybin.services.account_links_service.AccountLinksService.history")

--- a/tests/moneybin/test_cli/test_accounts_links.py
+++ b/tests/moneybin/test_cli/test_accounts_links.py
@@ -172,7 +172,9 @@ def _previewed_merge(
     approved = _approved_merge(
         transactions=transactions, links=links, decisions=decisions
     )
-    return approved, identity_confirm_message(approved.sentence, kinds=["account_link"])
+    return approved, identity_confirm_message(
+        approved.sentence, surface="cli", kinds=["account_link"]
+    )
 
 
 def _commit_running_verifier(

--- a/tests/moneybin/test_cli/test_accounts_links.py
+++ b/tests/moneybin/test_cli/test_accounts_links.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
+from datetime import date
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -26,6 +27,8 @@ from moneybin.cli.commands.accounts.links import (
 from moneybin.errors import UserError
 from moneybin.mcp.write_contracts import AccountLinkDecisionRequest
 from moneybin.services.account_links_service import AccountLinkAcceptImpact
+from moneybin.services.identity_confirmation import identity_confirm_message
+from moneybin.services.ledger_overlap import LedgerOverlap
 from moneybin.services.review_decisions_service import (
     IdentityDecisionPlan,
     IdentityDecisionPlanItem,
@@ -46,21 +49,28 @@ def _make_pending_group(
     decision_id: str = "dec001",
     candidate_id: str = "CAND001",
     candidate_name: str = "Candidate Account",
-    confidence: float = 0.85,
     signal: str = "institution_last4",
+    overlap: LedgerOverlap | None = None,
+    transactions: int = 346,
 ) -> MagicMock:
     """Build a mock PendingLinkGroup with sensible defaults."""
     candidate = MagicMock()
     candidate.decision_id = decision_id
     candidate.candidate_account_id = candidate_id
     candidate.candidate_display_name = candidate_name
-    candidate.confidence = confidence
     candidate.signal = signal
+    candidate.overlap = overlap or LedgerOverlap(
+        comparable=346,
+        matched=345,
+        window_start=date(2024, 5, 1),
+        window_end=date(2026, 8, 2),
+    )
 
     group = MagicMock()
     group.provisional_account_id = provisional_id
     group.provisional_display_name = provisional_name
     group.candidates = [candidate]
+    group.transactions = transactions
     return group
 
 
@@ -146,6 +156,23 @@ def _approved_merge(
         links=links,
         decisions=decisions,
     )
+
+
+def _previewed_merge(
+    *,
+    transactions: tuple[str, ...] = ("t1",),
+    links: tuple[str, ...] = ("L1",),
+    decisions: tuple[str, ...] = ("dec001",),
+) -> tuple[_ApprovedMerge, str]:
+    """What ``_merge_preview`` returns: the approval plus the text that earned it.
+
+    The message is rendered by the real builder rather than stubbed, so a test
+    asserting on what the operator read is asserting about the shipped sentence.
+    """
+    approved = _approved_merge(
+        transactions=transactions, links=links, decisions=decisions
+    )
+    return approved, identity_confirm_message(approved.sentence, kinds=["account_link"])
 
 
 def _commit_running_verifier(
@@ -340,7 +367,7 @@ class TestLinksSet:
         account's whole history into another on a single unprompted invocation.
         """
         mock_get_db.return_value.__enter__.return_value = MagicMock()
-        mock_preview.return_value = _approved_merge()
+        mock_preview.return_value = _previewed_merge()
 
         result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"], input="n\n")
 
@@ -366,7 +393,7 @@ class TestLinksSet:
         makes the answer more than a coin flip.
         """
         mock_get_db.return_value.__enter__.return_value = MagicMock()
-        mock_preview.return_value = _approved_merge(transactions=("t1", "t2", "t3"))
+        mock_preview.return_value = _previewed_merge(transactions=("t1", "t2", "t3"))
 
         result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"], input="y\n")
 
@@ -418,7 +445,7 @@ class TestLinksSet:
         verifier refuses a batch that no longer matches the sentence shown.
         """
         mock_get_db.return_value.__enter__.return_value = MagicMock()
-        mock_preview.return_value = _approved_merge(transactions=("t1",))
+        mock_preview.return_value = _previewed_merge(transactions=("t1",))
         mock_plan.return_value = _merge_plan(transactions=("t1", "t2", "t3"))
         mock_set.side_effect = _commit_running_verifier()
 
@@ -447,7 +474,7 @@ class TestLinksSet:
         refused everything would look correct.
         """
         mock_get_db.return_value.__enter__.return_value = MagicMock()
-        mock_preview.return_value = _approved_merge(transactions=("t1",))
+        mock_preview.return_value = _previewed_merge(transactions=("t1",))
         mock_plan.return_value = _merge_plan(transactions=("t1",))
         mock_set.side_effect = _commit_running_verifier()
 
@@ -479,7 +506,7 @@ class TestLinksSet:
         which is why comparing the plan alone cannot catch it.
         """
         mock_get_db.return_value.__enter__.return_value = MagicMock()
-        mock_preview.return_value = _approved_merge(decisions=("dec001",))
+        mock_preview.return_value = _previewed_merge(decisions=("dec001",))
         mock_plan.return_value = _merge_plan(transactions=("t1",))
         mock_set.side_effect = _commit_running_verifier(decisions=("dec001", "dec002"))
 
@@ -689,7 +716,7 @@ class TestLinksSet:
         place to leave the reader guessing whether anything moved.
         """
         mock_get_db.return_value.__enter__.return_value = MagicMock()
-        mock_preview.return_value = _approved_merge()
+        mock_preview.return_value = _previewed_merge()
 
         result = runner.invoke(app, ["set", "dec001", "--into", "CAND001"], input="n\n")
 

--- a/tests/moneybin/test_mcp/test_accounts.py
+++ b/tests/moneybin/test_mcp/test_accounts.py
@@ -20,7 +20,9 @@ import pytest
 from fastmcp import FastMCP
 
 from moneybin.database import get_database
+from moneybin.errors import UserError
 from moneybin.mcp.tools.accounts import (
+    _load_pending_account_proposal,  # pyright: ignore[reportPrivateUsage]  # the untested wiring is the subject
     accounts_balance_assert,
     accounts_balance_assert_coarse,
     accounts_balances_coarse,
@@ -31,6 +33,8 @@ from moneybin.mcp.tools.accounts import (
     register_accounts_coarse_writes,
     register_accounts_tools,
 )
+from moneybin.repositories.account_link_decisions_repo import AccountLinkDecisionsRepo
+from moneybin.repositories.account_links_repo import AccountLinksRepo
 
 pytestmark = pytest.mark.usefixtures("mcp_db")
 
@@ -1489,3 +1493,92 @@ class TestBalanceCurrency:
 
         assert [row.currency_code for row in response.data.assertions] == [None]
         assert response.summary.display_currency is None
+
+
+class TestPendingAccountProposal:
+    """Which account the merge absorbs, and which one survives.
+
+    ``_load_pending_account_proposal`` is where the MCP path decides that — it
+    reads a decision out of the live queue and hands ``merge_facts`` a
+    direction. Nothing else in this suite executes it, so a swapped pair of
+    keyword arguments here would ship a prompt describing the merge backwards
+    while every other test stayed green. That is the exact failure this
+    milestone exists to make legible, so it gets a direct test rather than an
+    inference from the rendered sentence.
+    """
+
+    @staticmethod
+    def _seed_merge_decision() -> None:
+        """One pending ACC001 → ACC002 decision over two differently-sized ledgers.
+
+        The two ledgers are deliberately unequal — three rows against five — so
+        a reversed direction cannot produce the asserted numbers. Equal ledgers
+        would satisfy the assertions in either order and prove nothing.
+        """
+        with get_database(read_only=False) as db:
+            AccountLinksRepo(db).insert(
+                link_id="lnk_acc001_00",
+                account_id="ACC001",
+                ref_kind="source_native",
+                ref_value="native-ref-1",
+                source_type="ofx",
+                source_origin="test_bank",
+                decided_by="auto",
+                actor="system",
+                status="accepted",
+            )
+            AccountLinkDecisionsRepo(db).insert(
+                decision_id="dec_merge_001",
+                provisional_account_id="ACC001",
+                candidate_account_id="ACC002",
+                confidence_score=0.9,
+                match_signals={"signal": "institution_last4", "value": "***"},
+                decided_by="auto",
+                actor="system",
+                status="pending",
+            )
+            for i, day in enumerate((3, 7, 11)):
+                db.execute(
+                    "INSERT INTO core.fct_transactions (transaction_id, "
+                    "account_id, transaction_date, amount) VALUES (?, ?, ?, ?)",
+                    [f"acc001_txn{i}", "ACC001", date(2026, 5, day), Decimal("-12.00")],
+                )
+            for i, day in enumerate((3, 7, 11, 15, 19)):
+                db.execute(
+                    "INSERT INTO core.fct_transactions (transaction_id, "
+                    "account_id, transaction_date, amount) VALUES (?, ?, ?, ?)",
+                    [f"acc002_txn{i}", "ACC002", date(2026, 5, day), Decimal("-40.50")],
+                )
+
+    @pytest.mark.unit
+    async def test_the_provisional_account_is_the_one_absorbed(
+        self, mcp_db: Path
+    ) -> None:
+        """The provisional account folds into the candidate, never the reverse.
+
+        Both halves are asserted by id *and* by ledger size: an id-only check
+        would still pass if the facts were read for the right account pair in
+        the wrong roles, because both ids appear either way.
+        """
+        self._seed_merge_decision()
+
+        proposal = _load_pending_account_proposal("dec_merge_001")
+
+        assert proposal.provisional_account_id == "ACC001"
+        assert proposal.candidate_account_id == "ACC002"
+        assert proposal.facts.absorbed.account_id == "ACC001"
+        assert proposal.facts.absorbed.transactions == 3
+        assert proposal.facts.survivor.account_id == "ACC002"
+        assert proposal.facts.survivor.transactions == 5
+
+    @pytest.mark.unit
+    async def test_a_decision_that_is_not_pending_is_refused_not_guessed(
+        self, mcp_db: Path
+    ) -> None:
+        """An unknown decision id raises rather than merging some other pair."""
+        self._seed_merge_decision()
+
+        with pytest.raises(UserError) as excinfo:
+            _load_pending_account_proposal("dec_does_not_exist")
+
+        assert excinfo.value.code == "mutation_nothing_to_do"

--- a/tests/moneybin/test_mcp/test_decorator.py
+++ b/tests/moneybin/test_mcp/test_decorator.py
@@ -11,7 +11,11 @@ from moneybin.errors import UserError
 from moneybin.mcp.decorator import internal_envelope_adapter, mcp_tool
 from moneybin.mcp.privacy import Sensitivity, log_tool_call
 from moneybin.privacy.introspection import PrivacyContractError
-from moneybin.privacy.payloads.accounts import AccountListPayload
+from moneybin.privacy.payloads.accounts import (
+    AccountLinksSetPayload,
+    AccountListPayload,
+)
+from moneybin.privacy.taxonomy import Tier
 from moneybin.protocol.envelope import ResponseEnvelope, SummaryMeta
 
 
@@ -71,6 +75,63 @@ class TestMCPToolDecorator:
             ...
 
         assert my_tool._mcp_sensitivity == Sensitivity.HIGH  # type: ignore[attr-defined]
+
+    @pytest.mark.unit
+    def test_discloses_raises_the_tier_above_the_payload_it_returns(self) -> None:
+        """A confirm prompt can disclose more than the response ever carries.
+
+        Deriving the tier from the typed payload is right for a tool whose only
+        output is that payload. A destructive tool that elicits first also
+        discloses whatever its prompt renders, and that text is invisible to the
+        payload walk — so ``summary.sensitivity`` and the audit event understated
+        what the caller was shown. ``discloses`` is the declaration that closes it.
+        """
+
+        @mcp_tool(read_only=False, destructive=True, discloses=Tier.MEDIUM)
+        def prompting_tool() -> ResponseEnvelope[AccountLinksSetPayload]:  # type: ignore[return]
+            ...
+
+        @mcp_tool(read_only=False, destructive=True)
+        def silent_tool() -> ResponseEnvelope[AccountLinksSetPayload]:  # type: ignore[return]
+            ...
+
+        assert silent_tool._mcp_sensitivity == Sensitivity.LOW  # type: ignore[attr-defined]
+        assert prompting_tool._mcp_sensitivity == Sensitivity.MEDIUM  # type: ignore[attr-defined]
+
+    @pytest.mark.unit
+    def test_discloses_never_lowers_a_payload_derived_tier(self) -> None:
+        """The declaration describes an addition to the payload, not a substitute.
+
+        Reading it as the answer rather than as a floor would let a tool declare
+        its prompt MEDIUM and thereby unmask a CRITICAL payload — a downgrade
+        expressed as a disclosure. The fixture's payload is CRITICAL precisely so
+        the max() is load-bearing; on a LOW payload both readings agree and the
+        test would prove nothing.
+        """
+
+        @mcp_tool(discloses=Tier.MEDIUM)
+        def declaring_tool() -> ResponseEnvelope[AccountListPayload]:  # type: ignore[return]
+            ...
+
+        @mcp_tool()
+        def baseline_tool() -> ResponseEnvelope[AccountListPayload]:  # type: ignore[return]
+            ...
+
+        assert baseline_tool._mcp_sensitivity == Sensitivity.CRITICAL  # type: ignore[attr-defined]
+        assert declaring_tool._mcp_sensitivity == Sensitivity.CRITICAL  # type: ignore[attr-defined]
+
+    @pytest.mark.unit
+    def test_discloses_is_rejected_on_a_dynamic_tool(self) -> None:
+        """A dynamic tool sets its own per-call tier, so a static floor misleads."""
+        with pytest.raises(ValueError, match="discloses"):
+
+            @mcp_tool(
+                dynamic_classification=True,
+                maximum_sensitivity=Sensitivity.HIGH,
+                discloses=Tier.MEDIUM,
+            )
+            def sample() -> ResponseEnvelope[Any]:  # type: ignore[return]
+                ...
 
     @pytest.mark.unit
     def test_decorator_preserves_function_name(self) -> None:

--- a/tests/moneybin/test_mcp/test_review.py
+++ b/tests/moneybin/test_mcp/test_review.py
@@ -115,6 +115,26 @@ def _identity_plan(
     return IdentityDecisionPlan(items=items)
 
 
+def _identity_preview(plan: IdentityDecisionPlan) -> Any:
+    """Wrap a plan the way the read-only preview hands it to the confirm gate.
+
+    The merge facts are empty here on purpose: these tests pin the confirmation
+    protocol — binding, token, replay — and an account merge's rendered prose is
+    covered where the renderer lives.
+    """
+    return reviews_module._IdentityPreview(  # pyright: ignore[reportPrivateUsage]
+        plan=plan,
+        merges=(),
+        kinds=tuple(
+            sorted({
+                item.request.kind
+                for item in plan.items
+                if item.changed and item.request.decision == "accept"
+            })
+        ),
+    )
+
+
 def _identity_decision_status(kind: str, decision_id: str) -> str:
     table = {
         "account_link": "app.account_link_decisions",
@@ -2177,7 +2197,9 @@ async def test_identity_confirmation_rechecks_live_state_and_consumes_token(
     )
 
     with patch.object(
-        reviews_module, "_preview_identity_decisions", return_value=initial
+        reviews_module,
+        "_preview_identity_decisions",
+        return_value=_identity_preview(initial),
     ):
         required = await identity_links_decide_coarse(decisions=decisions)
 
@@ -2201,7 +2223,7 @@ async def test_identity_confirmation_rechecks_live_state_and_consumes_token(
         patch.object(
             reviews_module,
             "_preview_identity_decisions",
-            return_value=initial,
+            return_value=_identity_preview(initial),
         ),
         patch.object(
             reviews_module,
@@ -2237,7 +2259,11 @@ async def test_identity_reject_batch_uses_public_privacy_actor() -> None:
     mcp = isolated_server(register_review_coarse_writes)
 
     with (
-        patch.object(reviews_module, "_preview_identity_decisions", return_value=plan),
+        patch.object(
+            reviews_module,
+            "_preview_identity_decisions",
+            return_value=_identity_preview(plan),
+        ),
         patch.object(reviews_module, "_apply_identity_decisions", return_value=plan),
         patch("moneybin.mcp.decorator.write_privacy_event", captured.append),
     ):

--- a/tests/moneybin/test_mcp/test_review.py
+++ b/tests/moneybin/test_mcp/test_review.py
@@ -2071,7 +2071,24 @@ async def test_identity_mixed_late_failure_rolls_back_then_shares_operation_id()
     assert audit_operation_ids == {response.data.operation_id}
 
 
-async def test_identity_standard_write_reports_low_sensitivity() -> None:
+async def test_identity_standard_write_reports_its_prompt_disclosure_tier() -> None:
+    """The privacy event records what the tool may show, not what it returns.
+
+    The payload is three low-tier classes, but the merge prompt renders ledger
+    dates and user-written account labels, so the tool declares
+    ``discloses=Tier.MEDIUM`` and the event records ``medium``.
+
+    This batch rejects a *merchant* link — it renders no ledger facts and elicits
+    nothing — and still reports ``medium``. That is the declared maximum working
+    as intended rather than a miscount: a static declaration is per-tool, so it
+    over-reports on the calls that disclose less. Over-reporting a tier is the
+    safe direction; the per-call alternative would have to be trusted to lower
+    itself correctly on every path.
+
+    ``classes_returned`` stays payload-derived, which is the other half: the
+    declaration raises the tier without inventing data classes the response
+    never carried.
+    """
     setup = _identity_merchant_setup("sensitivity")
     captured: list[dict[str, Any]] = []
     mcp = isolated_server(register_review_coarse_writes)
@@ -2094,7 +2111,7 @@ async def test_identity_standard_write_reports_low_sensitivity() -> None:
     assert response.structuredContent is not None
     assert response.structuredContent["status"] == "ok"
     assert len(captured) == 1
-    assert captured[0]["sensitivity"] == "low"
+    assert captured[0]["sensitivity"] == "medium"
     assert captured[0]["classes_returned"] == [
         "aggregate",
         "record_id",
@@ -2609,6 +2626,55 @@ async def test_identity_preview_absorbs_the_source_into_the_target(
     assert merge.absorbed.transactions == 2
     assert merge.survivor.account_id == setup["candidate"]
     assert merge.survivor.transactions == 4
+
+
+async def test_identity_preview_describes_every_account_merge_in_the_batch(
+    mcp_db: object,
+) -> None:
+    """Two account links in one batch produce two merge descriptions, not one.
+
+    The tool takes an ordered list and nothing bounds it to a single account
+    merge, but the ``merges`` comprehension has only ever run over a one-accept
+    batch. A per-accept map that dropped past the first, or paired the wrong
+    source with the wrong target across two accepts, would hand the human a
+    prompt describing one merge while committing two.
+
+    Each of the four ledgers is a different size, so a pair read into the wrong
+    roles — or a merge built from one decision's source and the other's target —
+    fails on the counts rather than passing on ids that appear either way.
+    """
+    first = _identity_account_setup("preview-batch-one")
+    second = _identity_account_setup("preview-batch-two")
+    _seed_account_ledger(first["provisional"], "prov-batch-one", rows=2)
+    _seed_account_ledger(first["candidate"], "cand-batch-one", rows=4)
+    _seed_account_ledger(second["provisional"], "prov-batch-two", rows=3)
+    _seed_account_ledger(second["candidate"], "cand-batch-two", rows=5)
+
+    preview = _preview_identity_decisions([
+        AccountLinkDecisionRequest(
+            kind="account_link",
+            decision_id=first["decision_id"],
+            decision="accept",
+            target_id=first["candidate"],
+        ),
+        AccountLinkDecisionRequest(
+            kind="account_link",
+            decision_id=second["decision_id"],
+            decision="accept",
+            target_id=second["candidate"],
+        ),
+    ])
+
+    assert [merge.absorbed.account_id for merge in preview.merges] == [
+        first["provisional"],
+        second["provisional"],
+    ]
+    assert [merge.survivor.account_id for merge in preview.merges] == [
+        first["candidate"],
+        second["candidate"],
+    ]
+    assert [merge.absorbed.transactions for merge in preview.merges] == [2, 3]
+    assert [merge.survivor.transactions for merge in preview.merges] == [4, 5]
 
 
 async def test_identity_preview_describes_no_merge_for_a_reject(

--- a/tests/moneybin/test_mcp/test_review.py
+++ b/tests/moneybin/test_mcp/test_review.py
@@ -19,6 +19,7 @@ from moneybin.database import get_database
 from moneybin.mcp.tools import reviews as reviews_module
 from moneybin.mcp.tools.reviews import (
     _identity_binding,  # pyright: ignore[reportPrivateUsage]
+    _preview_identity_decisions,  # pyright: ignore[reportPrivateUsage]  # the untested wiring is the subject
     identity_links_decide_coarse,
     register_review_coarse_reads,
     register_review_coarse_writes,
@@ -2553,3 +2554,82 @@ def test_an_identity_merge_still_claims_the_rows_it_re_points() -> None:
     (item,) = plan.items
     assert item.affected_ids["transactions"] == ("txn-radius-merge",)
     assert item.affected_ids["lots"] == ("lot-radius-merge",)
+
+
+def _seed_account_ledger(account_id: str, label: str, rows: int) -> None:
+    """Give an account ``rows`` transactions so its ledger size identifies it."""
+    with get_database(read_only=False) as db:
+        for i in range(rows):
+            db.execute(
+                """
+                INSERT INTO core.fct_transactions
+                    (transaction_id, account_id, transaction_date, amount)
+                VALUES (?, ?, ?, ?)
+                """,
+                [
+                    f"txn-{label}-{i}",
+                    account_id,
+                    date(2026, 5, 1 + i),
+                    Decimal("-9.00"),
+                ],
+            )
+
+
+async def test_identity_preview_absorbs_the_source_into_the_target(
+    mcp_db: object,
+) -> None:
+    """The batch preview folds the provisional account into the candidate.
+
+    Every other test in this module patches ``_preview_identity_decisions``
+    out, so its body — which maps ``item.source_id`` and ``item.target_id``
+    onto absorbed and survivor — has never run under test. A swap there
+    produces a confirmation prompt describing the merge backwards while the
+    renderer's own tests, which build ``merges`` by hand, stay green.
+
+    The two ledgers are sized differently on purpose: asserting ids alone would
+    still pass if the pair were read into the wrong roles, since both ids
+    appear either way.
+    """
+    setup = _identity_account_setup("preview-direction")
+    _seed_account_ledger(setup["provisional"], "prov-direction", rows=2)
+    _seed_account_ledger(setup["candidate"], "cand-direction", rows=4)
+
+    preview = _preview_identity_decisions([
+        AccountLinkDecisionRequest(
+            kind="account_link",
+            decision_id=setup["decision_id"],
+            decision="accept",
+            target_id=setup["candidate"],
+        )
+    ])
+
+    (merge,) = preview.merges
+    assert preview.kinds == ("account_link",)
+    assert merge.absorbed.account_id == setup["provisional"]
+    assert merge.absorbed.transactions == 2
+    assert merge.survivor.account_id == setup["candidate"]
+    assert merge.survivor.transactions == 4
+
+
+async def test_identity_preview_describes_no_merge_for_a_reject(
+    mcp_db: object,
+) -> None:
+    """A rejected link moves no history, so the prompt must not describe one.
+
+    ``merges`` is filtered on ``decision == "accept"``. Losing that filter
+    would render the whole absorbed-into-survivor block — "its transactions
+    move onto that account's history" — above a decision that keeps the two
+    accounts apart.
+    """
+    setup = _identity_account_setup("preview-reject")
+    _seed_account_ledger(setup["provisional"], "prov-reject", rows=2)
+
+    preview = _preview_identity_decisions([
+        AccountLinkDecisionRequest(
+            kind="account_link",
+            decision_id=setup["decision_id"],
+            decision="reject",
+        )
+    ])
+
+    assert preview.merges == ()

--- a/tests/moneybin/test_services/test_account_links_service.py
+++ b/tests/moneybin/test_services/test_account_links_service.py
@@ -79,12 +79,21 @@ def _insert_transaction(
     on: date,
     amount: str,
     source_type: str = "csv",
+    currency_code: str = "USD",
 ) -> None:
+    """Insert one core transaction.
+
+    ``currency_code`` defaults to a stated value rather than NULL because the
+    pipeline cannot produce a NULL one under an account that states its own:
+    ``fct_transactions.currency_code`` is ``COALESCE(t.currency_code,
+    a.currency_code)``. A fixture that left it NULL under a USD account would
+    let the overlap probe match rows production would have separated.
+    """
     db.execute(
         "INSERT INTO core.fct_transactions "
-        "(transaction_id, account_id, transaction_date, amount, source_type) "
-        "VALUES (?, ?, ?, ?, ?)",
-        [transaction_id, account_id, on, Decimal(amount), source_type],
+        "(transaction_id, account_id, transaction_date, amount, source_type, "
+        "currency_code) VALUES (?, ?, ?, ?, ?, ?)",
+        [transaction_id, account_id, on, Decimal(amount), source_type, currency_code],
     )
 
 
@@ -222,6 +231,12 @@ def seeded_ledgers(seeded: AccountLinksService, db: Database) -> AccountLinksSer
       amount-equal counterpart in cand_a; 30.00 has none — **2 matched**.
     - prov1's own ledger is **4**, deliberately different from the 3 comparable
       and the 2 matched so the three numbers cannot be confused for each other.
+
+    Both sides share one currency on purpose. The probe only matches rows that
+    agree on ``currency_code``, so a pair that disagreed on it would measure
+    zero overlap however equal the amounts looked — which is a different
+    fixture answering a different question (see ``test_ledger_overlap.py``).
+    Here the subtype is what tells the two accounts apart.
     """
     _set_account_traits(db, _PROV1, account_type="depository", currency_code="USD")
     _set_account_traits(
@@ -229,7 +244,7 @@ def seeded_ledgers(seeded: AccountLinksService, db: Database) -> AccountLinksSer
         _CAND_A,
         account_subtype="checking",
         account_type="depository",
-        currency_code="EUR",
+        currency_code="USD",
     )
     for i, (on, amount) in enumerate([
         (date(2026, 5, 1), "10.00"),

--- a/tests/moneybin/test_services/test_account_links_service.py
+++ b/tests/moneybin/test_services/test_account_links_service.py
@@ -10,6 +10,8 @@ Fixture layout:
 
 from __future__ import annotations
 
+from datetime import date
+from decimal import Decimal
 from typing import Any
 
 import pytest
@@ -51,6 +53,38 @@ def _insert_dim_account(db: Database, account_id: str, display_name: str) -> Non
         "INSERT INTO core.dim_accounts (account_id, display_name, source_type) "
         "VALUES (?, ?, ?)",
         [account_id, display_name, "csv"],
+    )
+
+
+def _set_account_traits(
+    db: Database,
+    account_id: str,
+    *,
+    account_subtype: str | None = None,
+    account_type: str | None = None,
+    currency_code: str | None = None,
+) -> None:
+    db.execute(
+        "UPDATE core.dim_accounts SET account_subtype = ?, account_type = ?, "
+        "currency_code = ? WHERE account_id = ?",
+        [account_subtype, account_type, currency_code, account_id],
+    )
+
+
+def _insert_transaction(
+    db: Database,
+    *,
+    transaction_id: str,
+    account_id: str,
+    on: date,
+    amount: str,
+    source_type: str = "csv",
+) -> None:
+    db.execute(
+        "INSERT INTO core.fct_transactions "
+        "(transaction_id, account_id, transaction_date, amount, source_type) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [transaction_id, account_id, on, Decimal(amount), source_type],
     )
 
 
@@ -173,6 +207,59 @@ def seeded(svc: AccountLinksService, db: Database) -> AccountLinksService:
     return svc
 
 
+@pytest.fixture()
+def seeded_ledgers(seeded: AccountLinksService, db: Database) -> AccountLinksService:
+    """``seeded`` plus transactions, so the ledger evidence is measurable.
+
+    Hand-derived against ``probe_ledger_overlap``'s ±3-day window, which scopes
+    the denominator to the period the *candidate* covers:
+
+    - cand_a spans 2026-05-02 → 2026-05-04, so prov1's comparable window is
+      2026-04-29 → 2026-05-07.
+    - prov1 holds four transactions; the 2026-01-15 one falls outside that
+      window, leaving **3 comparable**.
+    - Of those, 10.00 (1 day apart) and 20.00 (2 days apart) have an
+      amount-equal counterpart in cand_a; 30.00 has none — **2 matched**.
+    - prov1's own ledger is **4**, deliberately different from the 3 comparable
+      and the 2 matched so the three numbers cannot be confused for each other.
+    """
+    _set_account_traits(db, _PROV1, account_type="depository", currency_code="USD")
+    _set_account_traits(
+        db,
+        _CAND_A,
+        account_subtype="checking",
+        account_type="depository",
+        currency_code="EUR",
+    )
+    for i, (on, amount) in enumerate([
+        (date(2026, 5, 1), "10.00"),
+        (date(2026, 5, 2), "20.00"),
+        (date(2026, 5, 3), "30.00"),
+        (date(2026, 1, 15), "99.00"),
+    ]):
+        _insert_transaction(
+            db,
+            transaction_id=f"prov1_txn{i:04d}",
+            account_id=_PROV1,
+            on=on,
+            amount=amount,
+            source_type="pdf",
+        )
+    for i, (on, amount) in enumerate([
+        (date(2026, 5, 2), "10.00"),
+        (date(2026, 5, 4), "20.00"),
+    ]):
+        _insert_transaction(
+            db,
+            transaction_id=f"cand_a_txn{i:04d}",
+            account_id=_CAND_A,
+            on=on,
+            amount=amount,
+            source_type="ofx",
+        )
+    return seeded
+
+
 # ---------------------------------------------------------------------------
 # count_pending
 # ---------------------------------------------------------------------------
@@ -278,6 +365,164 @@ def test_pending_display_name_absent_dim_is_empty_string(
     g = groups[0]
     assert g.provisional_display_name == ""
     assert g.candidates[0].candidate_display_name == ""
+
+
+# ---------------------------------------------------------------------------
+# pending — browse-time ledger evidence
+# ---------------------------------------------------------------------------
+
+
+def test_pending_measures_each_candidate_against_the_provisional_ledger(
+    seeded_ledgers: AccountLinksService,
+) -> None:
+    """The queue's decisive number is measured, not carried from the proposal.
+
+    ``pending()`` is the only place these two reads are wired together, and the
+    CLI test drives a mocked group — so a probe called with its arguments
+    reversed, or against the wrong account, is invisible everywhere else.
+    """
+    by_prov = {g.provisional_account_id: g for g in seeded_ledgers.pending()}
+    candidate = next(
+        c for c in by_prov[_PROV1].candidates if c.candidate_account_id == _CAND_A
+    )
+
+    assert candidate.overlap.comparable == 3
+    assert candidate.overlap.matched == 2
+    assert candidate.overlap.window_start == date(2026, 5, 1)
+    assert candidate.overlap.window_end == date(2026, 5, 3)
+
+
+def test_pending_carries_the_provisional_ledger_size_not_the_comparable_count(
+    seeded_ledgers: AccountLinksService,
+) -> None:
+    """How much history moves is a different number from how much of it matched.
+
+    The group header states the magnitude of the merge; the candidate row states
+    the evidence for it. Seeding four transactions where only three are
+    comparable and two match keeps a wiring swap from passing.
+    """
+    by_prov = {g.provisional_account_id: g for g in seeded_ledgers.pending()}
+
+    assert by_prov[_PROV1].transactions == 4
+    assert by_prov[_PROV2].transactions == 0
+
+
+def test_pending_reports_an_unmeasurable_probe_rather_than_a_zero_ratio(
+    seeded_ledgers: AccountLinksService,
+) -> None:
+    """prov2 holds no transactions, so nothing about the pair is comparable."""
+    by_prov = {g.provisional_account_id: g for g in seeded_ledgers.pending()}
+    candidate = by_prov[_PROV2].candidates[0]
+
+    assert candidate.candidate_account_id == _CAND_A
+    assert not candidate.overlap.measurable
+    assert candidate.overlap.comparable == 0
+
+
+def test_pending_renders_before_core_is_materialized(db: Database) -> None:
+    """A profile has proposals before it has a transform.
+
+    ``core.dim_accounts`` and ``core.fct_transactions`` are SQLMesh-owned, so
+    the queue has to render in the window between a profile's first sync and
+    its first refresh. Three reads touch ``core`` on this path — the display
+    name, the overlap probe, and the ledger size — and each guards the catalog
+    error separately, so a missing guard raises where the queue should list.
+    """
+    _insert_decision(
+        db,
+        decision_id=_DEC1,
+        provisional_account_id=_PROV1,
+        candidate_account_id=_CAND_A,
+    )
+
+    groups = AccountLinksService(db, actor="cli").pending()
+
+    assert len(groups) == 1
+    assert groups[0].transactions == 0
+    assert not groups[0].candidates[0].overlap.measurable
+
+
+# ---------------------------------------------------------------------------
+# ledger_facts / merge_facts
+# ---------------------------------------------------------------------------
+
+
+def test_merge_facts_before_core_is_materialized_describes_both_sides_as_empty(
+    db: Database,
+) -> None:
+    """The confirm prompt has the same pre-transform window as the queue."""
+    facts = AccountLinksService(db, actor="cli").merge_facts(
+        absorbed_account_id=_PROV1, survivor_account_id=_CAND_A
+    )
+
+    assert facts.absorbed.account_id == _PROV1
+    assert facts.absorbed.transactions == 0
+    assert facts.absorbed.subtype is None
+    assert facts.survivor.account_id == _CAND_A
+    assert not facts.overlap.measurable
+
+
+def test_ledger_facts_describes_an_account_by_what_distinguishes_it(
+    seeded_ledgers: AccountLinksService,
+) -> None:
+    """Source origin, span, size, subtype, currency — never the shared last four."""
+    facts = seeded_ledgers.ledger_facts(_PROV1)
+
+    assert facts.account_id == _PROV1
+    assert facts.display_name == "Provisional One"
+    assert facts.source_types == ("pdf",)
+    assert facts.transactions == 4
+    assert facts.first_date == date(2026, 1, 15)
+    assert facts.last_date == date(2026, 5, 3)
+    assert facts.currency_code == "USD"
+
+
+def test_ledger_facts_prefers_the_subtype_a_human_recognizes(
+    seeded_ledgers: AccountLinksService,
+) -> None:
+    """A subtype tells the two sides apart where the canonical type cannot.
+
+    Both accounts are ``depository``; only cand_a states a subtype. Falling back
+    to the type is right when the subtype is absent and wrong when it is not —
+    prov1 covers the first half, cand_a the second.
+    """
+    assert seeded_ledgers.ledger_facts(_PROV1).subtype == "depository"
+    assert seeded_ledgers.ledger_facts(_CAND_A).subtype == "checking"
+
+
+def test_ledger_facts_on_an_account_with_no_ledger_is_empty_not_absent(
+    seeded_ledgers: AccountLinksService,
+) -> None:
+    """An account with no transactions still describes itself."""
+    facts = seeded_ledgers.ledger_facts(_PROV2)
+
+    assert facts.display_name == "Provisional Two"
+    assert facts.transactions == 0
+    assert facts.source_types == ()
+    assert facts.first_date is None
+
+
+def test_merge_facts_measures_the_overlap_in_the_direction_it_was_asked(
+    seeded_ledgers: AccountLinksService,
+) -> None:
+    """Absorbed and survivor are not interchangeable, and neither is the probe.
+
+    Reversing the pair re-scopes the comparable window to the other ledger's
+    period, so a builder that ignored the direction would return the same
+    numbers both ways.
+    """
+    forward = seeded_ledgers.merge_facts(
+        absorbed_account_id=_PROV1, survivor_account_id=_CAND_A
+    )
+    reversed_pair = seeded_ledgers.merge_facts(
+        absorbed_account_id=_CAND_A, survivor_account_id=_PROV1
+    )
+
+    assert forward.absorbed.account_id == _PROV1
+    assert forward.survivor.account_id == _CAND_A
+    assert (forward.overlap.comparable, forward.overlap.matched) == (3, 2)
+    assert reversed_pair.absorbed.account_id == _CAND_A
+    assert (reversed_pair.overlap.comparable, reversed_pair.overlap.matched) == (2, 2)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/moneybin/test_services/test_account_resolver.py
+++ b/tests/moneybin/test_services/test_account_resolver.py
@@ -1166,6 +1166,56 @@ def test_a_vetoed_name_match_across_institutions_stays_dropped(db: Database) -> 
     assert resolver.propose_existing("bank_one_checking") is None
 
 
+def test_a_coincidental_namesake_does_not_suppress_the_genuine_reissue(
+    db: Database,
+) -> None:
+    """The retype runs beside the name pass, not only when the name pass is empty.
+
+    Three accounts named "Sapphire Reserve": the subject, its reissued twin at
+    the same institution (last four changed — vetoed out of the name pass), and
+    an unrelated account at another bank whose last four is simply unknown.
+    Silence is not disagreement, so the unrelated one clears the veto and lands
+    in the name pass.
+
+    Gating the retype on an empty name pass let that coincidence decide: the
+    weakest of the two candidates populated the list, the genuine reissue was
+    never retyped, and the duplicated ledger stayed split — in exactly the
+    namesake case the retype exists to catch. Both are weak signals bound for
+    the same review queue, so surfacing both is the point; picking one is not
+    the resolver's call to make.
+    """
+    create_core_tables(db)
+    _seed_dim_account(
+        db,
+        account_id="reissued_old",
+        display_name="Sapphire Reserve",
+        institution_name="CHASE",
+        last_four="1234",
+    )
+    _seed_dim_account(
+        db,
+        account_id="reissued_new",
+        display_name="Sapphire Reserve",
+        institution_name="CHASE",
+        last_four="5678",
+    )
+    _seed_dim_account(
+        db,
+        account_id="unrelated_namesake",
+        display_name="Sapphire Reserve",
+        institution_name="ALLY",
+        last_four=None,
+    )
+    resolver = AccountResolver(db, actor="system")
+
+    proposal = resolver.propose_existing("reissued_old")
+
+    assert proposal is not None
+    surfaced = {(c.account_id, c.signal) for c in proposal.candidates}
+    assert ("reissued_new", "institution_reissue") in surfaced, surfaced
+    assert ("unrelated_namesake", "name") in surfaced, surfaced
+
+
 def test_mint_claims_full_number_strong_ref_for_later_adopt(db: Database) -> None:
     """A minted account claims its scoped full_number so a later source adopts it.
 

--- a/tests/moneybin/test_services/test_account_resolver.py
+++ b/tests/moneybin/test_services/test_account_resolver.py
@@ -1472,3 +1472,115 @@ def test_institution_matching_canonicalizes_a_hand_written_name(db: Database) ->
     assert [c.signal for c in proposal.candidates] == ["institution_last4"], (
         proposal.candidates
     )
+
+
+def test_name_signal_is_vetoed_when_both_last_fours_are_known_and_differ(
+    db: Database,
+) -> None:
+    """A name that matches across a last-four disagreement is not evidence at all.
+
+    Two accounts at one institution whose last fours disagree are, on the only
+    identifier either of them states, *different accounts*. The name signal
+    routinely fires across that anyway — one live queue paired a checking
+    account with a savings account on nothing but a shared institution word —
+    so a name match scoring below the last-four signal is not enough: the
+    disagreement has to veto it outright.
+    """
+    create_core_tables(db)
+    _seed_dim_account(
+        db,
+        account_id="acct_other",
+        last_four="9940",
+        institution_name="WELLS FARGO",
+        institution_slug="wells_fargo",
+        display_name="WF Checking 4267",  # equals the source name: the veto is the only thing suppressing it
+    )
+    resolver = AccountResolver(db, actor="system")
+
+    candidates = resolver._find_candidates(  # type: ignore[reportPrivateUsage]  # pin the veto on the candidate pass
+        _src(last_four="4267", account_name="WF Checking 4267"),
+        exclude_account_id="prov_new",
+    )
+
+    assert candidates == [], candidates
+
+
+def test_name_signal_survives_when_the_candidate_states_no_last_four(
+    db: Database,
+) -> None:
+    """Silence is not disagreement — an unknown last four cannot veto anything.
+
+    The reissue rung requires both sides to carry one, so nothing else would
+    surface this pair: vetoing here would drop the proposal entirely rather than
+    retype it.
+    """
+    create_core_tables(db)
+    _seed_dim_account(
+        db,
+        account_id="acct_other",
+        last_four=None,
+        institution_name="WELLS FARGO",
+        institution_slug="wells_fargo",
+        display_name="WF Checking 4267",
+    )
+    resolver = AccountResolver(db, actor="system")
+
+    candidates = resolver._find_candidates(  # type: ignore[reportPrivateUsage]  # pin the veto's own boundary
+        _src(last_four="4267", account_name="WF Checking 4267"),
+        exclude_account_id="prov_new",
+    )
+
+    assert [c.signal for c in candidates] == ["name"], candidates
+
+
+def test_name_signal_survives_when_the_source_states_no_last_four(
+    db: Database,
+) -> None:
+    """The other half of the same boundary — a source that states nothing."""
+    create_core_tables(db)
+    _seed_dim_account(
+        db,
+        account_id="acct_other",
+        last_four="9940",
+        institution_name="WELLS FARGO",
+        institution_slug="wells_fargo",
+        display_name="WF Checking 4267",
+    )
+    resolver = AccountResolver(db, actor="system")
+
+    candidates = resolver._find_candidates(  # type: ignore[reportPrivateUsage]  # pin the veto's own boundary
+        _src(last_four=None, account_name="WF Checking 4267"),
+        exclude_account_id="prov_new",
+    )
+
+    assert [c.signal for c in candidates] == ["name"], candidates
+
+
+def test_a_vetoed_name_match_resurfaces_as_the_reissue_signal(db: Database) -> None:
+    """The veto retypes an arriving-source proposal; it does not discard it.
+
+    A replacement card at the same institution is exactly a name match across a
+    changed last four. The reissue rung already exists for that shape and says
+    so honestly, where ``name`` claims the two are the same account because their
+    labels agree.
+    """
+    create_core_tables(db)
+    _seed_dim_account(
+        db,
+        account_id="acct_other",
+        last_four="9940",
+        institution_name="WELLS FARGO",
+        institution_slug="wells_fargo",
+        display_name="WF Checking 4267",
+    )
+    resolver = AccountResolver(db, actor="system")
+
+    candidates = resolver._find_candidates(  # type: ignore[reportPrivateUsage]  # pin the retype, not just the veto
+        _src(last_four="4267", account_name="WF Checking 4267"),
+        exclude_account_id="prov_new",
+        reissue=True,
+    )
+
+    assert [(c.signal, c.account_id) for c in candidates] == [
+        ("institution_reissue", "acct_other")
+    ], candidates

--- a/tests/moneybin/test_services/test_account_resolver.py
+++ b/tests/moneybin/test_services/test_account_resolver.py
@@ -1097,6 +1097,75 @@ def test_propose_existing_does_not_emit_reissue_candidates(db: Database) -> None
     assert resolver.propose_existing("acct_a") is None
 
 
+def test_backfill_retypes_a_vetoed_name_match_as_a_reissue(db: Database) -> None:
+    """The veto must retype the pair it discards, not swallow it on this path.
+
+    Two existing copies of a reissued card share a display name and differ on
+    last four. The name rung's veto is right to refuse calling that a ``name``
+    match — a stated last-four disagreement is evidence of a *different*
+    account. But ``propose_existing`` runs with ``reissue=False``, so before
+    this retype the vetoed pair had nothing to fall through to: a duplicate the
+    backfill queue used to surface went silently invisible, and it stays split,
+    double-counting its ledger.
+
+    Distinct from ``test_propose_existing_does_not_emit_reissue_candidates``,
+    whose names are dissimilar so the name matcher never fires: that fixture
+    isolates the unconditional same-institution sweep, which stays off here.
+    Only a pair the name signal actually matched is retyped.
+    """
+    create_core_tables(db)
+    _seed_dim_account(
+        db,
+        account_id="reissued_old",
+        display_name="Sapphire Reserve",
+        institution_name="CHASE",
+        last_four="1234",
+    )
+    _seed_dim_account(
+        db,
+        account_id="reissued_new",
+        display_name="Sapphire Reserve",
+        institution_name="CHASE",
+        last_four="5678",
+    )
+    resolver = AccountResolver(db, actor="system")
+
+    proposal = resolver.propose_existing("reissued_old")
+
+    assert proposal is not None
+    assert [c.account_id for c in proposal.candidates] == ["reissued_new"]
+    assert proposal.candidates[0].signal == "institution_reissue"
+
+
+def test_a_vetoed_name_match_across_institutions_stays_dropped(db: Database) -> None:
+    """The retype is same-institution only; across two banks it is just a collision.
+
+    "Checking" at two different institutions with different last fours is two
+    unrelated accounts that happen to share a common word. Retyping that as a
+    reissue would put a merge proposal in front of a human on no evidence at
+    all — the failure the veto exists to prevent, reintroduced under a
+    different label.
+    """
+    create_core_tables(db)
+    _seed_dim_account(
+        db,
+        account_id="bank_one_checking",
+        display_name="Checking",
+        institution_name="CHASE",
+        last_four="1234",
+    )
+    _seed_dim_account(
+        db,
+        account_id="bank_two_checking",
+        display_name="Checking",
+        institution_name="ALLY",
+        last_four="5678",
+    )
+    resolver = AccountResolver(db, actor="system")
+
+    assert resolver.propose_existing("bank_one_checking") is None
+
+
 def test_mint_claims_full_number_strong_ref_for_later_adopt(db: Database) -> None:
     """A minted account claims its scoped full_number so a later source adopts it.
 
@@ -1477,14 +1546,19 @@ def test_institution_matching_canonicalizes_a_hand_written_name(db: Database) ->
 def test_name_signal_is_vetoed_when_both_last_fours_are_known_and_differ(
     db: Database,
 ) -> None:
-    """A name that matches across a last-four disagreement is not evidence at all.
+    """A name that matches across a last-four disagreement is not a name match.
 
     Two accounts at one institution whose last fours disagree are, on the only
     identifier either of them states, *different accounts*. The name signal
     routinely fires across that anyway — one live queue paired a checking
     account with a savings account on nothing but a shared institution word —
     so a name match scoring below the last-four signal is not enough: the
-    disagreement has to veto it outright.
+    disagreement has to veto the label outright.
+
+    Vetoing the label is not vetoing the pair. Same institution, same name, a
+    last four that changed is the reissue shape, so it re-emerges under that
+    signal — which is what keeps ``accounts links run`` able to see it, since
+    backfill never enables the unconditional same-institution sweep.
     """
     create_core_tables(db)
     _seed_dim_account(
@@ -1502,7 +1576,8 @@ def test_name_signal_is_vetoed_when_both_last_fours_are_known_and_differ(
         exclude_account_id="prov_new",
     )
 
-    assert candidates == [], candidates
+    assert [c.signal for c in candidates] == ["institution_reissue"], candidates
+    assert "name" not in [c.signal for c in candidates]
 
 
 def test_name_signal_survives_when_the_candidate_states_no_last_four(

--- a/tests/moneybin/test_services/test_identity_confirmation.py
+++ b/tests/moneybin/test_services/test_identity_confirmation.py
@@ -363,6 +363,29 @@ def test_the_paragraph_names_only_the_kinds_the_batch_contains() -> None:
     assert "merchant" not in message
 
 
+def test_a_mixed_batch_names_every_kind_it_contains_in_one_sentence() -> None:
+    """The multi-kind join is a real path: one batch can accept two link kinds.
+
+    ``identity_links_decide`` takes an ordered batch, so an account link and a
+    merchant link commit together routinely. Every other test here passes one
+    kind, which exercises the single-clause branch and never the join — so the
+    clause order and the separator between them were unpinned. Order follows the
+    declared kind sequence rather than the caller's, because a human reading two
+    consequences in one sentence should get them the same way every time.
+    """
+    message = identity_confirm_message(
+        {"accounts": 2, "merchants": 3, "transactions": 346},
+        kinds=["merchant_link", "account_link"],
+    )
+
+    assert (
+        "Accepted links move one account's whole transaction history onto the "
+        "surviving account; merge merchant attribution onto the surviving "
+        "merchant." in message
+    )
+    assert "tax lot" not in message
+
+
 def test_a_security_batch_still_names_what_a_security_link_moves() -> None:
     """The other half of the kind-awareness boundary."""
     message = identity_confirm_message(

--- a/tests/moneybin/test_services/test_identity_confirmation.py
+++ b/tests/moneybin/test_services/test_identity_confirmation.py
@@ -197,6 +197,54 @@ def test_an_account_fed_by_two_sources_names_both() -> None:
     assert "the PDF+OFX-derived account" in sentence.split(" into ")[1], sentence
 
 
+def test_a_synced_account_is_named_by_its_channel_not_its_provider() -> None:
+    """The sync server is opaque, and this prompt is a user-facing surface.
+
+    ``source_type`` carries the provider slug the sync server happens to use,
+    and `AGENTS.md` holds that external providers are implementation details
+    hidden behind that server. Rendering it raw put the vendor's name into a
+    sentence a human reads in the CLI and an agent reads over MCP — a leak with
+    no user value, since the channel is what distinguishes the two sides.
+    """
+    shared_label = "Example Bank credit …0000"
+    absorbed = _facts("aaaaaaaaaaaa", display_name=shared_label, source_types=("pdf",))
+    survivor = _facts(
+        "ssssssssssss", display_name=shared_label, source_types=("plaid",)
+    )
+
+    message = identity_confirm_message(
+        {"accounts": 2, "transactions": 346},
+        merges=[_merge(absorbed, survivor)],
+        kinds=["account_link"],
+    )
+
+    assert "the SYNC-derived account" in message
+    assert "PLAID" not in message.upper()
+
+
+def test_two_synced_sources_collapse_to_one_channel_label() -> None:
+    """Neutralising two providers must not render the channel twice.
+
+    ``_source_label`` joins the distinct source types, so mapping two mediated
+    providers onto one label without de-duplicating would produce
+    "SYNC+SYNC" — a string that leaks the provider *count* and reads as a bug.
+    """
+    shared_label = "Example Bank credit …0000"
+    absorbed = _facts("aaaaaaaaaaaa", display_name=shared_label, source_types=("ofx",))
+    survivor = _facts(
+        "ssssssssssss", display_name=shared_label, source_types=("plaid", "plaid")
+    )
+
+    message = identity_confirm_message(
+        {"accounts": 2, "transactions": 346},
+        merges=[_merge(absorbed, survivor)],
+        kinds=["account_link"],
+    )
+
+    assert "the SYNC-derived account" in message
+    assert "SYNC+SYNC" not in message
+
+
 def test_the_sentence_names_the_survivor_and_the_absorbed_account() -> None:
     """A "link A to B" phrasing never says which one dies; this has to."""
     absorbed, survivor = _colliding_pair()

--- a/tests/moneybin/test_services/test_identity_confirmation.py
+++ b/tests/moneybin/test_services/test_identity_confirmation.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 from datetime import date
 
+import pytest
+from typer.testing import CliRunner
+
+from moneybin.cli.main import app as cli_app
 from moneybin.services.identity_confirmation import (
     IDENTITY_BLAST_RADIUS_CATEGORIES,
     IDENTITY_BLAST_RADIUS_LABELS,
+    UNDO_COMMANDS,
     AccountLedgerFacts,
     AccountMergeFacts,
     identity_confirm_message,
@@ -34,14 +39,17 @@ def test_the_identity_prompt_counts_every_category_it_moves() -> None:
     "security lots" and nothing else. A merge could move a user's hand-set
     valuations onto another instrument with no sentence anywhere saying so.
     """
-    message = identity_confirm_message({
-        "accounts": 0,
-        "merchants": 0,
-        "securities": 2,
-        "transactions": 7,
-        "lots": 3,
-        "price_marks": 4,
-    })
+    message = identity_confirm_message(
+        {
+            "accounts": 0,
+            "merchants": 0,
+            "securities": 2,
+            "transactions": 7,
+            "lots": 3,
+            "price_marks": 4,
+        },
+        surface="mcp",
+    )
 
     assert "4 price marks you set by hand" in message
     assert "7 transactions" in message
@@ -56,14 +64,17 @@ def test_the_identity_prompt_omits_categories_it_does_not_touch() -> None:
     that one, and would tell a user binding a price feed that the batch touches
     accounts and merchants it never opens.
     """
-    message = identity_confirm_message({
-        "accounts": 0,
-        "merchants": 0,
-        "securities": 1,
-        "transactions": 0,
-        "lots": 0,
-        "price_marks": 0,
-    })
+    message = identity_confirm_message(
+        {
+            "accounts": 0,
+            "merchants": 0,
+            "securities": 1,
+            "transactions": 0,
+            "lots": 0,
+            "price_marks": 0,
+        },
+        surface="mcp",
+    )
 
     assert "1 security" in message
     assert "account" not in message.split("This batch touches:")[-1]
@@ -157,6 +168,7 @@ def test_a_colliding_pair_still_renders_two_distinguishable_descriptions() -> No
 
     message = identity_confirm_message(
         {"accounts": 2, "transactions": 346},
+        surface="mcp",
         merges=[_merge(absorbed, survivor)],
         kinds=["account_link"],
     )
@@ -188,6 +200,7 @@ def test_an_account_fed_by_two_sources_names_both() -> None:
 
     message = identity_confirm_message(
         {"accounts": 2, "transactions": 346},
+        surface="mcp",
         merges=[_merge(absorbed, survivor)],
         kinds=["account_link"],
     )
@@ -214,6 +227,7 @@ def test_a_synced_account_is_named_by_its_channel_not_its_provider() -> None:
 
     message = identity_confirm_message(
         {"accounts": 2, "transactions": 346},
+        surface="mcp",
         merges=[_merge(absorbed, survivor)],
         kinds=["account_link"],
     )
@@ -237,6 +251,7 @@ def test_two_synced_sources_collapse_to_one_channel_label() -> None:
 
     message = identity_confirm_message(
         {"accounts": 2, "transactions": 346},
+        surface="mcp",
         merges=[_merge(absorbed, survivor)],
         kinds=["account_link"],
     )
@@ -251,6 +266,7 @@ def test_the_sentence_names_the_survivor_and_the_absorbed_account() -> None:
 
     message = identity_confirm_message(
         {"accounts": 2, "transactions": 346},
+        surface="mcp",
         merges=[_merge(absorbed, survivor)],
         kinds=["account_link"],
     )
@@ -283,6 +299,7 @@ def test_a_reversed_proposal_is_legible_as_reversed_from_the_sentence_alone() ->
 
     message = identity_confirm_message(
         {"accounts": 2, "transactions": 2342},
+        surface="mcp",
         merges=[reversed_merge],
         kinds=["account_link"],
     )
@@ -303,6 +320,7 @@ def test_the_sentence_carries_the_overlap_evidence() -> None:
 
     message = identity_confirm_message(
         {"accounts": 2, "transactions": 346},
+        surface="mcp",
         merges=[_merge(absorbed, survivor)],
         kinds=["account_link"],
     )
@@ -316,6 +334,7 @@ def test_no_comparable_period_reads_as_absent_evidence_not_as_zero_overlap() -> 
 
     message = identity_confirm_message(
         {"accounts": 2, "transactions": 346},
+        surface="mcp",
         merges=[
             _merge(
                 absorbed,
@@ -342,11 +361,53 @@ def test_the_account_paragraph_names_the_undo_path() -> None:
 
     message = identity_confirm_message(
         {"accounts": 2, "transactions": 346},
+        surface="mcp",
         merges=[_merge(absorbed, survivor)],
         kinds=["account_link"],
     )
 
     assert "system_audit_undo" in message
+
+
+@pytest.mark.parametrize("surface", sorted(UNDO_COMMANDS))
+def test_each_surface_names_the_undo_command_that_runs_there(surface: str) -> None:
+    """Derived from the mapping, so a surface added without wiring fails here.
+
+    The rest of this sentence is shared precisely so the two surfaces cannot
+    describe one merge differently. The recovery command is the exception that
+    proves it: identical text would leave one of the two audiences holding an
+    instruction it cannot run.
+    """
+    absorbed, survivor = _colliding_pair()
+
+    message = identity_confirm_message(
+        {"accounts": 2, "transactions": 346},
+        surface=surface,
+        merges=[_merge(absorbed, survivor)],
+        kinds=["account_link"],
+    )
+
+    assert UNDO_COMMANDS[surface] in message
+    for other, command in UNDO_COMMANDS.items():
+        if other != surface:
+            assert command not in message
+
+
+def test_the_cli_prompt_names_a_command_the_cli_actually_registers() -> None:
+    """The literal a CLI user would copy, resolved against the real command tree.
+
+    Asserting the rendered string against a hand-written expectation would only
+    prove the renderer agrees with the test. What makes the sentence true is that
+    `moneybin system audit undo` exists — so ask the CLI, which also keeps this
+    honest if the command is ever renamed.
+    """
+    words = UNDO_COMMANDS["cli"].split()
+    assert words[0] == "moneybin"
+    path = [w for w in words[1:] if not w.startswith("<")]
+
+    result = CliRunner().invoke(cli_app, [*path, "--help"])
+
+    assert result.exit_code == 0, result.output
 
 
 def test_a_two_merge_batch_describes_both_merges_in_the_batch_order() -> None:
@@ -383,6 +444,7 @@ def test_a_two_merge_batch_describes_both_merges_in_the_batch_order() -> None:
 
     message = identity_confirm_message(
         {"accounts": 4, "transactions": 403},
+        surface="mcp",
         merges=[
             _merge(first_absorbed, first_survivor),
             _merge(second_absorbed, second_survivor),
@@ -404,6 +466,7 @@ def test_the_paragraph_names_only_the_kinds_the_batch_contains() -> None:
 
     message = identity_confirm_message(
         {"accounts": 2, "transactions": 346},
+        surface="mcp",
         merges=[_merge(absorbed, survivor)],
         kinds=["account_link"],
     )
@@ -424,6 +487,7 @@ def test_a_mixed_batch_names_every_kind_it_contains_in_one_sentence() -> None:
     """
     message = identity_confirm_message(
         {"accounts": 2, "merchants": 3, "transactions": 346},
+        surface="mcp",
         kinds=["merchant_link", "account_link"],
     )
 
@@ -439,6 +503,7 @@ def test_a_security_batch_still_names_what_a_security_link_moves() -> None:
     """The other half of the kind-awareness boundary."""
     message = identity_confirm_message(
         {"securities": 2, "lots": 3, "price_marks": 4},
+        surface="mcp",
         kinds=["security_link"],
     )
 

--- a/tests/moneybin/test_services/test_identity_confirmation.py
+++ b/tests/moneybin/test_services/test_identity_confirmation.py
@@ -169,6 +169,34 @@ def test_a_colliding_pair_still_renders_two_distinguishable_descriptions() -> No
     assert "ofx" in described[1].lower(), sentence
 
 
+def test_an_account_fed_by_two_sources_names_both() -> None:
+    """A side that already merged two sources is described by both, joined.
+
+    ``_source_label`` joins with ``"+"`` for exactly this case, and every other
+    fixture here gives each side a single source — so the join had no coverage
+    and would have rendered whatever one element it happened to pick. An
+    account that already absorbed a statement archive into a feed is a normal
+    survivor by the second merge, and describing it as feed-only next to a
+    statement-only candidate is the label collision this sentence exists to
+    avoid.
+    """
+    shared_label = "Example Bank credit …0000"
+    absorbed = _facts("aaaaaaaaaaaa", display_name=shared_label, source_types=("pdf",))
+    survivor = _facts(
+        "ssssssssssss", display_name=shared_label, source_types=("pdf", "ofx")
+    )
+
+    message = identity_confirm_message(
+        {"accounts": 2, "transactions": 346},
+        merges=[_merge(absorbed, survivor)],
+        kinds=["account_link"],
+    )
+
+    sentence = message.splitlines()[0]
+    assert "the PDF-derived account" in sentence.split(" into ")[0], sentence
+    assert "the PDF+OFX-derived account" in sentence.split(" into ")[1], sentence
+
+
 def test_the_sentence_names_the_survivor_and_the_absorbed_account() -> None:
     """A "link A to B" phrasing never says which one dies; this has to."""
     absorbed, survivor = _colliding_pair()

--- a/tests/moneybin/test_services/test_identity_confirmation.py
+++ b/tests/moneybin/test_services/test_identity_confirmation.py
@@ -349,6 +349,55 @@ def test_the_account_paragraph_names_the_undo_path() -> None:
     assert "system_audit_undo" in message
 
 
+def test_a_two_merge_batch_describes_both_merges_in_the_batch_order() -> None:
+    """One batch can accept two account links, and both have to be legible.
+
+    ``identity_links_decide`` takes an ordered list of decisions; nothing bounds
+    it to one account merge per call. Every other test here passes a
+    single-element ``merges``, which exercises the one-block case and leaves the
+    per-merge mapping unpinned — a renderer that described only the first pair,
+    or reordered them, would ratify a second merge the sentence never mentions.
+
+    Order is the caller's here, unlike ``kinds``: the blocks follow the batch's
+    own decision sequence so a human can read them against the call they made.
+    The trailing "This batch touches" line stays singular and combined, because
+    the blast radius is the batch's, not each merge's.
+    """
+    first_absorbed, first_survivor = _colliding_pair()
+    second_absorbed = _facts(
+        "bbbbbbbbbbbb",
+        display_name="Example Credit Union checking …0000",
+        source_types=("csv",),
+        transactions=57,
+        first_date=date(2025, 2, 3),
+        last_date=date(2026, 7, 30),
+    )
+    second_survivor = _facts(
+        "tttttttttttt",
+        display_name="Example Credit Union checking …0000",
+        source_types=("ofx",),
+        transactions=612,
+        first_date=date(2021, 6, 9),
+        last_date=date(2026, 7, 30),
+    )
+
+    message = identity_confirm_message(
+        {"accounts": 4, "transactions": 403},
+        merges=[
+            _merge(first_absorbed, first_survivor),
+            _merge(second_absorbed, second_survivor),
+        ],
+        kinds=["account_link"],
+    )
+
+    folds = [line for line in message.splitlines() if "is folded into" in line]
+    assert len(folds) == 2, message
+    assert "aaaaaaaaaaaa" in folds[0] and "ssssssssssss" in folds[0]
+    assert "bbbbbbbbbbbb" in folds[1] and "tttttttttttt" in folds[1]
+    assert message.count("This batch touches:") == 1
+    assert "4 accounts, 403 transactions" in message
+
+
 def test_the_paragraph_names_only_the_kinds_the_batch_contains() -> None:
     """A card-to-card account link was told about security lots and price marks."""
     absorbed, survivor = _colliding_pair()

--- a/tests/moneybin/test_services/test_identity_confirmation.py
+++ b/tests/moneybin/test_services/test_identity_confirmation.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from datetime import date
+
 from moneybin.services.identity_confirmation import (
     IDENTITY_BLAST_RADIUS_CATEGORIES,
     IDENTITY_BLAST_RADIUS_LABELS,
+    AccountLedgerFacts,
+    AccountMergeFacts,
     identity_confirm_message,
 )
+from moneybin.services.ledger_overlap import LedgerOverlap
 
 
 def test_every_blast_radius_category_has_a_prompt_label() -> None:
@@ -63,3 +68,231 @@ def test_the_identity_prompt_omits_categories_it_does_not_touch() -> None:
     assert "1 security" in message
     assert "account" not in message.split("This batch touches:")[-1]
     assert "tax lot" not in message.split("This batch touches:")[-1]
+
+
+# ---------------------------------------------------------------------------
+# The account-merge sentence
+# ---------------------------------------------------------------------------
+
+
+def _facts(
+    account_id: str,
+    *,
+    display_name: str = "",
+    source_types: tuple[str, ...] = (),
+    subtype: str | None = None,
+    currency_code: str | None = None,
+    transactions: int = 0,
+    first_date: date | None = None,
+    last_date: date | None = None,
+) -> AccountLedgerFacts:
+    return AccountLedgerFacts(
+        account_id=account_id,
+        display_name=display_name,
+        source_types=source_types,
+        subtype=subtype,
+        currency_code=currency_code,
+        transactions=transactions,
+        first_date=first_date,
+        last_date=last_date,
+    )
+
+
+def _colliding_pair() -> tuple[AccountLedgerFacts, AccountLedgerFacts]:
+    """Two accounts whose display labels are identical — the case that motivated this.
+
+    Built from the shape, never from real data: one statement-derived side and
+    one feed-derived side that render the same masked label, differing in source
+    origin, ledger size, period, subtype, and currency.
+    """
+    shared_label = "Example Bank credit …0000"
+    absorbed = _facts(
+        "aaaaaaaaaaaa",
+        display_name=shared_label,
+        source_types=("pdf",),
+        transactions=346,
+        first_date=date(2024, 5, 1),
+        last_date=date(2026, 8, 2),
+    )
+    survivor = _facts(
+        "ssssssssssss",
+        display_name=shared_label,
+        source_types=("ofx",),
+        subtype="credit card",
+        currency_code="USD",
+        transactions=2342,
+        first_date=date(2019, 1, 4),
+        last_date=date(2026, 8, 2),
+    )
+    return absorbed, survivor
+
+
+def _merge(
+    absorbed: AccountLedgerFacts,
+    survivor: AccountLedgerFacts,
+    overlap: LedgerOverlap | None = None,
+) -> AccountMergeFacts:
+    return AccountMergeFacts(
+        absorbed=absorbed,
+        survivor=survivor,
+        overlap=overlap
+        or LedgerOverlap(
+            comparable=346,
+            matched=345,
+            window_start=date(2024, 5, 1),
+            window_end=date(2026, 8, 2),
+        ),
+    )
+
+
+def test_a_colliding_pair_still_renders_two_distinguishable_descriptions() -> None:
+    """The split-account case is the one naming-by-last-four cannot serve.
+
+    Both sides of the live pair rendered the same label, so a sentence built on
+    it read "link your card (••NNNN) to your existing card record (••NNNN)" —
+    useless in exactly the case this work exists to fix. Disambiguation has to
+    come from what differs.
+    """
+    absorbed, survivor = _colliding_pair()
+
+    message = identity_confirm_message(
+        {"accounts": 2, "transactions": 346},
+        merges=[_merge(absorbed, survivor)],
+        kinds=["account_link"],
+    )
+
+    sentence = message.splitlines()[0]
+    described = sentence.split(" into ")
+    assert len(described) == 2, sentence
+    assert described[0] != described[1], sentence
+    assert "pdf" in described[0].lower(), sentence
+    assert "ofx" in described[1].lower(), sentence
+
+
+def test_the_sentence_names_the_survivor_and_the_absorbed_account() -> None:
+    """A "link A to B" phrasing never says which one dies; this has to."""
+    absorbed, survivor = _colliding_pair()
+
+    message = identity_confirm_message(
+        {"accounts": 2, "transactions": 346},
+        merges=[_merge(absorbed, survivor)],
+        kinds=["account_link"],
+    )
+
+    assert "aaaaaaaaaaaa" in message
+    assert "ssssssssssss" in message
+    absorbed_clause = next(
+        line for line in message.splitlines() if "is folded into" in line
+    )
+    assert absorbed_clause.index("aaaaaaaaaaaa") < absorbed_clause.index(
+        "ssssssssssss"
+    ), absorbed_clause
+
+
+def test_a_reversed_proposal_is_legible_as_reversed_from_the_sentence_alone() -> None:
+    """A placeholder as survivor is the most expensive, least visible failure here.
+
+    The live queue produced one: accepting would have made a malformed
+    placeholder canonical and absorbed the real ledger into it. The rendered
+    string has to make that readable without consulting anything else.
+    """
+    _, survivor = _colliding_pair()
+    reversed_merge = AccountMergeFacts(
+        absorbed=survivor,
+        survivor=_facts("pppppppppppp", source_types=("pdf",)),
+        overlap=LedgerOverlap(
+            comparable=0, matched=0, window_start=None, window_end=None
+        ),
+    )
+
+    message = identity_confirm_message(
+        {"accounts": 2, "transactions": 2342},
+        merges=[reversed_merge],
+        kinds=["account_link"],
+    )
+
+    assert "2,342 transactions" in message
+    assert "no transactions of its own" in message
+    absorbed_clause = next(
+        line for line in message.splitlines() if "is folded into" in line
+    )
+    assert absorbed_clause.index("ssssssssssss") < absorbed_clause.index(
+        "pppppppppppp"
+    ), absorbed_clause
+
+
+def test_the_sentence_carries_the_overlap_evidence() -> None:
+    """The decisive fact is how much of the ledger the survivor already holds."""
+    absorbed, survivor = _colliding_pair()
+
+    message = identity_confirm_message(
+        {"accounts": 2, "transactions": 346},
+        merges=[_merge(absorbed, survivor)],
+        kinds=["account_link"],
+    )
+
+    assert "345 of 346" in message
+
+
+def test_no_comparable_period_reads_as_absent_evidence_not_as_zero_overlap() -> None:
+    """Absence of evidence must not render as evidence of absence."""
+    absorbed, survivor = _colliding_pair()
+
+    message = identity_confirm_message(
+        {"accounts": 2, "transactions": 346},
+        merges=[
+            _merge(
+                absorbed,
+                survivor,
+                LedgerOverlap(
+                    comparable=0, matched=0, window_start=None, window_end=None
+                ),
+            )
+        ],
+        kinds=["account_link"],
+    )
+
+    assert "0 of 0" not in message
+    assert "no comparable period" in message.lower()
+
+
+def test_the_account_paragraph_names_the_undo_path() -> None:
+    """The undo already rides in the result envelope; the prompt never said so.
+
+    The prompt is the one place a human decides whether the risk is acceptable,
+    so the reversal belongs there rather than in the receipt afterwards.
+    """
+    absorbed, survivor = _colliding_pair()
+
+    message = identity_confirm_message(
+        {"accounts": 2, "transactions": 346},
+        merges=[_merge(absorbed, survivor)],
+        kinds=["account_link"],
+    )
+
+    assert "system_audit_undo" in message
+
+
+def test_the_paragraph_names_only_the_kinds_the_batch_contains() -> None:
+    """A card-to-card account link was told about security lots and price marks."""
+    absorbed, survivor = _colliding_pair()
+
+    message = identity_confirm_message(
+        {"accounts": 2, "transactions": 346},
+        merges=[_merge(absorbed, survivor)],
+        kinds=["account_link"],
+    )
+
+    assert "tax lot" not in message
+    assert "merchant" not in message
+
+
+def test_a_security_batch_still_names_what_a_security_link_moves() -> None:
+    """The other half of the kind-awareness boundary."""
+    message = identity_confirm_message(
+        {"securities": 2, "lots": 3, "price_marks": 4},
+        kinds=["security_link"],
+    )
+
+    assert "price marks you set by hand" in message
+    assert "merchant" not in message

--- a/tests/moneybin/test_services/test_ledger_overlap.py
+++ b/tests/moneybin/test_services/test_ledger_overlap.py
@@ -27,15 +27,18 @@ def _insert_txn(
     txn_date: date,
     amount: str,
     suffix: str = "",
+    currency: str | None = None,
 ) -> None:
     db.execute(
         "INSERT INTO core.fct_transactions "
-        "(transaction_id, account_id, transaction_date, amount) VALUES (?, ?, ?, ?)",
+        "(transaction_id, account_id, transaction_date, amount, currency_code) "
+        "VALUES (?, ?, ?, ?, ?)",
         [
             f"{account_id}-{txn_date.isoformat()}-{amount}{suffix}",
             account_id,
             txn_date,
             amount,
+            currency,
         ],
     )
 
@@ -86,6 +89,95 @@ def test_a_control_over_the_same_period_matches_nothing(core_db: Database) -> No
 
     assert overlap.comparable == 3
     assert overlap.matched == 0
+
+
+def test_equal_amounts_in_different_currencies_are_not_the_same_transaction(
+    core_db: Database,
+) -> None:
+    """A nominal amount is not a sum of money until a currency names it.
+
+    ``core.fct_transactions.currency_code`` is populated precisely because two
+    accounts can differ on it — the transaction's own captured currency, else
+    inherited from ``core.dim_accounts``. A multi-currency institution's USD
+    checking and EUR savings can be proposed together by the name signal, and
+    without this predicate their nominally equal rows would read as a full-
+    overlap twin: the strongest possible evidence for a merge of two accounts
+    that provably hold different money.
+    """
+    for day, amount in ((3, "-12.00"), (7, "-40.50"), (11, "-8.25")):
+        _insert_txn(
+            core_db,
+            account_id=_TWIN,
+            txn_date=date(2026, 5, day),
+            amount=amount,
+            currency="USD",
+        )
+        _insert_txn(
+            core_db,
+            account_id=_SURVIVOR,
+            txn_date=date(2026, 5, day),
+            amount=amount,
+            currency="EUR",
+        )
+
+    overlap = probe_ledger_overlap(
+        core_db, account_id=_TWIN, against_account_id=_SURVIVOR
+    )
+
+    assert overlap.comparable == 3
+    assert overlap.matched == 0
+
+
+def test_two_ledgers_of_unknown_currency_still_match(core_db: Database) -> None:
+    """Silence on both sides is not disagreement — the predicate is NULL-safe.
+
+    ``currency_code`` is nullable, and an account whose source never stated one
+    inherits nothing to inherit. A plain ``=`` would make every such pair read
+    as zero overlap, which is the louder failure: it turns a genuine twin's
+    evidence off silently, for every ledger that predates a currency being
+    known. Only a *stated* disagreement may veto a match.
+    """
+    for day, amount in ((3, "-12.00"), (7, "-40.50")):
+        _insert_txn(
+            core_db, account_id=_TWIN, txn_date=date(2026, 5, day), amount=amount
+        )
+        _insert_txn(
+            core_db, account_id=_SURVIVOR, txn_date=date(2026, 5, day), amount=amount
+        )
+
+    overlap = probe_ledger_overlap(
+        core_db, account_id=_TWIN, against_account_id=_SURVIVOR
+    )
+
+    assert (overlap.comparable, overlap.matched) == (2, 2)
+
+
+def test_a_stated_currency_does_not_match_an_unstated_one(core_db: Database) -> None:
+    """One side knowing its currency and the other not is still not a match.
+
+    The NULL-safe predicate treats ``NULL`` as a value rather than as a
+    wildcard, so an unknown currency matches only another unknown one. Erring
+    this way costs a true twin its evidence where one source states a currency
+    and the other does not; erring the other way would let a EUR ledger match a
+    ledger of unknown denomination, which is the failure this probe exists to
+    prevent.
+    """
+    _insert_txn(
+        core_db,
+        account_id=_TWIN,
+        txn_date=date(2026, 5, 3),
+        amount="-12.00",
+        currency="USD",
+    )
+    _insert_txn(
+        core_db, account_id=_SURVIVOR, txn_date=date(2026, 5, 3), amount="-12.00"
+    )
+
+    overlap = probe_ledger_overlap(
+        core_db, account_id=_TWIN, against_account_id=_SURVIVOR
+    )
+
+    assert (overlap.comparable, overlap.matched) == (1, 0)
 
 
 def test_posting_lag_inside_the_window_still_matches(core_db: Database) -> None:

--- a/tests/moneybin/test_services/test_ledger_overlap.py
+++ b/tests/moneybin/test_services/test_ledger_overlap.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from datetime import date
 
 import pytest
+from prometheus_client import REGISTRY
 
 from moneybin.database import Database
 from moneybin.services.ledger_overlap import LedgerOverlap, probe_ledger_overlap
@@ -18,6 +19,16 @@ from tests.moneybin.db_helpers import create_core_tables
 
 _TWIN = "twin_acct0001"
 _SURVIVOR = "surv_acct0001"
+
+
+def _probes(result: str) -> float:
+    """Public read of the probe counter — no private attribute access."""
+    return (
+        REGISTRY.get_sample_value(
+            "moneybin_account_link_overlap_probes_total", {"result": result}
+        )
+        or 0.0
+    )
 
 
 def _insert_txn(
@@ -268,6 +279,83 @@ def test_ledgers_that_never_overlap_report_no_comparable_period(
         comparable=0, matched=0, window_start=None, window_end=None
     )
     assert not overlap.measurable
+
+
+def test_a_wider_survivor_span_pulls_more_rows_into_comparable(
+    core_db: Database,
+) -> None:
+    """The displayed ratio can worsen after the prompt, and nothing re-checks it.
+
+    ``span`` is ``MIN``/``MAX`` over the *survivor's* dates, so one survivor-side
+    row arriving outside the current span widens the comparison window and admits
+    absorbed rows that match nothing. The evidence a human ratified as "1 of 1"
+    is "1 of 4" by the time the merge commits, while ``_drift_check`` still
+    verifies — it holds the absorbed account's blast radius, not this window.
+
+    This pins the behavior rather than the fix: closing it needs an asymmetric
+    re-verification on both surfaces, tracked with the empty-survivor gap in
+    ``account-identity-resolution.md``. Until then this test is what keeps the
+    mechanism legible in code instead of only in prose.
+    """
+    for year in (2019, 2020, 2021):
+        _insert_txn(
+            core_db, account_id=_TWIN, txn_date=date(year, 5, 3), amount="-12.00"
+        )
+    _insert_txn(core_db, account_id=_TWIN, txn_date=date(2026, 5, 3), amount="-12.00")
+    _insert_txn(
+        core_db, account_id=_SURVIVOR, txn_date=date(2026, 5, 3), amount="-12.00"
+    )
+
+    displayed = probe_ledger_overlap(
+        core_db, account_id=_TWIN, against_account_id=_SURVIVOR
+    )
+
+    # A concurrent sync lands one older row on the survivor. It matches nothing
+    # in the absorbed ledger, so only the denominator can move.
+    _insert_txn(
+        core_db, account_id=_SURVIVOR, txn_date=date(2018, 1, 1), amount="-999.99"
+    )
+
+    at_commit = probe_ledger_overlap(
+        core_db, account_id=_TWIN, against_account_id=_SURVIVOR
+    )
+
+    assert (displayed.matched, displayed.comparable) == (1, 1)
+    assert (at_commit.matched, at_commit.comparable) == (1, 4)
+
+
+def test_a_measurable_probe_is_counted_as_measurable(core_db: Database) -> None:
+    """Without this counter, evidence that died in a deployment looks like silence.
+
+    A schema or source drift that makes every probe return "no comparable period"
+    degrades the merge prompt to prose with no number in it, and every surface
+    keeps rendering normally. The two label values are what tell a dead probe
+    from a quiet one.
+    """
+    before = _probes("measurable")
+    _insert_txn(core_db, account_id=_TWIN, txn_date=date(2026, 5, 3), amount="-12.00")
+    _insert_txn(
+        core_db, account_id=_SURVIVOR, txn_date=date(2026, 5, 3), amount="-12.00"
+    )
+
+    probe_ledger_overlap(core_db, account_id=_TWIN, against_account_id=_SURVIVOR)
+
+    assert _probes("measurable") == before + 1
+
+
+def test_a_probe_with_no_comparable_period_is_counted_as_unmeasurable(
+    core_db: Database,
+) -> None:
+    """The failure mode worth alarming on is this label climbing alone."""
+    before = _probes("unmeasurable")
+    _insert_txn(core_db, account_id=_TWIN, txn_date=date(2019, 5, 3), amount="-12.00")
+    _insert_txn(
+        core_db, account_id=_SURVIVOR, txn_date=date(2026, 5, 3), amount="-12.00"
+    )
+
+    probe_ledger_overlap(core_db, account_id=_TWIN, against_account_id=_SURVIVOR)
+
+    assert _probes("unmeasurable") == before + 1
 
 
 def test_an_empty_other_ledger_reports_no_comparable_period(core_db: Database) -> None:

--- a/tests/moneybin/test_services/test_ledger_overlap.py
+++ b/tests/moneybin/test_services/test_ledger_overlap.py
@@ -163,6 +163,102 @@ def test_two_ledgers_of_unknown_currency_still_match(core_db: Database) -> None:
     assert (overlap.comparable, overlap.matched) == (2, 2)
 
 
+def test_the_same_currency_spelled_in_two_cases_still_matches(
+    core_db: Database,
+) -> None:
+    """``usd`` and ``USD`` name one currency, so they may not veto each other.
+
+    Only the tabular path can produce the lowercase side: ``currency`` is one of
+    the extractor's pass-through string fields, copied out of the source cell
+    verbatim, while OFX and Plaid carry ISO codes. So the mixed-case pair is
+    exactly the cross-source shape this probe is asked about — and comparing the
+    raw strings would report ``0 of N`` for a genuine twin, which is the silent
+    evidence-loss the NULL-safe half of this predicate already refuses.
+    """
+    for day, amount in ((3, "-12.00"), (7, "-40.50")):
+        _insert_txn(
+            core_db,
+            account_id=_TWIN,
+            txn_date=date(2026, 5, day),
+            amount=amount,
+            currency="usd",
+        )
+        _insert_txn(
+            core_db,
+            account_id=_SURVIVOR,
+            txn_date=date(2026, 5, day),
+            amount=amount,
+            currency="USD",
+        )
+
+    overlap = probe_ledger_overlap(
+        core_db, account_id=_TWIN, against_account_id=_SURVIVOR
+    )
+
+    assert (overlap.comparable, overlap.matched) == (2, 2)
+
+
+def test_a_padded_currency_code_still_matches_its_unpadded_twin(
+    core_db: Database,
+) -> None:
+    """Surrounding whitespace is a spelling of the code, not a different currency.
+
+    A CSV reader hands the cell over as written; nothing between the source file
+    and ``core.fct_transactions`` strips it.
+    """
+    _insert_txn(
+        core_db,
+        account_id=_TWIN,
+        txn_date=date(2026, 5, 3),
+        amount="-12.00",
+        currency=" USD ",
+    )
+    _insert_txn(
+        core_db,
+        account_id=_SURVIVOR,
+        txn_date=date(2026, 5, 3),
+        amount="-12.00",
+        currency="USD",
+    )
+
+    overlap = probe_ledger_overlap(
+        core_db, account_id=_TWIN, against_account_id=_SURVIVOR
+    )
+
+    assert (overlap.comparable, overlap.matched) == (1, 1)
+
+
+def test_a_blank_currency_cell_reads_as_unstated_not_as_a_currency(
+    core_db: Database,
+) -> None:
+    """An empty cell is silence, and silence is not disagreement.
+
+    A statement that fills its currency column only on foreign transactions
+    leaves the domestic rows blank rather than NULL, because the tabular
+    extractor writes the cell through as-is. Reading ``''`` as a stated currency
+    would make those rows disagree with every counterpart — turning the evidence
+    off for precisely the ordinary domestic ledger the probe is usually asked
+    about. It matches an unstated counterpart and, per the test below, still
+    fails to match a stated one.
+    """
+    _insert_txn(
+        core_db,
+        account_id=_TWIN,
+        txn_date=date(2026, 5, 3),
+        amount="-12.00",
+        currency="   ",
+    )
+    _insert_txn(
+        core_db, account_id=_SURVIVOR, txn_date=date(2026, 5, 3), amount="-12.00"
+    )
+
+    overlap = probe_ledger_overlap(
+        core_db, account_id=_TWIN, against_account_id=_SURVIVOR
+    )
+
+    assert (overlap.comparable, overlap.matched) == (1, 1)
+
+
 def test_a_stated_currency_does_not_match_an_unstated_one(core_db: Database) -> None:
     """One side knowing its currency and the other not is still not a match.
 

--- a/tests/moneybin/test_services/test_ledger_overlap.py
+++ b/tests/moneybin/test_services/test_ledger_overlap.py
@@ -1,0 +1,196 @@
+"""Tests for the ledger-overlap probe.
+
+The probe answers one question a reviewer cannot answer from a signal label:
+do these two accounts hold the same transactions? Fixtures are built from the
+*shape* — two ledgers over a shared period, one carrying the same amounts and
+one carrying different ones — never from real institution or account data.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from moneybin.database import Database
+from moneybin.services.ledger_overlap import LedgerOverlap, probe_ledger_overlap
+from tests.moneybin.db_helpers import create_core_tables
+
+_TWIN = "twin_acct0001"
+_SURVIVOR = "surv_acct0001"
+
+
+def _insert_txn(
+    db: Database,
+    *,
+    account_id: str,
+    txn_date: date,
+    amount: str,
+    suffix: str = "",
+) -> None:
+    db.execute(
+        "INSERT INTO core.fct_transactions "
+        "(transaction_id, account_id, transaction_date, amount) VALUES (?, ?, ?, ?)",
+        [
+            f"{account_id}-{txn_date.isoformat()}-{amount}{suffix}",
+            account_id,
+            txn_date,
+            amount,
+        ],
+    )
+
+
+@pytest.fixture()
+def core_db(db: Database) -> Database:
+    """Database with the core tables the probe reads."""
+    create_core_tables(db)
+    return db
+
+
+def test_a_true_twin_matches_every_row(core_db: Database) -> None:
+    """Same amounts over the same period read as full overlap."""
+    for day, amount in ((3, "-12.00"), (7, "-40.50"), (11, "-8.25")):
+        _insert_txn(
+            core_db, account_id=_TWIN, txn_date=date(2026, 5, day), amount=amount
+        )
+        _insert_txn(
+            core_db, account_id=_SURVIVOR, txn_date=date(2026, 5, day), amount=amount
+        )
+
+    overlap = probe_ledger_overlap(
+        core_db, account_id=_TWIN, against_account_id=_SURVIVOR
+    )
+
+    assert overlap == LedgerOverlap(
+        comparable=3,
+        matched=3,
+        window_start=date(2026, 5, 3),
+        window_end=date(2026, 5, 11),
+    )
+
+
+def test_a_control_over_the_same_period_matches_nothing(core_db: Database) -> None:
+    """Different amounts over the same period read as no overlap, not as absent evidence."""
+    for day, amount in ((3, "-12.00"), (7, "-40.50"), (11, "-8.25")):
+        _insert_txn(
+            core_db, account_id=_TWIN, txn_date=date(2026, 5, day), amount=amount
+        )
+    for day, amount in ((3, "-99.00"), (7, "-1.05"), (11, "-77.25")):
+        _insert_txn(
+            core_db, account_id=_SURVIVOR, txn_date=date(2026, 5, day), amount=amount
+        )
+
+    overlap = probe_ledger_overlap(
+        core_db, account_id=_TWIN, against_account_id=_SURVIVOR
+    )
+
+    assert overlap.comparable == 3
+    assert overlap.matched == 0
+
+
+def test_posting_lag_inside_the_window_still_matches(core_db: Database) -> None:
+    """A statement's transaction date and a feed's posting date name one transaction.
+
+    This is the whole reason the probe carries a window: exact date + amount
+    scored 23% on the live pair because the two sources date the same row
+    differently.
+    """
+    _insert_txn(core_db, account_id=_TWIN, txn_date=date(2026, 5, 3), amount="-12.00")
+    _insert_txn(
+        core_db, account_id=_SURVIVOR, txn_date=date(2026, 5, 6), amount="-12.00"
+    )
+
+    overlap = probe_ledger_overlap(
+        core_db, account_id=_TWIN, against_account_id=_SURVIVOR
+    )
+
+    assert (overlap.comparable, overlap.matched) == (1, 1)
+
+
+def test_a_gap_wider_than_the_window_does_not_match(core_db: Database) -> None:
+    """One day past the window is a different transaction, not a lagged one.
+
+    The survivor's second row is what makes the probed row comparable at all —
+    without it the period is three days wide and the row falls outside, which is
+    a different verdict (no comparable period) reached for a different reason.
+    """
+    _insert_txn(core_db, account_id=_TWIN, txn_date=date(2026, 5, 11), amount="-12.00")
+    _insert_txn(
+        core_db, account_id=_SURVIVOR, txn_date=date(2026, 5, 7), amount="-12.00"
+    )
+    _insert_txn(
+        core_db, account_id=_SURVIVOR, txn_date=date(2026, 5, 30), amount="-99.00"
+    )
+
+    overlap = probe_ledger_overlap(
+        core_db, account_id=_TWIN, against_account_id=_SURVIVOR
+    )
+
+    assert (overlap.comparable, overlap.matched) == (1, 0)
+
+
+def test_rows_outside_the_other_ledgers_period_are_not_comparable(
+    core_db: Database,
+) -> None:
+    """History the survivor never covered cannot disconfirm the merge.
+
+    A statement archive that predates the feed's download window would otherwise
+    render as "0 of 400 match" — reading as evidence against a correct merge when
+    it is only evidence the survivor was not there yet.
+    """
+    for year in (2019, 2020):
+        _insert_txn(
+            core_db, account_id=_TWIN, txn_date=date(year, 5, 3), amount="-12.00"
+        )
+    _insert_txn(core_db, account_id=_TWIN, txn_date=date(2026, 5, 3), amount="-12.00")
+    _insert_txn(
+        core_db, account_id=_SURVIVOR, txn_date=date(2026, 5, 3), amount="-12.00"
+    )
+
+    overlap = probe_ledger_overlap(
+        core_db, account_id=_TWIN, against_account_id=_SURVIVOR
+    )
+
+    assert overlap == LedgerOverlap(
+        comparable=1,
+        matched=1,
+        window_start=date(2026, 5, 3),
+        window_end=date(2026, 5, 3),
+    )
+
+
+def test_ledgers_that_never_overlap_report_no_comparable_period(
+    core_db: Database,
+) -> None:
+    """No shared period is absence of evidence, and must not read as 0 of N."""
+    _insert_txn(core_db, account_id=_TWIN, txn_date=date(2019, 5, 3), amount="-12.00")
+    _insert_txn(
+        core_db, account_id=_SURVIVOR, txn_date=date(2026, 5, 3), amount="-12.00"
+    )
+
+    overlap = probe_ledger_overlap(
+        core_db, account_id=_TWIN, against_account_id=_SURVIVOR
+    )
+
+    assert overlap == LedgerOverlap(
+        comparable=0, matched=0, window_start=None, window_end=None
+    )
+    assert not overlap.measurable
+
+
+def test_an_empty_other_ledger_reports_no_comparable_period(core_db: Database) -> None:
+    """A survivor with no transactions yet bounds no window to compare against."""
+    _insert_txn(core_db, account_id=_TWIN, txn_date=date(2026, 5, 3), amount="-12.00")
+
+    overlap = probe_ledger_overlap(
+        core_db, account_id=_TWIN, against_account_id=_SURVIVOR
+    )
+
+    assert not overlap.measurable
+
+
+def test_an_unmaterialized_core_reports_no_comparable_period(db: Database) -> None:
+    """A first import before any transform has no ledger to probe, and must not raise."""
+    overlap = probe_ledger_overlap(db, account_id=_TWIN, against_account_id=_SURVIVOR)
+
+    assert not overlap.measurable


### PR DESCRIPTION
Accepting an account link folds one account's whole history into another. The queue offered exactly one number to decide on — a `confidence` score that was `0.5` when the institution+last-four signal fired and `0.4` when the name signal did. No input moved either. The number was the signal name in a less legible form, and the decision it was supposed to support had no evidence behind it at all.

This measures the thing that actually discriminates, fixes a rung that proposed merges across contradicting evidence, and collapses three descriptions of one merge into one.

## The ledger-overlap probe

`services/ledger_overlap.py` counts how many of one account's transactions already appear in the other's, matched on equal amount within a ±3-day posting-lag window.

The window is not decoration. A statement carries the transaction date and an OFX feed the posting date, so exact date+amount scores a true twin at roughly a quarter of its rows. Measured against a real duplicated card: 345 of 346 with the lag window, 0 of 346 against each of two unrelated accounts at the same institution.

Three properties are load-bearing:

- **Keyed on two account ids, not a decision id.** The matcher excludes same-`account_id` pairs, so the overlap cannot be computed after the merge it justifies. The two-id shape also leaves the probe reachable for `system doctor`'s `duplicate_account_overlap` pairs, which carry no proposal at all.
- **Scoped to the comparable period.** The denominator counts only the absorbed account's transactions falling inside the survivor's own span, widened by the lag. Without that, a statement archive predating a feed's download window renders as "0 of 400" — which reads as evidence *against* a correct merge.
- **Absence of evidence is not evidence of absence.** A probe with no comparable period says so in words. It never renders as `0 of 0`.

## The name rung defers to a stated contradiction

A fuzzy name match between two accounts that both state a last four and disagree is evidence of two *different* accounts. The rung proposed them anyway. It now skips that pair.

Silence is not disagreement: an account with no known last four still reaches the name rung, because vetoing there would drop a proposal nothing else surfaces. Where the pair also shares an institution, the reissue rung re-surfaces it under `institution_reissue` — the signal a replacement card actually carries — so the veto retypes the proposal rather than discarding it.

## One merge, one sentence

The CLI prompt, `accounts_links_set`, and `identity_links_decide` each described the same decision differently. The worst named both accounts by display label — identical text on both sides in exactly the split-account case this feature exists to fix.

All three now render through one builder that names each side by what *differs* (which source reported it, how much history it holds, the period it covers, subtype, currency), states direction, carries the overlap evidence, names the undo, and describes only the link kinds the batch contains. When the surviving account holds no transactions of its own — a malformed placeholder offered as survivor, which the live queue produced — the prompt says so and tells you to check the direction.

## Deliberately not bound

The approval still binds only what the write touches: the absorbed account's rows, plus the exact link and decision ids. The survivor's ledger size and the overlap ratio are rendered but unbound, because binding them would refuse a correct merge when a concurrent import made the evidence for it *stronger*. The reasoning is in `_ApprovedMerge`'s docstring.

## Removed

`confidence` is gone from `accounts links pending` / `history` on both surfaces and from their JSON envelopes. `app.account_link_decisions.confidence_score` is unchanged — it is the audit record of what was written.

## Verification

- `make check test` — 8,833 passed, 4 skipped
- `make test-scenarios` — 89 passed, including the three cross-source account-identity scenarios
- 32 test functions added, none removed. Both cases from the acceptance bar are covered: two accounts whose masked labels collide still produce distinguishable descriptions, and a reversed proposal is legible as reversed from the rendered string alone.
- Mutation-probed: reversing the probe's arguments, swapping the ledger size for the comparable count, and removing the catalog guard each fail exactly one test.
