### PR TITLE
Flag a source-native key that is really a canonical account id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   binding the document under an id no source could ever derive. The new
   `app_account_links_canonical_native_key` invariant `warn`s on those links:
   they still resolve to the right account, so the invariant is broken but no
-  row is wrong, and re-importing the file normalizes it. Now that pinned
+  row is wrong. Re-importing writes the document's own key alongside the old
+  link rather than retiring it — there is no automatic cleanup for these links
+  yet, and the warning says so instead of promising one. Now that pinned
   imports keep the source's own key, nothing can derive a canonical-shaped
   native key, so this is a regression guard on that contract.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **`doctor` catches a source key that is really a MoneyBin account id.** A
+  source-native key is what a *file* calls an account — a slugified label, a
+  `pdf_doc_*` digest, a content key. A canonical `account_id` is what MoneyBin
+  calls it. An `--account-id` pin used to overwrite the first with the second,
+  binding the document under an id no source could ever derive. The new
+  `app_account_links_canonical_native_key` invariant `warn`s on those links:
+  they still resolve to the right account, so the invariant is broken but no
+  row is wrong, and re-importing the file normalizes it. Now that pinned
+  imports keep the source's own key, nothing can derive a canonical-shaped
+  native key, so this is a regression guard on that contract.
+
 - **`moneybin --home <path>` picks the data directory.** Until now `MONEYBIN_HOME`
   was the only way to point MoneyBin at a different set of profiles, config and
   databases, and it appeared in no `--help` output — so the override was easy to

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -488,6 +488,7 @@ class DoctorService:
             self._run_proposed_rules_rule_fk(),
             self._run_transaction_categories_fk(),
             self._run_account_settings_account_fk(),
+            self._run_account_links_canonical_native_key(),
             self._run_balance_assertions_account_fk(),
             self._run_budgets_category_fk(),
             self._run_match_decisions_account_fk(),
@@ -1789,6 +1790,79 @@ class DoctorService:
                 affected_ids=affected,
             )
         return InvariantResult(name=name, status="pass", detail=None, affected_ids=[])
+
+    def _run_account_links_canonical_native_key(self) -> InvariantResult:
+        """Flag a ``source_native`` key that is really a canonical account id.
+
+        A native key is what the SOURCE calls an account — a slugified label, a
+        ``pdf_doc_*`` digest, a ``stem-digest`` content key. A canonical
+        ``dim_accounts.account_id`` is what MoneyBin calls it. Before pinned
+        imports kept the source's own key, ``--account-id`` overwrote the former
+        with the latter, binding the document under an id no source could ever
+        derive. Nothing derives a canonical id now, so this cannot fire on a
+        current import: it is a regression guard on that contract, and the
+        residue of older pins is what it finds today.
+
+        ``warn``, not ``fail``: such a link still resolves the document to the
+        right account. The invariant is broken; no row is wrong.
+
+        Deliberately does NOT escalate when the same ``source_origin`` carries
+        other native keys. That looks like "the document got bound twice", and it
+        is not:
+
+        - ``source_origin`` is the EXPORTER/format identity for tabular sources
+          (``matched_format.name`` — "monarch", "tiller"), not a document. Every
+          account in one export shares it, so a multi-account CSV always has
+          several keys under one origin.
+        - A pin used to *teach* the resolver the document's own key alongside
+          the canonical one. Two links, one import, nothing duplicated.
+
+        Neither shape means duplicated rows, and link rows cannot tell you
+        whether a document was imported twice — only the raw key-spaces can.
+        Do not add a fork condition here on the strength of the link table.
+
+        Reports ``account_id`` (a minted internal id), never ``ref_value`` or
+        ``source_origin`` — those can carry a real account number, or a filename
+        built from one (``.claude/rules/security.md``).
+        """
+        name = "app_account_links_canonical_native_key"
+        try:
+            rows = self._db.execute(
+                f"""
+                SELECT DISTINCT l.account_id
+                FROM {ACCOUNT_LINKS.full_name} l
+                WHERE l.status = 'accepted'
+                  AND l.ref_kind = 'source_native'
+                  AND EXISTS (
+                      SELECT 1 FROM {DIM_ACCOUNTS.full_name} a
+                      WHERE a.account_id = l.ref_value
+                  )
+                ORDER BY l.account_id
+                """  # noqa: S608  # TableRef constants, no user input
+            ).fetchall()
+        except Exception as e:  # noqa: BLE001 — core.dim_accounts may not exist yet
+            return InvariantResult(
+                name=name,
+                status="skipped",
+                detail=f"canonical-native-key check unavailable: {e}",
+                affected_ids=[],
+            )
+        if not rows:
+            return InvariantResult(
+                name=name, status="pass", detail=None, affected_ids=[]
+            )
+        affected = [str(r[0]) for r in rows]
+        return InvariantResult(
+            name=name,
+            status="warn",
+            detail=(
+                f"{len(affected)} account(s) store a canonical account id as a "
+                "source-native key (a legacy --account-id pin). Bindings still "
+                "resolve correctly; re-import those files to normalize — the "
+                "import supersedes the rows the old pin wrote."
+            ),
+            affected_ids=affected,
+        )
 
     def _run_balance_assertions_account_fk(self) -> InvariantResult:
         """Flag ``balance_assertions.account_id`` with no ``core.dim_accounts`` row.

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -1821,32 +1821,33 @@ class DoctorService:
         whether a document was imported twice — only the raw key-spaces can.
         Do not add a fork condition here on the strength of the link table.
 
+        "Is this a canonical id?" is asked of ``app.account_links`` alone, never
+        of ``core.dim_accounts``: that model's grain is
+        ``COALESCE(account_id, source_account_key)``, so an account the resolver
+        has never linked surfaces its raw source-native key through
+        ``account_id``. Matching against it reads an ordinary slug as residue
+        the moment some unresolved account derives the same string. A value the
+        resolver actually minted always appears as an ``account_links``
+        ``account_id``, which is what the ``EXISTS`` below asks.
+
         Reports ``account_id`` (a minted internal id), never ``ref_value`` or
         ``source_origin`` — those can carry a real account number, or a filename
         built from one (``.claude/rules/security.md``).
         """
         name = "app_account_links_canonical_native_key"
