### PR TITLE
Gate import reversion behind payload-bound confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1260,6 +1260,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   update.
 
 ### Security
+- **`import_revert` no longer deletes raw rows on the first call (#391).**
+  `import_revert(operation="revert_import")` explicitly *rejected* a
+  `confirmation_token` and went straight to the delete, so one call permanently
+  destroyed a batch's raw rows with no prompt, no token, and no undo — 368 rows
+  across 14 batches went in a single session before anyone noticed. The branch
+  now plans read-only, binds approval to the exact live row counts, and verifies
+  that binding against live state inside the write transaction, matching the
+  `delete_saved_format` branch beside it. Outcomes that would delete nothing
+  (`not_found`, `already_reverted`, `unsupported`, `superseded`) return their
+  error without prompting. The CLI already confirmed and still does; its prompt
+  now names the row count. The registered description carried the same defect —
+  its confirmation and `system_audit_undo` clauses sat next to the format branch
+  but read as covering the whole tool, so an agent could infer reversions were
+  recoverable. Each clause now sits with its own branch, and reversion is
+  labelled `permanent — no revert`.
 - **An unanswered confirmation prompt no longer mints a redeemable token
   (#389).**
   `grant_confirmation_or_raise` waited `elicitation_wait_seconds` (120 by

--- a/docs/specs/mcp-tool-surface-scaling.md
+++ b/docs/specs/mcp-tool-surface-scaling.md
@@ -421,12 +421,12 @@ If either gate fails, MoneyBin spends the additional tool slot deliberately.
 
 The deterministic current
 [`standard.json`](../../tests/fixtures/mcp_surface/standard.json) snapshot
-contains 49 tools, 55,341 bytes of serialized metadata, zero advertised output schemas,
+contains 49 tools, 55,480 bytes of serialized metadata, zero advertised output schemas,
 and registry SHA-256
-`d4cc3967a261055db1ab5b830e733dc852751ec11f056fe77c6c4ca64f8fa773`.
+`db2b14b59135a3f3e5dcaeb64617dd93a26d44b3ff3f21e58a9b65c96a034ec4`.
 The frozen baseline is 90,734 bytes with SHA-256
 `ea87a21b01e0f5181b80cef120beef2e9f46b31df121c7941329d9c493b48f79`.
-The delta is -35,393 bytes (-39.0%). The deterministic estimate is 13,836
+The delta is -35,254 bytes (-38.9%). The deterministic estimate is 13,870
 metadata tokens; a percentage of context is
 recorded only with observed host/model evidence because this contract does not
 invent a context-window size.

--- a/docs/specs/mcp-tool-surface-scaling.md
+++ b/docs/specs/mcp-tool-surface-scaling.md
@@ -421,12 +421,12 @@ If either gate fails, MoneyBin spends the additional tool slot deliberately.
 
 The deterministic current
 [`standard.json`](../../tests/fixtures/mcp_surface/standard.json) snapshot
-contains 49 tools, 55,480 bytes of serialized metadata, zero advertised output schemas,
+contains 49 tools, 55,444 bytes of serialized metadata, zero advertised output schemas,
 and registry SHA-256
-`db2b14b59135a3f3e5dcaeb64617dd93a26d44b3ff3f21e58a9b65c96a034ec4`.
+`7ad09206175186633b2f36b15cd7c93664eb5cab7e799b8081613dcb16940732`.
 The frozen baseline is 90,734 bytes with SHA-256
 `ea87a21b01e0f5181b80cef120beef2e9f46b31df121c7941329d9c493b48f79`.
-The delta is -35,254 bytes (-38.9%). The deterministic estimate is 13,870
+The delta is -35,290 bytes (-38.9%). The deterministic estimate is 13,861
 metadata tokens; a percentage of context is
 recorded only with observed host/model evidence because this contract does not
 invent a context-window size.

--- a/docs/specs/moneybin-capabilities.md
+++ b/docs/specs/moneybin-capabilities.md
@@ -100,7 +100,11 @@ the implementation:
    merchant or provider-native categorizations.
 5. The existing destructive `import_revert` boundary now uses a strict
    discriminated operation for either import rollback or audited user-saved
-   format deletion. Built-in formats remain immutable, and no read tool
+   format deletion. Both branches require exact payload-bound confirmation,
+   verified against live state inside the write transaction. They differ in
+   recovery: format deletion is audited and restorable with
+   `system_audit_undo`; import rollback permanently deletes the batch's raw
+   rows and has no undo. Built-in formats remain immutable, and no read tool
    mutates format state.
 
 The audit also found that category and merchant CLI names were placeholders.

--- a/docs/specs/moneybin-mcp.md
+++ b/docs/specs/moneybin-mcp.md
@@ -81,7 +81,7 @@ safety family without duplicating FastMCP's drifting JSON schema.
 | `import_preview` | `file_path`, `mapping` | Stage and inspect an import proposal | Staged write (`readOnlyHint=false`, `idempotentHint=false`) / dynamic / maximum critical / file-derived |
 | `import_confirm` | `account_bindings`, `account_id`, `account_metadata`, `account_name`, `bridge_response`, `confirmation_token`, `preview_id`, `save_format` | Ratify an import proposal | Confirmed write / dynamic / maximum critical / preview-derived |
 | `import_status` | `cursor`, `import_id`, `limit`, `sections` | Import lifecycle status | Read / dynamic / maximum medium / import-derived |
-| `import_revert` | `confirmation_token`, `format_name`, `import_id`, `operation` | Revert an import batch | Audited recovery / maximum low |
+| `import_revert` | `confirmation_token`, `format_name`, `import_id`, `operation` | Revert an import batch or delete a saved format | Confirmed destructive / maximum low — rollback is permanent with no undo; format deletion is audited and `system_audit_undo`-recoverable |
 | `import_inbox_sync` | `refresh` | Drain the import inbox | Audited workflow / maximum critical |
 | `import_labels_set` | `import_id`, `labels` | Import-label target state | Audited write / maximum medium |
 | `sync_link` | `institution`, `mode` | Start mediated provider linking | Credential flow / maximum medium |

--- a/docs/specs/smart-import-financial.md
+++ b/docs/specs/smart-import-financial.md
@@ -147,7 +147,7 @@ Legacy rows imported before this change have `import_id = NULL`. They appear in 
 - `README.md` — "What Works Today" section gains QBO + revert support per `shipping.md`.
 
 **Create:**
-- `src/moneybin/loaders/import_log.py` — module with `begin_import`, `finalize_import`, `get_import_history`, `find_existing_import` functions plus the `REVERT_TABLES` allowlist. Source-type-to-tables dispatch hard-coded in `REVERT_TABLES`; the actual revert orchestration lives on `ImportService.revert` (see "Module-level functions" key decision below).
+- `src/moneybin/loaders/import_log.py` — module with `begin_import`, `finalize_import`, `get_import_history`, `find_existing_import` functions plus the `REVERT_TABLES` allowlist. Source-type-to-tables dispatch hard-coded in `REVERT_TABLES`; the actual revert orchestration lives on `ImportService.plan_revert`/`revert_confirmed` (see "Module-level functions" key decision below).
 - `src/moneybin/sql/migrations/V0XX__ofx_import_batch_columns.py` — schema migration adding the new columns and backfilling `source_type='ofx'` literal on existing rows.
 - `tests/scenarios/ofx_single_account_checking/` — and the other six scenarios listed in Testing Strategy.
 - `tests/fixtures/ofx/qbo_intuit_*.qbo`, `tests/fixtures/ofx/qbo_bank_*.qbo` — sanitized fixtures.
@@ -190,7 +190,7 @@ def get_import_history(
     """List import_log entries (optionally filtered to a single import_id) with row counts."""
 ```
 
-`ImportService.revert` consults an explicit `source_type → tables` mapping owned by the loader module:
+`ImportService.revert_confirmed` consults an explicit `source_type → tables` mapping owned by the loader module:
 
 ```python
 REVERT_TABLES = {
@@ -246,7 +246,7 @@ Routes any file (regardless of extension) to the OFX pipeline if the signature m
 ### Key decisions
 
 - **Keep `raw.ofx_*` as a distinct schema.** Don't collapse into `raw.tabular_*`. Rationale in Background.
-- **Module-level functions, not a service class, for import-log primitives.** `begin_import`, `finalize_import`, `get_import_history`, and `find_existing_import` are single-table CRUD over `raw.import_log` — a primitive, not a domain. Matches `account_matching.py` organization. **Revert is the exception:** it cascades deletes across multiple raw tables and updates the log row's status under a transaction, so it lives on `ImportService.revert` per the service-layer convention (every multi-table mutation flows through the service that owns the domain). The loader module stays the source of truth for the `REVERT_TABLES` allowlist that the service consults.
+- **Module-level functions, not a service class, for import-log primitives.** `begin_import`, `finalize_import`, `get_import_history`, and `find_existing_import` are single-table CRUD over `raw.import_log` — a primitive, not a domain. Matches `account_matching.py` organization. **Revert is the exception:** it cascades deletes across multiple raw tables and updates the log row's status under a transaction, so it lives on `ImportService.plan_revert` (read-only) and `ImportService.revert_confirmed` (the confirmed write) per the service-layer convention (every multi-table mutation flows through the service that owns the domain). The loader module stays the source of truth for the `REVERT_TABLES` allowlist that the service consults.
 - **Hard-coded `source_type → tables` mapping in `REVERT_TABLES`.** Allowlist over runtime catalog query: simpler, explicit, and adding new formats is rare and deliberate.
 - **No automatic backfill of `import_id` for legacy rows.** Synthesizing batch IDs for un-tracked imports would obscure history; leave them as `NULL` and surface as pre-batch-tracking entries.
 - **Re-import behavior change is a breaking change worth flagging.** Today's silent overwrite becomes explicit duplicate rejection (with `--force` opt-out). Documented in CHANGELOG and release notes.

--- a/src/moneybin/cli/commands/import_cmd.py
+++ b/src/moneybin/cli/commands/import_cmd.py
@@ -2268,20 +2268,33 @@ def import_revert(
     """
     from moneybin.cli.utils import handle_cli_errors
     from moneybin.database import get_database  # noqa: PLC0415 — deferred import
-    from moneybin.services.import_service import ImportService
+    from moneybin.services.import_service import ImportRevertPlan, ImportService
 
-    if not yes:
+    with handle_cli_errors():
+        with get_database(read_only=True) as db:
+            plan = ImportService(db).plan_revert(import_id)
+
+    if plan.revertable and not yes:
         confirmed = typer.confirm(
-            f"Revert import {import_id[:8]}...? This will delete all rows from "
-            f"this batch and cannot be undone."
+            f"Revert import {import_id[:8]}...? This permanently deletes "
+            f"{plan.rows_to_delete} row(s) from this batch and cannot be undone."
         )
         if not confirmed:
             logger.info("Revert cancelled")
             raise typer.Exit(0)
 
+    def _verify(live: ImportRevertPlan) -> None:
+        """Refuse if the batch changed between the prompt and the delete."""
+        if live != plan:
+            raise UserError(
+                "Import state changed while the confirmation was pending; "
+                "nothing was deleted. Re-run to see the current plan.",
+                code=error_codes.MUTATION_CONFIRMATION_MISMATCH,
+            )
+
     with handle_cli_errors():
         with get_database(read_only=False) as db:
-            result = ImportService(db).revert(import_id)
+            result = ImportService(db).revert_confirmed(import_id, verify=_verify)
 
     status = result.get("status")
     if status == "not_found":

--- a/src/moneybin/loaders/import_log.py
+++ b/src/moneybin/loaders/import_log.py
@@ -6,9 +6,10 @@ query history (``get_import_history``), and check for prior imports of a
 source file (``find_existing_import``).
 
 The module is also the single source of truth for which raw tables a given
-source_type populates — see ``REVERT_TABLES`` below. ``ImportService.revert``
-(see ``moneybin/services/import_service.py``) consults this allowlist; the
-revert operation itself lives on the service, not here.
+source_type populates — see ``REVERT_TABLES`` below.
+``ImportService.revert_confirmed`` (see
+``moneybin/services/import_service.py``) consults this allowlist; the revert
+operation itself lives on the service, not here.
 """
 
 import json
@@ -55,7 +56,8 @@ _IMPORT_HISTORY_COLUMNS = [
 
 
 # Allowlist mapping source_type → raw tables that carry rows for that type.
-# ImportService.revert() consults this to know what to delete. Adding a new
+# ImportService.plan_revert()/revert_confirmed() consult this to know what to
+# count and delete. Adding a new
 # format means adding an entry here AND ensuring those tables have an
 # import_id column.
 _TABULAR_RAW_TABLES = [TABULAR_TRANSACTIONS, TABULAR_ACCOUNTS]

--- a/src/moneybin/mcp/tools/import_tools.py
+++ b/src/moneybin/mcp/tools/import_tools.py
@@ -129,12 +129,10 @@ _IMPORT_REVERT_INPUT_SCHEMA_EXTRA: dict[str, Any] = {
             "then": {
                 "properties": {"import_id": {"type": "string", "minLength": 1}},
                 "required": ["import_id"],
-                "not": {
-                    "anyOf": [
-                        {"required": ["format_name"]},
-                        {"required": ["confirmation_token"]},
-                    ]
-                },
+                # ``confirmation_token`` stays admissible here: the reversion
+                # gate hands non-eliciting clients a token to send back, and a
+                # schema-validating client could not make that second call.
+                "not": {"anyOf": [{"required": ["format_name"]}]},
             },
         },
     ]

--- a/src/moneybin/mcp/tools/import_tools.py
+++ b/src/moneybin/mcp/tools/import_tools.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from moneybin.services.import_confirmation import ConfirmationRequired
     from moneybin.services.import_service import (
         CreatedAccount,
+        ImportRevertPlan,
         SavedFormatDeletePlan,
     )
 
@@ -1263,36 +1264,11 @@ _REVERT_FAILURE_CODES = {
 }
 
 
-def import_revert(import_id: str) -> ResponseEnvelope[ImportRevertPayload]:
-    """Undo an import batch by deleting all rows it produced.
-
-    Looks up source_type from raw.import_log and deletes rows tagged with
-    import_id from the matching raw tables (raw.tabular_* or raw.ofx_*).
-    Updates the import_log row's status to 'reverted'.
-
-    Args:
-        import_id: UUID of the import batch to revert. Get it from
-            import_files's response or from import_status.
-    """
-    from moneybin.services.import_service import ImportService  # noqa: PLC0415
-
-    with get_database(read_only=False) as db:
-        result = ImportService(db).revert(import_id)
+def _revert_failure_envelope(
+    result: dict[str, str | int],
+) -> ResponseEnvelope[ImportRevertPayload]:
+    """Return the error envelope for one non-revertable outcome."""
     status = result.get("status")
-
-    if status == "reverted":
-        return build_envelope(
-            data=ImportRevertPayload(
-                import_id=import_id,
-                status="reverted",
-                rows_deleted=int(result["rows_deleted"])
-                if "rows_deleted" in result
-                else None,
-            ),
-            actions=[
-                "Use import_status to confirm the batch shows status='reverted'",
-            ],
-        )
     return build_error_envelope(
         error=UserError(
             str(result.get("reason") or f"Cannot revert (status={status})"),
@@ -1300,6 +1276,86 @@ def import_revert(import_id: str) -> ResponseEnvelope[ImportRevertPayload]:
                 str(status), error_codes.IMPORT_REVERT_UNSUPPORTED
             ),
         )
+    )
+
+
+def _import_revert_binding(plan: ImportRevertPlan) -> ConfirmationBinding:
+    """Bind reversion approval to one import batch's exact live row counts."""
+    return ConfirmationBinding(
+        arguments={
+            "operation": "revert_import",
+            "import_id": plan.import_id,
+            "outcome": plan.outcome,
+            "source_type": plan.source_type,
+            "rows_to_delete": plan.rows_to_delete,
+        },
+        resolved_ids=(plan.import_id,),
+        actor="mcp",
+        profile=get_settings().profile,
+        authorization_context="local-profile",
+        operation_kind="import_revert",
+        blast_radius=plan.blast_radius,
+    )
+
+
+async def import_revert(
+    import_id: str,
+    *,
+    confirmation_token: str | None = None,
+) -> ResponseEnvelope[ImportRevertPayload]:
+    """Undo an import batch by deleting all rows it produced.
+
+    Looks up source_type from raw.import_log and deletes rows tagged with
+    import_id from the matching raw tables (raw.tabular_* or raw.ofx_*).
+    Updates the import_log row's status to 'reverted'.
+
+    The deletion destroys the only copy of those rows and has no audited undo,
+    so it is gated on a payload-bound confirmation. Outcomes that would delete
+    nothing return their error without prompting — no confirmation is asked for
+    a no-op.
+
+    Args:
+        import_id: UUID of the import batch to revert. Get it from
+            import_files's response or from import_status.
+        confirmation_token: Opaque token from a prior
+            ``mutation_confirmation_required`` refusal, for clients that cannot
+            elicit.
+    """
+    from moneybin.services.import_service import ImportService  # noqa: PLC0415
+
+    with get_database(read_only=True) as db:
+        plan = ImportService(db).plan_revert(import_id)
+    if not plan.revertable:
+        return _revert_failure_envelope(plan.as_result())
+
+    grant: ConfirmationGrant = await grant_confirmation_or_raise(
+        binding=_import_revert_binding(plan) if confirmation_token is None else None,
+        message=(
+            f"Permanently delete {plan.rows_to_delete} raw row(s) from import "
+            f"{import_id[:8]}...? This destroys the only copy of that data and "
+            "cannot be undone — there is no system_audit_undo for a reversion."
+        ),
+        confirmation_token=confirmation_token,
+    )
+
+    with get_database(read_only=False) as db:
+        result = ImportService(db).revert_confirmed(
+            import_id,
+            verify=lambda live: grant.verify(_import_revert_binding(live)),
+        )
+    if result.get("status") != "reverted":
+        return _revert_failure_envelope(result)
+    return build_envelope(
+        data=ImportRevertPayload(
+            import_id=import_id,
+            status="reverted",
+            rows_deleted=int(result["rows_deleted"])
+            if "rows_deleted" in result
+            else None,
+        ),
+        actions=[
+            "Use import_status to confirm the batch shows status='reverted'",
+        ],
     )
 
 
@@ -2467,10 +2523,10 @@ async def import_revert_coarse(
 ) -> ResponseEnvelope[ImportRevertPayload | ImportSavedFormatDeletePayload]:
     """Revert one import or audit-delete one user-saved format."""
     if operation == "revert_import":
-        if not import_id or format_name is not None or confirmation_token is not None:
+        if not import_id or format_name is not None:
             raise UserError(
-                "operation='revert_import' requires exactly import_id and does "
-                "not accept confirmation_token.",
+                "operation='revert_import' requires exactly import_id, "
+                "optionally with confirmation_token.",
                 code=error_codes.IMPORT_REVERT_INVALID_TARGET,
             )
     elif import_id is not None or not format_name:
@@ -2488,7 +2544,10 @@ async def import_revert_coarse(
             ),
         )
 
-    response = import_revert(import_id=cast(str, import_id))
+    response = await import_revert(
+        import_id=cast(str, import_id),
+        confirmation_token=confirmation_token,
+    )
     if response.error is not None:
         return cast(
             ResponseEnvelope[ImportRevertPayload | ImportSavedFormatDeletePayload],
@@ -2599,10 +2658,12 @@ def register_import_workflow_tools(mcp: FastMCP) -> None:
         (
             import_revert_coarse,
             "import_revert",
-            "Revert one completed import or delete one user-saved format. Import "
-            "reversion permanently removes its raw rows; saved-format deletion "
-            "writes app.tabular_formats, requires exact payload-bound confirmation, "
-            "and is recoverable with system_audit_undo.",
+            "Revert one completed import or delete one user-saved format. Both "
+            "branches require exact payload-bound confirmation. Import reversion "
+            "deletes that batch's rows from raw.tabular_*/raw.ofx_* and flips "
+            "raw.import_log to 'reverted': permanent — no revert, and no "
+            "system_audit_undo counterpart. Saved-format deletion writes "
+            "app.tabular_formats and is recoverable with system_audit_undo.",
         ),
         (
             import_inbox_sync_coarse,

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -319,6 +319,54 @@ class SavedFormatDeletePlan:
         return {"saved_formats": 1}
 
 
+ImportRevertOutcome = Literal[
+    "revertable",
+    "not_found",
+    "already_reverted",
+    "unsupported",
+    "superseded",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ImportRevertPlan:
+    """Exact live state bound to one import reversion approval.
+
+    Non-revertable outcomes are plans too, so a batch that flips state between
+    approval and commit changes the binding rather than slipping past it.
+    """
+
+    import_id: str
+    outcome: ImportRevertOutcome
+    reason: str | None = None
+    source_type: str | None = None
+    source_origin: str | None = None
+    table_counts: tuple[tuple[str, int], ...] = ()
+
+    @property
+    def revertable(self) -> bool:
+        """Return whether this plan would actually delete or flip anything."""
+        return self.outcome == "revertable"
+
+    @property
+    def rows_to_delete(self) -> int:
+        """Return the total raw rows this reversion would destroy."""
+        return sum(count for _, count in self.table_counts)
+
+    @property
+    def blast_radius(self) -> dict[str, int]:
+        """Return the per-table destructive impact for confirmation metadata."""
+        radius = dict(self.table_counts)
+        radius["total_rows"] = self.rows_to_delete
+        return radius
+
+    def as_result(self) -> dict[str, str | int]:
+        """Return the legacy non-revertable response for this outcome."""
+        if self.reason is None:
+            return {"status": self.outcome}
+        return {"status": self.outcome, "reason": self.reason}
+
+
 @dataclass(frozen=True)
 class PerFileResult:
     """One file's outcome inside a batch import.
@@ -5486,24 +5534,15 @@ class ImportService:
             raise
         return event.operation_id
 
-    def revert(self, import_id: str) -> dict[str, str | int]:
-        """Revert an import batch by deleting its raw rows and flipping status.
+    def plan_revert(self, import_id: str) -> ImportRevertPlan:
+        """Return the exact live state bound to one import reversion.
 
-        Looks up source_type from raw.import_log to determine which tables to
-        delete from (via the ``REVERT_TABLES`` allowlist). Updates status to
-        'reverted'.
+        Read-only. The four non-revertable outcomes are plans too, so a batch
+        whose state flips between approval and commit changes the confirmation
+        binding instead of slipping past it.
 
         Args:
             import_id: UUID of the import batch in ``raw.import_log``.
-
-        Returns:
-            ``{'status': 'reverted', 'rows_deleted': N}`` on success.
-            ``{'status': 'not_found', 'reason': ...}`` if import_id doesn't exist.
-            ``{'status': 'already_reverted'}`` if already reverted.
-            ``{'status': 'unsupported', 'reason': ...}`` if the source_type is
-            not in the revert allowlist.
-            ``{'status': 'superseded', 'reason': ...}`` if a later import for
-            the same source_file already overwrote the rows.
         """
         # REVERT_TABLES is owned by import_log because begin_import also consults it.
         from moneybin.loaders.import_log import REVERT_TABLES  # noqa: PLC0415
@@ -5516,34 +5555,37 @@ class ImportService:
         ).fetchone()
 
         if row is None:
-            return {"status": "not_found", "reason": f"No import with ID {import_id}"}
+            return ImportRevertPlan(
+                import_id=import_id,
+                outcome="not_found",
+                reason=f"No import with ID {import_id}",
+            )
 
         src_type, status, source_file, started_at, source_origin = row
 
         if status == "reverted":
-            return {"status": "already_reverted"}
+            return ImportRevertPlan(import_id=import_id, outcome="already_reverted")
 
         if src_type not in REVERT_TABLES:
-            return {
-                "status": "unsupported",
-                "reason": f"Cannot revert source_type {src_type!r}",
-            }
+            return ImportRevertPlan(
+                import_id=import_id,
+                outcome="unsupported",
+                reason=f"Cannot revert source_type {src_type!r}",
+                source_type=src_type,
+            )
 
-        tables = REVERT_TABLES[src_type]
-
-        # Sum across every table the source_type populates. OFX statements with
-        # zero transactions but populated accounts/balances must still be
-        # detectable as live (not superseded) and reportable in rows_deleted.
-        rows_to_delete = 0
-        for table in tables:
+        # Count every table the source_type populates. OFX statements with zero
+        # transactions but populated accounts/balances must still be detectable
+        # as live (not superseded) and reportable in rows_deleted.
+        table_counts: list[tuple[str, int]] = []
+        for table in REVERT_TABLES[src_type]:
             result = self._db.execute(
                 f"SELECT COUNT(*) FROM {table.full_name} WHERE import_id = ?",
                 [import_id],
             ).fetchone()
-            if result:
-                rows_to_delete += result[0]
+            table_counts.append((table.full_name, int(result[0]) if result else 0))
 
-        if rows_to_delete == 0:
+        if sum(count for _, count in table_counts) == 0:
             # If a later import upserted over this one's rows, surface that
             # instead of a silent no-op revert.
             reimport_row = self._db.execute(
@@ -5561,34 +5603,69 @@ class ImportService:
             ).fetchone()
             if reimport_row:
                 newer_id = reimport_row[0]
-                return {
-                    "status": "superseded",
-                    "reason": (
+                return ImportRevertPlan(
+                    import_id=import_id,
+                    outcome="superseded",
+                    reason=(
                         f"File was re-imported as {newer_id[:8]}...; "
                         f"revert that batch to remove the data."
                     ),
-                }
+                    source_type=src_type,
+                )
+
+        return ImportRevertPlan(
+            import_id=import_id,
+            outcome="revertable",
+            source_type=src_type,
+            source_origin=source_origin,
+            table_counts=tuple(table_counts),
+        )
+
+    def revert_confirmed(
+        self,
+        import_id: str,
+        *,
+        verify: Callable[[ImportRevertPlan], None],
+    ) -> dict[str, str | int]:
+        """Revalidate and revert one import batch in the same transaction.
+
+        ``verify`` re-checks the caller's approval against the live plan read
+        *inside* the write transaction, immediately before the first delete, so
+        approval can never be applied to state it did not describe.
+
+        Returns:
+            ``{'status': 'reverted', 'rows_deleted': N}`` on success, else the
+            live non-revertable outcome.
+        """
+        from moneybin.loaders.import_log import REVERT_TABLES  # noqa: PLC0415
+        from moneybin.tables import IMPORT_LOG  # noqa: PLC0415
 
         self._db.begin()
         try:
-            for table in tables:
+            live = self.plan_revert(import_id)
+            verify(live)
+            if live.revertable:
+                for table in REVERT_TABLES[cast(str, live.source_type)]:
+                    self._db.execute(
+                        f"DELETE FROM {table.full_name} WHERE import_id = ?",
+                        [import_id],
+                    )
                 self._db.execute(
-                    f"DELETE FROM {table.full_name} WHERE import_id = ?",
+                    f"""
+                    UPDATE {IMPORT_LOG.full_name} SET
+                        status = 'reverted',
+                        reverted_at = CURRENT_TIMESTAMP
+                    WHERE import_id = ?
+                    """,
                     [import_id],
                 )
-            self._db.execute(
-                f"""
-                UPDATE {IMPORT_LOG.full_name} SET
-                    status = 'reverted',
-                    reverted_at = CURRENT_TIMESTAMP
-                WHERE import_id = ?
-                """,
-                [import_id],
-            )
             self._db.commit()
-        except Exception:
+        except BaseException:
             self._db.rollback()
             raise
+
+        if not live.revertable:
+            return live.as_result()
 
         # Drop the auto-generated raw.pdf_<alias> view after row deletion
         # succeeds. DDL is autocommit in DuckDB (cannot be inside the transaction),
@@ -5600,19 +5677,19 @@ class ImportService:
         # every row of identical content; a sibling import's log entry can be
         # 'complete' while holding zero rows, so the preserved view may be
         # legitimately empty after this revert.
-        if src_type == "pdf" and source_origin:
+        if live.source_type == "pdf" and live.source_origin:
             other_row = self._db.execute(
                 f"SELECT COUNT(*) FROM {IMPORT_LOG.full_name} "
                 f"WHERE source_type = 'pdf' AND source_origin = ? "
                 f"AND status = 'complete' AND import_id != ?",
-                [source_origin, import_id],
+                [live.source_origin, import_id],
             ).fetchone()
             if other_row is not None and other_row[0] == 0:
                 from sqlglot import exp  # noqa: PLC0415
 
-                safe_view = exp.to_identifier(f"pdf_{source_origin}", quoted=True).sql(
-                    "duckdb"
-                )
+                safe_view = exp.to_identifier(
+                    f"pdf_{live.source_origin}", quoted=True
+                ).sql("duckdb")
                 # DDL runs post-commit (DuckDB autocommits DDL outside the
                 # transaction). The rows are already gone and import_log is
                 # already 'reverted', so a catalog error here would orphan
@@ -5629,9 +5706,9 @@ class ImportService:
                     )
 
         logger.info(
-            f"Reverted import {import_id[:8]}...: {rows_to_delete} rows deleted"
+            f"Reverted import {import_id[:8]}...: {live.rows_to_delete} rows deleted"
         )
-        return {"status": "reverted", "rows_deleted": rows_to_delete}
+        return {"status": "reverted", "rows_deleted": live.rows_to_delete}
 
     # ------------------------------------------------------------------
     # Import labels (spec Req 22–24).

--- a/tests/fixtures/mcp_capabilities/outcome-map.json
+++ b/tests/fixtures/mcp_capabilities/outcome-map.json
@@ -783,12 +783,13 @@
       "import formats delete"
     ],
     "service_methods": [
-      "moneybin.services.import_service.ImportService.revert",
+      "moneybin.services.import_service.ImportService.plan_revert",
+      "moneybin.services.import_service.ImportService.revert_confirmed",
       "moneybin.services.import_service.ImportService.plan_saved_format_delete",
       "moneybin.services.import_service.ImportService.delete_saved_format_confirmed"
     ],
     "observable_outcomes": [
-      "the selected import's raw rows are removed and its status becomes reverted",
+      "the selected import's raw rows are removed and its status becomes reverted only after a payload-bound confirmation verified against live counts",
       "the exact confirmed user-saved format is audit-deleted with an undoable operation ID while built-ins remain immutable"
     ],
     "exemption": null

--- a/tests/fixtures/mcp_surface/standard.json
+++ b/tests/fixtures/mcp_surface/standard.json
@@ -1,5 +1,5 @@
 {
-  "sha256": "db2b14b59135a3f3e5dcaeb64617dd93a26d44b3ff3f21e58a9b65c96a034ec4",
+  "sha256": "7ad09206175186633b2f36b15cd7c93664eb5cab7e799b8081613dcb16940732",
   "tool_count": 49,
   "tools": [
     {
@@ -1829,11 +1829,6 @@
                       "required": [
                         "format_name"
                       ]
-                    },
-                    {
-                      "required": [
-                        "confirmation_token"
-                      ]
                     }
                   ]
                 },
@@ -1902,11 +1897,11 @@
         "name": "import_revert"
       },
       "description_bytes": 383,
-      "input_schema_bytes": 916,
+      "input_schema_bytes": 880,
       "name": "import_revert",
       "other_bytes": 55,
       "output_schema_bytes": 0,
-      "total_bytes": 1494
+      "total_bytes": 1458
     },
     {
       "annotation_bytes": 89,
@@ -5027,5 +5022,5 @@
       "total_bytes": 564
     }
   ],
-  "total_bytes": 55480
+  "total_bytes": 55444
 }

--- a/tests/fixtures/mcp_surface/standard.json
+++ b/tests/fixtures/mcp_surface/standard.json
@@ -1,5 +1,5 @@
 {
-  "sha256": "d4cc3967a261055db1ab5b830e733dc852751ec11f056fe77c6c4ca64f8fa773",
+  "sha256": "db2b14b59135a3f3e5dcaeb64617dd93a26d44b3ff3f21e58a9b65c96a034ec4",
   "tool_count": 49,
   "tools": [
     {
@@ -1773,7 +1773,7 @@
           "openWorldHint": false,
           "readOnlyHint": false
         },
-        "description": "Revert one completed import or delete one user-saved format. Import reversion permanently removes its raw rows; saved-format deletion writes app.tabular_formats, requires exact payload-bound confirmation, and is recoverable with system_audit_undo.",
+        "description": "Revert one completed import or delete one user-saved format. Both branches require exact payload-bound confirmation. Import reversion deletes that batch's rows from raw.tabular_*/raw.ofx_* and flips raw.import_log to 'reverted': permanent \u2014 no revert, and no system_audit_undo counterpart. Saved-format deletion writes app.tabular_formats and is recoverable with system_audit_undo.",
         "inputSchema": {
           "additionalProperties": false,
           "allOf": [
@@ -1901,12 +1901,12 @@
         },
         "name": "import_revert"
       },
-      "description_bytes": 247,
+      "description_bytes": 383,
       "input_schema_bytes": 916,
       "name": "import_revert",
       "other_bytes": 55,
       "output_schema_bytes": 0,
-      "total_bytes": 1355
+      "total_bytes": 1494
     },
     {
       "annotation_bytes": 89,
@@ -5027,5 +5027,5 @@
       "total_bytes": 564
     }
   ],
-  "total_bytes": 55341
+  "total_bytes": 55480
 }

