### PR TITLE
Show measured overlap, not a constant, on account candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -762,6 +762,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   binding failure is what split the account in the first place.
 
 ### Changed
+- **Account-merge candidates carry measured ledger overlap instead of a
+  constant `confidence`.** An import that offers to merge a file into an
+  account you already have returned a `confidence` on every candidate — a
+  literal stamped per resolution rung that no input could move. Two candidates
+  found on the same rung tied at the same number however differently their
+  ledgers overlapped, so a caller ranking on it could not tell an account
+  sharing every transaction from one sharing none, and the field's name invited
+  reading that tie as a judgement. `import_files` and `import_confirm` no longer
+  return the field; rank on `overlap_matched` / `overlap_comparable`, which the
+  candidate already carried. The review queue and decision history had dropped
+  it for the same reason, so all three surfaces now agree. Agents parsing
+  `account_proposals[].candidates[].confidence` must switch to the overlap
+  pair; an absent pair means the two ledgers share no comparable period, which
+  is absence of evidence rather than a zero (#416).
 - **A merge whose rebuild failed, or an accept the reconciliation refused, now
   exits non-zero.** `accounts links set`, `transactions matches set`, and
   `transactions review --confirm/--confirm-all` printed a warning and exited

--- a/docs/specs/account-identity-resolution.md
+++ b/docs/specs/account-identity-resolution.md
@@ -887,7 +887,9 @@ Guard-2 free-text resolution):
     signal (0.5 `institution_last4`, 0.4 `name`, 0.3 `institution_reissue`), so
     it restates `signal` in a less legible form; no input moves it. The column
     remains as the audit record of what was written when the proposal was
-    created, and is no longer projected onto either surface.
+    created, and is no longer projected onto any surface — the review queue,
+    the decision history, and the import gate's `account_proposals` all carry
+    `signal` plus the measured overlap instead.
 - **Status lifecycle.** `account_links`: `accepted` (live) / `reversed` (undone).
   `account_link_decisions`: `pending` (awaiting review) → `accepted` (merged onto
   the named candidate) / `rejected` (declined pairing — not re-proposed) /
@@ -1014,10 +1016,14 @@ remembered, so re-imports are silent.
 
 **AX (agent).** The same envelope is the agent's structured contract: per detected
 account an `account_proposal` (`{proposal_ref, proposed_account_id, is_new,
-candidates:[{account_id, display_name, confidence, signal, overlap_matched?,
+candidates:[{account_id, display_name, signal, overlap_matched?,
 overlap_comparable?, overlap_window_start?, overlap_window_end?}]}`) plus
 `actions[]`. `legacy_pdf_identity` is a review-only signal; overlap fields are
 aggregate/date-window evidence and never change the confirmation requirement.
+There is no `confidence` field: it was a per-signal constant, so ranking on it
+tied a candidate sharing every transaction with one sharing none. Rank on
+`overlap_matched` / `overlap_comparable`, and treat an absent pair as absence of
+evidence rather than a zero.
 The agent (a) returns an `account_bindings` map to `import_files` or
 `import_confirm` to bind deterministically — preferred, keyed by `proposal_ref`;
 or (b) self-accepts **only a strong-confirmer adoption** when `self_accept` is
@@ -1348,7 +1354,17 @@ Per [`observability.md`](observability.md), mirror the `DEDUP_*` family
 - `ACCOUNT_LINK_REVIEW_PENDING` — Gauge, current pending-decision count.
 - `ACCOUNT_LINK_CONFIDENCE` — Histogram of resolution confidence. Records the
   score written with a proposal, which is where that number is still meaningful;
-  it is deliberately not the review surfaces' evidence (Decision 5).
+  it is deliberately not the review surfaces' evidence (Decision 5). Because the
+  score is a per-signal constant, this describes which rungs fire rather than how
+  strong any one proposal is.
+- `ACCOUNT_LINK_OVERLAP_RATIO` — Histogram of `overlap_matched /
+  overlap_comparable` for every candidate an import gate surfaces with a
+  comparable period. The counterpart to the constant above: it varies with the
+  two accounts in front of the reviewer, so it is the one that says whether the
+  gate is asking real questions — mass near 1.0 is genuine twins found, mass near
+  0.0 is a confirmation spent on pairs the evidence already separates. Candidates
+  with no comparable period are absent rather than recorded as 0.0, since that is
+  absence of evidence; `ACCOUNT_LINK_OVERLAP_PROBES_TOTAL` counts those.
 
 - `ACCOUNT_LINK_OVERLAP_PROBES_TOTAL` — Counter,
   `result ∈ {measurable, unmeasurable}`, incremented inside