-        try:
-            rows = self._db.execute(
-                f"""
-                SELECT DISTINCT l.account_id
-                FROM {ACCOUNT_LINKS.full_name} l
-                WHERE l.status = 'accepted'
-                  AND l.ref_kind = 'source_native'
-                  AND EXISTS (
-                      SELECT 1 FROM {DIM_ACCOUNTS.full_name} a
-                      WHERE a.account_id = l.ref_value
-                  )
-                ORDER BY l.account_id
-                """  # noqa: S608  # TableRef constants, no user input
-            ).fetchall()
-        except Exception as e:  # noqa: BLE001 — core.dim_accounts may not exist yet
-            return InvariantResult(
-                name=name,
-                status="skipped",
-                detail=f"canonical-native-key check unavailable: {e}",
-                affected_ids=[],
-            )
+        rows = self._db.execute(
+            f"""
+            SELECT DISTINCT l.account_id
+            FROM {ACCOUNT_LINKS.full_name} l
+            WHERE l.status = 'accepted'
+              AND l.ref_kind = 'source_native'
+              AND EXISTS (
+                  SELECT 1 FROM {ACCOUNT_LINKS.full_name} m
+                  WHERE m.account_id = l.ref_value
+              )
+            ORDER BY l.account_id
+            """  # noqa: S608  # TableRef constants, no user input
+        ).fetchall()
         if not rows:
             return InvariantResult(
                 name=name, status="pass", detail=None, affected_ids=[]
@@ -1858,8 +1859,9 @@ class DoctorService:
             detail=(
                 f"{len(affected)} account(s) store a canonical account id as a "
                 "source-native key (a legacy --account-id pin). Bindings still "
-                "resolve correctly; re-import those files to normalize — the "
-                "import supersedes the rows the old pin wrote."
+                "resolve correctly and no rows are wrong. Re-importing writes "
+                "the document's own key alongside this one but does not retire "
+                "it — no automatic cleanup for the old link exists yet."
             ),
             affected_ids=affected,
         )

--- a/tests/moneybin/test_services/test_doctor_app_integrity.py
+++ b/tests/moneybin/test_services/test_doctor_app_integrity.py
@@ -19,6 +19,7 @@ from typing import Any
 import pytest
 
 from moneybin.database import Database
+from moneybin.repositories.account_links_repo import AccountLinksRepo
 from moneybin.repositories.account_settings_repo import AccountSettingsRepo
 from moneybin.repositories.balance_assertions_repo import BalanceAssertionsRepo
 from moneybin.repositories.budgets_repo import BudgetsRepo
@@ -1200,3 +1201,107 @@ def test_every_repo_table_has_audit_coverage_or_a_named_exemption(
     }
     uncovered = {c.table_ref.name for c in concrete_repo_classes()} - covered
     assert uncovered == _AUDIT_COVERAGE_GAPS