--- a/tests/moneybin/test_cli/test_cli_import_revert.py
+++ b/tests/moneybin/test_cli/test_cli_import_revert.py
@@ -1,0 +1,163 @@
+"""CLI tests for ``moneybin import revert``.
+
+The command reads a plan against a read-only connection, prompts on it, then
+re-plans inside the write transaction and refuses if anything moved. Both
+halves are CLI-owned wiring, so both are driven here through a real batch
+rather than through the service alone.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import itertools
+from collections.abc import Generator
+from contextlib import contextmanager
+
+import pytest
+from typer.testing import CliRunner
+
+from moneybin.cli.main import app
+from moneybin.database import Database
+from moneybin.loaders import import_log
+from moneybin.services.import_service import ImportRevertPlan, ImportService
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def patched_db(db: Database, monkeypatch: pytest.MonkeyPatch) -> Database:
+    """Redirect the command's deferred ``get_database`` to the test database."""
+
+    @contextmanager
+    def _shared(*_args: object, **_kwargs: object) -> Generator[Database, None, None]:
+        yield db
+
+    monkeypatch.setattr("moneybin.database.get_database", _shared)
+    return db
+
+
+def _seed_revertable_batch(database: Database, rows: int) -> str:
+    """Import ``rows`` tabular transactions under one complete batch."""
+    import_id = import_log.begin_import(
+        database,
+        source_file="/tmp/revert.csv",  # noqa: S108  # test fixture path
+        source_type="csv",
+        source_origin="tiller",
+        account_names=["checking"],
+    )
+    for index in range(rows):
+        database.execute(
+            """
+            INSERT INTO raw.tabular_transactions (
+                transaction_id, account_id, transaction_date, amount, description,
+                source_file, source_type, source_origin, import_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                f"csv_cli_{index}",
+                "checking",
+                "2026-01-01",
+                "-10.00",
+                "X",
+                "/tmp/revert.csv",  # noqa: S108  # test fixture path
+                "csv",
+                "tiller",
+                import_id,
+            ],
+        )
+    import_log.finalize_import(
+        database, import_id, status="complete", rows_total=rows, rows_imported=rows
+    )
+    return import_id
+
+
+def _remaining(database: Database, import_id: str) -> int:
+    row = database.execute(
+        "SELECT COUNT(*) FROM raw.tabular_transactions WHERE import_id = ?",
+        [import_id],
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _status(database: Database, import_id: str) -> str:
+    row = database.execute(
+        "SELECT status FROM raw.import_log WHERE import_id = ?", [import_id]
+    ).fetchone()
+    assert row is not None
+    return str(row[0])
+
+
+def test_import_revert_deletes_a_seeded_batch_and_reports_the_count(
+    runner: CliRunner, patched_db: Database
+) -> None:
+    """The success path deletes the batch's rows and says how many it removed."""
+    import_id = _seed_revertable_batch(patched_db, rows=2)
+
+    result = runner.invoke(app, ["import", "revert", import_id, "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert "2 rows deleted" in result.output
+    assert _remaining(patched_db, import_id) == 0
+    assert _status(patched_db, import_id) == "reverted"
+
+
+def test_import_revert_prompt_names_the_rows_it_would_destroy(
+    runner: CliRunner, patched_db: Database
+) -> None:
+    """Declining the prompt must leave the batch untouched."""
+    import_id = _seed_revertable_batch(patched_db, rows=2)
+
+    result = runner.invoke(app, ["import", "revert", import_id], input="n\n")
+
+    assert result.exit_code == 0, result.output
+    assert "2 row(s)" in result.output
+    assert _remaining(patched_db, import_id) == 2
+    assert _status(patched_db, import_id) == "complete"
+
+
+def test_import_revert_refuses_when_the_batch_moved_after_the_plan(
+    runner: CliRunner, patched_db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A batch that changes between the prompt and the write deletes nothing.
+
+    The command approves one exact plan. Here the planning read reports a row
+    count the live batch no longer has, which is what a concurrent write would
+    look like — the in-transaction re-plan must refuse rather than delete
+    whatever it now finds.
+    """
+    import_id = _seed_revertable_batch(patched_db, rows=2)
+    real_plan_revert = ImportService.plan_revert
+    reads = itertools.count()
+
+    def _stale_first_read(self: ImportService, target: str) -> ImportRevertPlan:
+        """Skew only the command's planning read; the re-plan sees live state."""
+        plan = real_plan_revert(self, target)
+        if next(reads) > 0:
+            return plan
+        return dataclasses.replace(
+            plan, table_counts=(("raw.tabular_transactions", 99),)
+        )
+
+    monkeypatch.setattr(ImportService, "plan_revert", _stale_first_read)
+
+    result = runner.invoke(app, ["import", "revert", import_id, "--yes"])
+
+    assert result.exit_code != 0, result.output
+    assert "nothing was deleted" in result.output
+    assert _remaining(patched_db, import_id) == 2
+    assert _status(patched_db, import_id) == "complete"
+
+
+def test_import_revert_of_an_unknown_batch_exits_nonzero(
+    runner: CliRunner, patched_db: Database
+) -> None:
+    """A no-op plan reports the reason without prompting for confirmation."""
+    result = runner.invoke(
+        app, ["import", "revert", "00000000-0000-0000-0000-000000000000"]
+    )
+
+    assert result.exit_code == 1, result.output

--- a/tests/moneybin/test_loaders/test_import_log.py
+++ b/tests/moneybin/test_loaders/test_import_log.py
@@ -136,7 +136,7 @@ class TestFindExistingImport:
         # Revert lives on the service, not the loader; use it as setup so the
         # real assertion (find_existing_import skips reverted batches) stays
         # focused on this module's behavior.
-        ImportService(db).revert(import_id)
+        ImportService(db).revert_confirmed(import_id, verify=lambda _live: None)
         result = import_log.find_existing_import(db, "/tmp/reverted.ofx")  # noqa: S108  # test fixture path
         assert result is None
 

--- a/tests/moneybin/test_mcp/test_import_tools.py
+++ b/tests/moneybin/test_mcp/test_import_tools.py
@@ -71,6 +71,10 @@ async def test_import_workflow_registrar_preserves_seven_trust_boundaries() -> N
     assert "saved format" in (revert.description or "").lower()
     assert "confirmation" in (revert.description or "").lower()
     assert "system_audit_undo" in (revert.description or "")
+    # Reversion has no undo counterpart, so the description must say so against
+    # its own branch — a recoverability clause that reads as covering the whole
+    # tool is what led an agent to revert 14 batches expecting them recoverable.
+    assert "permanent — no revert" in (revert.description or "")
     assert "confirmation_token" in revert.parameters["properties"]
     confirm = next(tool for tool in tools if tool.name == "import_confirm")
     assert "confirmation_token" in confirm.parameters["properties"]
@@ -149,7 +153,7 @@ async def test_import_revert_coarse_preserves_error_recovery(
     monkeypatch.setattr(
         import_tools_module,
         "import_revert",
-        MagicMock(return_value=response),
+        AsyncMock(return_value=response),
     )
 
     result = await import_revert_coarse(import_id="imp_accepted")
@@ -351,6 +355,224 @@ async def test_import_revert_refuses_builtin_format_deletion(mcp_db: Path) -> No
     ).to_dict()
 
     assert result["error"]["code"] == "import_saved_format_builtin_immutable"
+
+
+def _seed_revertable_import(*, rows: int = 2) -> str:
+    """Create one complete tabular import holding ``rows`` revertable raw rows."""
+    from moneybin.database import get_database
+    from moneybin.loaders import import_log
+
+    source_file = "/tmp/revert_gate.csv"  # noqa: S108  # test fixture path
+    with get_database(read_only=False) as db:
+        import_id = import_log.begin_import(
+            db,
+            source_file=source_file,
+            source_type="csv",
+            source_origin="tiller",
+            account_names=["checking"],
+        )
+        for index in range(rows):
+            db.execute(
+                """
+                INSERT INTO raw.tabular_transactions (
+                    transaction_id, account_id, transaction_date, amount,
+                    description, source_file, source_type, source_origin,
+                    import_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    f"csv_gate_{index}",
+                    "checking",
+                    "2026-01-01",
+                    "-10.00",
+                    "Coffee",
+                    source_file,
+                    "csv",
+                    "tiller",
+                    import_id,
+                ],
+            )
+        import_log.finalize_import(
+            db, import_id, status="complete", rows_total=rows, rows_imported=rows
+        )
+    return import_id
+
+
+def _supports_elicitation(_context: object) -> bool:
+    return True
+
+
+def _append_raw_row(import_id: str, *, index: int) -> None:
+    """Add one more raw row to an existing import, widening its blast radius."""
+    from moneybin.database import get_database
+
+    source_file = "/tmp/revert_gate.csv"  # noqa: S108  # test fixture path
+    with get_database(read_only=False) as db:
+        db.execute(
+            """
+            INSERT INTO raw.tabular_transactions (
+                transaction_id, account_id, transaction_date, amount,
+                description, source_file, source_type, source_origin, import_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                f"csv_gate_{index}",
+                "checking",
+                "2026-01-02",
+                "-25.00",
+                "Late arrival",
+                source_file,
+                "csv",
+                "tiller",
+                import_id,
+            ],
+        )
+
+
+def _surviving_raw_rows(import_id: str) -> int:
+    from moneybin.database import get_database
+
+    with get_database(read_only=True) as db:
+        row = db.execute(
+            "SELECT COUNT(*) FROM raw.tabular_transactions WHERE import_id = ?",
+            [import_id],
+        ).fetchone()
+    return int(row[0]) if row else 0
+
+
+async def test_import_revert_requires_confirmation_before_deleting_raw_rows(
+    mcp_db: Path,
+) -> None:
+    """The first no-token revert call must propose, never destroy raw rows."""
+    import_id = _seed_revertable_import(rows=2)
+
+    required = await import_revert_coarse(
+        operation="revert_import",
+        import_id=import_id,
+    )
+
+    assert required.error is not None
+    assert required.error.code == error_codes.MUTATION_CONFIRMATION_REQUIRED
+    assert _surviving_raw_rows(import_id) == 2
+
+
+async def test_import_revert_deletes_raw_rows_once_confirmed(mcp_db: Path) -> None:
+    """The opaque-token round trip a degraded client uses does revert."""
+    import_id = _seed_revertable_import(rows=3)
+
+    required = await import_revert_coarse(
+        operation="revert_import",
+        import_id=import_id,
+    )
+
+    assert required.error is not None
+    assert required.error.details is not None
+    assert required.error.details["operation_kind"] == "import_revert"
+    blast_radius = cast(dict[str, int], required.error.details["blast_radius"])
+    assert blast_radius["total_rows"] == 3
+    assert blast_radius["raw.tabular_transactions"] == 3
+
+    result = await import_revert_coarse(
+        operation="revert_import",
+        import_id=import_id,
+        confirmation_token=str(required.error.details["confirmation_token"]),
+    )
+
+    assert result.error is None
+    assert result.data.status == "reverted"
+    assert result.data.rows_deleted == 3
+    assert _surviving_raw_rows(import_id) == 0
+
+
+async def test_import_revert_refuses_a_token_bound_to_stale_row_counts(
+    mcp_db: Path,
+) -> None:
+    """A row arriving after approval widens the blast radius, so the token dies."""
+    import_id = _seed_revertable_import(rows=2)
+    required = await import_revert_coarse(
+        operation="revert_import",
+        import_id=import_id,
+    )
+    assert required.error is not None
+    assert required.error.details is not None
+
+    _append_raw_row(import_id, index=99)
+
+    result = await import_revert_coarse(
+        operation="revert_import",
+        import_id=import_id,
+        confirmation_token=str(required.error.details["confirmation_token"]),
+    )
+
+    assert result.error is not None
+    assert result.error.code == error_codes.MUTATION_CONFIRMATION_MISMATCH
+    assert _surviving_raw_rows(import_id) == 3
+
+
+async def test_import_revert_confirms_inline_when_the_client_can_elicit(
+    mcp_db: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """An elicitation-capable client confirms in one round trip, minting no token."""
+    from fastmcp.server.elicitation import AcceptedElicitation
+
+    import_id = _seed_revertable_import(rows=1)
+    ctx = SimpleNamespace(
+        elicit=AsyncMock(return_value=AcceptedElicitation(data=True)),
+    )
+    monkeypatch.setattr("moneybin.mcp.confirmation._active_context", lambda: ctx)
+    monkeypatch.setattr(
+        "moneybin.mcp.confirmation.supports_elicitation",
+        _supports_elicitation,
+    )
+
+    result = await import_revert_coarse(
+        operation="revert_import",
+        import_id=import_id,
+    )
+
+    assert result.error is None
+    assert result.data.rows_deleted == 1
+    assert _surviving_raw_rows(import_id) == 0
+    assert "cannot be undone" in ctx.elicit.await_args.args[0]
+
+
+async def test_import_revert_declined_elicitation_keeps_every_row(
+    mcp_db: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Answering the prompt with false must leave the batch untouched."""
+    from fastmcp.server.elicitation import AcceptedElicitation
+
+    import_id = _seed_revertable_import(rows=2)
+    ctx = SimpleNamespace(
+        elicit=AsyncMock(return_value=AcceptedElicitation(data=False)),
+    )
+    monkeypatch.setattr("moneybin.mcp.confirmation._active_context", lambda: ctx)
+    monkeypatch.setattr(
+        "moneybin.mcp.confirmation.supports_elicitation",
+        _supports_elicitation,
+    )
+
+    result = await import_revert_coarse(
+        operation="revert_import",
+        import_id=import_id,
+    )
+
+    assert result.error is not None
+    assert result.error.code == error_codes.MUTATION_CONFIRMATION_DECLINED
+    assert _surviving_raw_rows(import_id) == 2
+
+
+async def test_import_revert_does_not_confirm_a_no_op(mcp_db: Path) -> None:
+    """An unknown batch deletes nothing, so it must not raise a prompt."""
+    result = await import_revert_coarse(
+        operation="revert_import",
+        import_id="00000000-0000-0000-0000-000000000000",
+    )
+
+    assert result.error is not None
+    assert result.error.code == error_codes.IMPORT_REVERT_NOT_FOUND
 
 
 def _issue_coarse_preview(

--- a/tests/moneybin/test_mcp/test_import_tools.py
+++ b/tests/moneybin/test_mcp/test_import_tools.py
@@ -13,6 +13,9 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from jsonschema import Draft202012Validator
+from jsonschema import validate as validate_json_schema
+from jsonschema.exceptions import ValidationError as JSONSchemaValidationError
 from pytest import MonkeyPatch
 
 import moneybin.mcp.tools.import_tools as import_tools_module
@@ -46,7 +49,7 @@ from moneybin.services.import_service import (
     ReviewedTabularPlan,
 )
 from tests.moneybin.pdf_statement_fixtures import write_card_statement_pdf
-from tests.moneybin.test_mcp.schema_assertions import isolated_server
+from tests.moneybin.test_mcp.schema_assertions import isolated_server, listed_tool
 
 
 async def test_import_workflow_registrar_preserves_seven_trust_boundaries() -> None:
@@ -78,6 +81,49 @@ async def test_import_workflow_registrar_preserves_seven_trust_boundaries() -> N
     assert "confirmation_token" in revert.parameters["properties"]
     confirm = next(tool for tool in tools if tool.name == "import_confirm")
     assert "confirmation_token" in confirm.parameters["properties"]
+
+
+async def test_import_revert_schema_admits_the_confirmation_token_round_trip() -> None:
+    """The advertised schema must accept the token the tool tells clients to send.
+
+    The non-eliciting path issues a token on the first call and requires it on
+    the second. A client that validates arguments against ``inputSchema`` before
+    dispatch — standard behavior — cannot make that second call unless the
+    revert branch admits ``confirmation_token``, leaving the fallback gate
+    unusable for exactly the clients it exists to serve.
+    """
+    mcp = isolated_server(import_tools_module.register_import_workflow_tools)
+    revert = await listed_tool(mcp, "import_revert")
+
+    Draft202012Validator.check_schema(revert.inputSchema)
+    validate_json_schema(
+        {
+            "operation": "revert_import",
+            "import_id": "imp_20260809_abc",
+            "confirmation_token": "tok_abc",
+        },
+        revert.inputSchema,
+        cls=Draft202012Validator,
+    )
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {"operation": "revert_import", "import_id": "imp_1", "format_name": "tiller"},
+        {"operation": "delete_saved_format", "format_name": "t", "import_id": "imp_1"},
+    ],
+    ids=["revert_rejects_format_name", "delete_rejects_import_id"],
+)
+async def test_import_revert_schema_still_forbids_cross_branch_targets(
+    arguments: dict[str, str],
+) -> None:
+    """Admitting the token must not open the branches' target fields to each other."""
+    mcp = isolated_server(import_tools_module.register_import_workflow_tools)
+    revert = await listed_tool(mcp, "import_revert")
+
+    with pytest.raises(JSONSchemaValidationError):
+        validate_json_schema(arguments, revert.inputSchema, cls=Draft202012Validator)
 
 
 def test_import_human_confirmation_tools_allow_decision_window() -> None:

--- a/tests/moneybin/test_services/test_import_pdf.py
+++ b/tests/moneybin/test_services/test_import_pdf.py
@@ -30,7 +30,7 @@ def test_import_pdf_is_revertible(db: Database, simple_statement_pdf: Path) -> N
     svc = ImportService(db)
     result = svc.import_file(simple_statement_pdf, refresh=False)
     assert result.import_id is not None
-    out = svc.revert(result.import_id)
+    out = svc.revert_confirmed(result.import_id, verify=lambda _live: None)
     assert out["status"] == "reverted"
     row = db.execute("SELECT COUNT(*) FROM raw.pdf_seeds").fetchone()
     assert row is not None
@@ -144,7 +144,7 @@ def test_revert_preserves_view_when_other_imports_remain(
     assert result_a.import_id is not None
     assert result_b.import_id is not None
 
-    svc.revert(result_a.import_id)
+    svc.revert_confirmed(result_a.import_id, verify=lambda _live: None)
 
     # View must still exist because result_b's import remains complete.
     view_count = db.execute(
@@ -193,7 +193,7 @@ def test_reimport_preserves_first_import_id_ownership(
         assert import_id == result_a.import_id
 
     # Reverting B leaves A's rows intact
-    svc.revert(result_b.import_id)
+    svc.revert_confirmed(result_b.import_id, verify=lambda _live: None)
     rows_after_revert_b = db.execute(
         "SELECT COUNT(*) FROM raw.pdf_seeds WHERE alias = 'simple_statement'"
     ).fetchone()

--- a/tests/moneybin/test_services/test_import_pdf_transactions.py
+++ b/tests/moneybin/test_services/test_import_pdf_transactions.py
@@ -608,7 +608,7 @@ def test_pdf_revert_clears_tabular_transactions(db: Database, tmp_path: Path) ->
     assert before[0] > 0
 
     # Revert
-    out = svc.revert(result.import_id)
+    out = svc.revert_confirmed(result.import_id, verify=lambda _live: None)
     assert out["status"] == "reverted"
 
     # Rows gone after revert

--- a/tests/moneybin/test_services/test_import_service_ofx.py
+++ b/tests/moneybin/test_services/test_import_service_ofx.py
@@ -131,7 +131,9 @@ class TestImportOFXBatchLifecycle:
         import_id = latest["import_id"]
         assert isinstance(import_id, str)
 
-        result = ImportService(db).revert(import_id)
+        result = ImportService(db).revert_confirmed(
+            import_id, verify=lambda _live: None
+        )
         assert result["status"] == "reverted"
 
         remaining_row = db.execute(

--- a/tests/moneybin/test_services/test_import_service_revert.py
+++ b/tests/moneybin/test_services/test_import_service_revert.py
@@ -1,4 +1,4 @@
-"""Tests for ImportService.revert.
+"""Tests for ImportService.plan_revert and ImportService.revert_confirmed.
 
 Covers the full response envelope (``reverted``, ``not_found``,
 ``already_reverted``, ``unsupported``, ``superseded``) across OFX and
@@ -19,7 +19,9 @@ from tests.moneybin.db_helpers import create_core_tables
 
 def test_revert_unknown_import_id_returns_not_found(db: Database) -> None:
     """Reverting an unknown import_id returns status='not_found'."""
-    result = ImportService(db).revert("00000000-0000-0000-0000-000000000000")
+    result = ImportService(db).revert_confirmed(
+        "00000000-0000-0000-0000-000000000000", verify=lambda _live: None
+    )
     assert result["status"] == "not_found"
 
 
@@ -36,8 +38,8 @@ def test_revert_already_reverted_returns_already_reverted(db: Database) -> None:
         db, import_id, status="complete", rows_total=0, rows_imported=0
     )
     # First revert flips status; the second is the one we're asserting on.
-    ImportService(db).revert(import_id)
-    result = ImportService(db).revert(import_id)
+    ImportService(db).revert_confirmed(import_id, verify=lambda _live: None)
+    result = ImportService(db).revert_confirmed(import_id, verify=lambda _live: None)
     assert result == {"status": "already_reverted"}
 
 
@@ -86,7 +88,7 @@ def test_revert_tabular_deletes_matching_rows_and_marks_reverted(
         db, import_id, status="complete", rows_total=2, rows_imported=2
     )
 
-    result = ImportService(db).revert(import_id)
+    result = ImportService(db).revert_confirmed(import_id, verify=lambda _live: None)
 
     assert result["status"] == "reverted"
     assert result["rows_deleted"] == 2
@@ -159,7 +161,7 @@ def test_revert_manual_investment_deletes_rows_not_orphaned(db: Database) -> Non
     assert pre is not None
     assert pre[0] == 1
 
-    result = ImportService(db).revert(import_id)
+    result = ImportService(db).revert_confirmed(import_id, verify=lambda _live: None)
 
     assert result["status"] == "reverted"
     assert result["rows_deleted"] == 1
@@ -211,7 +213,68 @@ def test_revert_stuck_investment_import_not_superseded_by_cash_batch(
         db, cash_import_id, status="complete", rows_total=1, rows_imported=1
     )
 
-    result = ImportService(db).revert(stuck_investment_import_id)
+    result = ImportService(db).revert_confirmed(
+        stuck_investment_import_id, verify=lambda _live: None
+    )
 
     assert result["status"] == "reverted"
     assert result["rows_deleted"] == 0
+
+
+def test_plan_revert_reports_counts_without_deleting_anything(db: Database) -> None:
+    """Planning is read-only — the rows it counts must still be there after."""
+    import_id = import_log.begin_import(
+        db,
+        source_file="/tmp/plan.csv",  # noqa: S108  # test fixture path
+        source_type="csv",
+        source_origin="tiller",
+        account_names=["checking"],
+    )
+    db.execute(
+        """
+        INSERT INTO raw.tabular_transactions (
+            transaction_id, account_id, transaction_date, amount, description,
+            source_file, source_type, source_origin, import_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            "csv_plan_1",
+            "checking",
+            "2026-01-01",
+            "-10.00",
+            "X",
+            "/tmp/plan.csv",  # noqa: S108  # test fixture path
+            "csv",
+            "tiller",
+            import_id,
+        ],
+    )
+    import_log.finalize_import(
+        db, import_id, status="complete", rows_total=1, rows_imported=1
+    )
+
+    plan = ImportService(db).plan_revert(import_id)
+
+    assert plan.revertable
+    assert plan.rows_to_delete == 1
+    assert plan.blast_radius["total_rows"] == 1
+    remaining = db.execute(
+        "SELECT COUNT(*) FROM raw.tabular_transactions WHERE import_id = ?",
+        [import_id],
+    ).fetchone()
+    assert remaining is not None
+    assert remaining[0] == 1
+    status = db.execute(
+        "SELECT status FROM raw.import_log WHERE import_id = ?", [import_id]
+    ).fetchone()
+    assert status is not None
+    assert status[0] == "complete"
+
+
+def test_plan_revert_of_unknown_batch_is_not_revertable(db: Database) -> None:
+    """A no-op outcome is still a plan, so callers can refuse without prompting."""
+    plan = ImportService(db).plan_revert("00000000-0000-0000-0000-000000000000")
+
+    assert not plan.revertable
+    assert plan.outcome == "not_found"
+    assert plan.as_result()["status"] == "not_found"


### PR DESCRIPTION
## The defect

`import_revert(operation="revert_import", import_id=…)` deleted a batch's raw
rows on the **first** call, with no confirmation of any kind — no token, no
elicitation, no proposal. Observed live on 2026-08-09: a call carrying no
token returned `{"status": "reverted", "rows_deleted": 27}`, destroying 14
batches and 368 raw rows before anyone could intervene.

Reversion has no undo and no `system_audit_undo` counterpart, so a wrong
inference here was both unnoticeable and unrecoverable — the case
`design-principles.md` § "Magic stays visible" sets the highest confirmation
bar for.

The root cause was not re-derived: `ImportService.revert()` was a single
method that read the batch and deleted it in one call, and the MCP tool
invoked it directly. There was no seam a confirmation could attach to.

## The fix

The sibling branch in the same tool (`delete_saved_format`) was already
gated. Rather than invent a second shape, reversion now takes the identical
four steps — plan (read-only) → build a frozen binding → obtain a grant →
verify inside the write transaction immediately before mutation:

- `ImportService.revert()` splits into `plan_revert()` (read-only) and
  `revert_confirmed(verify=…)`, which re-plans **inside** the write
  transaction and verifies immediately before the first `DELETE`.
- Non-revertable outcomes are plans too, so state that flips between approval
  and commit changes the binding rather than slipping past it.
- The binding's `blast_radius` carries the batch's live per-table row counts,
  so a token minted against stale counts is refused.
- `not_found` / `already_reverted` / `unsupported` / `superseded` return their
  envelope **without prompting** — a no-op never asks for confirmation.

The CLI path was already gated (`typer.confirm` + `--yes`), so the gap was
MCP-only. The CLI is updated to the new method pair, its prompt now names the
row count, and it refuses on state drift with the same mismatch error.

## The description was part of the defect

Its confirmation and recoverability clauses attached grammatically to
`delete_saved_format` but read as covering the whole tool. Both an
under-protection and an over-protection mistake were made against it in a
single session. Each clause now sits with its own branch, and reversion is
labelled **"permanent — no revert"** per the description requirements in
`.claude/rules/mcp.md`.

## Scope decision

**Kept the single-`import_id` shape.** A batch form (`import_ids: list[str]`)
binding one confirmation to several reversions was considered and deliberately
deferred: it widens a public parameter contract, and it is not needed to close
the security gap this PR exists to close.

That leaves a real, unresolved ergonomics cost, stated plainly rather than
argued away: reverting N batches now costs N confirmations, and the incident
that surfaced this bug involved 14 batches that were one logical decision for
the operator. Per-batch confirmation is defensible — each batch carries its own
blast radius, and the binding is what makes the gate meaningful — but "one
confirm per item" is not automatically the right end state, and this PR does
not claim it is. The batch form is tracked as a followup rather than dropped.

## Docs corrected from this fix's own evidence

- `moneybin-mcp.md:84` labelled the whole row "Audited recovery". Reversion
  writes no audit row — even now — so the row states plainly that rollback is
  permanent with no undo, rather than claiming an audit trail that does not
  exist. (Adding audit logging to reversion is real scope growth and is
  deliberately not in this PR.)
- `moneybin-capabilities.md:101-104` was *incomplete* rather than false —
  "audited" attaches grammatically to the format-deletion branch only. It was
  silent on the rollback branch's gating, which is what is fixed.
- `smart-import-financial.md` and `tests/fixtures/mcp_capabilities/outcome-map.json`
  still named the replaced method. The capability's observable outcome now
  requires the confirmation; the previous wording would have been satisfied by
  the buggy behavior.

## Verification

TDD — the tests were written first and watched fail. The RED run produced
`error=None, status='ok'`, confirming the tool deleted on the first call.

Six new MCP tests cover: no-token first call (proposal path, not a delete),
correct-token confirm, a token bound to stale row counts, inline elicitation,
declined elicitation leaving every row intact, and no confirmation for a
no-op. Two new service tests cover the read-only planner.

A mutation probe replacing `verify(live)` with `pass` killed exactly one test
and nothing else, proving that test isolates the in-transaction verify rather
than passing incidentally.

`make check test` — 8980 passed, 4 skipped (the 4 are pre-existing).
Plus the two integration commands `make test` does not select:
`test_tool_surface_budget.py -m integration` (8 passed) and
`test_mcp_surface_docs.py` (213 passed).
