### PR TITLE
Require a prompt, not a token, to merge accounts

### DIFF
--- a/.claude/rules/mcp.md
+++ b/.claude/rules/mcp.md
@@ -235,7 +235,18 @@ and confirm only an accepted `true`, then compare a freshly recomputed binding.
 Do not use FastMCP's deprecated empty-schema elicitation. This elicited boolean
 is not a bare `confirm` tool argument: degraded clients receive an opaque token
 carrying the same binding, and no operation proceeds without exact binding
-verification. Treat approval as an immutable digest grant; verify that grant
+verification.
+
+**Exception — operations that forgo the token entirely.** The fallback token is
+returned to the *calling agent*, so it confirms nothing about a person for an
+operation whose wrong outcome is both hard to notice and hard to undo. Such an
+operation passes `elicitation_only=True` to `grant_confirmation_or_raise`: it
+refuses a supplied `confirmation_token` (without consuming it) and refuses a
+client that cannot prompt, naming the CLI equivalent instead of minting a key to
+its own unconfirmed write. An accepted account link is the current member —
+adding one is a design decision, not a local call-site choice.
+
+Treat approval as an immutable digest grant; verify that grant
 against live state inside the same write transaction, immediately before the
 first mutation. Never verify and then open a separate mutation transaction.
 Compatible same-intent writes may share one conservatively annotated tool;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1160,20 +1160,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   validates against a server on either side of the change (#412).
 
 - **An account merge can no longer be confirmed by the agent asking for it.**
-  `identity_links_decide` and `accounts_links_set` documented a confirmation
-  before a merge, and one existed — but a caller could take the opaque
-  `confirmation_token` out of the refusal it got on the first call and hand it
-  straight back on the second, merging without the prompt ever reaching a
-  person. One merge collapsing four accounts rewrote 520 transactions, touched
-  198 match decisions and auto-merged 135 duplicate pairs that way. An accepted
-  account link now takes the prompt or nothing: a supplied `confirmation_token`
-  is refused, and a client that cannot prompt is refused and pointed at
-  `moneybin accounts links set` rather than issued a token it could redeem
-  itself. Merchant- and security-link accepts are unchanged — neither re-keys a
-  transaction.
-
-  This does not close the case where an MCP client answers its own elicitation
-  prompt; that remains the caller's contract to honour (#414).
+  `identity_links_decide` and `accounts_links_set` gated a merge behind a
+  confirmation, but a caller could hand the opaque `confirmation_token` from the
+  first call's refusal straight back on the second and merge without the prompt
+  reaching a person. An accepted account link now takes the prompt or nothing —
+  a supplied token is refused, and a client that cannot prompt is pointed at
+  `moneybin accounts links set`; merchant- and security-link accepts keep the
+  token path, since neither re-keys a transaction (#414).
 
 - **`MONEYBIN_HOME` in a `.env` file no longer fails silently.** That file is
   looked up inside `<base>` — the very directory the setting would name — so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1159,6 +1159,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   now reads the id out of the record and still accepts a bare string, so it
   validates against a server on either side of the change (#412).
 
+- **An account merge can no longer be confirmed by the agent asking for it.**
+  `identity_links_decide` and `accounts_links_set` documented a confirmation
+  before a merge, and one existed — but a caller could take the opaque
+  `confirmation_token` out of the refusal it got on the first call and hand it
+  straight back on the second, merging without the prompt ever reaching a
+  person. One merge collapsing four accounts rewrote 520 transactions, touched
+  198 match decisions and auto-merged 135 duplicate pairs that way. An accepted
+  account link now takes the prompt or nothing: a supplied `confirmation_token`
+  is refused, and a client that cannot prompt is refused and pointed at
+  `moneybin accounts links set` rather than issued a token it could redeem
+  itself. Merchant- and security-link accepts are unchanged — neither re-keys a
+  transaction.
+
+  This does not close the case where an MCP client answers its own elicitation
+  prompt; that remains the caller's contract to honour (#414).
+
 - **`MONEYBIN_HOME` in a `.env` file no longer fails silently.** That file is
   looked up inside `<base>` — the very directory the setting would name — so the
   home is already resolved by the time it is read, and pydantic-settings dropped

--- a/docs/specs/account-identity-resolution.md
+++ b/docs/specs/account-identity-resolution.md
@@ -1379,6 +1379,12 @@ means a transported-but-undigested field on a primitive every destructive tool
 shares. That blast radius is why this lands as its own change rather than
 half-done on one surface.
 
+An account merge no longer takes that round trip: it is confirmed only by a
+prompt, and a client that cannot prompt is refused rather than issued a token
+(#414). The baseline therefore stays in process for `account_link`, and the
+transport problem above is now merchant- and security-link only. It is still
+the reason the check lands as one change across both surfaces.
+
 **The merge prompt is what makes `identity_links_decide` a medium-tier tool.**
 Its response payload carries record ids, a status, and counts — all `low`. The
 elicitation carries each ledger's first and last transaction dates and the

--- a/docs/specs/mcp-tool-surface-scaling.md
+++ b/docs/specs/mcp-tool-surface-scaling.md
@@ -421,12 +421,12 @@ If either gate fails, MoneyBin spends the additional tool slot deliberately.
 
 The deterministic current
 [`standard.json`](../../tests/fixtures/mcp_surface/standard.json) snapshot
-contains 49 tools, 58,016 bytes of serialized metadata, zero advertised output schemas,
+contains 49 tools, 58,164 bytes of serialized metadata, zero advertised output schemas,
 and registry SHA-256
-`1f43359806cfd3aafc105dae1fe7dd09bd2b2901318e1f8fac3f60aed8575661`.
+`d9ef170b1b5868c90ca5a16a375def5a09435ffd529a1951770e63f06c2df0da`.
 The frozen baseline is 90,734 bytes with SHA-256
 `ea87a21b01e0f5181b80cef120beef2e9f46b31df121c7941329d9c493b48f79`.
-The delta is -32,718 bytes (-36.1%). The deterministic estimate is 14,504
+The delta is -32,570 bytes (-35.9%). The deterministic estimate is 14,541
 metadata tokens; a percentage of context is
 recorded only with observed host/model evidence because this contract does not
 invent a context-window size.

--- a/docs/specs/mcp-tool-surface-scaling.md
+++ b/docs/specs/mcp-tool-surface-scaling.md
@@ -158,7 +158,12 @@ explicit boolean and confirms only an accepted `true`, followed by a fresh
 binding comparison. This avoids FastMCP's deprecated empty-schema elicitation,
 which can render a non-functional form in supported clients. The boolean is
 elicitation response data, not a bare `confirm` tool argument. Degraded clients
-use an opaque confirmation token carrying the same binding. Confirmation
+use an opaque confirmation token carrying the same binding — except where an
+operation forgoes the token entirely. That token is returned to the calling
+agent, so for a mutation whose wrong outcome is both hard to notice and hard to
+undo it confirms nothing about a person: an accepted account link refuses a
+supplied token and refuses a degraded client outright, naming the CLI route
+instead. Confirmation
 prevents the wrong mutation; `system_audit_undo` remains the recovery path when
 intent later changes. Issuance and consumption evict abandoned expired tokens
 from the active registry under the broker lock. A hard-capped tombstone

--- a/docs/specs/moneybin-mcp.md
+++ b/docs/specs/moneybin-mcp.md
@@ -211,7 +211,7 @@ and confirmation contracts.
   `confirmation_token` with `mutation_invalid_input`, and refuse a client that
   cannot elicit with `mutation_confirmation_required` naming the CLI, rather
   than issuing a token. The fallback token is returned to the *calling agent*,
-  so honouring it would let that agent satisfy the merge confirmation itself —
+  so honoring it would let that agent satisfy the merge confirmation itself —
   and a merge re-keys a whole account's transaction history, the case
   `design-principles.md` places at the top of the confirmation bar. Merchant-
   and security-link accepts keep the token path: neither re-keys a transaction.

--- a/docs/specs/moneybin-mcp.md
+++ b/docs/specs/moneybin-mcp.md
@@ -205,6 +205,16 @@ and confirmation contracts.
   and `gsheet` expose typed views or filters under one domain identity. Their
   paired `_set`, `_decide`, or domain verb tools retain material write and
   confirmation boundaries.
+- **An account merge is confirmed by prompt only.** `identity_links_decide`
+  accepting an `account_link`, and `accounts_links_set` with `action="accept"`,
+  are the one exception to the opaque-token fallback: they refuse a supplied
+  `confirmation_token` with `mutation_invalid_input`, and refuse a client that
+  cannot elicit with `mutation_confirmation_required` naming the CLI, rather
+  than issuing a token. The fallback token is returned to the *calling agent*,
+  so honouring it would let that agent satisfy the merge confirmation itself —
+  and a merge re-keys a whole account's transaction history, the case
+  `design-principles.md` places at the top of the confirmation bar. Merchant-
+  and security-link accepts keep the token path: neither re-keys a transaction.
 - `import_files` and `import_preview` establish an import; `import_confirm`
   ratifies system proposals, including an elicited human decision for a PDF
   sign inversion. Clients without elicitation receive an opaque,

--- a/src/moneybin/mcp/confirmation.py
+++ b/src/moneybin/mcp/confirmation.py
@@ -223,6 +223,40 @@ def _confirmation_required(
     )
 
 
+def _confirmation_unavailable(
+    binding: ConfirmationBinding,
+    *,
+    cli_equivalent: str | None,
+) -> UserError:
+    """Refuse rather than degrade an elicitation-only operation into a token.
+
+    Everywhere else, a client that cannot prompt gets an opaque token instead.
+    For an operation this hard to undo, that fallback IS the hole: the token is
+    returned to the *calling agent*, which can redeem it on its very next call
+    and never put the prompt in front of a person. Send the caller to a surface
+    that can actually ask a human instead.
+    """
+    route = cli_equivalent or "the moneybin CLI"
+    return UserError(
+        "This operation must be confirmed by a person, and this client cannot "
+        "show a confirmation prompt.",
+        code=error_codes.MUTATION_CONFIRMATION_REQUIRED,
+        hint=f"Run `{route}`, which prompts on the terminal.",
+        details={
+            "operation_kind": binding.operation_kind,
+            "blast_radius": binding.blast_radius,
+        },
+    )
+
+
+def _token_not_accepted() -> UserError:
+    return UserError(
+        "confirmation_token is not accepted for this operation: it must be "
+        "confirmed through a prompt answered by a person.",
+        code=error_codes.MUTATION_INVALID_INPUT,
+    )
+
+
 confirmation_broker = ConfirmationBroker()
 
 
@@ -231,9 +265,23 @@ async def grant_confirmation_or_raise(
     binding: ConfirmationBinding | None,
     message: str,
     confirmation_token: str | None,
+    elicitation_only: bool = False,
+    cli_equivalent: str | None = None,
     broker: ConfirmationBroker = confirmation_broker,
 ) -> ConfirmationGrant:
-    """Return a digest grant through elicitation or one consumed opaque token."""
+    """Return a digest grant through elicitation or one consumed opaque token.
+
+    ``elicitation_only`` removes the token from the contract entirely for
+    operations whose cost of a wrong silent action is too high to let the
+    caller confirm itself: a supplied token is refused rather than consumed,
+    and a client that cannot prompt is refused rather than handed one. The
+    prompt becomes the only route through. ``cli_equivalent`` names the command
+    that refusal points at, since a refusal with no way forward is a dead end.
+    """
+    if elicitation_only and confirmation_token is not None:
+        # Refuse before consuming: burning the token would also let a caller
+        # destroy a confirmation somebody else was about to redeem.
+        raise _token_not_accepted()
     if confirmation_token is not None:
         return broker.consume(confirmation_token, now=_utcnow())
     if binding is None:
@@ -263,6 +311,9 @@ async def grant_confirmation_or_raise(
         if isinstance(result, AcceptedElicitation) and result.data is True:
             return ConfirmationGrant(expected_digest)
         raise _confirmation_declined()
+
+    if elicitation_only:
+        raise _confirmation_unavailable(binding, cli_equivalent=cli_equivalent)
 
     token = broker.issue(binding, now=_utcnow())
     raise _confirmation_required(

--- a/src/moneybin/mcp/confirmation.py
+++ b/src/moneybin/mcp/confirmation.py
@@ -227,6 +227,7 @@ def _confirmation_unavailable(
     binding: ConfirmationBinding,
     *,
     cli_equivalent: str | None,
+    cli_note: str | None = None,
 ) -> UserError:
     """Refuse rather than degrade an elicitation-only operation into a token.
 
@@ -237,11 +238,17 @@ def _confirmation_unavailable(
     that can actually ask a human instead.
     """
     route = cli_equivalent or "the moneybin CLI"
+    hint = f"Run `{route}`, which prompts on the terminal."
+    if cli_note:
+        # That command completes the operation that forced this refusal. When
+        # the caller sent more than that, the rest went down with it, and a
+        # hint that stops here reads as "you are done".
+        hint = f"{hint} {cli_note}"
     return UserError(
         "This operation must be confirmed by a person, and this client cannot "
         "show a confirmation prompt.",
         code=error_codes.MUTATION_CONFIRMATION_REQUIRED,
-        hint=f"Run `{route}`, which prompts on the terminal.",
+        hint=hint,
         details={
             "operation_kind": binding.operation_kind,
             "blast_radius": binding.blast_radius,
@@ -267,6 +274,7 @@ async def grant_confirmation_or_raise(
     confirmation_token: str | None,
     elicitation_only: bool = False,
     cli_equivalent: str | None = None,
+    cli_note: str | None = None,
     broker: ConfirmationBroker = confirmation_broker,
 ) -> ConfirmationGrant:
     """Return a digest grant through elicitation or one consumed opaque token.
@@ -277,6 +285,8 @@ async def grant_confirmation_or_raise(
     and a client that cannot prompt is refused rather than handed one. The
     prompt becomes the only route through. ``cli_equivalent`` names the command
     that refusal points at, since a refusal with no way forward is a dead end.
+    ``cli_note`` adds what that command does not cover — a batch refused whole
+    loses the decisions travelling beside the one that forced the refusal.
     """
     if elicitation_only and confirmation_token is not None:
         # Refuse before consuming: burning the token would also let a caller
@@ -313,7 +323,11 @@ async def grant_confirmation_or_raise(
         raise _confirmation_declined()
 
     if elicitation_only:
-        raise _confirmation_unavailable(binding, cli_equivalent=cli_equivalent)
+        raise _confirmation_unavailable(
+            binding,
+            cli_equivalent=cli_equivalent,
+            cli_note=cli_note,
+        )
 
     token = broker.issue(binding, now=_utcnow())
     raise _confirmation_required(

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -752,8 +752,9 @@ async def accounts_links_set(
         target_account_id: With action="accept", the candidate account_id to
             merge into — must equal the decision's own candidate_account_id.
             Invalid with action="reject".
-        confirmation_token: Opaque payload-bound token returned to clients that
-            cannot elicit. Used only with action="accept".
+        confirmation_token: Not accepted here. A merge is confirmed only by a
+            prompt a person answers, so passing this is refused rather than
+            honoured; it stays on the signature to make that refusal explicit.
     """
     if action not in ("accept", "reject"):
         raise UserError(

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -712,7 +712,7 @@ async def accounts_links_set(
       the ONLY route: unlike other destructive tools this one has no fallback
       token, `confirmation_token` is refused with mutation_invalid_input, and a
       client that cannot prompt is refused with mutation_confirmation_required
-      naming the CLI instead. A token is returned to the caller, so honouring
+      naming the CLI instead. A token is returned to the caller, so honoring
       one would let the caller confirm its own merge. `target_account_id` is also a
       confirming safety check: it must equal the decision's own candidate, so a
       mistyped or stale decision_id cannot merge into the wrong account.
@@ -754,7 +754,7 @@ async def accounts_links_set(
             Invalid with action="reject".
         confirmation_token: Not accepted here. A merge is confirmed only by a
             prompt a person answers, so passing this is refused rather than
-            honoured; it stays on the signature to make that refusal explicit.
+            honored; it stays on the signature to make that refusal explicit.
     """
     if action not in ("accept", "reject"):
         raise UserError(

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -708,9 +708,12 @@ async def accounts_links_set(
     - `action="accept"` + `target_account_id=<the decision's own
       candidate_account_id>` MERGES. This REQUIRES explicit human confirmation:
       the tool prompts the user through an MCP elicitation naming both accounts
-      and the matching signal, and merges only if they agree. A client that
-      cannot prompt receives mutation_confirmation_required with a short-lived,
-      payload-bound token for an exact retry. `target_account_id` is also a
+      and the matching signal, and merges only if they agree. That prompt is
+      the ONLY route: unlike other destructive tools this one has no fallback
+      token, `confirmation_token` is refused with mutation_invalid_input, and a
+      client that cannot prompt is refused with mutation_confirmation_required
+      naming the CLI instead. A token is returned to the caller, so honouring
+      one would let the caller confirm its own merge. `target_account_id` is also a
       confirming safety check: it must equal the decision's own candidate, so a
       mistyped or stale decision_id cannot merge into the wrong account.
       Mismatched, empty, or missing `target_account_id` raises
@@ -778,32 +781,40 @@ async def accounts_links_set(
                 "that.",
                 code=error_codes.MUTATION_INVALID_INPUT,
             )
-        if confirmation_token is None:
-            proposal = await asyncio.to_thread(
-                _load_pending_account_proposal, decision_id
+        if confirmation_token is not None:
+            # A merge takes the prompt or nothing. The opaque-token fallback
+            # returns the confirmation to the *calling agent*, which can redeem
+            # it on its next call with no person ever seeing this merge — and a
+            # merge moves a whole ledger history onto another account. Refused
+            # ahead of the proposal load: a merge that cannot proceed should not
+            # first cost a database read.
+            raise UserError(
+                "confirmation_token is not accepted for an account merge: it "
+                "must be confirmed through a prompt answered by a person.",
+                code=error_codes.MUTATION_INVALID_INPUT,
+                hint="Retry without confirmation_token, or run `moneybin "
+                "accounts links set`, which prompts on the terminal.",
             )
-            if target_account_id != proposal.candidate_account_id:
-                # Refuse BEFORE prompting: a doomed merge must not cost the user a
-                # confirmation. The service re-checks this; this is the boundary copy.
-                raise UserError(
-                    f"'target_account_id' does not match decision '{decision_id}' — "
-                    "it must be the target_id shown by reviews(kind='account_links').",
-                    code=error_codes.MUTATION_INVALID_INPUT,
-                    hint="Re-read the decision with reviews(kind='account_links').",
-                )
-            binding = _account_link_binding(
+        proposal = await asyncio.to_thread(_load_pending_account_proposal, decision_id)
+        if target_account_id != proposal.candidate_account_id:
+            # Refuse BEFORE prompting: a doomed merge must not cost the user a
+            # confirmation. The service re-checks this; this is the boundary copy.
+            raise UserError(
+                f"'target_account_id' does not match decision '{decision_id}' — "
+                "it must be the target_id shown by reviews(kind='account_links').",
+                code=error_codes.MUTATION_INVALID_INPUT,
+                hint="Re-read the decision with reviews(kind='account_links').",
+            )
+        grant = await grant_confirmation_or_raise(
+            binding=_account_link_binding(
                 decision_id=decision_id,
                 target_account_id=target_account_id,
                 impact=proposal.impact,
-            )
-            message = _account_confirm_message(proposal)
-        else:
-            binding = None
-            message = ""
-        grant = await grant_confirmation_or_raise(
-            binding=binding,
-            message=message,
-            confirmation_token=confirmation_token,
+            ),
+            message=_account_confirm_message(proposal),
+            confirmation_token=None,
+            elicitation_only=True,
+            cli_equivalent="moneybin accounts links set",
         )
         rematch = await asyncio.to_thread(
             _apply_account_accept,

--- a/src/moneybin/mcp/tools/reviews.py
+++ b/src/moneybin/mcp/tools/reviews.py
@@ -1157,20 +1157,33 @@ def _preview_identity_decisions(
     return _IdentityPreview(plan=plan, merges=merges, kinds=kinds)
 
 
-def _identity_remainder_note(kinds: tuple[str, ...]) -> str | None:
+def _identity_remainder_note(plan: IdentityDecisionPlan) -> str | None:
     """Name what the CLI merge command will not have finished for this batch.
 
-    The refusal points at `moneybin accounts links set`, which decides one
-    account link. A batch is refused whole, so anything travelling beside the
-    merge was dropped as well and the caller has to send it again — a hint
-    that stops at the merge reads as if the batch were complete.
+    Counted over the planned items rather than the batch's kinds, because the
+    kind set answers a different question. It is deduplicated and accept-only,
+    so a second merge collapses into the first and a reject never appears at
+    all — both then read as nothing left over, when in fact the batch was
+    refused whole and every one of them still has to be sent again.
     """
-    remainder = [kind for kind in kinds if kind != "account_link"]
+    pending = [item for item in plan.items if item.changed]
+    handled = next(
+        (
+            item
+            for item in pending
+            if item.request.kind == "account_link" and item.request.decision == "accept"
+        ),
+        None,
+    )
+    remainder = [item for item in pending if item is not handled]
     if not remainder:
         return None
+    kinds = ", ".join(sorted({item.request.kind for item in remainder}))
+    noun = "decision" if len(remainder) == 1 else "decisions"
     return (
-        "The whole batch was refused and nothing was written, so resubmit the "
-        f"{', '.join(remainder)} decisions here once the merge is confirmed."
+        "The whole batch was refused and nothing was written. That command "
+        f"decides one account link; the other {len(remainder)} {noun} "
+        f"({kinds}) must be sent here again once the merge is confirmed."
     )
 
 
@@ -1262,7 +1275,7 @@ async def identity_links_decide_coarse(
             # keep the fallback: neither re-keys a transaction.
             elicitation_only="account_link" in preview.kinds,
             cli_equivalent="moneybin accounts links set",
-            cli_note=_identity_remainder_note(preview.kinds),
+            cli_note=_identity_remainder_note(preview.plan),
         )
     live = await asyncio.to_thread(
         _apply_identity_decisions,

--- a/src/moneybin/mcp/tools/reviews.py
+++ b/src/moneybin/mcp/tools/reviews.py
@@ -1157,6 +1157,23 @@ def _preview_identity_decisions(
     return _IdentityPreview(plan=plan, merges=merges, kinds=kinds)
 
 
+def _identity_remainder_note(kinds: tuple[str, ...]) -> str | None:
+    """Name what the CLI merge command will not have finished for this batch.
+
+    The refusal points at `moneybin accounts links set`, which decides one
+    account link. A batch is refused whole, so anything travelling beside the
+    merge was dropped as well and the caller has to send it again — a hint
+    that stops at the merge reads as if the batch were complete.
+    """
+    remainder = [kind for kind in kinds if kind != "account_link"]
+    if not remainder:
+        return None
+    return (
+        "The whole batch was refused and nothing was written, so resubmit the "
+        f"{', '.join(remainder)} decisions here once the merge is confirmed."
+    )
+
+
 def _apply_identity_decisions(
     decisions: list[IdentityDecisionRequest],
     *,
@@ -1245,6 +1262,7 @@ async def identity_links_decide_coarse(
             # keep the fallback: neither re-keys a transaction.
             elicitation_only="account_link" in preview.kinds,
             cli_equivalent="moneybin accounts links set",
+            cli_note=_identity_remainder_note(preview.kinds),
         )
     live = await asyncio.to_thread(
         _apply_identity_decisions,

--- a/src/moneybin/mcp/tools/reviews.py
+++ b/src/moneybin/mcp/tools/reviews.py
@@ -1237,6 +1237,14 @@ async def identity_links_decide_coarse(
                 kinds=preview.kinds,
             ),
             confirmation_token=confirmation_token,
+            # An account merge moves a whole ledger history onto another
+            # account and is the case `design-principles.md` names at the top
+            # of the confirmation bar. The opaque-token fallback hands that
+            # confirmation to the calling agent, so this batch forgoes it and
+            # takes the prompt or nothing. Merchant- and security-only batches
+            # keep the fallback: neither re-keys a transaction.
+            elicitation_only="account_link" in preview.kinds,
+            cli_equivalent="moneybin accounts links set",
         )
     live = await asyncio.to_thread(
         _apply_identity_decisions,
@@ -1314,7 +1322,9 @@ def register_review_coarse_writes(mcp: FastMCP) -> None:
         "accepted: `rematch_transfers_retired` counts those, and "
         "system_audit_undo() restores them. Any accepted merge or bind confirms "
         "the exact normalized full batch and complete live before-state; "
-        "reject-only batches do not prompt.",
+        "reject-only batches do not prompt. An accepted account link takes the "
+        "prompt only — it refuses confirmation_token, and refuses a client that "
+        "cannot prompt rather than issue one.",
         privacy_actor="identity_links_decide",
     )
 

--- a/tests/fixtures/mcp_surface/standard.json
+++ b/tests/fixtures/mcp_surface/standard.json
@@ -1,5 +1,5 @@
 {
-  "sha256": "1f43359806cfd3aafc105dae1fe7dd09bd2b2901318e1f8fac3f60aed8575661",
+  "sha256": "d9ef170b1b5868c90ca5a16a375def5a09435ffd529a1951770e63f06c2df0da",
   "tool_count": 49,
   "tools": [
     {
@@ -1148,7 +1148,7 @@
           "openWorldHint": false,
           "readOnlyHint": false
         },
-        "description": "Atomically accept or reject account, merchant, and security identity link decisions. Accepting a security decision either merges two instruments' tax lots, manual events, and price marks, or only binds a price-feed symbol to a security, which deletes nothing and moves no row; the confirmation prompt names which one and counts every category it moves. Accepting an account decision re-runs matching over the merged account, which can reverse a transfer the user already accepted: `rematch_transfers_retired` counts those, and system_audit_undo() restores them. Any accepted merge or bind confirms the exact normalized full batch and complete live before-state; reject-only batches do not prompt.",
+        "description": "Atomically accept or reject account, merchant, and security identity link decisions. Accepting a security decision either merges two instruments' tax lots, manual events, and price marks, or only binds a price-feed symbol to a security, which deletes nothing and moves no row; the confirmation prompt names which one and counts every category it moves. Accepting an account decision re-runs matching over the merged account, which can reverse a transfer the user already accepted: `rematch_transfers_retired` counts those, and system_audit_undo() restores them. Any accepted merge or bind confirms the exact normalized full batch and complete live before-state; reject-only batches do not prompt. An accepted account link takes the prompt only \u2014 it refuses confirmation_token, and refuses a client that cannot prompt rather than issue one.",
         "inputSchema": {
           "additionalProperties": false,
           "properties": {
@@ -1453,12 +1453,12 @@
         },
         "name": "identity_links_decide"
       },
-      "description_bytes": 696,
+      "description_bytes": 841,
       "input_schema_bytes": 2438,
       "name": "identity_links_decide",
       "other_bytes": 63,
       "output_schema_bytes": 0,
-      "total_bytes": 3333
+      "total_bytes": 3481
     },
     {
       "annotation_bytes": 91,
@@ -5034,5 +5034,5 @@
       "total_bytes": 564
     }
   ],
-  "total_bytes": 58016
+  "total_bytes": 58164
 }

--- a/tests/moneybin/test_mcp/test_accounts.py
+++ b/tests/moneybin/test_mcp/test_accounts.py
@@ -1585,6 +1585,62 @@ class TestPendingAccountProposal:
         assert excinfo.value.code == "mutation_nothing_to_do"
 
 
+def _stub_merge_prompt(monkeypatch: pytest.MonkeyPatch, accounts_module: Any) -> None:
+    """Stand in for the merge's confirmation prompt and the read that feeds it.
+
+    These tests are about what the accept envelope reports, not about the gate.
+    They used to reach the merge body by passing a confirmation token, which an
+    account merge no longer accepts — so the prompt itself is stubbed instead.
+    """
+
+    def _proposal(_decision_id: str) -> SimpleNamespace:
+        return SimpleNamespace(candidate_account_id="CAND001", impact=None)
+
+    def _binding(**_kw: object) -> None:
+        return None
+
+    def _message(_proposal: object) -> str:
+        return ""
+
+    monkeypatch.setattr(accounts_module, "_load_pending_account_proposal", _proposal)
+    monkeypatch.setattr(accounts_module, "_account_link_binding", _binding)
+    monkeypatch.setattr(accounts_module, "_account_confirm_message", _message)
+
+
+async def test_links_set_accept_refuses_a_confirmation_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A merge takes the prompt or nothing — a token must not buy its way in.
+
+    The opaque-token fallback exists so a client that cannot prompt can still
+    act, but the token is returned to the *calling agent*. Honouring one for a
+    merge would let that agent confirm its own rewrite of a whole ledger
+    history without a person ever seeing the prompt.
+
+    Refused before any database work: a merge that cannot proceed must not
+    first cost a proposal load.
+    """
+    from moneybin.mcp.tools import accounts as accounts_module
+
+    def _must_not_run(*_args: object, **_kw: object) -> object:
+        raise AssertionError("a token-bearing merge must be refused up front")
+
+    monkeypatch.setattr(accounts_module, "_apply_account_accept", _must_not_run)
+    monkeypatch.setattr(
+        accounts_module, "_load_pending_account_proposal", _must_not_run
+    )
+
+    with pytest.raises(UserError) as excinfo:
+        await accounts_module.accounts_links_set(
+            decision_id="dec001",
+            action="accept",
+            target_account_id="CAND001",
+            confirmation_token="tok",  # noqa: S106  # opaque grant id, not a credential
+        )
+
+    assert excinfo.value.code == "mutation_invalid_input"
+
+
 async def test_links_set_accept_reports_what_the_rematch_found(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1613,12 +1669,12 @@ async def test_links_set_accept_reports_what_the_rematch_found(
 
     monkeypatch.setattr(accounts_module, "_apply_account_accept", _accepted)
     monkeypatch.setattr(accounts_module, "grant_confirmation_or_raise", _granted)
+    _stub_merge_prompt(monkeypatch, accounts_module)
 
     envelope = await accounts_module.accounts_links_set(
         decision_id="dec001",
         action="accept",
         target_account_id="CAND001",
-        confirmation_token="tok",  # noqa: S106  # opaque grant id, not a credential; skips the elicitation branch
     )
 
     assert envelope.data.rematch_auto_merged == 2
@@ -1650,12 +1706,12 @@ async def test_links_set_accept_reports_a_retired_transfer_in_data(
 
     monkeypatch.setattr(accounts_module, "_apply_account_accept", _accepted)
     monkeypatch.setattr(accounts_module, "grant_confirmation_or_raise", _granted)
+    _stub_merge_prompt(monkeypatch, accounts_module)
 
     envelope = await accounts_module.accounts_links_set(
         decision_id="dec001",
         action="accept",
         target_account_id="CAND001",
-        confirmation_token="tok",  # noqa: S106  # opaque grant id, not a credential; skips the elicitation branch
     )
 
     assert envelope.data.rematch_transfers_retired == 3
@@ -1713,12 +1769,12 @@ async def test_links_set_accept_flags_a_failed_rebuild(
 
     monkeypatch.setattr(accounts_module, "_apply_account_accept", _accepted)
     monkeypatch.setattr(accounts_module, "grant_confirmation_or_raise", _granted)
+    _stub_merge_prompt(monkeypatch, accounts_module)
 
     envelope = await accounts_module.accounts_links_set(
         decision_id="dec001",
         action="accept",
         target_account_id="CAND001",
-        confirmation_token="tok",  # noqa: S106  # opaque grant id, not a credential; skips the elicitation branch
     )
 
     assert any("rebuild" in action.lower() for action in envelope.actions), (
@@ -1757,12 +1813,12 @@ async def test_links_set_accept_flags_a_match_pass_that_never_ran(
 
     monkeypatch.setattr(accounts_module, "_apply_account_accept", _accepted)
     monkeypatch.setattr(accounts_module, "grant_confirmation_or_raise", _granted)
+    _stub_merge_prompt(monkeypatch, accounts_module)
 
     envelope = await accounts_module.accounts_links_set(
         decision_id="dec001",
         action="accept",
         target_account_id="CAND001",
-        confirmation_token="tok",  # noqa: S106  # opaque grant id, not a credential; skips the elicitation branch
     )
 
     assert any("could not run" in action for action in envelope.actions), (

--- a/tests/moneybin/test_mcp/test_confirmation.py
+++ b/tests/moneybin/test_mcp/test_confirmation.py
@@ -580,3 +580,98 @@ async def test_degraded_client_gets_structured_opaque_token(
     assert isinstance(token, str)
     assert token not in error.message
     broker.consume(token, now=NOW).verify(BINDING)
+
+
+@pytest.mark.asyncio
+async def test_elicitation_only_mints_no_token_for_a_degraded_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An account merge must never hand the caller a key to its own merge.
+
+    The ordinary path degrades to an opaque token when the client cannot
+    prompt. For a merge that rewrites ledger history that degradation IS the
+    hole: the token goes back to the calling agent, which can replay it on the
+    next call and never reach a human. Refuse instead, and mint nothing --
+    withholding a token from the response would still leave the entry live for
+    the next call to redeem, which is why this asserts on the broker.
+    """
+    broker = _RecordingBroker(ttl_seconds=300)
+    monkeypatch.setattr("moneybin.mcp.confirmation._utcnow", lambda: NOW)
+    monkeypatch.setattr(
+        "moneybin.mcp.confirmation._active_context", lambda: MagicMock()
+    )
+    monkeypatch.setattr(
+        "moneybin.mcp.confirmation.supports_elicitation",
+        _does_not_support_elicitation,
+    )
+
+    with pytest.raises(UserError) as raised:
+        await grant_confirmation_or_raise(
+            binding=BINDING,
+            message="Merge two accounts?",
+            confirmation_token=None,
+            elicitation_only=True,
+            broker=broker,
+        )
+
+    error = raised.value
+    assert error.code == error_codes.MUTATION_CONFIRMATION_REQUIRED
+    assert broker.issued == [], "a token was minted for an elicitation-only merge"
+    assert "confirmation_token" not in (error.details or {})
+    # The refusal is a dead end unless it names a route that actually works.
+    assert "moneybin" in (error.hint or "")
+
+
+@pytest.mark.asyncio
+async def test_elicitation_only_refuses_a_supplied_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A token minted elsewhere must not buy its way past the merge prompt.
+
+    Without this the fix is cosmetic: a caller holding any live token for the
+    same binding could still skip the prompt entirely, which is exactly the
+    replay this closes.
+    """
+    broker = _RecordingBroker(ttl_seconds=300)
+    token = broker.issue(BINDING, now=NOW)
+    monkeypatch.setattr("moneybin.mcp.confirmation._utcnow", lambda: NOW)
+
+    with pytest.raises(UserError) as raised:
+        await grant_confirmation_or_raise(
+            binding=None,
+            message="",
+            confirmation_token=token,
+            elicitation_only=True,
+            broker=broker,
+        )
+
+    assert raised.value.code == error_codes.MUTATION_INVALID_INPUT
+    # The token must survive unconsumed: refusing by burning it would let a
+    # caller destroy a confirmation somebody else was about to use.
+    broker.consume(token, now=NOW).verify(BINDING)
+
+
+@pytest.mark.asyncio
+async def test_elicitation_only_still_grants_on_an_accepted_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The stricter path must still let a real human agreement through."""
+    broker = _RecordingBroker(ttl_seconds=300)
+    ctx = MagicMock()
+    ctx.elicit = AsyncMock(return_value=AcceptedElicitation(data=True))
+    monkeypatch.setattr("moneybin.mcp.confirmation._utcnow", lambda: NOW)
+    monkeypatch.setattr("moneybin.mcp.confirmation._active_context", lambda: ctx)
+    monkeypatch.setattr(
+        "moneybin.mcp.confirmation.supports_elicitation", _supports_elicitation
+    )
+
+    grant = await grant_confirmation_or_raise(
+        binding=BINDING,
+        message="Merge two accounts?",
+        confirmation_token=None,
+        elicitation_only=True,
+        broker=broker,
+    )
+
+    grant.verify(BINDING)
+    assert broker.issued == []

--- a/tests/moneybin/test_mcp/test_review.py
+++ b/tests/moneybin/test_mcp/test_review.py
@@ -2169,6 +2169,75 @@ async def test_identity_mixed_batch_refusal_names_the_decisions_left_to_resubmit
     )
 
 
+async def test_identity_refusal_counts_a_second_merge_the_cli_will_not_reach() -> None:
+    """`accounts links set` decides one link, so a second merge stays pending.
+
+    Both decisions are `account_link`, so a remainder derived from the batch's
+    deduplicated kinds collapses them into the one excluded entry and reports
+    nothing left over — the refusal then reads as if a single CLI call
+    finishes the batch.
+    """
+    first = _identity_account_setup("two-merges-a")
+    second = _identity_account_setup("two-merges-b")
+    decisions: list[IdentityDecisionRequest] = [
+        AccountLinkDecisionRequest(
+            kind="account_link",
+            decision_id=first["decision_id"],
+            decision="accept",
+            target_id=first["candidate"],
+        ),
+        AccountLinkDecisionRequest(
+            kind="account_link",
+            decision_id=second["decision_id"],
+            decision="accept",
+            target_id=second["candidate"],
+        ),
+    ]
+
+    refused = await identity_links_decide_coarse(decisions=decisions)
+
+    assert refused.error is not None
+    assert refused.error.hint is not None
+    assert "1 decision" in refused.error.hint
+    assert "account_link" in refused.error.hint
+    assert _identity_decision_status("account_link", first["decision_id"]) == "pending"
+    assert _identity_decision_status("account_link", second["decision_id"]) == "pending"
+
+
+async def test_identity_refusal_counts_a_reject_dropped_with_the_batch() -> None:
+    """A reject is refused with the batch even though it is not an accept.
+
+    Only accepts reach the batch's kind set, so a reject travelling beside a
+    merge left no trace in the remainder — yet nothing was written and it has
+    to be sent again like everything else.
+    """
+    account = _identity_account_setup("merge-plus-reject")
+    merchant = _identity_merchant_setup("merge-plus-reject")
+    decisions: list[IdentityDecisionRequest] = [
+        AccountLinkDecisionRequest(
+            kind="account_link",
+            decision_id=account["decision_id"],
+            decision="accept",
+            target_id=account["candidate"],
+        ),
+        MerchantLinkDecisionRequest(
+            kind="merchant_link",
+            decision_id=merchant["decision_id"],
+            decision="reject",
+        ),
+    ]
+
+    refused = await identity_links_decide_coarse(decisions=decisions)
+
+    assert refused.error is not None
+    assert refused.error.hint is not None
+    assert "1 decision" in refused.error.hint
+    assert "merchant_link" in refused.error.hint
+    assert _identity_decision_status("merchant_link", merchant["decision_id"]) == (
+        "pending"
+    )
+
+
 async def test_identity_security_persisted_state_mismatch_consumes_token() -> None:
     setup = _identity_security_setup("state-mismatch")
     decisions = [

--- a/tests/moneybin/test_mcp/test_review.py
+++ b/tests/moneybin/test_mcp/test_review.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Sequence
+from collections.abc import Generator, Sequence
+from contextlib import contextmanager
 from dataclasses import replace
 from datetime import UTC, date, datetime
 from decimal import Decimal
 from typing import Any, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import duckdb
 import pytest
+from fastmcp.server.elicitation import AcceptedElicitation
 from prometheus_client import REGISTRY
 
 from moneybin import error_codes
@@ -1868,6 +1870,31 @@ async def test_categorization_pending_uses_batch_attempt_projection() -> None:
     assert len(response.data.rows) == 1
 
 
+@contextmanager
+def _human_confirms() -> Generator[None]:
+    """Answer the confirmation prompt the way a person at the client would.
+
+    An account merge no longer accepts a confirmation token, so a test that
+    needs the merge to actually apply has to go through the prompt. Scoped
+    rather than applied for the whole test: a batch loop that also exercises
+    merchant and security links must leave those on the token path, and a
+    patch that outlived its case would silently convert them.
+
+    Tests that are about the token contract itself must NOT use this — they
+    would stop exercising the thing they are named for.
+    """
+    ctx = MagicMock()
+    ctx.elicit = AsyncMock(return_value=AcceptedElicitation(data=True))
+
+    def _supports(_ctx: object) -> bool:
+        return True
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("moneybin.mcp.confirmation._active_context", lambda: ctx)
+        mp.setattr("moneybin.mcp.confirmation.supports_elicitation", _supports)
+        yield
+
+
 async def test_identity_standard_boundary_accepts_and_rejects_each_domain() -> None:
     account_accept = _identity_account_setup("accept")
     account_reject = _identity_account_setup("reject")
@@ -1912,9 +1939,14 @@ async def test_identity_standard_boundary_accepts_and_rejects_each_domain() -> N
     ]
 
     for request in cases:
-        required = await identity_links_decide_coarse(decisions=[request])
-        response = required
-        if request.decision == "accept":
+        if request.decision != "accept":
+            response = await identity_links_decide_coarse(decisions=[request])
+        elif request.kind == "account_link":
+            # A merge has no token path at all — the prompt is the only route.
+            with _human_confirms():
+                response = await identity_links_decide_coarse(decisions=[request])
+        else:
+            required = await identity_links_decide_coarse(decisions=[request])
             assert required.error is not None
             assert required.error.code == error_codes.MUTATION_CONFIRMATION_REQUIRED
             assert required.error.details is not None
@@ -1933,7 +1965,19 @@ async def test_identity_standard_boundary_accepts_and_rejects_each_domain() -> N
         )
 
 
-async def test_identity_account_persisted_state_mismatch_consumes_token() -> None:
+async def test_identity_account_merge_rechecks_live_state_after_the_prompt() -> None:
+    """Agreeing to a prompt approves one exact merge, not merges in general.
+
+    Removing the token path must not also remove the recheck that rides on it:
+    the grant is a digest of the batch plus its complete live before-state, and
+    it is re-verified inside the write transaction. If the decision shifts
+    between the prompt and the commit, the merge the person agreed to is not
+    the merge about to run, and it must not proceed.
+
+    The state change here is the same one the token version of this test used
+    (``confidence_score``), so what moved is the confirmation vehicle, not the
+    condition being detected.
+    """
     setup = _identity_account_setup("state-mismatch")
     decisions = [
         AccountLinkDecisionRequest(
@@ -1943,33 +1987,90 @@ async def test_identity_account_persisted_state_mismatch_consumes_token() -> Non
             target_id=setup["candidate"],
         )
     ]
-    required = await identity_links_decide_coarse(decisions=decisions)
-    assert required.error is not None
-    assert required.error.details is not None
-    token = str(required.error.details["confirmation_token"])
-    with get_database(read_only=False) as db:
-        db.execute(
-            """
-            UPDATE app.account_link_decisions
-            SET confidence_score = 0.61
-            WHERE decision_id = ?
-            """,
-            [setup["decision_id"]],
-        )
 
-    mismatched = await identity_links_decide_coarse(
-        decisions=decisions,
-        confirmation_token=token,
-    )
-    replayed = await identity_links_decide_coarse(
-        decisions=decisions,
-        confirmation_token=token,
-    )
+    _real_preview = _preview_identity_decisions
+
+    # Shift the persisted decision out from under the approved digest at the
+    # one moment it matters: after the batch is planned and prompted, before
+    # apply re-plans it inside the write transaction.
+    def _drift_then_preview(requests: list[IdentityDecisionRequest]) -> Any:
+        preview = _real_preview(requests)
+        with get_database(read_only=False) as db:
+            db.execute(
+                """
+                UPDATE app.account_link_decisions
+                SET confidence_score = 0.61
+                WHERE decision_id = ?
+                """,
+                [setup["decision_id"]],
+            )
+        return preview
+
+    with _human_confirms():
+        with patch.object(
+            reviews_module,
+            "_preview_identity_decisions",
+            side_effect=_drift_then_preview,
+        ):
+            mismatched = await identity_links_decide_coarse(decisions=decisions)
 
     assert mismatched.error is not None
     assert mismatched.error.code == error_codes.MUTATION_CONFIRMATION_MISMATCH
-    assert replayed.error is not None
-    assert replayed.error.code == error_codes.MUTATION_CONFIRMATION_REPLAYED
+    assert _identity_decision_status("account_link", setup["decision_id"]) == "pending"
+
+
+async def test_identity_account_merge_is_refused_without_a_token_to_redeem() -> None:
+    """A client that cannot prompt gets a refusal, not a key to its own merge.
+
+    Every other destructive operation degrades to an opaque token here. For an
+    account merge that degradation was the whole hole: the token is returned to
+    the calling agent, so the documented "confirm before merging" contract was
+    satisfiable without a person ever seeing it. The refusal must carry no
+    token at all -- withholding it from the message while minting it anyway
+    would leave the entry live for the very next call.
+    """
+    setup = _identity_account_setup("no-token")
+    decisions = [
+        AccountLinkDecisionRequest(
+            kind="account_link",
+            decision_id=setup["decision_id"],
+            decision="accept",
+            target_id=setup["candidate"],
+        )
+    ]
+
+    refused = await identity_links_decide_coarse(decisions=decisions)
+
+    assert refused.error is not None
+    assert refused.error.code == error_codes.MUTATION_CONFIRMATION_REQUIRED
+    assert "confirmation_token" not in (refused.error.details or {})
+    assert _identity_decision_status("account_link", setup["decision_id"]) == "pending"
+
+
+async def test_identity_account_merge_refuses_a_supplied_token() -> None:
+    """A token minted elsewhere must not buy its way past the merge prompt.
+
+    Without this the refusal above is cosmetic: a caller holding any live token
+    -- one issued for a sibling operation, or carried over from before this
+    contract -- could still merge without a prompt.
+    """
+    setup = _identity_account_setup("token-refused")
+    decisions = [
+        AccountLinkDecisionRequest(
+            kind="account_link",
+            decision_id=setup["decision_id"],
+            decision="accept",
+            target_id=setup["candidate"],
+        )
+    ]
+
+    refused = await identity_links_decide_coarse(
+        decisions=decisions,
+        confirmation_token="any-token-at-all",  # noqa: S106  # opaque grant id, not a credential
+    )
+
+    assert refused.error is not None
+    assert refused.error.code == error_codes.MUTATION_INVALID_INPUT
     assert _identity_decision_status("account_link", setup["decision_id"]) == "pending"
 
 
@@ -2474,12 +2575,19 @@ def test_identity_plan_ignores_unchanged_accept_for_destructive_gate() -> None:
 async def test_identity_confirmation_rechecks_live_state_and_consumes_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Pin the full token protocol: binding recheck, mismatch, single use.
+
+    Uses a merchant link rather than an account one because an account merge
+    has no token path left to pin — it takes the prompt or nothing. The
+    account path's own live-state recheck is covered by
+    ``test_identity_account_merge_rechecks_live_state_after_the_prompt``.
+    """
     decisions = [
-        AccountLinkDecisionRequest(
-            kind="account_link",
-            decision_id="account-decision",
+        MerchantLinkDecisionRequest(
+            kind="merchant_link",
+            decision_id="merchant-decision",
             decision="accept",
-            target_id="account-target",
+            target_id="merchant-target",
         )
     ]
     initial = _identity_plan(decisions)

--- a/tests/moneybin/test_mcp/test_review.py
+++ b/tests/moneybin/test_mcp/test_review.py
@@ -1991,8 +1991,9 @@ async def test_identity_account_merge_rechecks_live_state_after_the_prompt() -> 
     _real_preview = _preview_identity_decisions
 
     # Shift the persisted decision out from under the approved digest at the
-    # one moment it matters: after the batch is planned and prompted, before
-    # apply re-plans it inside the write transaction.
+    # one moment it matters: after the batch is planned — so the binding the
+    # person approves is the pre-drift one — and before apply re-plans it
+    # inside the write transaction.
     def _drift_then_preview(requests: list[IdentityDecisionRequest]) -> Any:
         preview = _real_preview(requests)
         with get_database(read_only=False) as db:
@@ -2072,6 +2073,56 @@ async def test_identity_account_merge_refuses_a_supplied_token() -> None:
     assert refused.error is not None
     assert refused.error.code == error_codes.MUTATION_INVALID_INPUT
     assert _identity_decision_status("account_link", setup["decision_id"]) == "pending"
+
+
+async def test_identity_mixed_accept_batch_forces_the_whole_batch_to_the_prompt() -> (
+    None
+):
+    """One account accept strips the token path from every decision beside it.
+
+    A merchant accept on its own degrades to a token, so a batch carrying both
+    kinds is the boundary where this gate can be drawn wrong: reading "every
+    decision is an account link" instead of "any decision is" would hand the
+    mixed batch a token, and that batch still re-keys a transaction history.
+    The single-kind tests above cannot see that difference.
+    """
+    account = _identity_account_setup("mixed-batch")
+    merchant = _identity_merchant_setup("mixed-batch")
+    decisions: list[IdentityDecisionRequest] = [
+        AccountLinkDecisionRequest(
+            kind="account_link",
+            decision_id=account["decision_id"],
+            decision="accept",
+            target_id=account["candidate"],
+        ),
+        MerchantLinkDecisionRequest(
+            kind="merchant_link",
+            decision_id=merchant["decision_id"],
+            decision="accept",
+            target_id=merchant["merchant_id"],
+        ),
+    ]
+
+    refused = await identity_links_decide_coarse(
+        decisions=decisions,
+        confirmation_token="any-token-at-all",  # noqa: S106  # opaque grant id, not a credential
+    )
+    degraded = await identity_links_decide_coarse(decisions=decisions)
+    with _human_confirms():
+        response = await identity_links_decide_coarse(decisions=decisions)
+
+    assert refused.error is not None
+    assert refused.error.code == error_codes.MUTATION_INVALID_INPUT
+    assert degraded.error is not None
+    assert degraded.error.code == error_codes.MUTATION_CONFIRMATION_REQUIRED
+    assert "confirmation_token" not in (degraded.error.details or {})
+    assert response.error is None
+    assert _identity_decision_status("account_link", account["decision_id"]) == (
+        "accepted"
+    )
+    assert _identity_decision_status("merchant_link", merchant["decision_id"]) == (
+        "accepted"
+    )
 
 
 async def test_identity_security_persisted_state_mismatch_consumes_token() -> None:

--- a/tests/moneybin/test_mcp/test_review.py
+++ b/tests/moneybin/test_mcp/test_review.py
@@ -2125,6 +2125,50 @@ async def test_identity_mixed_accept_batch_forces_the_whole_batch_to_the_prompt(
     )
 
 
+async def test_identity_mixed_batch_refusal_names_the_decisions_left_to_resubmit() -> (
+    None
+):
+    """A refusal that hides half the work left to do is a dead end.
+
+    The batch is refused whole, so the merchant decision beside the merge is
+    dropped too — but the CLI command the refusal names only completes the
+    account link. A caller following the hint literally would merge and then
+    believe the merchant decision had been applied.
+    """
+    account = _identity_account_setup("mixed-hint")
+    merchant = _identity_merchant_setup("mixed-hint")
+    decisions: list[IdentityDecisionRequest] = [
+        AccountLinkDecisionRequest(
+            kind="account_link",
+            decision_id=account["decision_id"],
+            decision="accept",
+            target_id=account["candidate"],
+        ),
+        MerchantLinkDecisionRequest(
+            kind="merchant_link",
+            decision_id=merchant["decision_id"],
+            decision="accept",
+            target_id=merchant["merchant_id"],
+        ),
+    ]
+
+    mixed = await identity_links_decide_coarse(decisions=decisions)
+    account_only = await identity_links_decide_coarse(decisions=decisions[:1])
+
+    assert mixed.error is not None
+    assert mixed.error.hint is not None
+    assert "moneybin accounts links set" in mixed.error.hint
+    assert "merchant_link" in mixed.error.hint
+    # An account-only batch has nothing left over, so it must not grow the
+    # sentence -- the note is about the remainder, not decoration.
+    assert account_only.error is not None
+    assert account_only.error.hint is not None
+    assert "merchant_link" not in account_only.error.hint
+    assert _identity_decision_status("merchant_link", merchant["decision_id"]) == (
+        "pending"
+    )
+
+
 async def test_identity_security_persisted_state_mismatch_consumes_token() -> None:
     setup = _identity_security_setup("state-mismatch")
     decisions = [

--- a/tests/moneybin/test_mcp/test_tool_surface_budget.py
+++ b/tests/moneybin/test_mcp/test_tool_surface_budget.py
@@ -165,7 +165,14 @@ _CANONICAL_CARRYING_WEIGHT_BYTES = {
     # Grew by the same disclosure, for the same reason: accepting an account
     # decision re-runs matching, which can reverse a transfer the user
     # accepted. Still less than half the cohort it replaced.
-    "identity_links_decide": (3_333, 5_762),
+    #
+    # Then 148 more to say that an accepted account link takes the prompt only
+    # — no confirmation_token, and no fallback token for a client that cannot
+    # prompt. That is a divergence from every other destructive tool, and the
+    # description is the only place the agent can learn it: one that omitted it
+    # would have the agent retry a merge with a token, read the refusal as a
+    # bug, and route around the confirmation this exists to enforce.
+    "identity_links_decide": (3_481, 5_762),
     "taxonomy_set": (3_480, 3_223),
     "privacy_consent_set": (1_217, 2_188),
 }


### PR DESCRIPTION
Refs #407 — **narrows it; deliberately does not auto-close it.** See "What this
does NOT fix": one of #407's four "done when" criteria ("the agent path cannot
self-accept") is satisfied for the token and not for the elicitation, so closing
the issue on this PR would overstate what shipped.

## Why

`identity_links_decide` and `accounts_links_set` both documented a confirmation
before an account merge, and one genuinely existed. The hole was the fallback
underneath it.

When a client can't show an elicitation, `grant_confirmation_or_raise` mints an
opaque, payload-bound token and returns it in the `mutation_confirmation_required`
payload — **to the calling agent**. So the caller could take the token out of the
first call's refusal and hand it straight back on the second. The merge applied,
the binding verified, the audit log recorded a confirmed operation, and no person
ever saw the prompt.

This wasn't theoretical. A test in the repo already demonstrated the entire loop:

```python
required = await identity_links_decide_coarse(decisions=decisions)
assert required.error.code == MUTATION_CONFIRMATION_REQUIRED
response = await identity_links_decide_coarse(
    decisions=decisions,
    confirmation_token=str(required.error.details["confirmation_token"]),
)   # applies
```

The authors had already spotted the shape of this — `confirmation.py` refuses to
mint a token when an elicitation *times out*, commenting that doing so "hands the
calling agent a key to its own unconfirmed operation." That reasoning was never
applied to the ordinary path.

## What changed

An accepted **account link** now takes the prompt or nothing:

- A supplied `confirmation_token` is refused with `mutation_invalid_input`, and
  is **never consumed** — refusing must not burn a confirmation somebody else
  was about to redeem.
- A client that cannot elicit is refused with `mutation_confirmation_required`
  naming `moneybin accounts links set`, rather than being issued a token it
  could redeem itself. The refusal carries `operation_kind` and `blast_radius`
  but no token.
- `accounts_links_set` refuses a token *before* the proposal load — a merge that
  cannot proceed shouldn't first cost a database read.

Implemented as one `elicitation_only` flag on the shared
`grant_confirmation_or_raise`, so both call sites go through the same gate rather
than growing a second confirmation pattern.

**Merchant- and security-link accepts are unchanged** and keep the token path.
Neither re-keys a transaction.

## Threshold: the link kind, not a count

Any account merge takes the strict path, at any size. A merge is hard to notice
and hard to undo at five transactions as much as at 520, and
`design-principles.md` names a silent account merge by kind, not by magnitude. A
count threshold would also need a defensible N, and a merge one row under it
fails exactly the same way.

## What this does NOT fix

There are two ways the prompt gets bypassed. This closes one:

- **Token replay** — closed here.
- **The client answers its own elicitation prompt** — still open. `supports_elicitation()`
  is true whenever the client *declares the capability*; whether a human is behind
  it is the client's contract.

#407's own evidence ("requested no confirmation token, and returned no
confirmation payload") points at the second mechanism, since the first would have
returned a token on the initial call.

Two further facts from the session that filed #407, which sharpen this rather
than settle it:

- **It was not stale code.** The live server reported build revision `5f9b900c`,
  and both #385 ("Ask before the CLI merges two accounts") and #389 ("Refuse an
  unanswered confirmation instead of minting a token") are ancestors of it. The
  confirmation machinery was live and current when the ungated merge applied.
- **The root cause of that specific merge is unproven.** That session cannot rule
  out that the elicitation fired and was answered without a person — possibly by
  its own client. Its context was compacted, so the raw tool exchange is gone.
  What is recorded is what the tool returned; the *why* is inference. Part of
  that incident may therefore be operator error rather than a product defect.

The hole this PR closes is real and independent of that: the fallback token is
readable by the calling agent by construction, in current code, demonstrated by
an existing test. But the residual should stay open until someone reproduces an
ungated merge on a clean client with a human actually present. Hence `Refs`
rather than `Closes`. An out-of-band confirmation code — which would survive a
client answering its own prompt — was considered and deliberately deferred.

## Verification

`make check test` → **9663 passed, 4 skipped**; pyright 0 errors; ruff clean.
Count predicted before the run, not read off after. The four MCP surface files
run separately with the integration marker enabled (79 passed), since `make
test` excludes them.

Three pre-existing tests depended on the account token path. None were deleted
and no coverage was dropped:

- `test_identity_standard_boundary_accepts_and_rejects_each_domain` — account
  accepts now go through a scoped prompt helper; merchant and security cases
  still exercise the token path in the same loop.
- `test_identity_confirmation_rechecks_live_state_and_consumes_token` — moved to
  a merchant link so it still pins the full token protocol (binding recheck,
  mismatch, single use), which no longer exists for accounts.
- `test_identity_account_persisted_state_mismatch_consumes_token` → renamed to
  `..._rechecks_live_state_after_the_prompt`. Same condition (the decision drifts
  between confirmation and commit), same detection, different vehicle.

### Review round (f074ea1f)

- **CHANGELOG** condensed to the one-or-two sentences `shipping.md` asks for.
  The incident figures and the open elicitation case stay here in the PR body.
- **`.claude/rules/mcp.md`** now records the `elicitation_only` exception. That
  always-loaded rule still described the opaque-token fallback as
  unconditional — the file a contributor reads before touching `mcp/`.
- **New test** `test_identity_mixed_accept_batch_forces_the_whole_batch_to_the_prompt`
  drives the coarse tool end to end with an account accept *and* a merchant
  accept in one batch. It was written after the code, so it was checked by
  mutation rather than by assertion alone: narrowing the gate to
  `set(preview.kinds) == {"account_link"}` makes it fail
  (`mutation_confirmation_replayed` instead of `mutation_invalid_input`) while
  `test_identity_account_merge_refuses_a_supplied_token` still passes. That
  single-kind blind spot is exactly what the review flagged.
- **Two docstrings** corrected: `accounts_links_set` no longer advertises
  `confirmation_token` as usable with `action="accept"`, and the drift comment
  in the recheck test no longer claims the mutation lands after the prompt (it
  lands after the batch is planned, before it).

### Review round 2 (d0b241c0)

- **A mixed batch's refusal was a dead end.** It named `moneybin accounts
  links set`, which finishes only the account link — the merchant or security
  accept travelling beside it went down with the batch and the caller had no
  way to know. `grant_confirmation_or_raise` gains an optional `cli_note`;
  `_identity_remainder_note` fills it when the batch carries more than the
  merge. Written red-first: the test failed against the literal old hint.
- **Two specs still described the token fallback as universal.**
  `mcp-tool-surface-scaling.md` promised every degraded client a token;
  `account-identity-resolution.md`'s "Known gap" planned a deferred evidence
  check around an opaque-token round trip account links no longer take. Both
  reconciled — the round-trip constraint is now scoped to merchant/security.
- **Spelling.** The three `honour`/`honoured` occurrences were all introduced
  by this branch, so they now read American. Recording the correction to the
  premise, though: the codebase is **not** consistently American here — 61
  American against 26 British across `src/`, `tests/`, and `docs/`. This
  follows the majority; it does not fix a violation, and the other 26 are
  untouched.

## Notes for the reviewer

- The `identity_links_decide` description grew 148 bytes and needed the
  `standard.json` snapshot regenerated (via `scripts/mcp_surface_snapshot.py`),
  the carrying-weight constant updated with a rationale comment in the existing
  style, and the recorded runtime facts in `mcp-tool-surface-scaling.md`
  refreshed — total bytes, SHA-256, and the derived delta and token estimate.
- The CLI merge path is unaffected: it already prompts on the terminal.