+
+
+def _insert_account(db: Database, account_id: str) -> None:
+    db.execute(
+        "INSERT INTO core.dim_accounts "  # noqa: S608  # test input, not executing user SQL
+        "(account_id, account_type, institution_name, source_type) "
+        f"VALUES ('{account_id}', 'CHECKING', 'Bank', 'pdf')"  # noqa: S608
+    )
+
+
+def _link(
+    db: Database, *, link_id: str, account_id: str, ref_value: str, origin: str
+) -> None:
+    AccountLinksRepo(db).insert(
+        link_id=link_id,
+        account_id=account_id,
+        ref_kind="source_native",
+        ref_value=ref_value,
+        source_type="pdf",
+        source_origin=origin,
+        decided_by="user",
+        actor="cli",
+    )
+
+
+def test_canonical_native_key_warns_on_a_legacy_pinned_link(db: Database) -> None:
+    """A native key that IS a canonical id, with no sibling key, is residue only.
+
+    The document still resolves to the right account — nothing is double
+    counted — so this is a broken invariant, not broken data.
+    """
+    create_core_tables(db)
+    _insert_account(db, "e82e3c313704")
+    _link(
+        db,
+        link_id="lnk_pin",
+        account_id="e82e3c313704",
+        ref_value="e82e3c313704",
+        origin="statement.pdf",
+    )
+    result = DoctorService(db)._run_account_links_canonical_native_key()
+    assert result.status == "warn"
+    assert result.affected_ids == ["e82e3c313704"]
+
+
+def test_canonical_native_key_does_not_escalate_on_a_sibling_key(
+    db: Database,
+) -> None:
+    """A second native key on the same origin is not evidence of duplication.
+
+    It is the ordinary shape twice over: ``source_origin`` is the exporter
+    format for tabular sources, so every account in one export shares it, and a
+    pin used to teach the document's own key alongside the canonical one. Link
+    rows cannot distinguish either from a genuine double import, so the check
+    must stay at ``warn`` rather than claim rows were counted twice.
+    """
+    create_core_tables(db)
+    _insert_account(db, "e82e3c313704")
+    _link(
+        db,
+        link_id="lnk_pin",
+        account_id="e82e3c313704",
+        ref_value="e82e3c313704",
+        origin="statement.pdf",
+    )
+    _link(
+        db,
+        link_id="lnk_derived",
+        account_id="e82e3c313704",
+        ref_value="pdf_doc_932d2676c1e4",
+        origin="statement.pdf",
+    )
+    result = DoctorService(db)._run_account_links_canonical_native_key()
+    assert result.status == "warn"
+    assert result.affected_ids == ["e82e3c313704"]
+
+
+def test_canonical_native_key_passes_on_a_multi_account_file(db: Database) -> None:
+    """One file, several derived keys, several accounts — the ordinary case.
+
+    A multi-account CSV binds one ``source_origin`` to one key per account. Any
+    check keyed on "this origin has more than one native key" flags every such
+    file; only the canonical-id shape separates the defect from the normal case.
+    """
+    create_core_tables(db)
+    _insert_account(db, "aaaaaaaaaaaa")
+    _insert_account(db, "bbbbbbbbbbbb")
+    _link(
+        db,
+        link_id="lnk_a",
+        account_id="aaaaaaaaaaaa",
+        ref_value="primary-checking",
+        origin="export.csv",
+    )
+    _link(
+        db,
+        link_id="lnk_b",
+        account_id="bbbbbbbbbbbb",
+        ref_value="joint-savings",
+        origin="export.csv",
+    )
+    result = DoctorService(db)._run_account_links_canonical_native_key()
+    assert result.status == "pass"
+    assert result.affected_ids == []

--- a/tests/moneybin/test_services/test_doctor_app_integrity.py
+++ b/tests/moneybin/test_services/test_doctor_app_integrity.py
@@ -1207,7 +1207,7 @@ def _insert_account(db: Database, account_id: str) -> None:
     db.execute(
         "INSERT INTO core.dim_accounts "  # noqa: S608  # test input, not executing user SQL
         "(account_id, account_type, institution_name, source_type) "
-        f"VALUES ('{account_id}', 'CHECKING', 'Bank', 'pdf')"  # noqa: S608
+        f"VALUES ('{account_id}', 'CHECKING', 'Bank', 'pdf')"  # noqa: S608  # test input, not executing user SQL
     )
 
 
