### PR TITLE
Add project tracking locator

### DIFF
--- a/.agents/project-tracking.json
+++ b/.agents/project-tracking.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": 1,
+  "project_id": "moneybin",
+  "declaration_mode": "locator",
+  "delivery_repository": "bsaffel/moneybin",
+  "canonical_repository": "bsaffel/moneybin-private"
+}

--- a/.agents/project-tracking.yaml
+++ b/.agents/project-tracking.yaml
@@ -1,5 +1,0 @@
-schema_version: 1
-project_id: moneybin
-declaration_mode: locator
-delivery_repository: bsaffel/moneybin
-canonical_repository: bsaffel/moneybin-private

--- a/.agents/project-tracking.yaml
+++ b/.agents/project-tracking.yaml
@@ -1,0 +1,5 @@
+schema_version: 1
+project_id: moneybin
+declaration_mode: locator
+delivery_repository: bsaffel/moneybin
+canonical_repository: bsaffel/moneybin-private

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,11 @@ which persistence or navigation step is blocked, and hand the blocked material
 or link to the user; do not invent another tracker. Public delivery status and
 implementation-ready work belong in this repository's issues and pull requests.
 
+PAO reads `.agents/project-tracking.json`; `declaration_mode: locator` means it
+only locates the canonical declaration in `bsaffel/moneybin-private`, while
+coordination, knowledge, and archive state remain private and are not
+duplicated here.
+
 ## Configuration
 
 All config in `src/moneybin/config.py` — one `MoneyBinSettings` root via Pydantic Settings. Never hardcode paths, credentials, or tunable parameters. Env vars use `MONEYBIN_` prefix with `__` for nesting: `MONEYBIN_DATABASE__PATH`.

--- a/tests/test_documentation_policy.py
+++ b/tests/test_documentation_policy.py
@@ -20,12 +20,11 @@ matches fail.
 
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import subprocess  # noqa: S404 -- the policy test queries local Git metadata
 from pathlib import Path
-
-import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -287,8 +286,8 @@ def test_active_agent_instructions_do_not_route_to_retired_trackers_or_skills() 
 
 
 def test_project_tracking_locator_routes_to_canonical_private_declaration() -> None:
-    declaration = yaml.safe_load(
-        (_REPO_ROOT / ".agents/project-tracking.yaml").read_text(encoding="utf-8")
+    declaration = json.loads(
+        (_REPO_ROOT / ".agents/project-tracking.json").read_text(encoding="utf-8")
     )
 
     assert declaration == {

--- a/tests/test_documentation_policy.py
+++ b/tests/test_documentation_policy.py
@@ -25,6 +25,8 @@ import shutil
 import subprocess  # noqa: S404 -- the policy test queries local Git metadata
 from pathlib import Path
 
+import yaml
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -282,3 +284,17 @@ def test_active_agent_instructions_do_not_route_to_retired_trackers_or_skills() 
         "path must declare `<!-- retired-route-description-ok -->`.\n"
         + "\n".join(violations)
     )
+
+
+def test_project_tracking_locator_routes_to_canonical_private_declaration() -> None:
+    declaration = yaml.safe_load(
+        (_REPO_ROOT / ".agents/project-tracking.yaml").read_text(encoding="utf-8")
+    )
+
+    assert declaration == {
+        "schema_version": 1,
+        "project_id": "moneybin",
+        "declaration_mode": "locator",
+        "delivery_repository": "bsaffel/moneybin",
+        "canonical_repository": "bsaffel/moneybin-private",
+    }


### PR DESCRIPTION
## Summary

- Add the public MoneyBin tracking locator that identifies GitHub as the delivery repository and `bsaffel/moneybin-private` as the canonical tracking declaration.
- Use dependency-free JSON so installed agent workflows can validate the locator without PyYAML.
- Lock the locator's exact public-safe shape with a documentation-policy regression test.

## Test plan

- `env PYTHONDONTWRITEBYTECODE=1 UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest -q tests/test_documentation_policy.py` — 8 passed.
- Joined this locator to the private canonical declaration through the packaged PAO validator — passed.
