### PR TITLE
Carry Plaid's persistent account id through the sync contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -891,6 +891,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   audit trail keeps it (#387).
 
 ### Fixed
+- **Reconnecting a bank no longer splits one account's ledger in two.** Plaid
+  reissues every `account_id` when an institution is relinked, so an account that
+  came back under a new id read as one MoneyBin had never seen: it minted
+  a second canonical account beside the first, and the history divided between
+  them. Plaid also sends `persistent_account_id`, which survives a relink and
+  exists to answer exactly this question — but MoneyBin's wire model never
+  declared the field, and an undeclared field is discarded during validation
+  without an error or a log line, so every pull threw it away.
+  MoneyBin now stores it on `raw.plaid_accounts` and hands it to the
+  account resolver as the strong reference that reunites a returning account with
+  its own ledger. Plaid populates it for depository accounts at the three
+  institutions using tokenized account numbers — Chase, PNC, and US Bank — so a
+  credit card, or an account anywhere else, still resolves through the
+  weak-match review as before. Accounts synced before this change hold no value
+  for it — nothing retained a copy, so there is nothing to backfill — and pick
+  one up on their next sync (#395).
+- **Two accounts sharing one product name no longer match on it.**
+  MoneyBin named a Plaid account after `official_name`, which is the product's
+  marketing label rather than the account's: two different Chase cards both
+  read "Ultimate Rewards®" in name matching. The account's own `name` now leads
+  that fallback, with `official_name` behind it and the institution name behind
+  that. The review queue is unaffected — both sides of a merge proposal are
+  already labelled from `core.dim_accounts.display_name`, which is built from
+  institution, subtype, and last four (#395).
 - **Undoing a decision puts it back in the review queue, and the queue count now
   says so.** `system audit undo` restores a link decision to pending, but the
   counter that reports how many decisions await review was refreshed only by the

--- a/docs/reference/account-matching.md
+++ b/docs/reference/account-matching.md
@@ -49,9 +49,11 @@ flowchart TD
    X"). Adopted above all detection.
 2. **Strong key → silent auto-adopt.** A stable, upstream-assigned key that's
    already bound to an account: the source's own account key on a same-source
-   re-import (including Plaid's `account_id`, scoped to that connection), or a
-   full account number scoped by its routing/bank id. These are near-certain, so
-   MoneyBin adopts silently.
+   re-import (including Plaid's `account_id`, scoped to that connection), Plaid's
+   `persistent_account_id` where the institution supplies one (this is the key
+   that survives a relink, when `account_id` does not), or a full account number
+   scoped by its routing/bank id. These are near-certain, so MoneyBin adopts
+   silently.
 3. **Weak match → always a confirm.** A shared **institution + last 4 digits**,
    or a **fuzzy name** match. Weak signals collide — two Wells Fargo accounts can
    both end in `4267` — so MoneyBin *proposes* and waits. **It never merges two
@@ -134,11 +136,16 @@ Reading the table precisely requires four caveats:
 - **A bare bank CSV carries no identity.** Date/Description/Amount alone can't
   tell MoneyBin which account it is, so binding is always explicit — which is why
   the pick-list (rung 5) exists.
-- **Plaid's strong key is connection-scoped, not cross-connection.** The sync
-  broker's account contract does not carry Plaid's `persistent_account_id`, so
-  re-authenticating the same bank through Plaid Link (a new connection) does not
-  auto-adopt the existing account — it resolves through the weak-match rungs
-  (institution + last 4) like any other cross-source twin.
+- **Plaid's strong key crosses connections where the institution supplies one.**
+  Re-authenticating the same bank through Plaid Link issues fresh `account_id`
+  tokens, so the connection-scoped key cannot recognize a returning account.
+  Plaid's `persistent_account_id` survives that boundary, and MoneyBin adopts on
+  it directly (rung 2). Plaid populates it for depository accounts at the three
+  institutions that use tokenized account numbers — Chase, PNC, and US Bank. An
+  account without it — every credit card, and every account at the other
+  institutions — resolves through the weak-match rungs (institution + last 4)
+  like any other cross-source twin. Accounts synced before MoneyBin captured the
+  field hold no value for it until their next sync.
 
 ## When MoneyBin asks you: the import gate
 

--- a/docs/reference/data-sources.md
+++ b/docs/reference/data-sources.md
@@ -206,7 +206,7 @@ Live banking sync brokered through `moneybin-sync`. Implementation: `src/moneybi
 
 **What's pulled per sync:**
 
-- **Accounts** (`raw.plaid_accounts`): `account_id`, `account_type`, `account_subtype`, `institution_name`, `official_name`, `mask` (last-4).
+- **Accounts** (`raw.plaid_accounts`): `account_id`, `persistent_account_id`, `account_type`, `account_subtype`, `institution_name`, `name`, `official_name`, `mask` (last-4). `persistent_account_id` is the id that survives a relink where `account_id` does not; Plaid populates it only for depository accounts at institutions using tokenized account numbers (Chase, PNC, US Bank), so it is NULL elsewhere — and on every row synced before MoneyBin captured it.
 - **Transactions** (`raw.plaid_transactions`): `transaction_id`, `account_id`, `transaction_date`, `amount`, `description`, `merchant_name`, `category`, `pending`, `iso_currency_code`. Transactions carry the ISO field only — `unofficial_currency_code` is captured for balances, securities, investment transactions, and holdings, but not here.
 - **Balances** (`raw.plaid_balances`): `account_id`, `balance_date`, `current_balance`, `available_balance`, `iso_currency_code` / `unofficial_currency_code`.
 - **Removed transactions:** Plaid's incremental sync emits a separate `removed_transactions` list; corresponding rows are deleted from `raw.plaid_transactions` and surfaced as `transactions_removed` in the `PullResult`.

--- a/src/moneybin/connectors/sync_models.py
+++ b/src/moneybin/connectors/sync_models.py
@@ -22,10 +22,23 @@ from pydantic import (
 
 
 def _blank_to_none(value: object) -> object:
-    """A currency code that is empty or whitespace-only means absent, not ''."""
+    """An empty or whitespace-only string means absent, not ''."""
     if isinstance(value, str) and not value.strip():
         return None
     return value
+
+
+BlankToNone = Annotated[str | None, BeforeValidator(_blank_to_none)]
+"""An optional wire string whose blanks normalise to None.
+
+Nothing upstream promises a field the institution left empty arrives as JSON
+null rather than ``""`` or ``"  "`` — ``prep.stg_plaid__accounts`` wraps every
+free-text Plaid column in ``NULLIF(TRIM(...), '')`` for that reason, and
+``SourceAccount`` canonicalises ``mask`` for it. A blank must not reach the
+resolver truthy: ``persistent_token`` is a globally-scoped strong ref that
+auto-adopts with no review, so one whitespace token shared by two institutions'
+accounts merges their ledgers silently.
+"""
 
 
 CurrencyCode = Annotated[str | None, BeforeValidator(_blank_to_none)]
@@ -113,12 +126,22 @@ class SyncAckResponse(BaseModel):
 
 
 class SyncAccount(BaseModel):
-    """One account entry in GET /sync/data response."""
+    """One account entry in GET /sync/data response.
+
+    Every field the broker sends must be declared here. Pydantic's default
+    ``extra='ignore'`` destroys an undeclared key at validation with no error
+    and no log line, so a field this model forgets is indistinguishable from
+    one the broker never sent. That is how ``persistent_account_id`` — the key
+    that survives a Plaid relink — reached nothing downstream between the first
+    Plaid sync release (#134) and the change that declared it here.
+    """
 
     account_id: str
+    persistent_account_id: BlankToNone = None
     account_type: str | None = None
     account_subtype: str | None = None
     institution_name: str | None = None
+    name: BlankToNone = None
     official_name: str | None = None
     mask: str | None = Field(default=None, max_length=8)
 

--- a/src/moneybin/connectors/sync_models.py
+++ b/src/moneybin/connectors/sync_models.py
@@ -41,7 +41,7 @@ accounts merges their ledgers silently.
 """
 
 
-CurrencyCode = Annotated[str | None, BeforeValidator(_blank_to_none)]
+CurrencyCode = BlankToNone
 """An optional ISO/unofficial currency code, with blanks normalised to None.
 
 Plaid returns ``""`` for a currency it does not carry, and the two consumers of
@@ -140,9 +140,9 @@ class SyncAccount(BaseModel):
     persistent_account_id: BlankToNone = None
     account_type: str | None = None
     account_subtype: str | None = None
-    institution_name: str | None = None
+    institution_name: BlankToNone = None
     name: BlankToNone = None
-    official_name: str | None = None
+    official_name: BlankToNone = None
     mask: str | None = Field(default=None, max_length=8)
 
 

--- a/src/moneybin/extractors/plaid/extractor.py
+++ b/src/moneybin/extractors/plaid/extractor.py
@@ -95,9 +95,11 @@ class LoadResult:
 
 _ACCOUNTS_SCHEMA = pl.Schema({
     "account_id": pl.Utf8,
+    "persistent_account_id": pl.Utf8,
     "account_type": pl.Utf8,
     "account_subtype": pl.Utf8,
     "institution_name": pl.Utf8,
+    "name": pl.Utf8,
     "official_name": pl.Utf8,
     "mask": pl.Utf8,
     "source_file": pl.Utf8,

--- a/src/moneybin/extractors/plaid/schema/raw_plaid_accounts.sql
+++ b/src/moneybin/extractors/plaid/schema/raw_plaid_accounts.sql
@@ -1,9 +1,11 @@
 /* Bank accounts connected via Plaid; one record per account per institution */
 CREATE TABLE IF NOT EXISTS raw.plaid_accounts (
-    account_id VARCHAR NOT NULL,        -- Plaid account_id; globally unique per Plaid
+    account_id VARCHAR NOT NULL,        -- Plaid account_id; globally unique per Plaid, but reissued when the item is relinked
+    persistent_account_id VARCHAR,      -- Plaid persistent_account_id; survives relink, so it is the cross-connection identity ref. NULL where the institution does not supply one
     account_type VARCHAR,               -- depository, credit, loan, investment, other
     account_subtype VARCHAR,            -- checking, savings, credit card, etc.
     institution_name VARCHAR,           -- Human-readable name from Plaid
+    name VARCHAR,                       -- Account name as the institution reports it; distinguishes sibling accounts that share one official_name
     official_name VARCHAR,              -- Official account name from the institution
     mask VARCHAR,                       -- Last 4 digits of the account number
     source_file VARCHAR NOT NULL,       -- Logical identifier: sync_{job_id} (last sync to touch this row)

--- a/src/moneybin/services/sync_service.py
+++ b/src/moneybin/services/sync_service.py
@@ -279,10 +279,19 @@ class SyncService:
         account->item attribution so it is byte-identical to what raw recorded
         (a divergent scope would corrupt source_native uniqueness).
 
-        ``persistent_token`` (Plaid ``persistent_account_id``) is the
-        cross-connection strong ref, but the server's ``SyncAccount`` contract
-        does not expose it today, so it is always None here — cross-connection
-        identity for Plaid stays unwired until that field lands (followup).
+        ``persistent_token`` carries Plaid's ``persistent_account_id``, which
+        survives a relink where ``account_id`` does not: reconnecting an item
+        reissues every native id, so ``source_native`` alone cannot tell a
+        returning card from a new one and the resolver mints a second canonical
+        account for a ledger the user already has. The persistent id is the
+        strong ref that confirms identity across that boundary.
+
+        ``name`` leads the display fallback because ``official_name`` is the
+        product's marketing label — sibling Chase cards report one
+        ``Ultimate Rewards®`` between them, so it cannot discriminate on the
+        name rung of the candidate pass. It is that rung's input only: both
+        sides of a merge proposal are labelled from
+        ``core.dim_accounts.display_name``, never from this string.
         """
         if not sync_data.accounts:
             return
@@ -295,7 +304,8 @@ class SyncService:
                     source_origin=item_by_account[acc.account_id],
                     source_account_key=acc.account_id,
                     account_name=(
-                        acc.official_name
+                        acc.name
+                        or acc.official_name
                         or (
                             f"{acc.institution_name} account"
                             if acc.institution_name
@@ -305,7 +315,7 @@ class SyncService:
                     account_number=None,  # Plaid never exposes a full number
                     last_four=acc.mask,
                     institution=acc.institution_name,
-                    persistent_token=None,  # not in SyncAccount contract (followup)
+                    persistent_token=acc.persistent_account_id,
                 )
             )
             ACCOUNT_LINK_OUTCOMES_TOTAL.labels(result=resolved_account.outcome).inc()

--- a/src/moneybin/sql/migrations/V050__add_plaid_account_identity_fields.py
+++ b/src/moneybin/sql/migrations/V050__add_plaid_account_identity_fields.py
@@ -1,0 +1,58 @@
+"""V050: add persistent_account_id and name to raw.plaid_accounts.
+
+The broker has always sent both, but ``SyncAccount`` never declared them and
+Pydantic's ``extra='ignore'`` destroyed each one at validation — silently, with
+no error and no log line. Existing databases therefore hold no copy anywhere:
+the values never survived past the wire.
+
+Deliberately NOT backfilled, and the two columns are not equally cheap to guess.
+``persistent_account_id`` becomes an ``AccountResolver`` strong ref, which
+auto-adopts in step 1 of ``resolve()`` without surfacing a review — so a wrong
+value silently merges two ledgers, which is exactly the failure the field exists
+to prevent. Nothing already stored can derive it: ``account_id`` is the token a
+relink reissues, and ``official_name`` is a shared product label (two Chase
+cards report one ``Ultimate Rewards®`` between them).
+
+So both columns start NULL. NULL reads as "unknown" everywhere downstream — the
+resolver skips an empty strong ref, and the display fallback keeps using
+``official_name`` — and the next sync writes the true values through the raw
+primary key. The cost is bounded: cross-connection identity stays unavailable
+for accounts not yet re-synced, which is the status quo, not a regression.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def migrate(conn: object) -> None:
+    """Add both columns to raw.plaid_accounts, NULL for every existing row."""
+    logger.debug(
+        "V050: ADD COLUMN IF NOT EXISTS raw.plaid_accounts.persistent_account_id"
+    )
+    conn.execute(  # type: ignore[union-attr]
+        "ALTER TABLE raw.plaid_accounts "
+        "ADD COLUMN IF NOT EXISTS persistent_account_id VARCHAR"
+    )
+    # Byte-identical to the comment in raw_plaid_accounts.sql. `_apply_comments`
+    # re-runs that DDL's comments on every startup while this migration runs
+    # once, so a divergent string here would be overwritten on the next open and
+    # the catalog description would differ by which ran last.
+    conn.execute(  # type: ignore[union-attr]
+        "COMMENT ON COLUMN raw.plaid_accounts.persistent_account_id IS "
+        "'Plaid persistent_account_id; survives relink, so it is the "
+        "cross-connection identity ref. NULL where the institution does not "
+        "supply one'"
+    )
+
+    logger.debug("V050: ADD COLUMN IF NOT EXISTS raw.plaid_accounts.name")
+    conn.execute(  # type: ignore[union-attr]
+        "ALTER TABLE raw.plaid_accounts ADD COLUMN IF NOT EXISTS name VARCHAR"
+    )
+    conn.execute(  # type: ignore[union-attr]
+        "COMMENT ON COLUMN raw.plaid_accounts.name IS "
+        "'Account name as the institution reports it; distinguishes sibling "
+        "accounts that share one official_name'"
+    )

--- a/tests/moneybin/test_connectors/test_sync_models.py
+++ b/tests/moneybin/test_connectors/test_sync_models.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from moneybin.connectors.sync_models import (
     DeviceAuthorizationChallenge,
+    SyncAccount,
     SyncDataResponse,
     SyncHolding,
     SyncInvestmentTransaction,
@@ -34,6 +35,59 @@ def test_device_authorization_challenge_defaults_interval_to_five_seconds() -> N
     })
 
     assert challenge.interval == 5.0
+
+
+def test_account_keeps_persistent_account_id_and_name() -> None:
+    """The broker sends both; an undeclared field is destroyed, not carried.
+
+    Pydantic's default ``extra='ignore'`` drops an unmodelled key at
+    ``model_validate`` with no error and no log line, so a field the broker
+    adds reaches nothing downstream until the client declares it. That is the
+    exact mechanism that discarded ``persistent_account_id`` — Plaid's
+    cross-connection account identity — for seven weeks while the broker was
+    sending it. Asserting the wire keys survive is the only signal this layer
+    offers.
+    """
+    account = SyncAccount.model_validate({
+        "account_id": "acc_1",
+        "persistent_account_id": "ppa_survives_reconnect",
+        "account_type": "credit",
+        "account_subtype": "credit card",
+        "name": "Freedom Unlimited",
+        "official_name": "Ultimate Rewards®",
+        "mask": "1234",
+    })
+
+    assert account.persistent_account_id == "ppa_survives_reconnect"
+    assert account.name == "Freedom Unlimited"
+
+
+def test_account_without_the_new_fields_still_validates() -> None:
+    """A broker predating the field must not start failing validation."""
+    account = SyncAccount.model_validate({"account_id": "acc_1"})
+
+    assert account.persistent_account_id is None
+    assert account.name is None
+
+
+def test_account_blank_identity_fields_normalise_to_none() -> None:
+    """A blank must not reach the resolver truthy.
+
+    ``persistent_account_id`` becomes a ``persistent_token`` strong ref, which
+    is scoped globally and auto-adopts without review. A whitespace-only value
+    is truthy in Python, so two unrelated accounts carrying one would merge
+    into a single ledger silently. Nothing on the wire promises an empty field
+    arrives as null rather than ``""`` — ``prep.stg_plaid__accounts`` wraps
+    every free-text Plaid column in ``NULLIF(TRIM(...), '')`` for that reason.
+    """
+    account = SyncAccount.model_validate({
+        "account_id": "acc_1",
+        "persistent_account_id": "   ",
+        "name": "",
+    })
+
+    assert account.persistent_account_id is None
+    assert account.name is None
 
 
 def test_payload_without_investment_arrays_validates() -> None:

--- a/tests/moneybin/test_connectors/test_sync_models.py
+++ b/tests/moneybin/test_connectors/test_sync_models.py
@@ -43,10 +43,10 @@ def test_account_keeps_persistent_account_id_and_name() -> None:
     Pydantic's default ``extra='ignore'`` drops an unmodelled key at
     ``model_validate`` with no error and no log line, so a field the broker
     adds reaches nothing downstream until the client declares it. That is the
-    exact mechanism that discarded ``persistent_account_id`` — Plaid's
-    cross-connection account identity — for seven weeks while the broker was
-    sending it. Asserting the wire keys survive is the only signal this layer
-    offers.
+    exact mechanism by which ``persistent_account_id`` — Plaid's
+    cross-connection account identity — reached nothing downstream between the
+    first Plaid sync release (#134) and the change that declared it. Asserting
+    the wire keys survive is the only signal this layer offers.
     """
     account = SyncAccount.model_validate({
         "account_id": "acc_1",
@@ -88,6 +88,24 @@ def test_account_blank_identity_fields_normalise_to_none() -> None:
 
     assert account.persistent_account_id is None
     assert account.name is None
+
+
+def test_account_blank_display_fields_normalise_to_none() -> None:
+    """A blank must not win the display fallback either.
+
+    ``_resolve_accounts`` picks ``name or official_name or "<institution>
+    account"``, so a whitespace-only string short-circuits the chain and the
+    account surfaces under a name that renders empty. ``institution_name``
+    reaches the resolver's own ``institution`` field by the same route.
+    """
+    account = SyncAccount.model_validate({
+        "account_id": "acc_1",
+        "official_name": "   ",
+        "institution_name": "",
+    })
+
+    assert account.official_name is None
+    assert account.institution_name is None
 
 
 def test_payload_without_investment_arrays_validates() -> None:

--- a/tests/moneybin/test_extractors/fixtures/plaid_sync_response.yaml
+++ b/tests/moneybin/test_extractors/fixtures/plaid_sync_response.yaml
@@ -3,15 +3,19 @@
 # Amounts use Plaid convention (positive = expense).
 accounts:
   - account_id: acc_chase_check
+    persistent_account_id: ppa_chase_check_0001
     account_type: depository
     account_subtype: checking
     institution_name: Chase
+    name: Chase Checking
     official_name: Total Checking
     mask: "1234"
   - account_id: acc_chase_save
+    persistent_account_id: ppa_chase_save_0002
     account_type: depository
     account_subtype: savings
     institution_name: Chase
+    name: Chase Savings
     official_name: Total Savings
     mask: "5678"
 

--- a/tests/moneybin/test_extractors/test_plaid_extractor.py
+++ b/tests/moneybin/test_extractors/test_plaid_extractor.py
@@ -44,6 +44,32 @@ def test_loader_writes_accounts(db: Database, sync_data: SyncDataResponse) -> No
     )
 
 
+def test_loader_writes_persistent_account_id_and_name(
+    db: Database, sync_data: SyncDataResponse
+) -> None:
+    """Both columns must reach raw, or the wire model's copy dies at the loader.
+
+    ``_ACCOUNTS_SCHEMA`` selects which keys of ``SyncAccount.model_dump()``
+    become columns, so declaring the fields on the model is only half the path
+    — an unlisted key is dropped again here, just as silently. ``raw`` is where
+    a later backfill would have to read them from, and nothing upstream retains
+    a copy once the pull is acked.
+    """
+    loader = PlaidExtractor(db)
+    loader.load(sync_data, job_id=sync_data.metadata.job_id)
+
+    rows = db.execute(
+        """
+        SELECT account_id, persistent_account_id, name, official_name
+        FROM raw.plaid_accounts ORDER BY account_id
+        """
+    ).fetchall()
+    assert rows == [
+        ("acc_chase_check", "ppa_chase_check_0001", "Chase Checking", "Total Checking"),
+        ("acc_chase_save", "ppa_chase_save_0002", "Chase Savings", "Total Savings"),
+    ]
+
+
 def test_loader_writes_transactions_preserving_plaid_sign(
     db: Database, sync_data: SyncDataResponse
 ) -> None:

--- a/tests/moneybin/test_migration_v050.py
+++ b/tests/moneybin/test_migration_v050.py
@@ -1,0 +1,141 @@
+"""V050: add persistent_account_id and name to raw.plaid_accounts.
+
+Pure additive DDL (``ADD COLUMN ... NULL``, no DEFAULT), so per
+``.claude/rules/database.md`` populated fixtures are not required. They are here
+anyway because the load-bearing claim is about rows that predate the columns:
+the values are unrecoverable for them, and a migration that appeared to
+reconstruct one would license a cross-connection merge on invented evidence.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from moneybin.database import Database
+from moneybin.sql.migrations.V050__add_plaid_account_identity_fields import migrate
+from tests.moneybin.migration_helpers import column_exists, insert_rows, run_migration
+
+pytestmark = pytest.mark.fresh_db
+
+_PRE_MIGRATION_COLUMNS = (
+    "account_id",
+    "account_type",
+    "account_subtype",
+    "institution_name",
+    "official_name",
+    "mask",
+    "source_file",
+    "source_type",
+    "source_origin",
+)
+
+
+_PRE_V050_DDL = """
+CREATE TABLE raw.plaid_accounts (
+    account_id VARCHAR NOT NULL,
+    account_type VARCHAR,
+    account_subtype VARCHAR,
+    institution_name VARCHAR,
+    official_name VARCHAR,
+    mask VARCHAR,
+    source_file VARCHAR NOT NULL,
+    source_type VARCHAR NOT NULL DEFAULT 'plaid',
+    source_origin VARCHAR NOT NULL,
+    extracted_at TIMESTAMP,
+    loaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (account_id, source_origin)
+)
+"""
+
+
+@pytest.fixture
+def pre_v050_db(db: Database) -> Database:
+    """A populated table without the columns, so migrate() does real work.
+
+    Rebuilt from the pre-V050 DDL rather than ALTER-dropped: the primary key
+    indexes ``source_origin``, and DuckDB refuses to drop any column ahead of an
+    indexed one. Recreating is also the truer fixture — this is the table shape
+    an existing database actually has.
+    """
+    db.execute("DROP TABLE raw.plaid_accounts")
+    db.execute(_PRE_V050_DDL)
+    insert_rows(
+        db,
+        "raw",
+        "plaid_accounts",
+        _PRE_MIGRATION_COLUMNS,
+        [
+            (
+                "acc_old_check",
+                "depository",
+                "checking",
+                "Chase",
+                "Total Checking",
+                "1234",
+                "sync_job_a",
+                "plaid",
+                "item_chase_abc",
+            ),
+            (
+                "acc_old_card_a",
+                "credit",
+                "credit card",
+                "Chase",
+                "Ultimate Rewards®",
+                "1111",
+                "sync_job_a",
+                "plaid",
+                "item_chase_abc",
+            ),
+            (
+                "acc_old_card_b",
+                "credit",
+                "credit card",
+                "Chase",
+                "Ultimate Rewards®",
+                "2222",
+                "sync_job_a",
+                "plaid",
+                "item_chase_abc",
+            ),
+        ],
+    )
+    return db
+
+
+def test_v050_adds_both_columns(pre_v050_db: Database) -> None:
+    assert not column_exists(
+        pre_v050_db, "raw", "plaid_accounts", "persistent_account_id"
+    )
+    assert not column_exists(pre_v050_db, "raw", "plaid_accounts", "name")
+
+    run_migration(pre_v050_db, migrate)
+
+    assert column_exists(pre_v050_db, "raw", "plaid_accounts", "persistent_account_id")
+    assert column_exists(pre_v050_db, "raw", "plaid_accounts", "name")
+
+
+def test_v050_leaves_pre_existing_rows_null(pre_v050_db: Database) -> None:
+    """No backfill is possible, and a guessed one would be worse than none.
+
+    Neither value is derivable from anything already stored: ``official_name``
+    is the shared product label on the two cards above, and ``account_id`` is
+    the very token a relink reissues. A ``persistent_account_id`` invented here
+    would be an ``AccountResolver`` strong ref — it auto-adopts without review
+    — so a wrong guess silently merges two ledgers. NULL means "unknown", the
+    resolver skips the ref, and the next sync writes the real value.
+    """
+    run_migration(pre_v050_db, migrate)
+
+    rows = pre_v050_db.execute(
+        "SELECT persistent_account_id, name FROM raw.plaid_accounts ORDER BY account_id"
+    ).fetchall()
+    assert rows == [(None, None), (None, None), (None, None)]
+
+
+def test_v050_is_idempotent(pre_v050_db: Database) -> None:
+    run_migration(pre_v050_db, migrate)
+    run_migration(pre_v050_db, migrate)
+
+    row = pre_v050_db.execute("SELECT COUNT(*) FROM raw.plaid_accounts").fetchone()
+    assert row is not None and row[0] == 3

--- a/tests/moneybin/test_services/test_sync_service.py
+++ b/tests/moneybin/test_services/test_sync_service.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from datetime import UTC, date, datetime
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -75,6 +77,76 @@ def mock_investments_client(investments_sync_data: SyncDataResponse) -> MagicMoc
     )
     client.get_data.return_value = investments_sync_data
     return client
+
+
+def _payload(accounts: list[dict[str, Any]], *, item_id: str) -> SyncDataResponse:
+    """A minimal one-institution /sync/data response carrying only accounts."""
+    return SyncDataResponse.model_validate({
+        "accounts": accounts,
+        "transactions": [],
+        "balances": [],
+        "removed_transactions": [],
+        "metadata": {
+            "job_id": f"job-{item_id}",
+            "synced_at": "2026-08-15T12:00:00Z",
+            "institutions": [
+                {
+                    "provider_item_id": item_id,
+                    "institution_name": "Chase",
+                    "status": "completed",
+                    "transaction_count": 0,
+                }
+            ],
+        },
+    })
+
+
+def _relinked_payload() -> SyncDataResponse:
+    """The same card after a relink: new account_id, new item, same persistent id."""
+    return _payload(
+        [
+            {
+                "account_id": "acc_chase_check_reissued",
+                "persistent_account_id": "ppa_chase_check_0001",
+                "account_type": "depository",
+                "account_subtype": "checking",
+                "institution_name": "Chase",
+                "name": "Chase Checking",
+                "official_name": "Total Checking",
+                "mask": "1234",
+            }
+        ],
+        item_id="item_chase_xyz",
+    )
+
+
+def _payload_with_shared_official_name() -> SyncDataResponse:
+    """Two Chase cards whose official_name is the same product label."""
+    return _payload(
+        [
+            {
+                "account_id": "acc_card_a",
+                "persistent_account_id": "ppa_card_a",
+                "account_type": "credit",
+                "account_subtype": "credit card",
+                "institution_name": "Chase",
+                "name": "Freedom Unlimited",
+                "official_name": "Ultimate Rewards®",
+                "mask": "1111",
+            },
+            {
+                "account_id": "acc_card_b",
+                "persistent_account_id": "ppa_card_b",
+                "account_type": "credit",
+                "account_subtype": "credit card",
+                "institution_name": "Chase",
+                "name": "Sapphire Preferred",
+                "official_name": "Ultimate Rewards®",
+                "mask": "2222",
+            },
+        ],
+        item_id="item_chase_cards",
+    )
 
 
 def test_pull_happy_path(
@@ -1226,6 +1298,115 @@ class TestPullResolvesAccounts:
         assert all(r[2] == "item_chase_abc" for r in rows)
         # Each resolves to a freshly minted canonical uuid4[:12].
         assert all(len(r[1]) == 12 for r in rows)
+
+    def test_pull_records_persistent_account_id_as_a_strong_ref(
+        self,
+        mock_client: MagicMock,
+        db: Database,
+        loader: PlaidExtractor,
+    ) -> None:
+        """Plaid's persistent_account_id must land as a persistent_token ref.
+
+        ``AccountResolver`` already treats ``persistent_token`` as a strong
+        confirmer that auto-adopts (step 1 of ``resolve``); the field was simply
+        never handed to it, so every Plaid account minted with the ref column
+        empty and cross-connection identity could never fire.
+        """
+        service = SyncService(client=mock_client, db=db, loader=loader)
+        service.pull(refresh=False)
+
+        rows = db.execute(
+            """
+            SELECT ref_value, account_id
+            FROM app.account_links
+            WHERE status = 'accepted' AND ref_kind = 'persistent_token'
+              AND source_type = 'plaid'
+            ORDER BY ref_value
+            """,
+        ).fetchall()
+        assert [r[0] for r in rows] == ["ppa_chase_check_0001", "ppa_chase_save_0002"]
+
+    def test_relinked_account_adopts_the_same_canonical_id(
+        self,
+        mock_client: MagicMock,
+        db: Database,
+        loader: PlaidExtractor,
+    ) -> None:
+        """A relink reissues account_id and item_id; persistent_account_id survives.
+
+        This is the whole reason the field exists, and the failure it prevents
+        is the 2026-08-08 incident: Chase relinked, Plaid minted a fresh
+        ``account_id`` under a fresh ``provider_item_id``, and with no strong
+        ref to confirm identity the resolver minted a *second* canonical
+        account for a card the user already had — splitting one ledger in two.
+
+        Both source_native keys must end up pointing at one canonical id.
+        """
+        service = SyncService(client=mock_client, db=db, loader=loader)
+        service.pull(refresh=False)
+        before = db.execute(
+            "SELECT account_id FROM app.account_links "
+            "WHERE status = 'accepted' AND ref_kind = 'source_native' "
+            "AND ref_value = 'acc_chase_check'",
+        ).fetchone()
+        assert before is not None
+
+        mock_client.get_data.return_value = _relinked_payload()
+        service.pull(refresh=False)
+
+        after = db.execute(
+            "SELECT account_id FROM app.account_links "
+            "WHERE status = 'accepted' AND ref_kind = 'source_native' "
+            "AND ref_value = 'acc_chase_check_reissued'",
+        ).fetchone()
+        assert after is not None, "relinked account never resolved"
+        assert after[0] == before[0], (
+            "relinked account minted a second canonical id instead of adopting "
+            "the one its persistent_account_id already confirms"
+        )
+        # A strong ref adopts silently (step 1 of resolve, ahead of the
+        # candidate pass), so the relink must leave the review queue empty —
+        # a pending row here means it resolved through a weak rung instead.
+        pending = db.execute(
+            "SELECT COUNT(*) FROM app.account_link_decisions WHERE status = 'pending'"
+        ).fetchone()
+        assert pending is not None and pending[0] == 0
+
+    def test_pull_prefers_the_account_name_over_the_official_name(
+        self,
+        mock_client: MagicMock,
+        db: Database,
+        loader: PlaidExtractor,
+    ) -> None:
+        """``name`` distinguishes siblings that share one ``official_name``.
+
+        Plaid's ``official_name`` is the product's marketing label, so two
+        different Chase cards both report "Ultimate Rewards®" while ``name``
+        keeps them apart. The resolver feeds this string to ``match_account``
+        on the name rung of the candidate pass, so a label shared by two
+        accounts cannot discriminate between them there.
+
+        Asserts on the ``SourceAccount`` the service constructs — the resolver
+        itself is the collaborator boundary here, and its own adoption
+        behaviour is covered above.
+        """
+        captured: list[object] = []
+
+        class _Capturing:
+            def __init__(self, *_a: object, **_kw: object) -> None:
+                pass
+
+            def resolve(self, src: object) -> object:
+                captured.append(src)
+                return SimpleNamespace(account_id="acct_1", outcome="minted_new")
+
+        mock_client.get_data.return_value = _payload_with_shared_official_name()
+        with patch("moneybin.services.sync_service.AccountResolver", _Capturing):
+            service = SyncService(client=mock_client, db=db, loader=loader)
+            service.pull(refresh=False)
+
+        names = [getattr(src, "account_name", None) for src in captured]
+        assert names == ["Freedom Unlimited", "Sapphire Preferred"]
 
     def test_pull_resolver_failure_does_not_fail_the_pull(
         self,

--- a/tests/privacy/test_sql_lineage.py
+++ b/tests/privacy/test_sql_lineage.py
@@ -1278,6 +1278,42 @@ def test_undeclared_raw_column_floors() -> None:
     assert _class_of_key(("raw", "ofx_transactions", "memo")) is DataClass.FLOORED
 
 
+def test_plaid_persistent_account_id_rides_the_content_net() -> None:
+    """A deliberate FLOORED, recorded so a later reader can argue with it.
+
+    ``persistent_account_id`` is Plaid's opaque cross-connection surrogate —
+    the same kind of provider-minted token as the ``account_id`` beside it,
+    which this table leaves readable on purpose so an agent can correlate a
+    Plaid import while debugging. The account-number material rides ``mask``,
+    which stays CRITICAL.
+
+    The tempting objection is that ``app.account_links.ref_value`` holds this
+    identical string and IS CRITICAL, so reading it here defeats that mask by
+    a join. It does — and that is the intended end state, not a leak:
+    ``ref_value`` is masked only because it is polymorphic and may also hold a
+    full account number, and ``taxonomy.py`` already names per-ref_kind
+    un-masking of opaque persistent_tokens as wanted work. A monomorphic column
+    that provably holds only the token gets there early.
+
+    Anchored on the loader's own schema first: an undeclared raw column floors
+    whether or not it exists, so asserting the class alone would pass just as
+    happily against a typo.
+    """
+    from moneybin.extractors.plaid.extractor import (
+        _ACCOUNTS_SCHEMA,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    assert "persistent_account_id" in _ACCOUNTS_SCHEMA
+    assert (
+        _class_of_key(("raw", "plaid_accounts", "persistent_account_id"))
+        is DataClass.FLOORED
+    )
+    assert "mask" in _ACCOUNTS_SCHEMA
+    assert _class_of_key(("raw", "plaid_accounts", "mask")) is (
+        DataClass.INSTITUTION_ACCOUNT_NUMBER
+    )
+
+
 def test_undeclared_core_column_does_not_floor() -> None:
     """core/app keep their fail-closed default — the floor is raw/prep only."""
     assert _class_of_key(("core", "fct_transactions", "no_such_column")) is None


### PR DESCRIPTION
Closes out M1S.2. The broker sends Plaid's `persistent_account_id`; MoneyBin has
been discarding it at the front door.

## The defect

`SyncAccount` never declared the field. Pydantic's default `extra='ignore'`
destroys an undeclared key at `model_validate` — no error, no log line — so the
value died on the wire and nothing downstream ever saw it. `_resolve_accounts`
then passed a hardcoded `persistent_token=None` to the resolver, under a
docstring that blamed the broker for not sending the field. The broker sends it.

The consequence is a split ledger. Relinking an institution makes Plaid reissue
every `account_id`, so an account that came back read as one MoneyBin had never
seen, and the resolver minted a second canonical account beside the first.
`persistent_account_id` survives that boundary and exists to answer exactly this
question.

## Read this before merging: the scope is narrower than the defect

Plaid documents `persistent_account_id` as populated **for depository accounts**
at the three institutions using tokenized account numbers — Chase, PNC, and US
Bank ([API reference](https://plaid.com/docs/api/accounts/)). A credit card, or
an account at any other institution, does not carry it and still resolves
through the weak-match review exactly as before.

That matters for how this PR is credited. The incident that motivated the work
was a **Chase credit card** reissue, so on Plaid's documented behavior this
change does not fix that incident — it fixes the depository half of the problem
class. The remaining exposure for cards is the weak-match review path and the
separate ordering defect tracked in #388.

This has not been confirmed against a live wire capture; it is Plaid's
documentation applied to the account type in question. The capture is still
worth doing, and is the one thing that would turn "documented not to" into
"observed not to."

## What changed

- `SyncAccount` declares `persistent_account_id` and `name`, with a docstring
  recording why an omission here is indistinguishable from the broker never
  sending the field.
- Both fields normalise blanks to `None` via `BlankToNone`. This is not
  cosmetic: `""` is caught by truthiness but `"  "` is not, and
  `_lookup_strong_ref` matches `persistent_token` **globally**, with no
  institution or source scope. One whitespace token shared by two unrelated
  accounts would auto-adopt them into a single ledger with no review entry —
  the exact failure this PR exists to prevent.
- `_resolve_accounts` passes the value through as `persistent_token`, and its
  docstring states what the field does rather than what the broker allegedly
  doesn't.
- Both columns reach `raw.plaid_accounts` — schema DDL, `_ACCOUNTS_SCHEMA`, and
  migration `V050`. The migration's `COMMENT ON COLUMN` text is byte-identical
  to the DDL's, because `_apply_comments` re-runs the DDL comments on every
  open while the migration runs once; a divergent string would silently settle
  on whichever ran last.
- `name` leads the display fallback. Note the narrow effect: it feeds the
  resolver's **name rung** only. Both sides of a merge proposal are labelled
  from `core.dim_accounts.display_name` (institution + subtype + last four), so
  the review queue's rendering is unchanged.

## No backfill, deliberately

`V050` adds both columns NULL and leaves them there. Nothing retained a copy of
a value that never survived validation, and neither column is derivable from
what is stored: `account_id` is the token a relink reissues, and `official_name`
is a shared product label.

That asymmetry matters more than usual. `persistent_account_id` becomes a
resolver *strong ref*, which auto-adopts in step 1 without surfacing a review
(`account_resolver.py:255`), so a guessed value would silently merge two
ledgers. NULL reads as "unknown" everywhere downstream, the resolver skips an
empty ref, and the next sync writes the true value through the raw primary key.

## Privacy

`persistent_account_id` is left undeclared in `CLASSIFICATION`, so it rides the
`INTERNAL_CRITICAL` content net as `FLOORED` and stays readable through
`sql_query` — matching the sibling `raw.plaid_accounts.account_id`, readable so
an agent can correlate a Plaid import across tables while debugging.

`app.account_links.ref_value` holds the identical string at CRITICAL, which
looks like a counter-argument. It is masked because it is *polymorphic* — the
same column may hold a full account number — not because a persistent token is
sensitive. `account-identity-resolution.md` states that a Plaid
`persistent_token` is an opaque non-PII token, and `taxonomy.py` already names
per-`ref_kind` unmasking of exactly these tokens as wanted work. The reasoning
is pinned in a test rather than left in this description.

## Tests

Eleven new tests, each written and watched fail before the fix. The load-bearing
one is `test_relinked_account_adopts_the_same_canonical_id`, which reproduces
the incident directly: it failed with two different canonical ids for one
account, and now returns one and asserts the review queue stayed empty — the
silent-adopt half of the claim, not just the id half.

`plaid_sync_response.yaml` gains the two fields it was always missing, so the
golden wire fixture matches what the broker sends.

## Out of scope

- **A detector for the next dropped field.** `SyncAccount`'s docstring states a
  rule nothing enforces. The fix — logging unexpected keys — belongs on every
  `Sync*` model, not one of them, so a single-model version would be a second
  pattern beside the first. Worth a follow-up.
- **Projecting `name` downstream.** The column reaches `raw` with no reader in
  `prep`/`core`, so the accounts surfaces still show the shared `official_name`.
  That is a `core` schema change.
- `holder_category`, the third field `extra='ignore'` was dropping.
  `app.account_settings.holder_category` already exists, so wiring the Plaid one
  raises a which-wins question that belongs in its own change.
- Balance fields (`limit`, `last_updated_datetime`) — different table, different
  migration.