@@ -1305,3 +1305,36 @@ def test_canonical_native_key_passes_on_a_multi_account_file(db: Database) -> No
     result = DoctorService(db)._run_account_links_canonical_native_key()
     assert result.status == "pass"
     assert result.affected_ids == []
+
+
+def test_canonical_native_key_ignores_an_unresolved_accounts_fallback_id(
+    db: Database,
+) -> None:
+    """A ``dim_accounts.account_id`` is not proof the value is a canonical id.
+
+    ``core/dim_accounts.sql`` derives its grain as
+    ``COALESCE(account_id, source_account_key)``, so an account the resolver has
+    never linked surfaces its raw SOURCE-NATIVE key through ``account_id``.
+    Matching ``ref_value`` against that column therefore reads an ordinary key
+    as canonical residue whenever an unrelated, still-unresolved account happens
+    to derive the same string — a false positive on ordinary data. Only ids the
+    resolver actually minted count.
+    """
+    create_core_tables(db)
+    # An account that never went through AccountResolver: its grain falls back
+    # to the source-native key, so that key is what sits in account_id.
+    _insert_account(db, "checking")
+    # A different, correctly-resolved account whose document calls itself
+    # "checking" too — an ordinary slug collision, not pin residue.
+    _insert_account(db, "b11111111111")
+    _link(
+        db,
+        link_id="lnk_ok",
+        account_id="b11111111111",
+        ref_value="checking",
+        origin="statement.pdf",
+    )
+    result = DoctorService(db)._run_account_links_canonical_native_key()
+    assert result.status == "pass", (
+        f"an unresolved account's fallback id was read as canonical: {result.detail}"
+    )

--- a/tests/moneybin/test_services/test_doctor_service.py
+++ b/tests/moneybin/test_services/test_doctor_service.py
@@ -777,8 +777,10 @@ def test_run_all_returns_expected_invariants(
     # under two identities — invisible to the matcher, which blocks candidate
     # pairs on account_id) + unproposed_cross_source_duplicates (the same two
     # sources *after* the link is accepted, which is where the overlap check
-    # stops applying and dedup_reconciliation never applied).
-    assert len(report.invariants) == 58
+    # stops applying and dedup_reconciliation never applied)
+    # + app_account_links_canonical_native_key (a source-native key that is
+    # really a canonical account id — the pre-#438 --account-id pin).
+    assert len(report.invariants) == 59
     names = [r.name for r in report.invariants]
     assert "fct_transactions_fk_integrity" in names
     assert "fct_transactions_sign_convention" in names
@@ -804,6 +806,7 @@ def test_run_all_returns_expected_invariants(
     assert "app_audit_coverage_user_reports" in names
     assert "app_user_categories_uniqueness" in names
     assert "app_account_settings_account_fk" in names
+    assert "app_account_links_canonical_native_key" in names
     assert "app_balance_assertions_account_fk" in names
     assert "app_budgets_category_fk" in names
     assert "app_match_decisions_account_fk" in names


### PR DESCRIPTION
Adds the `app_account_links_canonical_native_key` doctor invariant.

A source-native key is what a *file* calls an account — a slugified label, a `pdf_doc_*` digest, a content key. A canonical `account_id` is what MoneyBin calls it. An `--account-id` pin used to overwrite the first with the second, binding a document under an id no source could ever derive.

The check reports accepted `source_native` links whose `ref_value` matches a `core.dim_accounts.account_id`.

**`warn`, not `fail`.** Such a link still resolves the document to the right account: the invariant is broken, but no row is wrong, and re-importing the file normalizes it.

**Stacked on #438.** That PR is what makes a canonical-shaped native key underivable. Without it this check reports on current behavior rather than guarding a contract — a pinned PDF import on `main` today produces exactly the shape it looks for. Merge #438 first; GitHub will retarget this to `main` automatically.

### It does not escalate on a "forked" origin

An earlier revision failed when one `source_origin` carried several native keys, on the theory that the document had been imported twice. That is wrong twice over:

- `source_origin` is the **exporter/format** identity for tabular sources (`matched_format.name` — "monarch", "tiller"), not a document. Every account in one multi-account export shares it.
- A pin used to *teach* the resolver the document's own key alongside the canonical one — two links, one import, nothing duplicated.

Link rows cannot distinguish either shape from a genuine double import; only the raw key-spaces can. The check no longer claims otherwise, and a test pins that.

### Verification

- 9711 passed, 4 skipped; 92 scenarios
- `ruff` clean, `pyright` 0 errors
- On a live profile: 1 affected account → `warn`, matching the hand-derived prediction