--- a/docs/specs/account-identity-resolution.md
+++ b/docs/specs/account-identity-resolution.md
@@ -1109,7 +1109,8 @@ with nothing to pick. So `AccountResolver.propose()` (the **preview** that fills
 the gate envelope, not `resolve()`) supplies a **fallback** candidate list when
 the real matchers return nothing — the institution-scoped accounts if any match
 the source's institution, else *all* accounts (capped at `_FALLBACK_CANDIDATE_CAP`),
-tagged `signal="institution"` / `signal="fallback"` at low confidence (0.2 / 0.1).
+tagged `signal="institution"` / `signal="fallback"` — the ladder's two weakest
+rungs, and, like every candidate, surfaced with no confidence number.
 These are gate-only decision support: they widen what the confirmer can pick, and
 are **never eligible for silent auto-adopt** (only `explicit` / strong-ref signals
 are). `resolve()` is untouched — confirming "new" still mints with zero candidates.

--- a/docs/specs/smart-import-inbox.md
+++ b/docs/specs/smart-import-inbox.md
@@ -165,7 +165,7 @@ projection of the existing `import_status` tool.
           "is_new": true, "requires_confirm": true,
           "candidates": [
             {"account_id": "9f8e7d6c5b4a", "display_name": "Wells Fargo Checking ••9940",
-             "confidence": 0.2, "signal": "institution"}
+             "signal": "institution"}
           ]}
        ]}
     ],
