### PR TITLE
Keep encryption key material out of CLI error output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1882,6 +1882,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   update.
 
 ### Security
+- **CLI tracebacks no longer render local variables, and database attach
+  errors are sanitized.** DuckDB cannot parameterize `ENCRYPTION_KEY`, so the
+  database key is written inline into the `ATTACH` statement — which puts it in
+  frame locals, and in some failure modes into the error text DuckDB hands
+  back. Neither is a log record, so the log sanitizer never applied to either.
+  The root CLI app now pins locals off instead of inheriting the dependency's
+  default, and attach failures are stripped of key material before they
+  surface, keeping their exception type and lock-contention classification
+  intact.
 - **A rejected currency code no longer reaches the durable CLI log (#393).**
   `moneybin fx` and `moneybin investments prices set` / `delete` take the
   currency as free text, and both services interpolated whatever was typed into

--- a/src/moneybin/cli/commands/db.py
+++ b/src/moneybin/cli/commands/db.py
@@ -768,7 +768,7 @@ def db_key_rotate(
 
     new_key = secrets_mod.token_hex(32)
 
-    from moneybin.database import build_attach_sql
+    from moneybin.database import build_attach_sql, scrub_key_material
 
     rotated_path = db_path.with_suffix(".rotated.duckdb")
     with _load_encryption_key() as old_key:
@@ -781,6 +781,11 @@ def db_key_rotate(
             conn.execute(build_attach_sql(rotated_path, new_key, alias="new_db"))
             conn.execute("COPY FROM DATABASE old_db TO new_db")
         except Exception as e:  # noqa: BLE001 — duckdb raises untyped errors on ATTACH/COPY failure
+            # Both ATTACHes carry a plaintext key, and DuckDB echoes the failing
+            # statement back in parser errors. This message goes to logger.error,
+            # which the unfiltered file handler persists to cli_YYYY-MM-DD.log —
+            # and SanitizedLogFormatter masks digit runs, never a hex key.
+            scrub_key_material(e, old_key, new_key)
             logger.error(f"❌ Key rotation failed: {e}")
             rotated_path.unlink(missing_ok=True)
             raise typer.Exit(1) from e

--- a/src/moneybin/cli/main.py
+++ b/src/moneybin/cli/main.py
@@ -64,6 +64,14 @@ app = typer.Typer(
     add_completion=True,
     rich_markup_mode="rich",
     no_args_is_help=True,
+    # Pinned, not merely inherited: frames on the database-open path hold the
+    # plaintext encryption key and profile passphrases as locals, and a rich
+    # traceback is not a log record, so SanitizedLogFormatter cannot redact it.
+    # Typer defaults this to False today, but the dependency floor is a range
+    # — state it here so the guarantee does not rest on a dependency default.
+    # Sub-apps render through this root app's handler, so setting it once here
+    # covers every command group.
+    pretty_exceptions_show_locals=False,
 )
 
 

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -385,11 +385,66 @@ def check_core_schema_drift(db: "Database") -> dict[str, list[str]]:
     return drift
 
 
-def _attach_encrypted(conn: "duckdb.DuckDBPyConnection", sql: str) -> None:
+# Shortest run of the encryption key treated as a leak when it turns up in a
+# DuckDB error message. DuckDB truncates the statement it echoes back, so the
+# realistic leak is a long fragment rather than the whole 64-hex literal;
+# 8 hex characters is short enough to catch those and long enough that an
+# ordinary diagnostic never collides with a random key by accident.
+_MIN_LEAKED_KEY_RUN = 8
+_REDACTED_KEY = "<redacted>"
+
+
+def _mask_key_runs(text: str, key: str) -> str:
+    """Replace every run of ``key`` at least ``_MIN_LEAKED_KEY_RUN`` long."""
+    for length in range(len(key), _MIN_LEAKED_KEY_RUN - 1, -1):
+        for start in range(len(key) - length + 1):
+            run = key[start : start + length]
+            if run in text:
+                text = text.replace(run, _REDACTED_KEY)
+    return text
+
+
+def scrub_key_material(exc: BaseException, *keys: str) -> None:
+    """Mask any run of ``keys`` that leaked into ``exc``'s message, in place.
+
+    DuckDB echoes the failing statement back in ``ParserException`` messages —
+    a truncated window centred on the error position — so a statement carrying
+    an ENCRYPTION_KEY can surface most of that key in ``str(exc)``. Neither a
+    traceback nor an f-stringed ``{e}`` is a log record the sanitizer can
+    reach, and ``SanitizedLogFormatter`` would not match a hex key anyway: it
+    masks SSNs, dollar amounts and 8+ *digit* runs.
+
+    Mutates ``exc`` in place instead of raising a sanitized replacement. That
+    preserves the exception's type and identity for callers, and avoids the
+    trap where ``raise Sanitized(...) from exc`` prints the unscrubbed
+    original anyway as the chained cause.
+    """
+    usable = [key for key in keys if len(key) >= _MIN_LEAKED_KEY_RUN]
+    if not usable:
+        return
+    scrubbed: list[object] = []
+    for arg in exc.args:
+        if isinstance(arg, str):
+            for key in usable:
+                arg = _mask_key_runs(arg, key)
+        scrubbed.append(arg)
+    if tuple(scrubbed) != exc.args:
+        exc.args = tuple(scrubbed)
+
+
+def _attach_encrypted(
+    conn: "duckdb.DuckDBPyConnection", sql: str, encryption_key: str
+) -> None:
     """Execute an ATTACH statement, mapping lock/config errors to DatabaseLockError.
 
     Closes ``conn`` and raises ``DatabaseLockError`` if DuckDB reports a
-    lock-contention condition. Re-raises other DuckDB exceptions unchanged.
+    lock-contention condition. Re-raises other DuckDB exceptions with their
+    type and identity intact, scrubbed of any key material DuckDB echoed back
+    from the statement (see ``scrub_key_material``).
+
+    ``encryption_key`` is passed rather than recovered from ``sql``: the path
+    is interpolated ahead of the options, so a path containing the option's
+    own text would shadow the real literal and the scrub would mask a decoy.
 
     DuckDB 1.5.3 unified previously-distinct messages (``"Conflicting lock"``
     IO error + ``"different configuration"`` catalog error in 1.5.2) into a
@@ -399,15 +454,22 @@ def _attach_encrypted(conn: "duckdb.DuckDBPyConnection", sql: str) -> None:
     try:
         conn.execute(sql)
     except duckdb.CatalogException as e:
+        scrub_key_material(e, encryption_key)
         conn.close()
         if "different configuration" in str(e):
             raise DatabaseLockError(str(e)) from e
         raise
     except duckdb.IOException as e:
+        scrub_key_material(e, encryption_key)
         conn.close()
         msg = str(e)
         if "Could not set lock on file" in msg or "Conflicting lock" in msg:
             raise DatabaseLockError(msg) from e
+        raise
+    except duckdb.Error as e:
+        # Parser/binder/invalid-input failures never closed the connection
+        # here — the callers' ExitStack owns that. Scrub and re-raise only.
+        scrub_key_material(e, encryption_key)
         raise
 
 
@@ -533,6 +595,7 @@ class Database:
                 _attach_encrypted(
                     self._conn,
                     build_attach_sql(db_path, encryption_key, read_only=True),
+                    encryption_key,
                 )
                 self._conn.execute(f"USE {_DATABASE_ALIAS}")
                 stack.pop_all()
@@ -560,7 +623,11 @@ class Database:
         with ExitStack() as stack:
             stack.callback(self._conn.close)
             _seal_connection(self._conn, writable=True)
-            _attach_encrypted(self._conn, build_attach_sql(db_path, encryption_key))
+            _attach_encrypted(
+                self._conn,
+                build_attach_sql(db_path, encryption_key),
+                encryption_key,
+            )
             self._conn.execute(f"USE {_DATABASE_ALIAS}")
 
             if is_new and sys.platform != "win32":

--- a/tests/moneybin/test_cli/test_cli_db_key.py
+++ b/tests/moneybin/test_cli/test_cli_db_key.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -93,3 +94,72 @@ class TestLoadEncryptionKey:
             with pytest.raises(_SentinelError):
                 with _load_encryption_key():
                     raise _SentinelError("body raised")
+
+
+class TestDbKeyRotateSecrets:
+    """`db key rotate` must not write key material to the durable CLI log.
+
+    Rotation attaches both databases directly rather than through
+    ``_attach_encrypted``, then reports failure with
+    ``logger.error(f"... {e}")``. DuckDB echoes the failing statement back in
+    ``ParserException`` messages, and the file handler has no level filter, so
+    an unscrubbed message persists to ``cli_YYYY-MM-DD.log``.
+    ``SanitizedLogFormatter`` cannot help: it masks SSNs, dollar amounts and
+    8+ *digit* runs, and a 64-hex key is none of those.
+    """
+
+    _OLD_KEY = "8c4b1f70d29e35a6be08d417c5392fda60b7e148a2c93f5d071e6ba4c82d9e17"
+    _NEW_KEY = "1a7e93c05b2d48f6ae310c97d5e824bf0639a1c7e5840b2c96f1a3d70e85b4cf"
+
+    @staticmethod
+    def _leaks(text: str, key: str, run: int = 8) -> bool:
+        return any(key[i : i + run] in text for i in range(len(key) - run + 1))
+
+    @pytest.mark.unit
+    def test_rotation_failure_does_not_log_key_material(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import contextlib
+        import logging
+
+        import duckdb
+
+        db_file = tmp_path / "moneybin.duckdb"
+        db_file.write_bytes(b"encrypted-bytes")
+
+        settings = MagicMock()
+        settings.database.path = db_file
+
+        @contextlib.contextmanager
+        def _fake_key() -> Generator[str, None, None]:
+            yield self._OLD_KEY
+
+        def _execute(sql: str, *_a: object, **_k: object) -> object:
+            if "ENCRYPTION_KEY" in sql:
+                # Mirrors DuckDB's LINE 1 excerpt, windowed past the key.
+                raise duckdb.ParserException(
+                    'Parser Error: syntax error at or near "GARBAGE"\n\n'
+                    f"LINE 1: ...{sql[30:]} GARBAGE ;;\n"
+                )
+            return MagicMock()
+
+        conn = MagicMock()
+        conn.execute.side_effect = _execute
+
+        with (
+            patch("moneybin.config.get_settings", return_value=settings),
+            patch("moneybin.secrets.SecretStore", return_value=MagicMock()),
+            patch("moneybin.cli.commands.db._load_encryption_key", _fake_key),
+            patch("secrets.token_hex", return_value=self._NEW_KEY),
+            patch("duckdb.connect", return_value=conn),
+            caplog.at_level(logging.ERROR),
+        ):
+            result = runner.invoke(db_app, ["key", "rotate", "--yes"])
+
+        assert result.exit_code == 1
+        assert "Key rotation failed" in caplog.text, "expected the failure path to run"
+        assert not self._leaks(caplog.text, self._OLD_KEY), "old key in the CLI log"
+        assert not self._leaks(caplog.text, self._NEW_KEY), "new key in the CLI log"

--- a/tests/moneybin/test_cli/test_cli_traceback_secrets.py
+++ b/tests/moneybin/test_cli/test_cli_traceback_secrets.py
@@ -1,0 +1,57 @@
+"""The CLI's rich tracebacks must never render frame locals.
+
+Frames on the database-open path hold the plaintext encryption key
+(``build_attach_sql`` interpolates it — DuckDB cannot parameterize
+ENCRYPTION_KEY) and profile passphrases. A rich traceback is not a log
+record, so ``SanitizedLogFormatter`` never sees it: rendered locals would go
+straight to terminal scrollback and CI logs.
+
+Typer 0.25.1 already defaults ``pretty_exceptions_show_locals`` to False, so
+these tests pin an existing guarantee rather than a change in behavior. That
+is the point — the project's dependency floor is a range (``typer>=0.24.1``),
+and the guarantee must not rest on a dependency's default staying put.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+import typer.main
+
+from moneybin.cli.main import app
+
+
+def test_root_app_does_not_render_locals_in_tracebacks() -> None:
+    assert app.pretty_exceptions_show_locals is False
+
+
+def test_show_locals_setting_reaches_typers_renderer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Assert the wiring, not just the attribute.
+
+    Typer carries the setting to its excepthook by stamping a
+    ``DeveloperExceptionConfig`` onto the escaping exception in the *root*
+    app's ``__call__``. That is the only ``__call__`` the CLI invokes —
+    ``main()`` calls ``app()``, and every command group is mounted with
+    ``add_typer`` — so what this asserts for one command holds for all of
+    them, at any nesting depth.
+    """
+    monkeypatch.setattr(sys, "excepthook", sys.excepthook)
+
+    def _boom(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("secret-bearing frame")
+
+    monkeypatch.setattr("moneybin.cli.commands.stats.get_database", _boom)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        app(["stats"], standalone_mode=False)
+
+    config = getattr(
+        excinfo.value,
+        typer.main._typer_developer_exception_attr_name,  # pyright: ignore[reportPrivateUsage]
+        None,
+    )
+    assert config is not None, "Typer did not stamp its traceback config"
+    assert config.pretty_exceptions_show_locals is False

--- a/tests/moneybin/test_database/test_attach_classification.py
+++ b/tests/moneybin/test_database/test_attach_classification.py
@@ -17,6 +17,9 @@ from moneybin.database import (
     _attach_encrypted,  # pyright: ignore[reportPrivateUsage]
 )
 
+# No ENCRYPTION_KEY in these statements; the scrubber has nothing to mask.
+_KEY = "b" * 64
+
 
 def _make_mock_conn(exc: Exception) -> MagicMock:
     conn = MagicMock()
@@ -32,7 +35,7 @@ def test_duckdb_1_5_3_lock_message_classified_as_lock_error() -> None:
     )
     conn = _make_mock_conn(duckdb.IOException(msg))
     with pytest.raises(DatabaseLockError):
-        _attach_encrypted(conn, "ATTACH '/tmp/probe.duckdb' AS m (TYPE DUCKDB)")
+        _attach_encrypted(conn, "ATTACH '/tmp/probe.duckdb' AS m (TYPE DUCKDB)", _KEY)
 
 
 def test_duckdb_1_5_2_lock_message_still_classified() -> None:
@@ -43,7 +46,7 @@ def test_duckdb_1_5_2_lock_message_still_classified() -> None:
     )
     conn = _make_mock_conn(duckdb.IOException(msg))
     with pytest.raises(DatabaseLockError):
-        _attach_encrypted(conn, "ATTACH '/tmp/probe.duckdb' AS m (TYPE DUCKDB)")
+        _attach_encrypted(conn, "ATTACH '/tmp/probe.duckdb' AS m (TYPE DUCKDB)", _KEY)
 
 
 def test_duckdb_1_5_2_catalog_message_still_classified() -> None:
@@ -58,7 +61,7 @@ def test_duckdb_1_5_2_catalog_message_still_classified() -> None:
     )
     conn = _make_mock_conn(duckdb.CatalogException(msg))
     with pytest.raises(DatabaseLockError):
-        _attach_encrypted(conn, "ATTACH '/tmp/probe.duckdb' AS m (TYPE DUCKDB)")
+        _attach_encrypted(conn, "ATTACH '/tmp/probe.duckdb' AS m (TYPE DUCKDB)", _KEY)
 
 
 def test_unrelated_ioexception_reraised_unchanged() -> None:
@@ -71,7 +74,7 @@ def test_unrelated_ioexception_reraised_unchanged() -> None:
     exc = duckdb.IOException(msg)
     conn = _make_mock_conn(exc)
     with pytest.raises(duckdb.IOException) as excinfo:
-        _attach_encrypted(conn, "ATTACH '/tmp/probe.duckdb' AS m (TYPE DUCKDB)")
+        _attach_encrypted(conn, "ATTACH '/tmp/probe.duckdb' AS m (TYPE DUCKDB)", _KEY)
     assert excinfo.value is exc
 
 
@@ -84,5 +87,5 @@ def test_unrelated_catalog_exception_reraised_unchanged() -> None:
     exc = duckdb.CatalogException(msg)
     conn = _make_mock_conn(exc)
     with pytest.raises(duckdb.CatalogException) as excinfo:
-        _attach_encrypted(conn, "ATTACH '/tmp/probe.duckdb' AS m (TYPE DUCKDB)")
+        _attach_encrypted(conn, "ATTACH '/tmp/probe.duckdb' AS m (TYPE DUCKDB)", _KEY)
     assert excinfo.value is exc

--- a/tests/moneybin/test_database/test_attach_key_redaction.py
+++ b/tests/moneybin/test_database/test_attach_key_redaction.py
@@ -1,0 +1,165 @@
+"""`_attach_encrypted` must never surface an exception carrying key material.
+
+``build_attach_sql`` interpolates the plaintext encryption key into the ATTACH
+statement (DuckDB cannot parameterize it). DuckDB echoes the statement text
+back in ``ParserException`` messages — a ~72-character window centred on the
+error position — so a syntax error positioned after the key puts a long
+contiguous run of it into ``str(exc)``. A traceback is not a log record, so
+``SanitizedLogFormatter`` never sees it: the message reaches terminal
+scrollback and CI logs verbatim.
+
+Runs, not just whole keys: DuckDB's excerpt truncates, so the realistic leak
+is 60 of 64 hex characters rather than the full key.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import duckdb
+import pytest
+
+from moneybin.database import (
+    DatabaseLockError,
+    _attach_encrypted,  # pyright: ignore[reportPrivateUsage]
+    build_attach_sql,
+)
+
+# Random-looking hex so no run of it can collide with the surrounding path.
+_KEY = "3f9c1a7d4e2b86055c0d9f31ae74b2c8d61f0a9573e4bc28d05a6e1f7b3c94d2"
+_DB_PATH = Path("/tmp/probe.duckdb")  # noqa: S108 — SQL string fixture, never opened
+_MIN_RUN = 8
+
+
+def _leaked_runs(text: str, key: str = _KEY, run: int = _MIN_RUN) -> list[str]:
+    """Every ``run``-length slice of ``key`` that survives in ``text``."""
+    return [
+        key[i : i + run] for i in range(len(key) - run + 1) if key[i : i + run] in text
+    ]
+
+
+def _assert_no_key_material(exc: BaseException) -> None:
+    assert _leaked_runs(str(exc)) == [], f"key material in str(): {str(exc)!r}"
+    for arg in exc.args:
+        assert _leaked_runs(str(arg)) == [], f"key material in args: {arg!r}"
+
+
+def _make_mock_conn(exc: Exception) -> MagicMock:
+    conn = MagicMock()
+    conn.execute.side_effect = exc
+    return conn
+
+
+def _attach_sql(read_only: bool = False) -> str:
+    return build_attach_sql(_DB_PATH, _KEY, read_only=read_only)
+
+
+def test_attach_sql_actually_contains_the_key() -> None:
+    """Pins the premise — if ATTACH stops carrying the key, these tests are moot."""
+    assert _KEY in _attach_sql()
+
+
+def test_parser_error_echoing_key_excerpt_is_scrubbed() -> None:
+    """DuckDB's ``LINE 1: ...`` excerpt can centre on the key. Mask the run.
+
+    Mirrors real DuckDB 1.5.4 output for a syntax error positioned after the
+    ENCRYPTION_KEY literal: the echo is truncated, so 60 of the 64 key
+    characters survive into the message.
+    """
+    leaked_run = _KEY[4:]
+    msg = (
+        'Parser Error: syntax error at or near "GARBAGE"\n\n'
+        f"LINE 1: ...{leaked_run}') GARBAGE ;;\n"
+        "                                    ^"
+    )
+    exc = duckdb.ParserException(msg)
+    conn = _make_mock_conn(exc)
+
+    with pytest.raises(duckdb.ParserException) as excinfo:
+        _attach_encrypted(conn, _attach_sql(), _KEY)
+
+    _assert_no_key_material(excinfo.value)
+
+
+def test_full_key_echo_is_scrubbed_without_reclassifying() -> None:
+    """A whole-key echo is masked, and the error keeps its original type."""
+    exc = duckdb.IOException(f"IO Error: failed while running {_attach_sql()}")
+    conn = _make_mock_conn(exc)
+
+    with pytest.raises(duckdb.IOException) as excinfo:
+        _attach_encrypted(conn, _attach_sql(), _KEY)
+
+    _assert_no_key_material(excinfo.value)
+    assert not isinstance(excinfo.value, DatabaseLockError)
+
+
+def test_lock_error_scrubs_both_the_wrapper_and_its_cause() -> None:
+    """The chained ``__cause__`` prints too — scrubbing only the wrapper leaks.
+
+    ``raise DatabaseLockError(...) from e`` makes Python print "The above
+    exception was the direct cause", followed by the original message. Both
+    have to be clean.
+    """
+    msg = (
+        'IO Error: Could not set lock on file "/tmp/probe.duckdb": Resource '
+        f"temporarily unavailable, while running: {_attach_sql()}"
+    )
+    conn = _make_mock_conn(duckdb.IOException(msg))
+
+    with pytest.raises(DatabaseLockError) as excinfo:
+        _attach_encrypted(conn, _attach_sql(), _KEY)
+
+    _assert_no_key_material(excinfo.value)
+    cause = excinfo.value.__cause__
+    assert cause is not None
+    _assert_no_key_material(cause)
+
+
+def test_real_duckdb_parser_error_does_not_surface_the_key() -> None:
+    """End-to-end against real DuckDB, not a hand-written mock message.
+
+    The mocked cases above encode what DuckDB 1.5.4 emits today; this one
+    asks DuckDB itself. A grammar change that moves the echo window still
+    has to clear the same bar.
+    """
+    conn = duckdb.connect()
+    sql = f"{_attach_sql()} GARBAGE ;;"
+
+    with pytest.raises(duckdb.Error) as excinfo:
+        _attach_encrypted(conn, sql, _KEY)
+
+    assert "Parser Error" in str(excinfo.value)
+    _assert_no_key_material(excinfo.value)
+
+
+def test_a_decoy_in_the_database_path_does_not_shadow_the_real_key() -> None:
+    """The scrubbed secret must be the key itself, not one recovered from text.
+
+    The path is interpolated ahead of the options, so anything recovered by
+    scanning the statement can be shadowed by path text — and
+    ``MONEYBIN_DATABASE__PATH`` is user-settable.
+    """
+    decoy = Path("/tmp/ENCRYPTION_KEY 'decoy'/probe.duckdb")  # noqa: S108 — SQL fixture
+    conn = duckdb.connect()
+
+    with pytest.raises(duckdb.Error) as excinfo:
+        _attach_encrypted(conn, f"{build_attach_sql(decoy, _KEY)} GARBAGE ;;", _KEY)
+
+    _assert_no_key_material(excinfo.value)
+
+
+def test_error_without_key_material_is_left_untouched() -> None:
+    """No key in the message means no rewriting — identity and args preserved.
+
+    Guards against the scrubber churning ordinary diagnostics, which would
+    also break the classification tests' ``is exc`` identity contract.
+    """
+    exc = duckdb.IOException("IO Error: No space left on device")
+    conn = _make_mock_conn(exc)
+
+    with pytest.raises(duckdb.IOException) as excinfo:
+        _attach_encrypted(conn, _attach_sql(), _KEY)
+
+    assert excinfo.value is exc
+    assert excinfo.value.args == ("IO Error: No space left on device",)

--- a/tests/moneybin/test_database/test_get_database_lock_integration.py
+++ b/tests/moneybin/test_database/test_get_database_lock_integration.py
@@ -264,7 +264,7 @@ def test_f10_read_init_failure_rolls_back_conn(
         captured.append(conn)
         return conn
 
-    def boom_attach(conn: object, sql: str) -> None:
+    def boom_attach(conn: object, sql: str, encryption_key: str) -> None:
         raise RuntimeError("attach boom")
 
     monkeypatch.setattr(db_module.duckdb, "connect", capturing_connect)


### PR DESCRIPTION
## Summary

Hardening pass on the CLI's error paths so database encryption key material cannot reach terminal scrollback, CI output, or log files. A traceback is not a log record, so `SanitizedLogFormatter` never sees it — the guarantee has to be made both where the error is raised and where it is rendered.

Deliberately filed without an issue: the defect concerns key disclosure, so it ships as a fix rather than a public writeup.

## Changes

- **CLI tracebacks** — `pretty_exceptions_show_locals=False` is now pinned explicitly on the root Typer app rather than left to the dependency default. Every command group renders through this one app, so setting it here covers all of them.
- **Database attach errors** — errors surfaced from the attach path are sanitized in place, which preserves exception type, identity, and chained cause. The existing lock-error classification behaviour is unchanged.
- **Key rotation** — the rotation failure handler reuses the same sanitizer before logging.
- **Tests** — coverage for both paths, including an end-to-end case driven against real DuckDB rather than only hand-written mock messages, plus a case proving the sanitizer keys off the actual secret rather than anything recovered from statement text.

## Test plan

- [x] `make check` — format, lint, pyright (0 errors, 3 pre-existing warnings)
- [x] `make test` — 9641 collected, 9637 passed, 0 failed, 4 skipped
- [x] Mutation-checked: flipping the Typer flag back to `True` fails the wiring test
- [x] `/code-review medium` run before shipping; findings addressed
- [ ] Reviewer: confirm the lock-error classification tests still assert exception identity (`is exc`)

## Deferred finding

The automated review raised one finding on an adjacent surface that this PR does not touch. It was reviewed and accepted as an explicit deferral rather than fixed here, so that this change stays scoped to the two paths it hardens.

It is not dropped: the finding, the analysis behind it, and a constraint that rules out the reviewer's suggested remedy are recorded in the project's private tracker. It is deliberately not filed as a public issue, for the same reason this PR has none.
