### PR TITLE
Name the build system_status is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   new commit while the process still ran the old code — corroborating precisely
   the wrong conclusion. Reported on the degraded database-locked path too,
   since it needs no database connection and that is when a caller most needs it.
+
+  The registered `system_status` description tells the agent to cite
+  `overview.build` before concluding that live behavior contradicts the code.
+  A docstring cannot: the agent never reads one, and the field is only as
+  useful as the instruction to look at it. `revision` is read from the
+  repository top level only, so a wheel installed beneath an unrelated checkout
+  reports `null` rather than that project's commit.
 - **Read the ingestion pipeline through `sql_query` (M2O.2).** `sql_query` and
   `moneybin sql query` reach `raw` and `prep` alongside `core`, `app`, and
   `reports` — five schemas, up from three. The seed sheets the gsheet and PDF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   confirmation prompt without the ledger-evidence sentence added in #387, which
   was written up as the confirmation gate being absent. The gate was present.
 
-  `revision` is resolved once at import rather than per call. A checkout can
-  move underneath a running server, and a per-call read would then report the
-  new commit while the process still ran the old code — corroborating precisely
-  the wrong conclusion. Reported on the degraded database-locked path too,
-  since it needs no database connection and that is when a caller most needs it.
+  Both fields are resolved once at import rather than per call. A checkout can
+  move underneath a running server and an environment can be upgraded beneath
+  one; a per-call read would then report the new commit or the new version while
+  the process still ran the old code — corroborating precisely the wrong
+  conclusion. `version` is the more dangerous of the two to read late, because
+  a wheel install reports no revision and leaves the version as the only signal.
+  Reported on the degraded database-locked path too, since it needs no database
+  connection and that is when a caller most needs it.
 
   The registered `system_status` description tells the agent to cite
   `overview.build` before concluding that live behavior contradicts the code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **`system_status` names the build it is running.** The envelope carries a
+  `build` block with the package `version` and the `revision` the source
+  checkout was on when the process started (`null` for an installed wheel).
+  A stdio MCP server is a long-lived process pinned to whatever the checkout
+  held at boot, and until now nothing in the surface said which. A caller
+  comparing live behaviour against `main` could not separate a stale process
+  from a real defect — and did not: a three-day-old server rendered a
+  confirmation prompt without the ledger-evidence sentence added in #387, which
+  was written up as the confirmation gate being absent. The gate was present.
+
+  `revision` is resolved once at import rather than per call. A checkout can
+  move underneath a running server, and a per-call read would then report the
+  new commit while the process still ran the old code — corroborating precisely
+  the wrong conclusion. Reported on the degraded database-locked path too,
+  since it needs no database connection and that is when a caller most needs it.
 - **Read the ingestion pipeline through `sql_query` (M2O.2).** `sql_query` and
   `moneybin sql query` reach `raw` and `prep` alongside `core`, `app`, and
   `reports` — five schemas, up from three. The seed sheets the gsheet and PDF

--- a/docs/specs/mcp-tool-surface-scaling.md
+++ b/docs/specs/mcp-tool-surface-scaling.md
@@ -421,12 +421,12 @@ If either gate fails, MoneyBin spends the additional tool slot deliberately.
 
 The deterministic current
 [`standard.json`](../../tests/fixtures/mcp_surface/standard.json) snapshot
-contains 49 tools, 55,151 bytes of serialized metadata, zero advertised output schemas,
+contains 49 tools, 55,341 bytes of serialized metadata, zero advertised output schemas,
 and registry SHA-256
-`a0bb19b0226cad556677cc14e10e6f741a72206e514fbdc34504c8ccc4898937`.
+`d4cc3967a261055db1ab5b830e733dc852751ec11f056fe77c6c4ca64f8fa773`.
 The frozen baseline is 90,734 bytes with SHA-256
 `ea87a21b01e0f5181b80cef120beef2e9f46b31df121c7941329d9c493b48f79`.
-The delta is -35,583 bytes (-39.2%). The deterministic estimate is 13,788
+The delta is -35,393 bytes (-39.0%). The deterministic estimate is 13,836
 metadata tokens; a percentage of context is
 recorded only with observed host/model evidence because this contract does not
 invent a context-window size.