@@ -178,9 +178,16 @@ projection of the existing `import_status` tool.
   pending entry carries the resolver's `account_proposals[]` **in the response
   envelope itself** (mirrored in the `.pending.yml` sidecar). A proposal has
   `{source_account_key, proposed_account_id, is_new, requires_confirm,
-  candidates[]}`; each candidate is `{account_id, display_name, confidence,
-  signal}`. This lets a REST/MCP/CLI-JSON caller render the pick-list and bind
-  an account without reading the sidecar off disk. When the source carries no
+  candidates[]}`; each candidate is `{account_id, display_name, signal}`, plus
+  `{overlap_matched, overlap_comparable, overlap_window_start,
+  overlap_window_end}` when the channel supplied the incoming ledger to measure
+  against. There is no `confidence` field — it was a per-signal constant, so
+  ranking on it tied a candidate sharing every transaction with one sharing
+  none. Rank on the overlap pair, and read an absent pair as absence of
+  evidence rather than a zero
+  ([`account-identity-resolution.md`](account-identity-resolution.md)). This
+  lets a REST/MCP/CLI-JSON caller render the pick-list and bind an account
+  without reading the sidecar off disk. When the source carries no
   account number and no institution match (a bare single-account CSV), the
   resolver supplies a **fallback** candidate list — the institution-scoped
   accounts if any match, else all accounts (capped) — so the gate is never a

--- a/src/moneybin/metrics/registry.py
+++ b/src/moneybin/metrics/registry.py
@@ -555,6 +555,10 @@ ACCOUNT_LINK_OVERLAP_RATIO = Histogram(
     "spending a confirmation on pairs the evidence already separates. Candidates "
     "with no comparable period are absent rather than 0 — that is absence of "
     "evidence, and ACCOUNT_LINK_OVERLAP_PROBES_TOTAL counts it.",
+    # Both tails carry the signal, so neither collapses: 0.0 is its own bucket
+    # because a measurable pair sharing nothing is a wasted confirmation, not a
+    # rounding of 0.03, and 0.9/0.99 separate a near-twin from an exact one.
+    buckets=(0.0, 0.05, 0.25, 0.5, 0.75, 0.9, 0.99, 1.0),
 )
 
 ACCOUNT_LINK_OVERLAP_PROBES_TOTAL = Counter(

--- a/src/moneybin/metrics/registry.py
+++ b/src/moneybin/metrics/registry.py
@@ -538,7 +538,23 @@ ACCOUNT_LINK_REVIEW_PENDING = Gauge(
 
 ACCOUNT_LINK_CONFIDENCE = Histogram(
     "moneybin_account_link_confidence",
-    "Resolution confidence for account-link candidate proposals.",
+    "Resolution confidence stamped onto a queued account-link decision. A "
+    "per-signal constant, so this describes which rungs fire rather than how "
+    "strong any one proposal is — it is the distribution of what gets "
+    "persisted to account_link_decisions.confidence_score, nothing more. For "
+    "evidence about a specific pair, see ACCOUNT_LINK_OVERLAP_RATIO.",
+)
+
+ACCOUNT_LINK_OVERLAP_RATIO = Histogram(
+    "moneybin_account_link_overlap_ratio",
+    "Share of an incoming ledger that a candidate account already holds, over "
+    "the period both cover, for every candidate an import gate surfaced. Unlike "
+    "ACCOUNT_LINK_CONFIDENCE this varies with the two accounts in front of the "
+    "reviewer, so it is the one that says whether the gate is asking real "
+    "questions: mass near 1.0 is genuine twins found, mass near 0.0 is the gate "
+    "spending a confirmation on pairs the evidence already separates. Candidates "
+    "with no comparable period are absent rather than 0 — that is absence of "
+    "evidence, and ACCOUNT_LINK_OVERLAP_PROBES_TOTAL counts it.",
 )
 
 ACCOUNT_LINK_OVERLAP_PROBES_TOTAL = Counter(

--- a/src/moneybin/privacy/payloads/imports.py
+++ b/src/moneybin/privacy/payloads/imports.py
@@ -81,11 +81,16 @@ class ImportConfirmationSignSample(TypedDict, total=False):
 
 
 class ImportConfirmationAccountCandidate(TypedDict, total=False):
-    """One existing-account candidate inside an import proposal."""
+    """One existing-account candidate inside an import proposal.
+
+    No confidence field, for the same reason as ``LinkCandidateRow``: the
+    resolver's number was a per-signal constant no input could move, and a
+    reader treating it as this candidate's score was reading a label.
+    ``overlap_matched`` / ``overlap_comparable`` are the measurement.
+    """
 
     account_id: Annotated[str, DataClass.RECORD_ID]
     display_name: Annotated[str, DataClass.USER_NOTE]
-    confidence: Annotated[float, DataClass.AGGREGATE]
     signal: Annotated[str, DataClass.TXN_TYPE]
     overlap_matched: Annotated[int, DataClass.AGGREGATE]
     overlap_comparable: Annotated[int, DataClass.AGGREGATE]

--- a/src/moneybin/services/account_resolution_types.py
+++ b/src/moneybin/services/account_resolution_types.py
@@ -25,7 +25,6 @@ class AccountCandidateDict(TypedDict):
 
     account_id: str
     display_name: str
-    confidence: float
     signal: str
     overlap_matched: NotRequired[int]
     overlap_comparable: NotRequired[int]
@@ -47,7 +46,19 @@ class AccountProposalDict(TypedDict):
 
 @dataclass(frozen=True)
 class AccountCandidate:
-    """One weak-signal merge candidate surfaced for confirmation."""
+    """One weak-signal merge candidate surfaced for confirmation.
+
+    ``confidence`` is a literal per rung that no input can move, so candidates
+    found on one rung tie at one number however differently their ledgers
+    overlap. It survives here for one job only: it is what gets written to
+    ``app.account_link_decisions.confidence_score``, whose stored meaning is
+    'the constant the resolver stamped'. ``to_dict`` deliberately drops it, for
+    the same reason ``PendingLinkCandidate`` and ``LinkCandidateRow`` have no
+    such field: a number named confidence invites whoever answers the gate — a
+    human skimming, or an agent choosing a binding — to read a tie as a
+    judgement about these two accounts. ``overlap`` is what the surface
+    carries instead, because it varies with them.
+    """
 
     account_id: str
     display_name: str
@@ -112,7 +123,7 @@ class AccountProposal:
     def to_dict(self, *, proposal_ref: str) -> AccountProposalDict:
         """Serialise to a typed dict for surface display.
 
-        Includes opaque ids, display_name, confidence, signal, and optional
+        Includes opaque ids, display_name, signal, and optional
         aggregate/date-window ledger-overlap evidence.
         Never exposes ref_value or other PII-bearing fields.
 
@@ -125,7 +136,6 @@ class AccountProposal:
             serialized: AccountCandidateDict = {
                 "account_id": candidate.account_id,
                 "display_name": candidate.display_name,
-                "confidence": candidate.confidence,
                 "signal": candidate.signal,
             }
             if candidate.overlap is not None:

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -2214,15 +2214,27 @@ class ImportService:
             return source_accounts
         from moneybin.extractors.confidence import Confidence
         from moneybin.metrics.registry import (
-            ACCOUNT_LINK_CONFIDENCE,
+            ACCOUNT_LINK_OVERLAP_RATIO,
             IMPORT_CONFIRMATIONS_TOTAL,
         )
 
+        # Observe the measured overlap, not the resolver's per-signal constant:
+        # the constant is the same for every candidate on a rung, so a histogram
+        # of it reported which rungs fired and never whether a proposal was any
+        # good. A candidate with no comparable period is skipped rather than
+        # recorded as 0.0 — no shared period is absence of evidence, and folding
+        # it in as a zero would read as evidence against every such pair.
         for surfaced in proposals:
             for candidate in surfaced["candidates"]:
+                comparable = candidate.get("overlap_comparable")
+                matched = candidate.get("overlap_matched")
+                if type(comparable) is not int or type(matched) is not int:
+                    continue
+                if comparable == 0:
+                    continue
                 record_observation(
-                    ACCOUNT_LINK_CONFIDENCE,
-                    candidate["confidence"],
+                    ACCOUNT_LINK_OVERLAP_RATIO,
+                    matched / comparable,
                     labels={},
                     emit_metrics=emit_metrics,
                     observations=observations,

--- a/tests/moneybin/test_services/test_account_resolver.py
+++ b/tests/moneybin/test_services/test_account_resolver.py
@@ -489,7 +489,6 @@ def test_alphanumeric_pdf_proposal_is_review_only_and_does_not_surface_identifie
             # Institution alone: the identifier carries no four digits to mask,
             # and the file's own account_name is no longer eligible to name it.
             "display_name": "Chase",
-            "confidence": 0.5,
             "signal": "legacy_pdf_identity",
         }
     ]

--- a/tests/moneybin/test_services/test_import_binding.py
+++ b/tests/moneybin/test_services/test_import_binding.py
@@ -711,20 +711,20 @@ def test_resolve_emits_account_link_metrics(
     assert gauge == 1.0
 
 
-def test_account_gate_observes_the_confidence_of_every_candidate_it_surfaces(
+def test_the_gate_surfaces_ledger_evidence_without_a_constant_confidence_score(
     db: Database,
 ) -> None:
-    """The gate carries the confidence signal the pending queue used to emit.
+    """A surfaced candidate carries measured overlap, never a per-signal constant.
 
-    ``resolve()`` observed candidate confidence as it queued. The inversion put
-    a gate in front of that, so imports now surface the same candidates and
-    never queue — the histogram has to be fed where the decision is made or the
-    interactive path goes dark.
+    ``confidence`` was a literal per rung that no input could move, so two
+    candidates found on the same rung tied at the same number however differently
+    their ledgers overlapped — and the field's name invited whoever answered the
+    gate to read that tie as a judgement. The review queue
+    (``LinkCandidateRow``) and the decision history (``LinkHistoryRow``) each
+    dropped it for exactly that reason; this pins the import gate to the same
+    shape, leaving ``signal`` plus the overlap measurement as the evidence.
     """
-    from prometheus_client import REGISTRY
-
     _seed_existing_account(db, account_id="wf_existing01", display_name="WF Checking")
-    before = REGISTRY.get_sample_value("moneybin_account_link_confidence_count") or 0.0
     with pytest.raises(ImportConfirmationRequiredError) as exc:
         ImportService(db).import_file(
             _STANDARD_CSV,
@@ -733,14 +733,15 @@ def test_account_gate_observes_the_confidence_of_every_candidate_it_surfaces(
             confirm=True,
             actor_kind="human",
         )
-    surfaced = sum(len(p["candidates"]) for p in exc.value.outcome.account_proposals)
-    assert surfaced > 0
-    after = REGISTRY.get_sample_value("moneybin_account_link_confidence_count") or 0.0
-    assert after == before + surfaced
-    # Nothing was queued, so the review gauge stays where it was.
-    assert db.execute("SELECT COUNT(*) FROM app.account_link_decisions").fetchone() == (
-        0,
-    )
+    candidates = [
+        candidate
+        for proposal in exc.value.outcome.account_proposals
+        for candidate in proposal["candidates"]
+    ]
+    assert candidates, "the gate must surface a candidate for this to say anything"
+    for candidate in candidates:
+        assert "confidence" not in candidate
+        assert "signal" in candidate
 
 
 @pytest.mark.parametrize(

--- a/tests/moneybin/test_services/test_import_pdf_transactions.py
+++ b/tests/moneybin/test_services/test_import_pdf_transactions.py
@@ -2581,6 +2581,64 @@ def test_partial_pdf_confirmation_reports_ledger_overlap(
     assert candidate.get("overlap_window_end") == "2024-01-20"
 
 
+def test_pdf_gate_observes_the_measured_overlap_of_the_candidate_it_surfaces(
+    db: Database,
+    tmp_path: Path,
+) -> None:
+    """The gate feeds the histogram that varies with the accounts in front of it.
+
+    Confidence was a per-signal constant, so a histogram of it reported which
+    rungs fired and never whether a proposal was any good. The overlap ratio is
+    fed instead, at the one point overlap is measured. Same fixture as
+    ``test_partial_pdf_confirmation_reports_ledger_overlap``: two of the
+    statement's rows are already held by the twin and both match, so one
+    candidate is surfaced and observed at a ratio of 2/2.
+    """
+    from prometheus_client import REGISTRY
+
+    _seed_chase_twin(db)
+    for transaction_id, transaction_date, amount in (
+        ("existing-coffee", "2024-01-15", "-50.00"),
+        ("existing-paycheck", "2024-01-21", "150.00"),
+    ):
+        db.execute(
+            "INSERT INTO core.fct_transactions "  # noqa: S608  # test fixture
+            "(transaction_id, account_id, transaction_date, amount, currency_code) "
+            "VALUES (?, ?, ?, ?, ?)",
+            [transaction_id, "acct_existing01", transaction_date, amount, None],
+        )
+    doc = _standard_doc()
+    svc, fake_pdf = _service_with_fake_pdf(db, doc, tmp_path)
+    before_count = (
+        REGISTRY.get_sample_value("moneybin_account_link_overlap_ratio_count") or 0.0
+    )
+    before_sum = (
+        REGISTRY.get_sample_value("moneybin_account_link_overlap_ratio_sum") or 0.0
+    )
+
+    with (
+        patch(
+            "moneybin.extractors.pdf.extractor.PDFExtractor.extract",
+            return_value=doc,
+        ),
+        pytest.raises(ImportConfirmationRequiredError) as exc,
+    ):
+        svc.import_file(fake_pdf, refresh=False)
+
+    [candidate] = exc.value.outcome.account_proposals[0]["candidates"]
+    assert "confidence" not in candidate
+    after_count = (
+        REGISTRY.get_sample_value("moneybin_account_link_overlap_ratio_count") or 0.0
+    )
+    after_sum = (
+        REGISTRY.get_sample_value("moneybin_account_link_overlap_ratio_sum") or 0.0
+    )
+    assert after_count == before_count + 1
+    # Exact, not approximate: the ratio is 2/2, and adding 1.0 to the running
+    # sum here is the same float operation the histogram just performed.
+    assert after_sum == before_sum + 1.0
+
+
 @pytest.mark.integration
 def test_pdf_account_metadata_populates_the_raw_account(
     db: Database,

--- a/tests/moneybin/test_services/test_import_pdf_transactions.py
+++ b/tests/moneybin/test_services/test_import_pdf_transactions.py
@@ -2581,6 +2581,7 @@ def test_partial_pdf_confirmation_reports_ledger_overlap(
     assert candidate.get("overlap_window_end") == "2024-01-20"
 
 
+@pytest.mark.integration
 def test_pdf_gate_observes_the_measured_overlap_of_the_candidate_it_surfaces(
     db: Database,
     tmp_path: Path,

--- a/tests/moneybin/test_services/test_inbox_service.py
+++ b/tests/moneybin/test_services/test_inbox_service.py
@@ -864,7 +864,6 @@ class TestSyncFailure:
                 {
                     "account_id": "acct_a",
                     "display_name": "WF CHECKING …4267",
-                    "confidence": 0.1,
                     "signal": "fallback",
                 }
             ],


### PR DESCRIPTION
Closes #416.

## The problem

An import that offers to merge a file into an account you already have returns a list of candidates. Every candidate carried a `confidence` — a literal stamped per resolution rung (0.3 reissue, 0.4 name, 0.5 last-four) that no input could move.

So two candidates found on the same rung tied at the same number however differently their ledgers overlapped. #416 reproduced this across twelve consecutive statements: the correct account matched 9/9, 13/13, … 27/27 while the wrong one matched 0 in eleven of twelve — and both were reported at `confidence: 0.3` in all twenty-four entries. A caller ranking on the field named "confidence" could not tell an account sharing every transaction from one sharing none.

## Why this shape, rather than the one the issue proposed

#416 suggested deriving `confidence` from the measured overlap. Investigating, the project had already answered this question three times, the other way:

- `PendingLinkCandidate` — *"Carries no confidence number … Rendering a constant as a score invited a reviewer to read it as one. `overlap` is what replaces it."*
- `LinkCandidateRow` — *"No confidence field: the resolver's number was a per-signal constant no input could move…"*
- `LinkHistoryRow` — *"No confidence field, for the same reason as `LinkCandidateRow`."*

And the spec's own doctrine (`account-identity-resolution.md`): *"`confidence_score` is not a review surface … no longer projected onto either surface."*

The import gate was the last surface still projecting it. Deriving a better number would have put a fourth pattern beside three that agree — so this drops the field instead, which is also what the evidence-bearing pair already supports.

## What changed

- `confidence` is gone from `AccountCandidateDict`, `AccountProposal.to_dict`, and `ImportConfirmationAccountCandidate`. Rank on `overlap_matched` / `overlap_comparable`.
- `AccountCandidate.confidence` **stays**, because it is what gets written to `app.account_link_decisions.confidence_score`. Removing it there would have made that column constant-from-one-writer and NULL-from-the-other — the same dual-meaning trap #418 reports about `raw.tabular_accounts.account_id`.
- New `ACCOUNT_LINK_OVERLAP_RATIO` histogram, observed where overlap is measured. `ACCOUNT_LINK_CONFIDENCE` histogrammed a constant, so it reported which rungs fired and never whether a proposal was any good. Candidates with no comparable period are skipped rather than recorded as `0.0` — no shared period is absence of evidence, and `ACCOUNT_LINK_OVERLAP_PROBES_TOTAL` already counts those.

## Contract change

`import_files` / `import_confirm` no longer return `account_proposals[].candidates[].confidence`. An agent reading that key must switch to the overlap pair. Nothing rendered it — the CLI's `format_account_candidate` already printed signal + overlap and ignored the field.

## Verification

- 9708 unit tests + 92 scenarios pass; `uv run pyright` reports 0 errors; ruff clean.
- MCP surface tests run with the marker filter cleared (`-m ""`) so the integration-only ones actually executed: 26 passed.
- New test pins the absent field at the gate; new PDF-path test pins the metric firing at a hand-derived 2/2 → ratio 1.0.

## Flagged, not fixed

Only the **PDF** gate supplies `incoming_transactions`, so only PDF candidates ever carry overlap evidence — the CSV (`import_service.py:3236`) and OFX (`:1928`) gates surface candidates with a rung name and nothing else. That predates this PR and is unchanged by it (the constant they carried conveyed nothing about the pair either). Filing separately.

One consequence worth naming: the constant histogram's `_count` incidentally counted surfaced candidates on those two paths, and nothing counts them now. `IMPORT_CONFIRMATIONS_TOTAL` still counts the proposals. Closing the overlap gap above is what would restore a per-candidate number that means something.
