### PR TITLE
Refuse an unanswered confirmation instead of minting a token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1235,7 +1235,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   update.
 
 ### Security
-- **An unanswered confirmation prompt no longer mints a redeemable token.**
+- **An unanswered confirmation prompt no longer mints a redeemable token
+  (#389).**
   `grant_confirmation_or_raise` waited `elicitation_wait_seconds` (120 by
   default) for a human and then issued an opaque confirmation token, which is
   returned to the caller — so ignoring a destructive prompt for two minutes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1235,6 +1235,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   update.
 
 ### Security
+- **An unanswered confirmation prompt no longer mints a redeemable token.**
+  `grant_confirmation_or_raise` waited `elicitation_wait_seconds` (120 by
+  default) for a human and then issued an opaque confirmation token, which is
+  returned to the caller — so ignoring a destructive prompt for two minutes
+  handed the calling agent a key to its own unconfirmed operation. The timeout
+  now refuses with `MUTATION_CONFIRMATION_DECLINED` and `reason: "timeout"`,
+  minting nothing. Clients that never declared elicitation support keep the
+  token path, the only case with no prompt to retry. All 13 confirm-gated tool
+  modules share the helper, so this covers every destructive confirm.
 - **A `UserError` hint shown on the CLI no longer reaches the durable log file
   (#382).** `handle_cli_errors` logged every hint via `logger.info` and the CLI
   file handler has no level filter, which became a disclosure once `sql_query`'s

--- a/docs/specs/mcp-tool-timeouts.md
+++ b/docs/specs/mcp-tool-timeouts.md
@@ -40,8 +40,13 @@ Related code: `src/moneybin/mcp/` (tool registration and dispatch), `src/moneybi
    the operation. The exclusion is safe because no confirm-gated tool holds a
    DuckDB connection across its prompt; verify that still holds before adding a
    confirm to a tool that opens one first. The human wait has its own separate
-   bound (below), after which the call degrades to the opaque-token path rather
-   than failing. Every bounded wait increments
+   bound (below), after which the call refuses with
+   `MUTATION_CONFIRMATION_DECLINED` and `reason: "timeout"`, minting no token.
+   The token travels to the caller, so degrading an unanswered prompt into one
+   hands the calling agent a key to its own unconfirmed operation — a client
+   that rendered the prompt can render it again. The opaque-token path stays
+   for clients that never declared elicitation support, which is the only case
+   with no prompt to retry. Every bounded wait increments
    `moneybin_mcp_elicitations_total{site,outcome}` — both `answered` and
    `timeout`, because a miss count without the answers it is a fraction of
    cannot say whether the configured window is long enough.

--- a/src/moneybin/mcp/confirmation.py
+++ b/src/moneybin/mcp/confirmation.py
@@ -99,6 +99,15 @@ def _confirmation_declined() -> UserError:
     )
 
 
+def _confirmation_timed_out() -> UserError:
+    return UserError(
+        "Nobody answered the confirmation prompt in time. Nothing was written.",
+        code=error_codes.MUTATION_CONFIRMATION_DECLINED,
+        hint="Ask the user to answer the prompt, then request this operation again.",
+        details={"reason": "timeout"},
+    )
+
+
 def _require_digest(expected: bytes, binding: ConfirmationBinding) -> None:
     actual = _binding_digest(binding)
     if not secrets.compare_digest(expected, actual):
@@ -241,12 +250,16 @@ async def grant_confirmation_or_raise(
             ),
             site="confirmation_grant",
         )
-        # result is None only when nobody answered in time; fall through to the
-        # opaque-token path so the caller keeps a way to finish, not a dead end.
-        if result is not None:
-            if isinstance(result, AcceptedElicitation) and result.data is True:
-                return ConfirmationGrant(expected_digest)
-            raise _confirmation_declined()
+        # result is None only when nobody answered in time. Refuse rather than
+        # minting a token: the token is returned to the *caller*, so degrading
+        # an unanswered prompt into one hands the calling agent a key to its
+        # own unconfirmed operation. A client that rendered the prompt can
+        # render it again; only a client that never offered one needs a token.
+        if result is None:
+            raise _confirmation_timed_out()
+        if isinstance(result, AcceptedElicitation) and result.data is True:
+            return ConfirmationGrant(expected_digest)
+        raise _confirmation_declined()
 
     token = broker.issue(binding, now=_utcnow())
     raise _confirmation_required(

--- a/src/moneybin/mcp/confirmation.py
+++ b/src/moneybin/mcp/confirmation.py
@@ -103,7 +103,10 @@ def _confirmation_timed_out() -> UserError:
     return UserError(
         "Nobody answered the confirmation prompt in time. Nothing was written.",
         code=error_codes.MUTATION_CONFIRMATION_DECLINED,
-        hint="Ask the user to answer the prompt, then request this operation again.",
+        hint=(
+            "Request this operation again to raise a fresh prompt, then have "
+            "the user answer it."
+        ),
         details={"reason": "timeout"},
     )
 

--- a/tests/moneybin/test_mcp/test_confirmation.py
+++ b/tests/moneybin/test_mcp/test_confirmation.py
@@ -449,6 +449,12 @@ async def test_unanswered_elicitation_refuses_without_issuing_a_token(
     assert raised.value.code == error_codes.MUTATION_CONFIRMATION_DECLINED
     assert raised.value.details == {"reason": "timeout"}
     assert broker.issued == []
+    # `wait_for` already cancelled the elicitation, so no dialog is live to
+    # answer. The hint has to order the retry first or it sends the user to a
+    # dead prompt and burns a second wait window before the retry that would
+    # have rendered a fresh one.
+    hint = raised.value.hint or ""
+    assert hint.index("again") < hint.index("answer")
 
 
 @pytest.mark.asyncio

--- a/tests/moneybin/test_mcp/test_confirmation.py
+++ b/tests/moneybin/test_mcp/test_confirmation.py
@@ -37,6 +37,25 @@ def _does_not_support_elicitation(_context: object) -> bool:
     return False
 
 
+class _RecordingBroker(ConfirmationBroker):
+    """Real broker that also records every token it mints.
+
+    Asserting only on the raised error would still pass if a token were minted
+    and merely withheld from the response — the entry would sit live for the
+    next call to redeem. This records the mint itself.
+    """
+
+    def __init__(self, *, ttl_seconds: int | None = None) -> None:
+        super().__init__(ttl_seconds=ttl_seconds)
+        self.issued: list[str] = []
+
+    def issue(self, binding: ConfirmationBinding, *, now: datetime) -> str:
+        """Issue through the real broker, recording the token."""
+        token = super().issue(binding, now=now)
+        self.issued.append(token)
+        return token
+
+
 def _make_binding(**updates: object) -> ConfirmationBinding:
     values: dict[str, object] = {
         "arguments": {
@@ -391,10 +410,16 @@ async def test_declined_or_cancelled_elicitation_refuses_confirmation(
 
 
 @pytest.mark.asyncio
-async def test_unanswered_elicitation_degrades_to_a_usable_token(
+async def test_unanswered_elicitation_refuses_without_issuing_a_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A prompt nobody answers must leave a working token, not a dead end."""
+    """A dialog nobody answered must not degrade into a token.
+
+    The token travels to the *caller*, so minting one after an unanswered
+    prompt hands the calling agent a key to its own unanswered confirmation.
+    A client that showed the dialog has a working way to ask again; only a
+    client that never offered one needs the token path.
+    """
 
     async def answers_too_late(
         *_args: object, **_kwargs: object
@@ -411,7 +436,7 @@ async def test_unanswered_elicitation_degrades_to_a_usable_token(
     monkeypatch.setattr(
         "moneybin.mcp.elicitation.elicitation_wait_seconds", lambda: 0.05
     )
-    broker = ConfirmationBroker(ttl_seconds=300)
+    broker = _RecordingBroker(ttl_seconds=300)
 
     with pytest.raises(UserError) as raised:
         await grant_confirmation_or_raise(
@@ -421,11 +446,9 @@ async def test_unanswered_elicitation_degrades_to_a_usable_token(
             broker=broker,
         )
 
-    assert raised.value.code == error_codes.MUTATION_CONFIRMATION_REQUIRED
-    details = raised.value.details or {}
-    # A token that cannot be redeemed is still a dead end — redeem it.
-    grant = broker.consume(details["confirmation_token"], now=datetime.now(UTC))
-    grant.verify(BINDING)
+    assert raised.value.code == error_codes.MUTATION_CONFIRMATION_DECLINED
+    assert raised.value.details == {"reason": "timeout"}
+    assert broker.issued == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`grant_confirmation_or_raise` showed a confirmation prompt, waited `elicitation_wait_seconds` (120 by default), and on timeout fell through to issue an opaque confirmation token. That token is returned to the caller in `error.details`, so an unanswered prompt handed the calling agent a redeemable key to its own unconfirmed operation: ignore a destructive dialog for two minutes, call again with the token, and the operation applies with no human having answered.

The timeout now refuses with `MUTATION_CONFIRMATION_DECLINED` and `reason: "timeout"`, minting nothing. A client that rendered the prompt can render it again, so it needs no token. Clients that never declared elicitation support keep the token path — the only case with no prompt to retry — and that carve-out's existing coverage is unchanged and still asserts the token is issued and redeemable.

All 13 confirm-gated tool modules share this helper, so every destructive confirm now refuses on an unanswered prompt rather than only account merges.

## Background

This is not the defect that was originally reported. The reported finding was that `identity_links_decide` applied an account merge with no confirmation gate at all. That finding was false and has been retracted: the gate has existed since #344, `reviews.py` gates on `plan.destructive`, which is true for any changed accept, and `test_review.py` already asserts that a null-token `account_link` accept returns `MUTATION_CONFIRMATION_REQUIRED`. The merge that prompted the report was gated and was approved by a human; the MCP server process was running a stale checkout whose dialog predated #387's ledger-evidence sentence, which made it look ungated from the caller's side.

Investigating that report surfaced the real hole, which is narrower and more serious: the gate fails open to the caller on timeout.

The old behaviour was deliberate and pinned by a passing test named `test_unanswered_elicitation_degrades_to_a_usable_token`, which explicitly redeemed the token to prove it stayed usable, under the comment "A token that cannot be redeemed is still a dead end — redeem it." Its own prompt string was "Merge the PDF-derived account into the OFX account?", so the destructive account merge was the case it was written around. Inverting that test is the load-bearing half of this diff and is an approved intentional change, not a test fixup — the old assertion is precisely what permitted the hole. `docs/specs/mcp-tool-timeouts.md` stated the same behaviour as intended contract ("the call degrades to the opaque-token path rather than failing") and is corrected here.

The replacement test asserts against broker state rather than the error code alone. Raising the correct refusal while still minting the token would leave a live entry in the broker for the next call to redeem, and a code-only assertion would pass. `_RecordingBroker` delegates to the real `super().issue()` and records what it mints, so the assertion covers the production path without touching private attributes.

This has never fired in the wild. A search of every session transcript on the development machine covering 2026-07-31 through 2026-08-14 found zero confirmation tokens ever issued to a caller. The fallthrough only became reachable when #385 stopped the tool deadline from cancelling the call first, so the exposure is recent and nothing depends on the removed behaviour.

## Test plan

- [x] `make check test` — exit 0: ruff format and lint clean across 1389 files, pyright 0 errors, pytest 8962 passed / 4 skipped / 0 failed. The total is unchanged from the base because this inverts a test in place rather than adding one.
- [x] Mutation probe confirms the new guard can fail: temporarily minting a token *and* raising the correct refusal makes the test fail on the recorded token (`assert ['DryNT7xo...'] == []`). Reverted before commit.
- [x] The degraded-client carve-out is unchanged and green — `test_degraded_client_gets_structured_opaque_token`, parametrized over both no-context and no-elicitation-support, still asserts the token is issued and redeemable.
- [ ] Reviewer: confirm the inverted test is intended and not a fixup. The behaviour it previously pinned is the vulnerability.
- [ ] Reviewer: confirm the uniform blast radius is wanted. This changes every destructive confirm across `import_tools`, `sync`, `exports`, `reviews`, `accounts`, `transactions`, `investments`, `gsheet`, `taxonomy`, `privacy`, `merchants`, and `transactions_categorize`, not only identity merges.