--- a/src/moneybin/mcp/server.py
+++ b/src/moneybin/mcp/server.py
@@ -30,7 +30,7 @@ mcp = FastMCP(
 
         Standard tools cover system, profile, reports, accounts, investments, transactions, reviews, taxonomy, import, sync, gsheet, exports, privacy, refresh, and sql. Names use domain_<sub>_verb with the verb last.
 
-        Call system_status first to inspect available data, freshness, review queues, and whether derived core.* tables need refresh_run. Call reports() without a report_id to discover registered analytics, then pass a stable report_id and parameters to run one. sql_query is the privacy-safe read-only SQL escape hatch; use sql_schema for its curated schema.
+        Call system_status first to inspect available data, freshness, review queues, and whether derived core.* tables need refresh_run; its overview.build names the version and commit this server is running, so cite it before concluding that live behavior contradicts the code, because a long-lived process can predate the checkout. Call reports() without a report_id to discover registered analytics, then pass a stable report_id and parameters to run one. sql_query is the privacy-safe read-only SQL escape hatch; use sql_schema for its curated schema.
 
         Every tool returns {summary, data, actions}. Prefer batch tools; list parameters are capped per call, and summary.has_more plus actions explain continuation.
 

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -11,7 +11,7 @@ import os
 import subprocess  # noqa: S404 — subprocess used for git rev-parse; static args only
 from collections.abc import Callable
 from datetime import datetime
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Annotated, Any, Literal, cast
 
@@ -289,7 +289,11 @@ _GIT_REVISION_TIMEOUT_SECONDS = 5.0
 
 
 def _read_git_revision(root: Path) -> str | None:
-    """Return the commit ``root`` is checked out at, or None if it is not a repo root.
+    """Return the commit ``root`` is checked out at, or None when it can't be read.
+
+    None covers every unreadable case, not just a non-repository: no ``git`` on
+    PATH, a launch failure, a timeout, an unparseable answer, or a ``root`` that
+    is inside a checkout rather than its top level.
 
     Delegates to ``git`` rather than parsing ``.git`` by hand: a linked worktree
     stores a *file* there pointing elsewhere, and a branch tip may live in
@@ -351,9 +355,34 @@ def _read_git_revision(root: Path) -> str | None:
 _REVISION: str | None = _read_git_revision(Path(__file__).resolve().parents[4])
 
 
+def _read_package_version() -> str | None:
+    """Return the installed distribution version, or None when it has none.
+
+    Guarded rather than allowed to propagate: this value is resolved at import,
+    so an unreadable distribution would otherwise take the whole server down at
+    boot. A missing version is a fine answer from a status tool; a server that
+    will not start is not.
+    """
+    try:
+        return version("moneybin")
+    except PackageNotFoundError:
+        return None
+
+
+#: Captured at import for the same reason as ``_REVISION``, and it is the more
+#: dangerous of the two to read late. ``version()`` re-reads the installed
+#: distribution's metadata on every call, so upgrading the environment beneath a
+#: live server reports the *new* version while the process still holds the old
+#: modules — and a wheel install answers ``revision: None``, leaving this field
+#: as the only signal a caller has. Reading it per call therefore produces a
+#: confident wrong answer in precisely the stale-server case the block exists to
+#: diagnose.
+_VERSION: str | None = _read_package_version()
+
+
 def _build_info() -> SystemStatusBuildInfo:
     """Name the build this process is running."""
-    return SystemStatusBuildInfo(version=version("moneybin"), revision=_REVISION)
+    return SystemStatusBuildInfo(version=_VERSION, revision=_REVISION)
 
 
 def _locked_status_envelope(

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -8,8 +8,10 @@ import inspect
 import json
 import logging
 import os
+import subprocess  # noqa: S404 — subprocess used for git rev-parse; static args only
 from collections.abc import Callable
 from datetime import datetime
+from importlib.metadata import version
 from pathlib import Path
 from typing import Annotated, Any, Literal, cast
 
@@ -49,6 +51,7 @@ from moneybin.privacy.payloads.system import (
     SystemDoctorPayload,
     SystemStatusAccountLinksInfo,
     SystemStatusAccountsInfo,
+    SystemStatusBuildInfo,
     SystemStatusCategorizationInfo,
     SystemStatusCoarsePayload,
     SystemStatusDatabaseConnectionsInfo,
@@ -280,6 +283,50 @@ def _database_connections_block(db_path: Path) -> dict[str, Any]:
     return {"writers": writers, "readers": readers}
 
 
+#: Bound on the `git rev-parse` probe. Generous for a local repository read;
+#: it exists so a wedged git can never delay server import indefinitely.
+_GIT_REVISION_TIMEOUT_SECONDS = 5.0
+
+
+def _read_git_revision(root: Path) -> str | None:
+    """Return the commit ``root`` is checked out at, or None if it is not a repo.
+
+    Delegates to ``git`` rather than parsing ``.git`` by hand: a linked worktree
+    stores a *file* there pointing elsewhere, and a branch tip may live in
+    ``packed-refs`` rather than as a loose ref. Both are cases this project
+    actually runs in, and both are ones a hand-rolled reader gets wrong.
+    """
+    try:
+        completed = subprocess.run(  # noqa: S603 — git with static args
+            ["git", "-C", str(root), "rev-parse", "HEAD"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=_GIT_REVISION_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        # No git on PATH, or it failed to launch. An unknown revision is a
+        # perfectly good answer here; a broken system_status is not.
+        return None
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip() or None
+
+
+#: Resolved once at import — that is, at server boot — rather than per call.
+#: The whole point of reporting a revision is to name the code this process
+#: actually loaded, and a checkout can move underneath a long-lived server. A
+#: per-call read would then report the *new* commit while still running the old
+#: code, which is worse than reporting nothing: it would corroborate exactly the
+#: wrong conclusion.
+_REVISION: str | None = _read_git_revision(Path(__file__).resolve().parent)
+
+
+def _build_info() -> SystemStatusBuildInfo:
+    """Name the build this process is running."""
+    return SystemStatusBuildInfo(version=version("moneybin"), revision=_REVISION)
+
+
 def _locked_status_envelope(
     db_connections: SystemStatusDatabaseConnectionsInfo,
 ) -> ResponseEnvelope[SystemStatusPayload]:
@@ -311,6 +358,7 @@ def _locked_status_envelope(
                 total_connections=0, by_status={}, needs_attention=[]
             ),
             database_connections=db_connections,
+            build=_build_info(),
         ),
         degraded=True,
         degraded_reason=(
@@ -331,6 +379,9 @@ def system_status() -> ResponseEnvelope[SystemStatusPayload]:
     needs user attention before suggesting any analytical query. The
     ``gsheet`` block summarizes Google Sheets connection health: drift-detected
     connections surface a paired ``gsheet_reconnect`` hint in ``actions[]``.
+    The ``build`` block names the package version and source revision this
+    server is running: cite it before concluding that any MCP behaviour
+    contradicts the code, because a long-running server can predate it.
     """
     from moneybin.config import get_settings
     from moneybin.database import DatabaseLockError, get_database
@@ -445,6 +496,7 @@ def system_status() -> ResponseEnvelope[SystemStatusPayload]:
                 ],
             ),
             database_connections=db_connections,
+            build=_build_info(),
         ),
         actions=actions,
     )

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -289,16 +289,30 @@ _GIT_REVISION_TIMEOUT_SECONDS = 5.0
 
 
 def _read_git_revision(root: Path) -> str | None:
-    """Return the commit ``root`` is checked out at, or None if it is not a repo.
+    """Return the commit ``root`` is checked out at, or None if it is not a repo root.
 
     Delegates to ``git`` rather than parsing ``.git`` by hand: a linked worktree
     stores a *file* there pointing elsewhere, and a branch tip may live in
     ``packed-refs`` rather than as a loose ref. Both are cases this project
     actually runs in, and both are ones a hand-rolled reader gets wrong.
+
+    ``root`` must be the repository's own top level, and that is checked rather
+    than assumed. ``git`` answers about the nearest enclosing checkout, so an
+    installed wheel sitting under someone else's repository — a virtualenv
+    inside the user's own project, which is where ``uv`` puts one by default —
+    would otherwise report *that* project's HEAD as MoneyBin's build: a
+    confidently wrong stamp, worse than the documented ``null``.
     """
     try:
         completed = subprocess.run(  # noqa: S603 — git with static args
-            ["git", "-C", str(root), "rev-parse", "HEAD"],  # noqa: S607
+            [  # noqa: S607
+                "git",
+                "-C",
+                str(root),
+                "rev-parse",
+                "--show-toplevel",
+                "HEAD",
+            ],
             capture_output=True,
             text=True,
             timeout=_GIT_REVISION_TIMEOUT_SECONDS,
@@ -310,7 +324,17 @@ def _read_git_revision(root: Path) -> str | None:
         return None
     if completed.returncode != 0:
         return None
-    return completed.stdout.strip() or None
+    # Split on line terminators, never on arbitrary whitespace: git prints the
+    # top level unquoted, so a checkout path containing a space would otherwise
+    # parse as three tokens and silently blank the stamp — and a blank reads as
+    # a legitimate wheel install, hiding the failure.
+    lines = completed.stdout.splitlines()
+    if len(lines) != 2:
+        return None
+    toplevel, revision = lines
+    if Path(toplevel).resolve() != root.resolve():
+        return None
+    return revision or None
 
 
 #: Resolved once at import — that is, at server boot — rather than per call.
@@ -319,7 +343,12 @@ def _read_git_revision(root: Path) -> str | None:
 #: per-call read would then report the *new* commit while still running the old
 #: code, which is worse than reporting nothing: it would corroborate exactly the
 #: wrong conclusion.
-_REVISION: str | None = _read_git_revision(Path(__file__).resolve().parent)
+#:
+#: ``parents[4]`` is the checkout root of a source tree laid out as
+#: ``<root>/src/moneybin/mcp/tools/system.py``; from an installed wheel it is
+#: some directory above ``site-packages``, which is not a repository top level
+#: and so answers None.
+_REVISION: str | None = _read_git_revision(Path(__file__).resolve().parents[4])
 
 
 def _build_info() -> SystemStatusBuildInfo:
@@ -1200,7 +1229,10 @@ def register_system_coarse_reads(mcp: FastMCP) -> None:
         "inventory, integrity doctor checks, categorization coverage, and export "
         "readiness. "
         "detail='full' deepens the "
-        "doctor scan and includes auto-categorization health.",
+        "doctor scan and includes auto-categorization health. "
+        "overview.build names the version and commit this server is running; "
+        "cite it before concluding that live behavior contradicts the code, "
+        "because a long-lived process can predate the checkout.",
         privacy_actor="system_status",
     )
     register(

--- a/src/moneybin/privacy/payloads/system.py
+++ b/src/moneybin/privacy/payloads/system.py
@@ -292,7 +292,9 @@ class SystemStatusBuildInfo:
     # AGGREGATE rather than RECORD_ID to match every registry column named
     # ``version``; the registry-sync guard cross-checks payload fields by name,
     # and two classes for one column name is the drift it exists to catch.
-    version: Annotated[str, DataClass.AGGREGATE]
+    # None when the distribution metadata is unreadable — the same posture as
+    # ``revision``: say nothing rather than guess.
+    version: Annotated[str | None, DataClass.AGGREGATE]
     # The version alone cannot identify a build — it reads the same on every
     # commit between releases. ``revision`` is what actually separates two
     # servers started days apart. None when running from an installed wheel,

--- a/src/moneybin/privacy/payloads/system.py
+++ b/src/moneybin/privacy/payloads/system.py
@@ -25,6 +25,7 @@ Tier derivation summary:
   - ``SystemStatusWriter``          → Tier.LOW (RECORD_ID + TXN_TYPE + TIMESTAMP_OBSERVABILITY)
   - ``SystemStatusReader``          → Tier.LOW (RECORD_ID + TXN_TYPE)
   - ``SystemStatusDatabaseConnectionsInfo`` → Tier.LOW (composition only)
+  - ``SystemStatusBuildInfo``       → Tier.LOW (AGGREGATE + RECORD_ID)
   - ``SystemStatusPayload``         → Tier.LOW (no DESCRIPTION fields)
   - ``ExportsStatus``               → Tier.MEDIUM (destination name = USER_NOTE)
   - ``SystemStatusCLIPayload``      → Tier.MEDIUM (exports include USER_NOTE)

--- a/src/moneybin/privacy/payloads/system.py
+++ b/src/moneybin/privacy/payloads/system.py
@@ -275,6 +275,32 @@ class SystemStatusDatabaseConnectionsInfo:
 
 
 @dataclass(frozen=True, slots=True)
+class SystemStatusBuildInfo:
+    """Which build of MoneyBin this server process is actually running.
+
+    Operations metadata, not user data: a version string and a commit id
+    describe the software, not the ledger. Classified RECORD_ID (LOW) on that
+    basis — see `.claude/rules/security.md`, "Operations metadata is judged by
+    disclosure, not by column class".
+
+    Load-bearing because a stdio MCP server is pinned to whatever the checkout
+    held when it started. A caller who cannot name the build cannot distinguish
+    a stale process from a real defect, and will attribute one to the other.
+    """
+
+    # AGGREGATE rather than RECORD_ID to match every registry column named
+    # ``version``; the registry-sync guard cross-checks payload fields by name,
+    # and two classes for one column name is the drift it exists to catch.
+    version: Annotated[str, DataClass.AGGREGATE]
+    # The version alone cannot identify a build — it reads the same on every
+    # commit between releases. ``revision`` is what actually separates two
+    # servers started days apart. None when running from an installed wheel,
+    # which has no repository to interrogate. RECORD_ID because a commit id is
+    # exactly that: an opaque surrogate, with no registry column to match.
+    revision: Annotated[str | None, DataClass.RECORD_ID]
+
+
+@dataclass(frozen=True, slots=True)
 class SystemStatusPayload:
     """Payload for ``system_status`` — data inventory snapshot."""
 
@@ -292,6 +318,10 @@ class SystemStatusPayload:
     # the degraded "database locked" path (it reads the lock file + lsof, no DB
     # connection required).
     database_connections: SystemStatusDatabaseConnectionsInfo
+    # Same contract as database_connections, and for the same reason: it needs
+    # no DB connection, and the degraded path is exactly when a caller most
+    # needs to know which build produced the answer.
+    build: SystemStatusBuildInfo
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fixtures/mcp_surface/standard.json
+++ b/tests/fixtures/mcp_surface/standard.json
@@ -1,5 +1,5 @@
 {
-  "sha256": "a0bb19b0226cad556677cc14e10e6f741a72206e514fbdc34504c8ccc4898937",
+  "sha256": "d4cc3967a261055db1ab5b830e733dc852751ec11f056fe77c6c4ca64f8fa773",
   "tool_count": 49,
   "tools": [
     {
@@ -3443,7 +3443,7 @@
           "openWorldHint": false,
           "readOnlyHint": false
         },
-        "description": "Return selected operator status sections. Sections cover overview inventory, integrity doctor checks, categorization coverage, and export readiness. detail='full' deepens the doctor scan and includes auto-categorization health.",
+        "description": "Return selected operator status sections. Sections cover overview inventory, integrity doctor checks, categorization coverage, and export readiness. detail='full' deepens the doctor scan and includes auto-categorization health. overview.build names the version and commit this server is running; cite it before concluding that live behavior contradicts the code, because a long-lived process can predate the checkout.",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -3485,12 +3485,12 @@
         },
         "name": "system_status"
       },
-      "description_bytes": 227,
+      "description_bytes": 417,
       "input_schema_bytes": 287,
       "name": "system_status",
       "other_bytes": 55,
       "output_schema_bytes": 0,
-      "total_bytes": 706
+      "total_bytes": 896
     },
     {
       "annotation_bytes": 89,
@@ -5027,5 +5027,5 @@
       "total_bytes": 564
     }
   ],
-  "total_bytes": 55151
+  "total_bytes": 55341
 }

--- a/tests/moneybin/test_mcp/test_system_status_build.py
+++ b/tests/moneybin/test_mcp/test_system_status_build.py
@@ -85,6 +85,50 @@ def test_revision_is_absent_outside_a_source_checkout(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_revision_is_absent_when_the_repository_is_merely_an_ancestor() -> None:
+    """A directory *inside* someone's checkout is not that checkout's build.
+
+    ``git`` answers about the nearest enclosing repository, so an installed
+    wheel under a virtualenv in the user's own project would otherwise stamp
+    MoneyBin's build with that project's HEAD — a confident wrong answer where
+    the contract promises ``null``.
+    """
+    assert _read_git_revision(Path(__file__).resolve().parent) is None
+
+
+@pytest.mark.unit
+def test_revision_survives_a_checkout_path_containing_a_space(tmp_path: Path) -> None:
+    """A space in the checkout path must not silently blank the stamp.
+
+    ``git rev-parse --show-toplevel`` prints the path unquoted, so splitting its
+    two-line answer on arbitrary whitespace turns one such path into three
+    tokens and discards the revision. macOS paths routinely contain spaces, and
+    the failure is invisible: the field reads ``null``, which is also exactly
+    what a legitimate wheel install reports.
+    """
+    repo = tmp_path / "space test dir"
+    repo.mkdir()
+    for command in (
+        ["init", "-q"],
+        ["-c", "user.email=t@example.com", "-c", "user.name=t"]
+        + ["commit", "-q", "--allow-empty", "-m", "x"],
+    ):
+        subprocess.run(  # noqa: S603 — git with static args
+            ["git", "-C", str(repo), *command],  # noqa: S607
+            capture_output=True,
+            check=True,
+        )
+    head = subprocess.run(  # noqa: S603 — git with static args
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    assert _read_git_revision(repo) == head
+
+
+@pytest.mark.unit
 async def test_the_registered_tool_surfaces_the_build(mcp_db: object) -> None:
     """The build reaches the agent through the tool it actually calls.
 
@@ -93,7 +137,7 @@ async def test_the_registered_tool_surfaces_the_build(mcp_db: object) -> None:
     A projection that dropped the field on the way out would leave every test
     above green while the stamp never reached a caller.
     """
-    response = await system_status_coarse()
+    response = await system_status_coarse(sections=["overview"])
 
     overview = next(
         section

--- a/tests/moneybin/test_mcp/test_system_status_build.py
+++ b/tests/moneybin/test_mcp/test_system_status_build.py
@@ -11,14 +11,16 @@ was missing from a three-day-old server.
 from __future__ import annotations
 
 import subprocess  # noqa: S404 — reads HEAD to derive the expected value
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 import pytest
 
 from moneybin.database import DatabaseLockError
 from moneybin.mcp.tools.system import (
+    _build_info,  # pyright: ignore[reportPrivateUsage]
     _read_git_revision,  # pyright: ignore[reportPrivateUsage]
+    _read_package_version,  # pyright: ignore[reportPrivateUsage]
     system_status,
     system_status_coarse,
 )
@@ -76,6 +78,49 @@ async def test_source_checkout_reports_the_commit_it_is_running(
     data = system_status().to_dict()["data"]
 
     assert data["build"]["revision"] == head
+
+
+@pytest.mark.unit
+def test_version_is_resolved_at_import_not_per_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Upgrading the environment must not make a live server claim the new version.
+
+    ``importlib.metadata.version`` re-reads the installed distribution's
+    metadata on every call, so upgrading MoneyBin underneath a running server
+    would report the *new* version while the process still holds the old
+    modules. That is the stale-server scenario this whole block exists to
+    diagnose, and it is the worst place to be confidently wrong: an installed
+    wheel reports ``revision: null``, leaving ``version`` as the only signal.
+    """
+    captured = _build_info().version
+
+    def _upgraded(_name: str) -> str:
+        return "99.99.99"
+
+    monkeypatch.setattr("moneybin.mcp.tools.system.version", _upgraded)
+
+    assert _build_info().version == captured
+
+
+@pytest.mark.unit
+def test_absent_distribution_metadata_reports_no_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unreadable metadata degrades the field; it must never fail the import.
+
+    The version is resolved at import, so an unguarded lookup would turn a
+    missing distribution into a server that cannot boot — trading a rare
+    degraded answer for a total outage on the one surface whose job is to keep
+    answering when everything else is broken.
+    """
+
+    def _missing(_name: str) -> str:
+        raise PackageNotFoundError("moneybin")
+
+    monkeypatch.setattr("moneybin.mcp.tools.system.version", _missing)
+
+    assert _read_package_version() is None
 
 
 @pytest.mark.unit

--- a/tests/moneybin/test_mcp/test_system_status_build.py
+++ b/tests/moneybin/test_mcp/test_system_status_build.py
@@ -1,0 +1,103 @@
+"""``system_status`` must name the build the server is actually running.
+
+A stdio MCP server is a long-lived process pinned to whatever the checkout held
+when it started. Without a build stamp in the response, a caller comparing live
+behaviour against ``main`` cannot tell a stale process from a real defect — and
+on 2026-08-14 that ambiguity produced a filed finding claiming a confirmation
+gate did not exist, when the gate was present and only its evidence sentence
+was missing from a three-day-old server.
+"""
+
+from __future__ import annotations
+
+import subprocess  # noqa: S404 — reads HEAD to derive the expected value
+from importlib.metadata import version
+from pathlib import Path
+
+import pytest
+
+from moneybin.database import DatabaseLockError
+from moneybin.mcp.tools.system import (
+    _read_git_revision,  # pyright: ignore[reportPrivateUsage]
+    system_status,
+    system_status_coarse,
+)
+
+
+@pytest.mark.unit
+async def test_system_status_names_the_running_package_version(
+    mcp_db: object,
+) -> None:
+    """The envelope carries the installed distribution version, not a placeholder."""
+    data = system_status().to_dict()["data"]
+
+    assert data["build"]["version"] == version("moneybin")
+
+
+@pytest.mark.unit
+async def test_locked_database_still_names_the_build(
+    mcp_db: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The degraded path reports the build too — it needs no DB connection.
+
+    This is the case that motivates the field. When a caller is already seeing
+    something they cannot explain, "which build am I talking to" must not be
+    the one question the server refuses to answer.
+    """
+
+    def _locked(*_args: object, **_kwargs: object) -> object:
+        raise DatabaseLockError("a writer holds the lock")
+
+    monkeypatch.setattr("moneybin.database.get_database", _locked)
+
+    envelope = system_status().to_dict()
+
+    assert envelope["summary"]["degraded"] is True
+    assert envelope["data"]["build"]["version"] == version("moneybin")
+
+
+@pytest.mark.unit
+async def test_source_checkout_reports_the_commit_it_is_running(
+    mcp_db: object,
+) -> None:
+    """``revision`` names the checkout's HEAD.
+
+    The version alone cannot do this job: it reads ``0.1.0`` on every commit,
+    so it would not have separated #386 from #387 — the exact distinction whose
+    absence caused the misdiagnosis. The commit is the load-bearing half.
+    """
+    head = subprocess.run(  # noqa: S603 — git with static args
+        ["git", "-C", str(Path(__file__).resolve().parent), "rev-parse", "HEAD"],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    data = system_status().to_dict()["data"]
+
+    assert data["build"]["revision"] == head
+
+
+@pytest.mark.unit
+def test_revision_is_absent_outside_a_source_checkout(tmp_path: Path) -> None:
+    """An installed wheel has no repository to interrogate; say so, don't guess."""
+    assert _read_git_revision(tmp_path) is None
+
+
+@pytest.mark.unit
+async def test_the_registered_tool_surfaces_the_build(mcp_db: object) -> None:
+    """The build reaches the agent through the tool it actually calls.
+
+    ``system_status`` is registered as ``system_status_coarse``; the block above
+    tests the inner overview builder, which is not the surface an agent drives.
+    A projection that dropped the field on the way out would leave every test
+    above green while the stamp never reached a caller.
+    """
+    response = await system_status_coarse()
+
+    overview = next(
+        section
+        for section in response.to_dict()["data"]["sections"]
+        if section.get("kind") == "overview"
+    )
+    assert overview["overview"]["build"]["version"] == version("moneybin")

--- a/tests/moneybin/test_mcp/test_tool_surface_budget.py
+++ b/tests/moneybin/test_mcp/test_tool_surface_budget.py
@@ -127,7 +127,7 @@ _REPLACED_TOOL_NAME_COHORTS = {
 }
 
 _CANONICAL_CARRYING_WEIGHT_BYTES = {
-    "system_status": (706, 2_725),
+    "system_status": (896, 2_725),
     "system_audit": (746, 1_958),
     "accounts": (823, 2_240),
     "accounts_balances": (1_069, 2_786),


### PR DESCRIPTION
## Why

A stdio MCP server is a long-lived process pinned to whatever the checkout held when it booted. Nothing on the surface said which build that was, so a caller comparing live behaviour against `main` could not separate a stale process from a real defect.

That is not hypothetical. On 2026-08-14 a three-day-old server rendered an account-merge confirmation without the ledger-evidence sentence added in #387, and it was written up as the confirmation gate being *absent*. The gate was present and was approved by a human. The reflog settles it: `main` sat on #386 from 2026-08-10 and moved to #387 at 00:20:42 EDT, twenty minutes *after* the dialog fired at 00:00:56. A build stamp would have closed that in one call instead of a multi-hour investigation and a retracted finding.

`version` alone could not have done it — it reads `0.1.0` on every commit between releases, so it never separates #386 from #387. The commit is the load-bearing half.

## What

`system_status` gains a `build` block carrying `version` and the `revision` the checkout was on at process start. It is reported on the degraded database-locked path too: that path needs no database connection, and a caller staring at something they cannot explain is exactly who most needs to know which build answered.

**Both fields resolve once at import, never per call.** A checkout moves underneath a running server — that is precisely what happened above — and an environment gets upgraded beneath one. A per-call read would report the *new* commit or the *new* version while the process still ran the old code, which is worse than silence: it corroborates the wrong conclusion with false authority. `version` is the more dangerous of the two to read late, because a wheel install reports no revision and leaves the version as the only signal a caller has. It is guarded against `PackageNotFoundError`, so absent distribution metadata degrades the field to `null` rather than failing the import — the field is `str | None`, matching the posture `revision` already had.

**`revision` is read only when the resolved directory is the repository's own top level.** `git rev-parse` answers about the nearest *enclosing* checkout, so resolving from the module's own directory let a wheel installed into a venv inside the user's project — where `uv` puts one by default — report that project's HEAD as MoneyBin's build. A confidently wrong stamp is worse than the `null` this contract promises, and wrong in exactly the case the field exists to diagnose.

**That answer is parsed on line terminators, not arbitrary whitespace.** Git prints the top level unquoted, so a checkout path containing a space parsed as three tokens and silently blanked the revision. The blank is indistinguishable from a legitimate wheel install, so the failure left no trace — and macOS paths routinely contain spaces.

**The guidance reaches the agent.** It first landed on the inner overview builder, which no agent reads; the registered description is the only schema-attached prose available at tool-selection time, per `.claude/rules/mcp.md`. A field is only as useful as the instruction to cite it. Cost: 190 bytes, taking `system_status` from 706 to 896 — against the 2,725 spent by the tools this coarse read replaced. Registry stays at 49 tools.

Regenerating the surface snapshot restated the five figures in `mcp-tool-surface-scaling.md` that are derived from it: byte count, registry SHA, delta, delta percentage, and token estimate. All five reconcile against the untouched baseline — 90,734 − 55,341 = 35,393 = 39.0%, and ⌈55,341/4⌉ = 13,836.

## Test plan

Nine tests in `tests/moneybin/test_mcp/test_system_status_build.py`, each written before the code that satisfies it.

- The envelope names the installed distribution version, and still does on the degraded lock path.
- A source checkout reports its own HEAD.
- A non-repository directory reports `null`.
- A directory that is *merely inside* a checkout reports `null` — the case that made the enclosing-repo bug invisible, since `tmp_path` is not a repo at all and every implementation passes it.
- A checkout path containing a space still reports its revision.
- Upgrading the environment under a live process does not change the reported version — the test replaces the metadata reader after import and asserts the stamp holds.
- Absent distribution metadata reports `null` instead of failing the import.
- The build reaches the agent through `system_status_coarse`, the tool actually registered — a projection dropping the field on the way out would leave the other tests green while the stamp never reached a caller.

Mutation-verified rather than assumed: the version assertion passed on first run, so production was mutated to a literal `"unknown"` to confirm that test — and only that test — failed, then reverted.

Full gate: **8972 passed, 4 skipped**, ruff clean, pyright 0 errors. Each count was predicted before its run and matched exactly; an unpredicted number would have meant something unaccounted for. Surface tests run separately with `-m ""` because the covering registry test is integration-marked and `make test` does not select it.

## Deliberately not done

- A dirty working tree reports its clean HEAD. Appending `-dirty` changes the field's documented shape and is a contract decision, not a review fix.
