### PR TITLE
Add CONTEXT.md, the project's shared vocabulary

### DIFF
--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -32,6 +32,7 @@ not as the starting point.
 - `README.md`
 - `CHANGELOG.md`
 - `CONTRIBUTING.md`
+- `CONTEXT.md`
 - `docs/*.md` — top-level: `architecture.md`, `audience.md`, `comparison.md`, `features.md`, `licensing.md`, `roadmap.md`
 - `docs/guides/`
 - `docs/reference/`
@@ -65,7 +66,7 @@ Two uses:
 
 1. **Scope detection.** Future runs can identify docs whose stamp
    predates the newest in-scope `src/` change — those are review
-   candidates. Grep: `grep -rln '<!-- Last reviewed:' README.md CHANGELOG.md CONTRIBUTING.md docs/`.
+   candidates. Grep: `grep -rln '<!-- Last reviewed:' README.md CHANGELOG.md CONTRIBUTING.md CONTEXT.md docs/`.
 2. **Reader signal.** A doc stamped six months ago has earned skepticism;
    a doc stamped last week is fresh.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,13 @@ lines and it could be 50, rewrite it.
 
 - **Sync server is opaque.** The client communicates only with moneybin-sync's API surface. External service providers are implementation details hidden behind the server.
 
+## Shared Vocabulary
+
+[`CONTEXT.md`](CONTEXT.md) is the glossary: the canonical word for each concept,
+and the resolution for overloaded ones (`provider`, `tier`, `audit`, `source`).
+Consult it when naming or writing. Where code disagrees, the glossary wins for
+new writing; existing uses migrate as they are touched.
+
 ## Design System
 
 MoneyBin's visual language lives in `design-system/`. The repo is canonical;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,8 @@ lines and it could be 50, rewrite it.
 [`CONTEXT.md`](CONTEXT.md) is the glossary: the canonical word for each concept,
 and the resolution for overloaded ones (`provider`, `tier`, `audit`, `source`).
 Consult it when naming or writing. Where code disagrees, the glossary wins for
-new writing; existing uses migrate as they are touched.
+new writing and internal names migrate as they are touched; renaming a shipped
+schema column, MCP tool, or CLI command is a public-contract change first.
 
 ## Design System
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ lines and it could be 50, rewrite it.
 
 ## Design Philosophy
 
-- **Sync server is opaque.** The client communicates only with moneybin-sync's API surface. External service providers are implementation details hidden behind the server.
+- **Sync server is opaque.** The client communicates only with moneybin-sync's API surface. External aggregators are implementation details hidden behind the server.
 
 ## Shared Vocabulary
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,12 +66,13 @@ _Avoid_: rebuild, update, sync, reprocess
 **Source type**:
 The kind of source one typed row came from — a file format, an aggregator, or a
 derivation — carried from Raw onward. Several types share one ingestion
-pathway. Rows with no single source, such as canonical dimensions and the
-untyped seed payloads, carry none.
+pathway. Rows with no single source, such as derived facts, canonical
+dimensions, and the untyped seed payloads, carry none.
 _Avoid_: source, format, provider, channel
 
 **Source origin**:
-The institution, connection, or exporter that produced a row. It scopes native
+What produced a row — an institution, a connection, an exporter, or MoneyBin
+itself for rows the user entered and rows it backfilled. It scopes native
 identifiers, so two institutions using the same account number stay distinct.
 _Avoid_: origin, institution, connection, item
 
@@ -352,7 +353,8 @@ _Avoid_: tier, level, grade, rating
   **Core** collapses origin wherever it merges, and derived facts and canonical
   dimensions carry neither
 - Every **Golden record** collapses one or more source rows; **Provenance**
-  records every contributor
+  recovers its contributors, though only **Transactions** have a relation
+  dedicated to it
 - A **Match** groups source rows; a **Transfer** pairs two **Transactions**
   across two **Accounts**
 - A **Link** binds one **Native reference** to one **Account**, **Merchant**,
@@ -453,7 +455,9 @@ _Avoid_: tier, level, grade, rating
 - **"Provenance"** and **"lineage"** are used interchangeably but name different
   things: **Provenance** traces a **Golden record** back to its source rows;
   lineage traces a column back through the SQL that produced it, which is how a
-  **Data class** is resolved. Resolved: keep both, never as synonyms.
+  **Data class** is resolved. Resolved: keep both, never as synonyms. Code
+  also calls a **Report**'s upstream tables and a conversion's rate evidence
+  "provenance"; the first is lineage, the second is neither.
 
 - **"Package"** names both an **Analysis package** and an ordinary Python
   package, and the repository contains both. Resolved: the analysis sense is

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -76,7 +76,8 @@ _Avoid_: origin, institution, connection, item
 ### The warehouse
 
 **Raw**:
-The layer holding ingested data untouched, re-importable from the original.
+The layer holding ingested data untouched, re-importable from the original. A
+few tables hold user-entered rows that merely live here; those are editable.
 _Avoid_: bronze, landing, source layer, staging
 
 **Staging**:
@@ -188,8 +189,7 @@ the user's own accounts.
 _Avoid_: internal transaction, contra entry, double entry, self-transfer
 
 **Proposal**:
-An inference offered for ratification rather than applied — a candidate Link,
-Match, Rule, or Category.
+An inference offered for ratification rather than applied.
 _Avoid_: suggestion, candidate, recommendation, draft
 
 **Decision**:
@@ -340,7 +340,8 @@ _Avoid_: tier, level, grade, rating
 - A **Report** reads the warehouse: a model in the `reports` schema reads
   **Core** and **App state**, while a saved one may also read **Raw** and
   **Staging**
-- **App state** is joined into **Core**, never derived from it
+- **App state** is joined into **Core**, and no derived **Core** value is
+  snapshotted back into it
 - Every typed row carries a **Source type** from **Raw** onward; **Source
   origin** rides alongside it wherever native identifiers need scoping, and
   **Core** collapses origin wherever it merges

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -192,7 +192,8 @@ The recorded, reversible answer to one Proposal, carrying who decided and when.
 _Avoid_: approval, resolution, verdict, vote
 
 **Review queue**:
-The Proposals of one kind still awaiting Decisions.
+The items of one kind still awaiting Decisions. Most carry a Proposal; the
+categorization queue carries transactions with no candidate offered.
 _Avoid_: inbox, backlog, pending list, worklist
 
 **Confirm**:
@@ -262,7 +263,9 @@ _Avoid_: workspace, account, environment, instance, tenant
 ### Privacy
 
 **Data class**:
-What a column actually holds, in privacy terms, assigned per column.
+What a column actually holds, in privacy terms, declared per column across
+`core` and `app`. Columns elsewhere fall back to a floor rather than a
+declaration.
 _Avoid_: tag, label, PII type, classification
 
 **Sensitivity tier**:
@@ -288,8 +291,8 @@ passing or failing. See **"Invariant"** under Flagged ambiguities.
 _Avoid_: check, constraint, assertion, validation
 
 **Doctor**:
-The run that executes every Invariant and reports how many hold — the project's
-trust artifact.
+The run that executes the Invariants and reports how many hold — the project's
+trust artifact. Some sample rather than scan, and some report as skipped.
 _Avoid_: health check, diagnostics, lint, validate
 
 **Scenario**:
@@ -344,8 +347,8 @@ _Avoid_: tier, level, grade, rating
 - An **Account** holds many **Holdings**; a **Holding** is composed of **Lots**
   of one **Security**
 - A **Profile** owns exactly one database and everything in it
-- Every column carries one **Data class**, which fixes its **Sensitivity tier**
-  and how **Redaction** treats it
+- A **Data class** is declared for each **Core** and **App state** column,
+  fixing its **Sensitivity tier** and how **Redaction** treats it
 - The MCP server and most of the CLI's JSON output return the same **Response
   envelope**; direct SQL returns rows
 - A **Split** divides one **Transaction**; an unsplit **Transaction** is still
@@ -395,7 +398,7 @@ _Avoid_: tier, level, grade, rating
   different value sets. Resolved: always qualify. Bare "tier" is not a term.
 
 - **"Audit"** carries three unrelated meanings: a data-invariant check that runs
-  against a model, the trail recording every **App state** mutation, and the
+  against a model, the trail recording **App state** mutations, and the
   general sense of examining something. Resolved: say **Invariant** for the
   check, **audit log** for the trail, and **review** for the general sense.
 
@@ -455,6 +458,7 @@ _Avoid_: tier, level, grade, rating
   **Sensitivity tier**.
 
 - **Is "connection" a first-class term?** It appears in **Source origin**, in
-  **Connect**, and in the aggregator sense of a login covering several
-  **Accounts**, but nothing defines it. Either it earns an entry or each use
+  **Connect**, in the aggregator sense of a login covering several
+  **Accounts**, and as a stored Google Sheet connection — the only one of the
+  four the code defines. Either it earns an entry or each use
   should name what it actually means.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -63,8 +63,9 @@ step, matching, transformation, categorization, identity, and rates.
 _Avoid_: rebuild, update, sync, reprocess
 
 **Source type**:
-The ingestion pathway a row arrived by, carried from Raw onward on every typed
-row. The seed-payload tables store their rows untyped and carry none.
+The kind of source one typed row came from — a file format, an aggregator, or a
+derivation — carried from Raw onward. Several types share one ingestion
+pathway. The seed-payload tables store their rows untyped and carry none.
 _Avoid_: source, format, provider, channel
 
 **Source origin**:
@@ -80,7 +81,7 @@ _Avoid_: bronze, landing, source layer, staging
 
 **Staging**:
 The layer that cleans, types, and unions each source into a common shape. Its
-intermediate models are a sub-tier within it, not a layer of their own.
+intermediate models belong to it rather than forming a layer of their own.
 _Avoid_: silver, cleansing layer, transform layer
 
 **Core**:
@@ -188,7 +189,9 @@ Match, Rule, or Category.
 _Avoid_: suggestion, candidate, recommendation, draft
 
 **Decision**:
-The recorded, reversible answer to one Proposal, carrying who decided and when.
+The recorded, reversible answer to one Review queue item, carrying who decided
+and when. It ratifies a Proposal where one was offered, and otherwise supplies
+the answer itself.
 _Avoid_: approval, resolution, verdict, vote
 
 **Review queue**:
@@ -340,8 +343,8 @@ _Avoid_: tier, level, grade, rating
   across two **Accounts**
 - A **Link** binds one **Native reference** to one **Account**, **Merchant**,
   or **Security**
-- A **Proposal** waits in a **Review queue** until a **Decision** resolves it;
-  every **Decision** names an **Actor**
+- A **Review queue** item waits until a **Decision** resolves it, whether or
+  not a **Proposal** was offered; every **Decision** names an **Actor**
 - A **Confirm** stands between an uncertain inference or a destructive change
   and its effect
 - An **Account** holds many **Holdings**; a **Holding** is composed of **Lots**
@@ -407,11 +410,13 @@ _Avoid_: tier, level, grade, rating
   Resolved: **Invariant** is the data property; say **architecture invariant**
   for the codebase rule.
 
-- **"Recipe"** carries three unrelated meanings: the recovery steps offered when
+- **"Recipe"** carries four unrelated meanings: the recovery steps offered when
   an **Invariant** fails, the learned deterministic instructions for parsing one
-  PDF layout, and the curated library of built-in **Reports**. Resolved: always
-  qualify — **recovery recipe**, **parse recipe**, **report recipe**. For the
-  ordinary how-to sense say **steps**; bare "recipe" is not a term.
+  PDF layout, the curated library of built-in **Reports**, and the contributor
+  procedure for turning a bug report into a permanent **Scenario**. Resolved:
+  always qualify — **recovery recipe**, **parse recipe**, **report recipe**,
+  **bug-report recipe**. For the ordinary how-to sense say **steps**; bare
+  "recipe" is not a term.
 
 - **"Seed"** carries four unrelated meanings: reference data shipped in the
   repository, the untyped payload storage a catch-all source writes into, the
@@ -419,9 +424,9 @@ _Avoid_: tier, level, grade, rating
   pre-populating anything. Resolved: always qualify — **seed data**, **seed
   payload**, **random seed**. Bare "seed" is not a term.
 
-- **"Source"** carries three meanings that must not collapse: the ingestion
-  pathway (**Source type**), the institution or exporter behind a row (**Source
-  origin**), and the file a row came from. Bare "source" keeps its ordinary
+- **"Source"** carries three meanings that must not collapse: what kind of
+  source produced a row (**Source type**), the institution or exporter behind
+  it (**Source origin**), and the file it came from. Bare "source" keeps its ordinary
   sense — the external system or dataset being ingested. Resolved: qualify it
   wherever one of the three specific meanings is meant.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,12 +80,11 @@ _Avoid_: origin, institution, connection, item
 ### The warehouse
 
 **Raw**:
-The layer each ingestion lands in, where a source owns its own tables, before
-any cross-source reconciliation. It records what a source supplied rather than
-archiving it: a loader may normalize or repair a value on the way in, and a
-later ingestion may revise or withdraw what an earlier one wrote. A few tables
-hold rows that merely live here rather than arriving from a source; those are
-editable.
+The layer each ingestion lands in, before any cross-source reconciliation. It
+records what a source supplied rather than archiving it: a loader may normalize
+or repair a value on the way in, and a later ingestion may revise or withdraw
+what an earlier one wrote. A few tables hold rows that merely live here rather
+than arriving from a source; those are editable.
 _Avoid_: bronze, landing, source layer, staging
 
 **Staging**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -278,7 +278,9 @@ _Avoid_: envelope, payload, wrapper, result object
 
 **Report**:
 A named, re-runnable answer to one money question, with declared columns,
-reachable identically from the CLI and from MCP.
+reachable identically from the CLI and from MCP. One either arrives with the
+code — MoneyBin's own or an Analysis package's — or is saved by the user from
+SQL of their own.
 _Avoid_: view, query, dashboard, chart, analysis
 
 **Profile**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,9 +48,9 @@ The bank, broker, or issuer that holds an Account.
 _Avoid_: bank, provider, issuer, source, org
 
 **Format**:
-A saved, reusable description of one source layout, so a file that has been
-read once can be read again without asking. For a PDF, the instructions it
-stores are a **parse recipe**.
+A reusable description of one source layout, so a file of that shape can be
+read without asking. Some ship with MoneyBin; the rest are saved from a file
+read once. For a PDF, the instructions it stores are a **parse recipe**.
 _Avoid_: profile, template, mapping, layout, schema
 
 **Inbox**:
@@ -434,9 +434,9 @@ _Avoid_: tier, level, grade, rating
 
 - **"Source"** carries three meanings that must not collapse: what kind of
   source produced a row (**Source type**), the institution or exporter behind
-  it (**Source origin**), and the file it came from. Bare "source" keeps its ordinary
-  sense — the external system or dataset being ingested. Resolved: qualify it
-  wherever one of the three specific meanings is meant.
+  it (**Source origin**), and the file it came from. Bare "source" keeps its
+  ordinary sense — the external system or dataset being ingested. Resolved:
+  qualify it wherever one of the three specific meanings is meant.
 
 - **"Actor"** carries two different value sets: the surface or internal driver
   recorded on an audit-log entry, and the domain actor recorded on a

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -65,10 +65,8 @@ _Avoid_: rebuild, update, sync, reprocess
 
 **Source type**:
 The kind of source one typed row came from — a file format, an aggregator, or a
-derivation — carried from Raw onward. Several types share one ingestion
-pathway. A merged row keeps its winner's. Rows with no source at all — derived
-facts, the dimensions MoneyBin assembles itself, and the untyped seed payloads
-— carry none.
+derivation. An ingested type rides along from Raw; a derived one is minted in
+Core. Several types share one ingestion pathway.
 _Avoid_: source, format, provider, channel
 
 **Source origin**:
@@ -350,10 +348,10 @@ _Avoid_: tier, level, grade, rating
   **Staging**
 - **App state** is joined into **Core**, and no derived **Core** value is
   snapshotted back into it
-- A row that came from a source carries a **Source type** from **Raw** onward,
-  with **Source origin** alongside it wherever native identifiers need scoping;
-  **Core** collapses origin wherever it merges and keeps the winner's type;
-  rows with no source carry neither
+- An ingested row carries a **Source type** from **Raw** onward, with **Source
+  origin** alongside it wherever native identifiers need scoping; **Core**
+  collapses origin where it merges, keeps the winner's type, and mints a type
+  for what it derives. A row with no source carries neither
 - Every **Golden record** collapses one or more source rows; **Provenance**
   recovers its contributors, though only **Transactions** have a relation
   dedicated to it

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,8 +66,9 @@ _Avoid_: rebuild, update, sync, reprocess
 **Source type**:
 The kind of source one typed row came from — a file format, an aggregator, or a
 derivation — carried from Raw onward. Several types share one ingestion
-pathway. Rows with no single source, such as derived facts, canonical
-dimensions, and the untyped seed payloads, carry none.
+pathway. A merged row keeps its winner's. Rows with no source at all — derived
+facts, the dimensions MoneyBin assembles itself, and the untyped seed payloads
+— carry none.
 _Avoid_: source, format, provider, channel
 
 **Source origin**:
@@ -350,8 +351,8 @@ _Avoid_: tier, level, grade, rating
   snapshotted back into it
 - A row that came from a source carries a **Source type** from **Raw** onward,
   with **Source origin** alongside it wherever native identifiers need scoping;
-  **Core** collapses origin wherever it merges, and derived facts and canonical
-  dimensions carry neither
+  **Core** collapses origin wherever it merges and keeps the winner's type;
+  rows with no source carry neither
 - Every **Golden record** collapses one or more source rows; **Provenance**
   recovers its contributors, though only **Transactions** have a relation
   dedicated to it

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,8 +5,10 @@ files and connected services, resolves them into one canonical warehouse, and
 answers questions about them through a CLI, an MCP server, and direct SQL.
 
 This is the project's shared vocabulary. Use these terms exactly in new and
-edited prose, code, commit messages, issues, and conversation. Where a term is
-listed under `_Avoid_`, it means the same thing and should not be used. Prose
+edited prose, code, commit messages, issues, and conversation. A word under
+`_Avoid_` is banned for that entry's sense only: some are plain synonyms, some
+are near neighbours that must not blur, and some are bare forms the glossary
+always qualifies elsewhere. Prose
 and internal names written before this glossary migrate as they are touched, so
 the glossary states what the repository is converging on rather than claiming it
 already complies. Shipped `core` and `app` columns, MCP tool names, and CLI
@@ -24,7 +26,7 @@ analysis, and serving; the groupings below are for reading, not boundaries.
 An in-tree component that ingests one external source into the Raw layer.
 Always qualified when the aggregator sense is meant — see **"Provider"** under
 Flagged ambiguities.
-_Avoid_: extractor, loader, importer, adapter, connector
+_Avoid_: extractor, loader, importer
 
 **Import**:
 Ingestion driven by a file the user supplies, whether handed over directly or
@@ -47,8 +49,8 @@ _Avoid_: bank, provider, issuer, source, org
 
 **Format**:
 A saved, reusable description of one source layout, so a file that has been
-read once can be read again without asking. Its stored parsing instructions are
-a **parse recipe**.
+read once can be read again without asking. For a PDF, the instructions it
+stores are a **parse recipe**.
 _Avoid_: profile, template, mapping, layout, schema
 
 **Inbox**:
@@ -57,7 +59,7 @@ _Avoid_: watch folder, dropbox, queue, staging folder
 
 **Refresh**:
 The one pass that brings the warehouse up to date, covering the connected-sheet
-pull, matching, transformation, categorization, identity, and rates.
+step, matching, transformation, categorization, identity, and rates.
 _Avoid_: rebuild, update, sync, reprocess
 
 **Source type**:
@@ -112,8 +114,13 @@ _Avoid_: entry, posting, record, txn
 
 **Split**:
 A user's division of one Transaction into parts that carry their own
-Categories. The Transaction keeps its total; each part is one line of it.
-_Avoid_: allocation, breakdown, itemization, sub-transaction, line item
+Categories. The Transaction keeps its total.
+_Avoid_: allocation, breakdown, itemization, sub-transaction
+
+**Transaction line**:
+One row of the split-expanded grain: the whole Transaction when it carries no
+Split, or one Split of it when it does.
+_Avoid_: line item, split line, child transaction
 
 **Sign convention**:
 MoneyBin's fixed reading of a signed amount: negative is money leaving,
@@ -242,7 +249,7 @@ _Avoid_: envelope, payload, wrapper, result object
 
 **Report**:
 A named, re-runnable answer to one money question, with declared columns,
-reachable identically from every Surface.
+reachable identically from the CLI and from MCP.
 _Avoid_: view, query, dashboard, chart, analysis
 
 **Profile**:
@@ -314,10 +321,12 @@ _Avoid_: tier, level, grade, rating
 - An **Institution** holds many **Accounts**; an **Account** has many
   **Transactions**
 - A **Provider** ingests one source into **Raw**; **Raw** feeds **Staging**,
-  **Staging** feeds **Core**, and **Core** feeds the `reports` schema where each
-  **Report** is defined
+  **Staging** feeds **Core**, and every **Report** draws on **Core** and
+  **App state**
 - **App state** is joined into **Core**, never derived from it
-- Every row carries one **Source type** and one **Source origin**
+- Every row carries a **Source type** from **Raw** onward; **Source origin**
+  rides alongside it wherever native identifiers need scoping, and **Core**
+  collapses origin wherever it merges
 - Many source rows collapse into one **Golden record**; **Provenance** records
   every contributor
 - A **Match** groups source rows; a **Transfer** pairs two **Transactions**
@@ -332,10 +341,10 @@ _Avoid_: tier, level, grade, rating
 - A **Profile** owns exactly one database and everything in it
 - Every column carries one **Data class**, which fixes its **Sensitivity tier**
   and how **Redaction** treats it
-- The CLI and the MCP server return the same **Response envelope**; direct SQL
-  returns rows
-- A **Split** divides one **Transaction** into lines carrying their own
-  **Categories**
+- The MCP server and the CLI's JSON output return the same **Response
+  envelope**; direct SQL returns rows
+- A **Split** divides one **Transaction**; an unsplit **Transaction** is still
+  one **Transaction line**
 - A **Scenario** judges generated data against the **Ground truth** its
   **Persona** produced
 
@@ -346,9 +355,10 @@ _Avoid_: tier, level, grade, rating
   arrives by **Sync**, the AI vendor a **Consent** grant names, and the
   market-data or exchange-rate vendor a price adapter fetches from. Resolved:
   **Provider** keeps the ingestion sense; say **aggregator**, **AI provider**,
-  and **market-data vendor** for the other three. Price and rate feeds are
-  ingestion, but they arrive by none of **Import**, **Sync**, or **Connect**;
-  that pathway has no name yet.
+  and **market-data vendor** for the other three. Prices fetched from a
+  market-data vendor are ingestion, but they arrive by none of **Import**,
+  **Sync**, or **Connect**; that pathway has no name yet. Prices that ride in
+  on an aggregator's feed arrive by **Sync** like any other row.
 
 - **"Extractor"** and **"Loader"** named the file-driven and sync-driven halves
   of ingestion before one Protocol unified them. Resolved: **Provider** is the

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -90,9 +90,10 @@ entity at its primary grain.
 _Avoid_: gold, marts, analytics layer, warehouse
 
 **App state**:
-User-owned mutable state that no derivation can reproduce from Raw — notes,
-tags, rules, settings, decisions.
-_Avoid_: metadata, user data, overrides, config
+Mutable state no derivation can reproduce from Raw — the user's notes, tags,
+rules, settings, and decisions, alongside the application's own operational
+metadata.
+_Avoid_: user data, overrides, config, cache
 
 **Grain**:
 The one thing a single row of a model stands for.
@@ -140,12 +141,13 @@ never change.
 _Avoid_: target currency, converted currency, view currency
 
 **Category**:
-One node of MoneyBin's own canonical spending taxonomy, referenced by id.
+One node of MoneyBin's spending taxonomy, referenced by id. The taxonomy ships
+with a default set and the user may add to it.
 _Avoid_: label, classification, bucket, tag
 
 **Tag**:
-A user-authored slug label on a Transaction. Unlike a Category it comes from no
-fixed taxonomy, and a Transaction may carry many.
+A user-authored slug label on a Transaction. Unlike a Category it belongs to no
+taxonomy at all, and a Transaction may carry many.
 _Avoid_: label, category, keyword, flag
 
 **Rule**:
@@ -290,8 +292,9 @@ _Avoid_: permission, opt-in, authorization, approval
 ### Verification
 
 **Invariant**:
-A named property of the data that must hold, checked on demand and reported as
-passing or failing. See **"Invariant"** under Flagged ambiguities.
+A named property of the data that must hold, checked on demand. A check reports
+passing, failing, a warning, or skipped. See **"Invariant"** under Flagged
+ambiguities.
 _Avoid_: check, constraint, assertion, validation
 
 **Doctor**:
@@ -300,8 +303,9 @@ trust artifact. Some sample rather than scan, and some report as skipped.
 _Avoid_: health check, diagnostics, lint, validate
 
 **Scenario**:
-A whole-pipeline test that drives an empty database through ingestion and
-judges the result against independently derived expectations.
+A whole-system test of one end-to-end behaviour against a real database. Most
+drive ingestion and judge the result against independently derived
+expectations; others exercise infrastructure the pipeline depends on.
 _Avoid_: e2e test, integration test, fixture, golden test
 
 **Persona**:
@@ -357,8 +361,8 @@ _Avoid_: tier, level, grade, rating
   envelope**; direct SQL returns rows
 - A **Split** divides one **Transaction**; an unsplit **Transaction** is still
   one **Transaction line**
-- A **Scenario** judges generated data against the **Ground truth** its
-  **Persona** produced
+- An ingestion **Scenario** judges generated data against the **Ground truth**
+  its **Persona** produced
 
 ## Flagged ambiguities
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -322,8 +322,10 @@ _Avoid_: tier, level, grade, rating
 - An **Institution** holds many **Accounts**; an **Account** has many
   **Transactions**
 - A **Provider** ingests one source into **Raw**; **Raw** feeds **Staging**,
-  **Staging** feeds **Core**, and every **Report** draws on **Core** and
-  **App state**
+  **Staging** feeds **Core**
+- A **Report** reads the warehouse: a model in the `reports` schema reads
+  **Core** and **App state**, while a saved one may also read **Raw** and
+  **Staging**
 - **App state** is joined into **Core**, never derived from it
 - Every typed row carries a **Source type** from **Raw** onward; **Source
   origin** rides alongside it wherever native identifiers need scoping, and

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,9 +7,11 @@ answers questions about them through a CLI, an MCP server, and direct SQL.
 This is the project's shared vocabulary. Use these terms exactly in new and
 edited prose, code, commit messages, issues, and conversation. Where a term is
 listed under `_Avoid_`, it means the same thing and should not be used. Prose
-and code written before this glossary migrate as they are touched, so the
-glossary states what the repository is converging on rather than claiming it
-already complies.
+and internal names written before this glossary migrate as they are touched, so
+the glossary states what the repository is converging on rather than claiming it
+already complies. Shipped `core` and `app` columns, MCP tool names, and CLI
+command names are public contracts: renaming one is a contract change, not a
+migration this glossary authorizes.
 
 MoneyBin is a single context. The same words mean the same things in ingestion,
 analysis, and serving; the groupings below are for reading, not boundaries.
@@ -45,7 +47,8 @@ _Avoid_: bank, provider, issuer, source, org
 
 **Format**:
 A saved, reusable description of one source layout, so a file that has been
-read once can be read again without asking.
+read once can be read again without asking. Its stored parsing instructions are
+a **parse recipe**.
 _Avoid_: profile, template, mapping, layout, schema
 
 **Inbox**:
@@ -53,8 +56,8 @@ The watched folder where a user drops files for unattended Import.
 _Avoid_: watch folder, dropbox, queue, staging folder
 
 **Refresh**:
-The pass that brings the warehouse up to date after new data lands, covering
-matching, transformation, categorization, identity, and rates.
+The one pass that brings the warehouse up to date, covering the connected-sheet
+pull, matching, transformation, categorization, identity, and rates.
 _Avoid_: rebuild, update, sync, reprocess
 
 **Source type**:
@@ -73,8 +76,9 @@ The layer holding ingested data untouched, re-importable from the original.
 _Avoid_: bronze, landing, source layer, staging
 
 **Staging**:
-The layer that cleans, types, and unions each source into a common shape.
-_Avoid_: silver, intermediate, cleansing, transform layer
+The layer that cleans, types, and unions each source into a common shape. Its
+intermediate models are a sub-tier within it, not a layer of their own.
+_Avoid_: silver, cleansing layer, transform layer
 
 **Core**:
 The canonical, deduplicated, multi-source layer: one model per real-world
@@ -97,14 +101,19 @@ _Avoid_: gold record, master record, survivor, winner
 **Provenance**:
 The recorded trail from a Golden record back to every source row that
 contributed to it. Not lineage — see Flagged ambiguities.
-_Avoid_: lineage, history, audit trail, source tracking
+_Avoid_: history, audit trail, source tracking
 
 ### Money
 
 **Transaction**:
 One posted movement of money against an Account. Investment activity is a
 separate ledger — see **"Transaction"** under Flagged ambiguities.
-_Avoid_: entry, posting, record, txn, line item
+_Avoid_: entry, posting, record, txn
+
+**Split**:
+A user's division of one Transaction into parts that carry their own
+Categories. The Transaction keeps its total; each part is one line of it.
+_Avoid_: allocation, breakdown, itemization, sub-transaction, line item
 
 **Sign convention**:
 MoneyBin's fixed reading of a signed amount: negative is money leaving,
@@ -237,8 +246,8 @@ reachable identically from every Surface.
 _Avoid_: view, query, dashboard, chart, analysis
 
 **Profile**:
-One isolated MoneyBin instance — its own database, its own encryption key, its
-own logs and configuration.
+One isolated MoneyBin setup — its own database, its own encryption key, its own
+logs and configuration.
 _Avoid_: workspace, account, environment, instance, tenant
 
 ### Privacy
@@ -305,7 +314,8 @@ _Avoid_: tier, level, grade, rating
 - An **Institution** holds many **Accounts**; an **Account** has many
   **Transactions**
 - A **Provider** ingests one source into **Raw**; **Raw** feeds **Staging**,
-  **Staging** feeds **Core**, **Core** feeds **Reports**
+  **Staging** feeds **Core**, and **Core** feeds the `reports` schema where each
+  **Report** is defined
 - **App state** is joined into **Core**, never derived from it
 - Every row carries one **Source type** and one **Source origin**
 - Many source rows collapse into one **Golden record**; **Provenance** records
@@ -322,23 +332,29 @@ _Avoid_: tier, level, grade, rating
 - A **Profile** owns exactly one database and everything in it
 - Every column carries one **Data class**, which fixes its **Sensitivity tier**
   and how **Redaction** treats it
-- Every **Surface** returns the same **Response envelope**
+- The CLI and the MCP server return the same **Response envelope**; direct SQL
+  returns rows
+- A **Split** divides one **Transaction** into lines carrying their own
+  **Categories**
 - A **Scenario** judges generated data against the **Ground truth** its
   **Persona** produced
 
 ## Flagged ambiguities
 
-- **"Provider"** carries three unrelated meanings: the in-tree ingestion
+- **"Provider"** carries four unrelated meanings: the in-tree ingestion
   component (**Provider**), the third-party financial aggregator whose data
-  arrives by **Sync**, and the AI vendor a **Consent** grant names. Resolved:
-  **Provider** keeps the ingestion sense; say **aggregator** for the financial
-  third party and **AI provider** for the vendor.
+  arrives by **Sync**, the AI vendor a **Consent** grant names, and the
+  market-data or exchange-rate vendor a price adapter fetches from. Resolved:
+  **Provider** keeps the ingestion sense; say **aggregator**, **AI provider**,
+  and **market-data vendor** for the other three. Price and rate feeds are
+  ingestion, but they arrive by none of **Import**, **Sync**, or **Connect**;
+  that pathway has no name yet.
 
 - **"Extractor"** and **"Loader"** named the file-driven and sync-driven halves
   of ingestion before one Protocol unified them. Resolved: **Provider** is the
   term. The `extractors/` directory, the `*Extractor` class names, and the
-  residual `loaders/` package are unmigrated, not a second pattern; they
-  migrate as they are touched.
+  residual `loaders/` package still carry the old one. They are internal
+  naming, so they migrate as they are touched.
 
 - **"Account"** carries four meanings across the sources MoneyBin reads: the
   real account at an institution, a source's own identifier for it, a login
@@ -374,8 +390,8 @@ _Avoid_: tier, level, grade, rating
 - **"Recipe"** carries three unrelated meanings: the recovery steps offered when
   an **Invariant** fails, the learned deterministic instructions for parsing one
   PDF layout, and the curated library of built-in **Reports**. Resolved: always
-  qualify — **recovery recipe**, **parse recipe**, **report recipe**. Bare
-  "recipe" is not a term.
+  qualify — **recovery recipe**, **parse recipe**, **report recipe**. For the
+  ordinary how-to sense say **steps**; bare "recipe" is not a term.
 
 - **"Seed"** carries four unrelated meanings: reference data shipped in the
   repository, the untyped payload storage a catch-all source writes into, the
@@ -385,8 +401,9 @@ _Avoid_: tier, level, grade, rating
 
 - **"Source"** carries three meanings that must not collapse: the ingestion
   pathway (**Source type**), the institution or exporter behind a row (**Source
-  origin**), and the file a row came from. Resolved: never write bare "source"
-  where one of the three is meant.
+  origin**), and the file a row came from. Bare "source" keeps its ordinary
+  sense — the external system or dataset being ingested. Resolved: qualify it
+  wherever one of the three specific meanings is meant.
 
 - **"Actor"** carries two different value sets: the surface or internal driver
   recorded on an audit-log entry, and the domain actor recorded on a

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,10 +80,11 @@ _Avoid_: origin, institution, connection, item
 ### The warehouse
 
 **Raw**:
-The layer holding each source's own fields, with the values as that source
-supplied them. It tracks its sources rather than freezing them: a later
-ingestion may revise or withdraw what an earlier one wrote. A few tables hold
-rows that merely live here rather than arriving from a source; those are
+The layer each ingestion lands in, one table per source, before any
+cross-source reconciliation. It records what a source supplied rather than
+archiving it: a loader may normalize or repair a value on the way in, and a
+later ingestion may revise or withdraw what an earlier one wrote. A few tables
+hold rows that merely live here rather than arriving from a source; those are
 editable.
 _Avoid_: bronze, landing, source layer, staging
 
@@ -115,7 +116,8 @@ _Avoid_: gold record, master record, survivor, winner
 
 **Provenance**:
 The recorded trail from a Golden record back to every source row that
-contributed to it. Not lineage — see Flagged ambiguities.
+contributed to it. Not lineage — see **"Provenance"** under Flagged
+ambiguities.
 _Avoid_: history, audit trail, source tracking
 
 ### Money
@@ -259,7 +261,8 @@ _Avoid_: interface, client, frontend, channel, endpoint
 **Parity**:
 The guarantee that the same outcome is reachable from the CLI and from MCP. It
 is functional, not name-for-name, and exempts secret material and hands-on
-operator work, which stay CLI-only.
+operator work, which stay CLI-only. See **"Parity"** under Flagged
+ambiguities.
 _Avoid_: symmetry, feature parity, mirroring, equivalence
 
 **Response envelope**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,8 +80,8 @@ _Avoid_: origin, institution, connection, item
 ### The warehouse
 
 **Raw**:
-The layer each ingestion lands in, one table per source, before any
-cross-source reconciliation. It records what a source supplied rather than
+The layer each ingestion lands in, where a source owns its own tables, before
+any cross-source reconciliation. It records what a source supplied rather than
 archiving it: a loader may normalize or repair a value on the way in, and a
 later ingestion may revise or withdraw what an earlier one wrote. A few tables
 hold rows that merely live here rather than arriving from a source; those are
@@ -89,8 +89,10 @@ editable.
 _Avoid_: bronze, landing, source layer, staging
 
 **Staging**:
-The layer that cleans, types, and unions each source into a common shape. Its
-intermediate models belong to it rather than forming a layer of their own.
+The layer that cleans and types each source into a shape Core can combine. It
+unions sources only where one pipeline needs it early; the canonical
+multi-source union is Core's. Its intermediate models belong to it rather than
+forming a layer of their own.
 _Avoid_: silver, cleansing layer, transform layer
 
 **Core**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,7 +7,7 @@ answers questions about them through a CLI, an MCP server, and direct SQL.
 This is the project's shared vocabulary. Use these terms exactly in new and
 edited prose, code, commit messages, issues, and conversation. A word under
 `_Avoid_` is banned for that entry's sense only: some are plain synonyms, some
-are near neighbours that must not blur, and some are bare forms the glossary
+are near neighbors that must not blur, and some are bare forms the glossary
 always qualifies elsewhere. Prose
 and internal names written before this glossary migrate as they are touched, so
 the glossary states what the repository is converging on rather than claiming it
@@ -117,8 +117,9 @@ activity is a separate ledger — see **"Transaction"** under Flagged ambiguitie
 _Avoid_: entry, posting, record, txn
 
 **Split**:
-A user's division of one Transaction into parts that carry their own
-Categories. The Transaction keeps its total.
+A user's division of one Transaction into parts that may each carry their own
+Category, inheriting the Transaction's where they do not. The Transaction keeps
+its total.
 _Avoid_: allocation, breakdown, itemization, sub-transaction
 
 **Transaction line**:
@@ -225,8 +226,9 @@ A position in one Security in one Account at a point in time.
 _Avoid_: position, balance, stake
 
 **Lot**:
-One acquisition of a Security, carrying its own cost basis and acquisition
-date.
+One acquisition of a Security, carrying its own acquisition date and its cost
+basis where the source supplied one. A Lot opened without one is marked as
+such rather than reading as a zero basis.
 _Avoid_: tranche, purchase, batch, parcel
 
 **Asset**:
@@ -303,7 +305,7 @@ trust artifact. Some sample rather than scan, and some report as skipped.
 _Avoid_: health check, diagnostics, lint, validate
 
 **Scenario**:
-A whole-system test of one end-to-end behaviour against a real database. Most
+A whole-system test of one end-to-end behavior against a real database. Most
 drive ingestion and judge the result against independently derived
 expectations; others exercise infrastructure the pipeline depends on.
 _Avoid_: e2e test, integration test, fixture, golden test

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -63,7 +63,8 @@ step, matching, transformation, categorization, identity, and rates.
 _Avoid_: rebuild, update, sync, reprocess
 
 **Source type**:
-The ingestion pathway a row arrived by. Carried on every row from Raw onward.
+The ingestion pathway a row arrived by, carried from Raw onward on every typed
+row. The seed-payload tables store their rows untyped and carry none.
 _Avoid_: source, format, provider, channel
 
 **Source origin**:
@@ -108,8 +109,8 @@ _Avoid_: history, audit trail, source tracking
 ### Money
 
 **Transaction**:
-One posted movement of money against an Account. Investment activity is a
-separate ledger — see **"Transaction"** under Flagged ambiguities.
+One movement of money against an Account, posted or still pending. Investment
+activity is a separate ledger — see **"Transaction"** under Flagged ambiguities.
 _Avoid_: entry, posting, record, txn
 
 **Split**:
@@ -243,8 +244,8 @@ is functional, not name-for-name.
 _Avoid_: symmetry, feature parity, mirroring, equivalence
 
 **Response envelope**:
-The one response shape every MCP tool result and every JSON CLI result takes.
-Always qualified; bare "envelope" is not a term.
+The one response shape MCP tool results and JSON CLI results take, which a few
+CLI commands have yet to adopt. Always qualified; bare "envelope" is not a term.
 _Avoid_: envelope, payload, wrapper, result object
 
 **Report**:
@@ -324,9 +325,9 @@ _Avoid_: tier, level, grade, rating
   **Staging** feeds **Core**, and every **Report** draws on **Core** and
   **App state**
 - **App state** is joined into **Core**, never derived from it
-- Every row carries a **Source type** from **Raw** onward; **Source origin**
-  rides alongside it wherever native identifiers need scoping, and **Core**
-  collapses origin wherever it merges
+- Every typed row carries a **Source type** from **Raw** onward; **Source
+  origin** rides alongside it wherever native identifiers need scoping, and
+  **Core** collapses origin wherever it merges
 - Many source rows collapse into one **Golden record**; **Provenance** records
   every contributor
 - A **Match** groups source rows; a **Transfer** pairs two **Transactions**
@@ -341,7 +342,7 @@ _Avoid_: tier, level, grade, rating
 - A **Profile** owns exactly one database and everything in it
 - Every column carries one **Data class**, which fixes its **Sensitivity tier**
   and how **Redaction** treats it
-- The MCP server and the CLI's JSON output return the same **Response
+- The MCP server and most of the CLI's JSON output return the same **Response
   envelope**; direct SQL returns rows
 - A **Split** divides one **Transaction**; an unsplit **Transaction** is still
   one **Transaction line**
@@ -373,7 +374,7 @@ _Avoid_: tier, level, grade, rating
   opaque id. Say **Native reference** for a source's identifier, **connection**
   for a login covering several, and **Profile** for the installation.
 
-- **"Transaction"** carries three unrelated meanings: the posted money movement
+- **"Transaction"** carries three unrelated meanings: the money movement
   (**Transaction**), an entry in the separate investment ledger, and a database
   transaction. Resolved: **Transaction** is the money movement; say
   **investment transaction** for the ledger entry; leave the database sense to

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -99,7 +99,8 @@ The one thing a single row of a model stands for.
 _Avoid_: granularity, level, key, cardinality
 
 **Golden record**:
-The single canonical row that a group of matched source rows collapses to.
+The single canonical row its contributing source rows collapse to, whether one
+row contributed or many.
 _Avoid_: gold record, master record, survivor, winner
 
 **Provenance**:
@@ -337,8 +338,8 @@ _Avoid_: tier, level, grade, rating
 - Every typed row carries a **Source type** from **Raw** onward; **Source
   origin** rides alongside it wherever native identifiers need scoping, and
   **Core** collapses origin wherever it merges
-- Many source rows collapse into one **Golden record**; **Provenance** records
-  every contributor
+- Every **Golden record** collapses one or more source rows; **Provenance**
+  records every contributor
 - A **Match** groups source rows; a **Transfer** pairs two **Transactions**
   across two **Accounts**
 - A **Link** binds one **Native reference** to one **Account**, **Merchant**,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -194,9 +194,9 @@ An inference offered for ratification rather than applied.
 _Avoid_: suggestion, candidate, recommendation, draft
 
 **Decision**:
-The recorded, reversible answer to one Review queue item, carrying who decided
-and when. It ratifies a Proposal where one was offered, and otherwise supplies
-the answer itself.
+The recorded answer to one Review queue item, carrying who decided and when. It
+ratifies a Proposal where one was offered, and otherwise supplies the answer
+itself. Whether it can be reversed depends on the queue.
 _Avoid_: approval, resolution, verdict, vote
 
 **Review queue**:
@@ -318,8 +318,9 @@ generator produces.
 _Avoid_: profile, fixture, sample user, archetype
 
 **Ground truth**:
-The labels the synthetic generator emits alongside the data it generated, which
-a Scenario judges against.
+The expectations a Scenario judges against, derived independently of the
+pipeline — emitted by the synthetic generator, or hand-authored before the
+run.
 _Avoid_: expected output, golden data, answer key
 
 ### Extension
@@ -367,8 +368,8 @@ _Avoid_: tier, level, grade, rating
   envelope**; direct SQL returns rows
 - A **Split** divides one **Transaction**; an unsplit **Transaction** is still
   one **Transaction line**
-- An ingestion **Scenario** judges generated data against the **Ground truth**
-  its **Persona** produced
+- An ingestion **Scenario** judges what the pipeline produced against its
+  **Ground truth**, which for generated data comes from its **Persona**
 
 ## Flagged ambiguities
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -293,8 +293,9 @@ class.
 _Avoid_: masking, sanitization, scrubbing, anonymization, obfuscation
 
 **Consent**:
-The user's recorded, revocable grant allowing one named feature category to
-send data to an AI provider.
+The user's recorded, revocable grant naming one feature category that may send
+data to an AI provider. It is a ledger of what the user intends: the gate that
+withholds data per call is not yet built.
 _Avoid_: permission, opt-in, authorization, approval
 
 ### Verification

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,8 +80,11 @@ _Avoid_: origin, institution, connection, item
 ### The warehouse
 
 **Raw**:
-The layer holding ingested data untouched, re-importable from the original. A
-few tables hold user-entered rows that merely live here; those are editable.
+The layer holding each source's own fields, with the values as that source
+supplied them. It tracks its sources rather than freezing them: a later
+ingestion may revise or withdraw what an earlier one wrote. A few tables hold
+rows that merely live here rather than arriving from a source; those are
+editable.
 _Avoid_: bronze, landing, source layer, staging
 
 **Staging**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,3 +1,4 @@
+<!-- Last reviewed: 2026-08-26 -->
 # MoneyBin
 
 Personal financial data platform: it ingests a person's financial records from
@@ -64,9 +65,9 @@ rates; a caller may select a subset.
 _Avoid_: rebuild, update, sync, reprocess
 
 **Source type**:
-The kind of source one typed row came from — a file format, an aggregator, or a
-derivation. An ingested type rides along from Raw; a derived one is minted in
-Core. Several types share one ingestion pathway.
+The discriminator naming what produced one typed row. An ingested type rides
+along from Raw; a derived one is minted in Core. Several types share one
+ingestion pathway.
 _Avoid_: source, format, provider, channel
 
 **Source origin**:
@@ -291,9 +292,9 @@ class.
 _Avoid_: masking, sanitization, scrubbing, anonymization, obfuscation
 
 **Consent**:
-The user's recorded, revocable grant naming one feature category that may send
-data to an AI provider. It is a ledger of what the user intends: the gate that
-withholds data per call is not yet built.
+The user's recorded, revocable grant pairing one feature category with the one
+AI backend that may receive data for it. It is a ledger of what the user
+intends: the gate that withholds data per call is not yet built.
 _Avoid_: permission, opt-in, authorization, approval
 
 ### Verification
@@ -408,11 +409,11 @@ _Avoid_: tier, level, grade, rating
   **investment transaction** for the ledger entry; leave the database sense to
   context, and never abbreviate any of the three to "txn" in prose.
 
-- **"Tier"** carries at least five unrelated meanings: privacy severity
+- **"Tier"** carries at least six unrelated meanings: privacy severity
   (**Sensitivity tier**), the AI data-flow bands a **Consent** grant is written
-  against, the numbered matcher stages — whose labels the categorizer reuses
-  for its own, unrelated stages — extension maturity (**Quality scale**), and
-  the high/medium/low confidence band on a smart-import inference. Two of these
+  against, the numbered matcher stages, the two-tier category-source bridge the
+  categorizer runs against, extension maturity (**Quality scale**), and the
+  high/medium/low confidence band on a smart-import inference. Two of these
   are types literally named `Tier`, one in privacy and one in ingestion, with
   different value sets. Resolved: always qualify. Bare "tier" is not a term.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -65,7 +65,8 @@ _Avoid_: rebuild, update, sync, reprocess
 **Source type**:
 The kind of source one typed row came from — a file format, an aggregator, or a
 derivation — carried from Raw onward. Several types share one ingestion
-pathway. The seed-payload tables store their rows untyped and carry none.
+pathway. Rows with no single source, such as canonical dimensions and the
+untyped seed payloads, carry none.
 _Avoid_: source, format, provider, channel
 
 **Source origin**:
@@ -250,7 +251,8 @@ _Avoid_: interface, client, frontend, channel, endpoint
 
 **Parity**:
 The guarantee that the same outcome is reachable from the CLI and from MCP. It
-is functional, not name-for-name.
+is functional, not name-for-name, and exempts secret material and hands-on
+operator work, which stay CLI-only.
 _Avoid_: symmetry, feature parity, mirroring, equivalence
 
 **Response envelope**:
@@ -342,9 +344,10 @@ _Avoid_: tier, level, grade, rating
   **Staging**
 - **App state** is joined into **Core**, and no derived **Core** value is
   snapshotted back into it
-- Every typed row carries a **Source type** from **Raw** onward; **Source
-  origin** rides alongside it wherever native identifiers need scoping, and
-  **Core** collapses origin wherever it merges
+- A row that came from a source carries a **Source type** from **Raw** onward,
+  with **Source origin** alongside it wherever native identifiers need scoping;
+  **Core** collapses origin wherever it merges, and derived facts and canonical
+  dimensions carry neither
 - Every **Golden record** collapses one or more source rows; **Provenance**
   records every contributor
 - A **Match** groups source rows; a **Transfer** pairs two **Transactions**

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,9 +24,10 @@ analysis, and serving; the groupings below are for reading, not boundaries.
 ### Ingestion
 
 **Provider**:
-An in-tree component that ingests one external source into the Raw layer.
-Always qualified when the aggregator sense is meant — see **"Provider"** under
-Flagged ambiguities.
+The in-tree component behind the `Provider` protocol, which ingests one
+external source into the Raw layer. A price adapter also writes to Raw but
+implements its own protocol and keeps its own name. Always qualified when the
+aggregator sense is meant — see **"Provider"** under Flagged ambiguities.
 _Avoid_: extractor, loader, importer
 
 **Import**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -159,9 +159,9 @@ _Avoid_: payee, vendor, counterparty, entity
 ### Identity and review
 
 **Account**:
-One real financial account held at an Institution, identified by an opaque
-canonical id that no source supplies. See **"Account"** under Flagged
-ambiguities.
+One real financial account held at an Institution, identified by a canonical
+id — MoneyBin's own once the account is linked, the source's own key until
+then. See **"Account"** under Flagged ambiguities.
 _Avoid_: item, login, connection, ledger, profile
 
 **Native reference**:
@@ -196,8 +196,9 @@ The Proposals of one kind still awaiting Decisions.
 _Avoid_: inbox, backlog, pending list, worklist
 
 **Confirm**:
-The visible ratification step an uncertain inference must pass before it takes
-effect. Silence is reserved for near-certain signals.
+The visible ratification step an uncertain inference or a destructive change
+must pass before it takes effect. Silence is reserved for near-certain signals
+with little at stake.
 _Avoid_: prompt, approval, checkpoint, gate
 
 **Actor**:
@@ -338,7 +339,8 @@ _Avoid_: tier, level, grade, rating
   or **Security**
 - A **Proposal** waits in a **Review queue** until a **Decision** resolves it;
   every **Decision** names an **Actor**
-- A **Confirm** stands between an uncertain inference and its effect
+- A **Confirm** stands between an uncertain inference or a destructive change
+  and its effect
 - An **Account** holds many **Holdings**; a **Holding** is composed of **Lots**
   of one **Security**
 - A **Profile** owns exactly one database and everything in it
@@ -372,9 +374,11 @@ _Avoid_: tier, level, grade, rating
 - **"Account"** carries four meanings across the sources MoneyBin reads: the
   real account at an institution, a source's own identifier for it, a login
   covering several accounts at once, and, loosely, the user's own MoneyBin
-  installation. Resolved: **Account** is the real account, named by MoneyBin's
-  opaque id. Say **Native reference** for a source's identifier, **connection**
-  for a login covering several, and **Profile** for the installation.
+  installation. Resolved: **Account** is the real account, named by its
+  canonical id — MoneyBin's own once the account is linked, the source's own
+  key until then, so it is not unconditionally opaque. Say **Native reference**
+  for a source's identifier, **connection** for a login covering several, and
+  **Profile** for the installation.
 
 - **"Transaction"** carries three unrelated meanings: the money movement
   (**Transaction**), an entry in the separate investment ledger, and a database

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -145,12 +145,17 @@ positive is money arriving.
 _Avoid_: polarity, direction, debit/credit convention
 
 **Home currency**:
-The single currency the user's own totals are expressed in.
+The profile's standing default for the currency money is priced in, used when
+a request names no Display currency. It is optional and it is a target, not a
+guarantee: with none chosen, or with no rate to apply, amounts stay in the
+currencies they are already in.
 _Avoid_: base currency, default currency, local currency, primary currency
 
 **Display currency**:
-The currency one response is converted into for presentation. Stored originals
-never change.
+The currency a request asks one response to be priced in, overriding Home
+currency for that response alone. Stored originals never change, and a
+response with no rate to apply comes back split by currency rather than
+converted.
 _Avoid_: target currency, converted currency, view currency
 
 **Category**:
@@ -398,8 +403,10 @@ _Avoid_: tier, level, grade, rating
 
 - **"Extractor"** and **"Loader"** named the file-driven and sync-driven halves
   of ingestion before one Protocol unified them. Resolved: **Provider** is the
-  term. The `extractors/` directory, the `*Extractor` class names, and the
-  residual `loaders/` package still carry the old one. They are internal
+  term, and it covers only what implements the Protocol — a class that merely
+  parses a file into an intermediate shape is not one, whatever it is named.
+  The `extractors/` directory, the residual `loaders/` package, and the
+  Providers' own class names still carry the old term. They are internal
   naming, so they migrate as they are touched.
 
 - **"Account"** carries four meanings across the sources MoneyBin reads: the

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -58,8 +58,9 @@ The watched folder where a user drops files for unattended Import.
 _Avoid_: watch folder, dropbox, queue, staging folder
 
 **Refresh**:
-The one pass that brings the warehouse up to date, covering the connected-sheet
-step, matching, transformation, categorization, identity, and rates.
+The pass that brings the warehouse up to date. A full one covers the
+connected-sheet step, matching, transformation, categorization, identity, and
+rates; a caller may select a subset.
 _Avoid_: rebuild, update, sync, reprocess
 
 **Source type**:
@@ -87,8 +88,9 @@ intermediate models belong to it rather than forming a layer of their own.
 _Avoid_: silver, cleansing layer, transform layer
 
 **Core**:
-The canonical, deduplicated, multi-source layer: one model per real-world
-entity at its primary grain.
+The canonical, deduplicated, multi-source layer. One model names each
+real-world entity at its primary grain, alongside the relationships, derived
+facts, and review projections built on them.
 _Avoid_: gold, marts, analytics layer, warehouse
 
 **App state**:
@@ -238,9 +240,9 @@ house, a car, jewelry. If a market ticker prices it, it is an investment.
 _Avoid_: holding, property, possession, item
 
 **Price basis**:
-What the publisher of a price series says it did to the numbers: unadjusted,
-split-adjusted, or split-and-dividend-adjusted. Declared by whatever supplied
-the series, never inferred from the numbers.
+What the publisher of a price series says it did to the numbers: `raw`,
+`split_adjusted`, or `split_and_dividend_adjusted`. Declared by whatever
+supplied the series, never inferred from the numbers.
 _Avoid_: adjustment, price type, series type
 
 ### Surfaces

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,426 @@
+# MoneyBin
+
+Personal financial data platform: it ingests a person's financial records from
+files and connected services, resolves them into one canonical warehouse, and
+answers questions about them through a CLI, an MCP server, and direct SQL.
+
+This is the project's shared vocabulary. Use these terms exactly in new and
+edited prose, code, commit messages, issues, and conversation. Where a term is
+listed under `_Avoid_`, it means the same thing and should not be used. Prose
+and code written before this glossary migrate as they are touched, so the
+glossary states what the repository is converging on rather than claiming it
+already complies.
+
+MoneyBin is a single context. The same words mean the same things in ingestion,
+analysis, and serving; the groupings below are for reading, not boundaries.
+
+## Language
+
+### Ingestion
+
+**Provider**:
+An in-tree component that ingests one external source into the Raw layer.
+Always qualified when the aggregator sense is meant — see **"Provider"** under
+Flagged ambiguities.
+_Avoid_: extractor, loader, importer, adapter, connector
+
+**Import**:
+Ingestion driven by a file the user supplies, whether handed over directly or
+dropped in the Inbox.
+_Avoid_: upload, ingest, load, drop
+
+**Sync**:
+Ingestion of a third-party aggregator's data, mediated on the user's behalf by
+the MoneyBin sync server. The client never speaks to the aggregator.
+_Avoid_: fetch, pull, download, refresh
+
+**Connect**:
+Ingestion the client performs directly against a storage service the user
+themselves controls, with no server in between.
+_Avoid_: integration, hookup, sync, live link
+
+**Institution**:
+The bank, broker, or issuer that holds an Account.
+_Avoid_: bank, provider, issuer, source, org
+
+**Format**:
+A saved, reusable description of one source layout, so a file that has been
+read once can be read again without asking.
+_Avoid_: profile, template, mapping, layout, schema
+
+**Inbox**:
+The watched folder where a user drops files for unattended Import.
+_Avoid_: watch folder, dropbox, queue, staging folder
+
+**Refresh**:
+The pass that brings the warehouse up to date after new data lands, covering
+matching, transformation, categorization, identity, and rates.
+_Avoid_: rebuild, update, sync, reprocess
+
+**Source type**:
+The ingestion pathway a row arrived by. Carried on every row from Raw onward.
+_Avoid_: source, format, provider, channel
+
+**Source origin**:
+The institution, connection, or exporter that produced a row. It scopes native
+identifiers, so two institutions using the same account number stay distinct.
+_Avoid_: origin, institution, connection, item
+
+### The warehouse
+
+**Raw**:
+The layer holding ingested data untouched, re-importable from the original.
+_Avoid_: bronze, landing, source layer, staging
+
+**Staging**:
+The layer that cleans, types, and unions each source into a common shape.
+_Avoid_: silver, intermediate, cleansing, transform layer
+
+**Core**:
+The canonical, deduplicated, multi-source layer: one model per real-world
+entity at its primary grain.
+_Avoid_: gold, marts, analytics layer, warehouse
+
+**App state**:
+User-owned mutable state that no derivation can reproduce from Raw — notes,
+tags, rules, settings, decisions.
+_Avoid_: metadata, user data, overrides, config
+
+**Grain**:
+The one thing a single row of a model stands for.
+_Avoid_: granularity, level, key, cardinality
+
+**Golden record**:
+The single canonical row that a group of matched source rows collapses to.
+_Avoid_: gold record, master record, survivor, winner
+
+**Provenance**:
+The recorded trail from a Golden record back to every source row that
+contributed to it. Not lineage — see Flagged ambiguities.
+_Avoid_: lineage, history, audit trail, source tracking
+
+### Money
+
+**Transaction**:
+One posted movement of money against an Account. Investment activity is a
+separate ledger — see **"Transaction"** under Flagged ambiguities.
+_Avoid_: entry, posting, record, txn, line item
+
+**Sign convention**:
+MoneyBin's fixed reading of a signed amount: negative is money leaving,
+positive is money arriving.
+_Avoid_: polarity, direction, debit/credit convention
+
+**Home currency**:
+The single currency the user's own totals are expressed in.
+_Avoid_: base currency, default currency, local currency, primary currency
+
+**Display currency**:
+The currency one response is converted into for presentation. Stored originals
+never change.
+_Avoid_: target currency, converted currency, view currency
+
+**Category**:
+One node of MoneyBin's own canonical spending taxonomy, referenced by id.
+_Avoid_: label, classification, bucket, tag
+
+**Tag**:
+A user-authored slug label on a Transaction. Unlike a Category it comes from no
+fixed taxonomy, and a Transaction may carry many.
+_Avoid_: label, category, keyword, flag
+
+**Rule**:
+A user-owned pattern that assigns a Category deterministically, with neither a
+model nor a person in the loop.
+_Avoid_: filter, mapping, matcher, automation
+
+**Merchant**:
+The counterparty a Transaction was with, resolved to one canonical identity
+across the spellings each source uses.
+_Avoid_: payee, vendor, counterparty, entity
+
+### Identity and review
+
+**Account**:
+One real financial account held at an Institution, identified by an opaque
+canonical id that no source supplies. See **"Account"** under Flagged
+ambiguities.
+_Avoid_: item, login, connection, ledger, profile
+
+**Native reference**:
+A source's own identifier for something MoneyBin has its own id for.
+_Avoid_: source id, external id, foreign key, raw id
+
+**Link**:
+An accepted, reversible binding from one Native reference to one canonical
+entity.
+_Avoid_: mapping, alias, binding, association
+
+**Match**:
+A scored pair or group of rows judged to represent the same real-world event.
+_Avoid_: duplicate, dedup, merge, pairing
+
+**Transfer**:
+A matched pair of Transactions that are the two sides of one movement between
+the user's own accounts.
+_Avoid_: internal transaction, contra entry, double entry, self-transfer
+
+**Proposal**:
+An inference offered for ratification rather than applied — a candidate Link,
+Match, Rule, or Category.
+_Avoid_: suggestion, candidate, recommendation, draft
+
+**Decision**:
+The recorded, reversible answer to one Proposal, carrying who decided and when.
+_Avoid_: approval, resolution, verdict, vote
+
+**Review queue**:
+The Proposals of one kind still awaiting Decisions.
+_Avoid_: inbox, backlog, pending list, worklist
+
+**Confirm**:
+The visible ratification step an uncertain inference must pass before it takes
+effect. Silence is reserved for near-certain signals.
+_Avoid_: prompt, approval, checkpoint, gate
+
+**Actor**:
+Who caused a recorded change. Two vocabularies are in use — see **"Actor"**
+under Flagged ambiguities.
+_Avoid_: user, author, owner, source
+
+### Investments
+
+**Security**:
+A tradable instrument, resolved to one canonical identity across the brokers
+that report it.
+_Avoid_: ticker, symbol, instrument, asset
+
+**Holding**:
+A position in one Security in one Account at a point in time.
+_Avoid_: position, balance, stake
+
+**Lot**:
+One acquisition of a Security, carrying its own cost basis and acquisition
+date.
+_Avoid_: tranche, purchase, batch, parcel
+
+**Asset**:
+A thing of value priced by appraisal or estimate rather than a market quote — a
+house, a car, jewelry. If a market ticker prices it, it is an investment.
+_Avoid_: holding, property, possession, item
+
+**Price basis**:
+What the publisher of a price series says it did to the numbers: unadjusted,
+split-adjusted, or split-and-dividend-adjusted. Declared by whatever supplied
+the series, never inferred from the numbers.
+_Avoid_: adjustment, price type, series type
+
+### Surfaces
+
+**Surface**:
+One of the ways MoneyBin is driven: the CLI, the MCP server, or direct SQL.
+_Avoid_: interface, client, frontend, channel, endpoint
+
+**Parity**:
+The guarantee that the same outcome is reachable from the CLI and from MCP. It
+is functional, not name-for-name.
+_Avoid_: symmetry, feature parity, mirroring, equivalence
+
+**Response envelope**:
+The one response shape every MCP tool result and every JSON CLI result takes.
+Always qualified; bare "envelope" is not a term.
+_Avoid_: envelope, payload, wrapper, result object
+
+**Report**:
+A named, re-runnable answer to one money question, with declared columns,
+reachable identically from every Surface.
+_Avoid_: view, query, dashboard, chart, analysis
+
+**Profile**:
+One isolated MoneyBin instance — its own database, its own encryption key, its
+own logs and configuration.
+_Avoid_: workspace, account, environment, instance, tenant
+
+### Privacy
+
+**Data class**:
+What a column actually holds, in privacy terms, assigned per column.
+_Avoid_: tag, label, PII type, classification
+
+**Sensitivity tier**:
+The ordered severity band a Data class belongs to. Always qualified — see
+**"Tier"** under Flagged ambiguities.
+_Avoid_: tier, level, severity, sensitivity
+
+**Redaction**:
+Replacing a value on its way across a Surface boundary, according to its Data
+class.
+_Avoid_: masking, sanitization, scrubbing, anonymization, obfuscation
+
+**Consent**:
+The user's recorded, revocable grant allowing one named feature category to
+send data to an AI provider.
+_Avoid_: permission, opt-in, authorization, approval
+
+### Verification
+
+**Invariant**:
+A named property of the data that must hold, checked on demand and reported as
+passing or failing. See **"Invariant"** under Flagged ambiguities.
+_Avoid_: check, constraint, assertion, validation
+
+**Doctor**:
+The run that executes every Invariant and reports how many hold — the project's
+trust artifact.
+_Avoid_: health check, diagnostics, lint, validate
+
+**Scenario**:
+A whole-pipeline test that drives an empty database through ingestion and
+judges the result against independently derived expectations.
+_Avoid_: e2e test, integration test, fixture, golden test
+
+**Persona**:
+The parameterized description of a synthetic person whose financial life the
+generator produces.
+_Avoid_: profile, fixture, sample user, archetype
+
+**Ground truth**:
+The labels the synthetic generator emits alongside the data it generated, which
+a Scenario judges against.
+_Avoid_: expected output, golden data, answer key
+
+### Extension
+
+**Analysis package**:
+A separately shipped unit of analysis that extends MoneyBin's warehouse. Always
+qualified — see **"Package"** under Flagged ambiguities.
+_Avoid_: bare "package", plugin, module, add-on
+
+**Quality scale**:
+The declared maturity level an extension ships at, from bronze to platinum.
+_Avoid_: tier, level, grade, rating
+
+## Relationships
+
+- An **Institution** holds many **Accounts**; an **Account** has many
+  **Transactions**
+- A **Provider** ingests one source into **Raw**; **Raw** feeds **Staging**,
+  **Staging** feeds **Core**, **Core** feeds **Reports**
+- **App state** is joined into **Core**, never derived from it
+- Every row carries one **Source type** and one **Source origin**
+- Many source rows collapse into one **Golden record**; **Provenance** records
+  every contributor
+- A **Match** groups source rows; a **Transfer** pairs two **Transactions**
+  across two **Accounts**
+- A **Link** binds one **Native reference** to one **Account**, **Merchant**,
+  or **Security**
+- A **Proposal** waits in a **Review queue** until a **Decision** resolves it;
+  every **Decision** names an **Actor**
+- A **Confirm** stands between an uncertain inference and its effect
+- An **Account** holds many **Holdings**; a **Holding** is composed of **Lots**
+  of one **Security**
+- A **Profile** owns exactly one database and everything in it
+- Every column carries one **Data class**, which fixes its **Sensitivity tier**
+  and how **Redaction** treats it
+- Every **Surface** returns the same **Response envelope**
+- A **Scenario** judges generated data against the **Ground truth** its
+  **Persona** produced
+
+## Flagged ambiguities
+
+- **"Provider"** carries three unrelated meanings: the in-tree ingestion
+  component (**Provider**), the third-party financial aggregator whose data
+  arrives by **Sync**, and the AI vendor a **Consent** grant names. Resolved:
+  **Provider** keeps the ingestion sense; say **aggregator** for the financial
+  third party and **AI provider** for the vendor.
+
+- **"Extractor"** and **"Loader"** named the file-driven and sync-driven halves
+  of ingestion before one Protocol unified them. Resolved: **Provider** is the
+  term. The `extractors/` directory, the `*Extractor` class names, and the
+  residual `loaders/` package are unmigrated, not a second pattern; they
+  migrate as they are touched.
+
+- **"Account"** carries four meanings across the sources MoneyBin reads: the
+  real account at an institution, a source's own identifier for it, a login
+  covering several accounts at once, and, loosely, the user's own MoneyBin
+  installation. Resolved: **Account** is the real account, named by MoneyBin's
+  opaque id. Say **Native reference** for a source's identifier, **connection**
+  for a login covering several, and **Profile** for the installation.
+
+- **"Transaction"** carries three unrelated meanings: the posted money movement
+  (**Transaction**), an entry in the separate investment ledger, and a database
+  transaction. Resolved: **Transaction** is the money movement; say
+  **investment transaction** for the ledger entry; leave the database sense to
+  context, and never abbreviate any of the three to "txn" in prose.
+
+- **"Tier"** carries at least five unrelated meanings: privacy severity
+  (**Sensitivity tier**), the AI data-flow bands a **Consent** grant is written
+  against, the numbered matcher stages — whose labels the categorizer reuses
+  for its own, unrelated stages — extension maturity (**Quality scale**), and
+  the high/medium/low confidence band on a smart-import inference. Two of these
+  are types literally named `Tier`, one in privacy and one in ingestion, with
+  different value sets. Resolved: always qualify. Bare "tier" is not a term.
+
+- **"Audit"** carries three unrelated meanings: a data-invariant check that runs
+  against a model, the trail recording every **App state** mutation, and the
+  general sense of examining something. Resolved: say **Invariant** for the
+  check, **audit log** for the trail, and **review** for the general sense.
+
+- **"Invariant"** names both a property of the data that **Doctor** checks and a
+  numbered rule of the codebase that reviewers enforce against new code.
+  Resolved: **Invariant** is the data property; say **architecture invariant**
+  for the codebase rule.
+
+- **"Recipe"** carries three unrelated meanings: the recovery steps offered when
+  an **Invariant** fails, the learned deterministic instructions for parsing one
+  PDF layout, and the curated library of built-in **Reports**. Resolved: always
+  qualify — **recovery recipe**, **parse recipe**, **report recipe**. Bare
+  "recipe" is not a term.
+
+- **"Seed"** carries four unrelated meanings: reference data shipped in the
+  repository, the untyped payload storage a catch-all source writes into, the
+  deterministic starting value the synthetic generator uses, and the verb for
+  pre-populating anything. Resolved: always qualify — **seed data**, **seed
+  payload**, **random seed**. Bare "seed" is not a term.
+
+- **"Source"** carries three meanings that must not collapse: the ingestion
+  pathway (**Source type**), the institution or exporter behind a row (**Source
+  origin**), and the file a row came from. Resolved: never write bare "source"
+  where one of the three is meant.
+
+- **"Actor"** carries two different value sets: the surface or internal driver
+  recorded on an audit-log entry, and the domain actor recorded on a
+  **Decision**, where an agent ratifying a **Confirm** counts as the user rather
+  than as automation. Resolved: always qualify — **audit actor** and **deciding
+  actor**. Whether the two should converge is an open question.
+
+- **"Provenance"** and **"lineage"** are used interchangeably but name different
+  things: **Provenance** traces a **Golden record** back to its source rows;
+  lineage traces a column back through the SQL that produced it, which is how a
+  **Data class** is resolved. Resolved: keep both, never as synonyms.
+
+- **"Package"** names both an **Analysis package** and an ordinary Python
+  package, and the repository contains both. Resolved: the analysis sense is
+  always qualified; bare "package" means the Python one.
+
+- **"Parity"** and **"symmetry"** are both used for the CLI/MCP guarantee.
+  Resolved: **Parity** is the term.
+
+## Open questions
+
+- **Should "Actor" have one vocabulary or two?** The audit-log value set and the
+  **Decision** value set answer different questions — which surface drove this,
+  versus who owns this judgement — but nothing records that they are meant to
+  differ, so a reader meeting the second one first will misread the first.
+
+- **Is "confidence" one thing?** Smart import unified its three channels onto a
+  single contract that grades an inference high, medium, or low. Matching
+  expresses confidence as a numeric score against its own thresholds instead.
+  Whether these are one concept measured two ways or two concepts sharing a
+  word is unresolved, and the smart-import band's type name collides with
+  **Sensitivity tier**.
+
+- **Is "connection" a first-class term?** It appears in **Source origin**, in
+  **Connect**, and in the aggregator sense of a login covering several
+  **Accounts**, but nothing defines it. Either it earns an entry or each use
+  should name what it actually means.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ under `src/moneybin/`; SQL transformations under `src/moneybin/sqlmesh/`; tests 
 `tests/`. Read these as you need them:
 
 - [`AGENTS.md`](AGENTS.md) — critical rules, key abstractions, code standards.
+- [`CONTEXT.md`](CONTEXT.md) — the glossary: the canonical word for each concept.
 - [`docs/architecture.md`](docs/architecture.md) — system shape and data layers.
 - [`docs/specs/INDEX.md`](docs/specs/INDEX.md) — every feature spec and its status.
 - [`.claude/rules/`](.claude/rules/) — per-domain rules (security, database,

--- a/tests/test_documentation_policy.py
+++ b/tests/test_documentation_policy.py
@@ -104,7 +104,7 @@ def _active_agent_instruction_files(repo_root: Path = _REPO_ROOT) -> list[Path]:
         relative = Path(raw_path)
         posix = relative.as_posix()
         if (
-            relative.name in {"AGENTS.md", "CLAUDE.md"}
+            relative.name in {"AGENTS.md", "CLAUDE.md", "CONTEXT.md"}
             or (posix.startswith(".claude/") and relative.suffix == ".md")
             or (posix.startswith(".cursor/rules/") and relative.suffix == ".mdc")
             or posix
@@ -154,6 +154,7 @@ def test_active_agent_instruction_files_include_all_harness_surfaces() -> None:
     expected = {
         _REPO_ROOT / "AGENTS.md",
         _REPO_ROOT / "CLAUDE.md",
+        _REPO_ROOT / "CONTEXT.md",
         _REPO_ROOT / "design-system/CLAUDE.md",
     }
     for root in (

--- a/tests/test_documentation_policy.py
+++ b/tests/test_documentation_policy.py
@@ -41,6 +41,7 @@ _AUTHORITY_DOCS = (_REPO_ROOT / "docs" / "specs", _REPO_ROOT / "docs" / "decisio
 _PUBLIC_DOC_FILES = (
     _REPO_ROOT / "README.md",
     _REPO_ROOT / "CONTRIBUTING.md",
+    _REPO_ROOT / "CONTEXT.md",
     _REPO_ROOT / "CHANGELOG.md",
     _REPO_ROOT / "SECURITY.md",
 )


### PR DESCRIPTION
## Summary

MoneyBin had no single place recording which word is canonical for each concept, and the specs, the code, and the prose had drifted apart on several. Mining `docs/specs/`, `docs/decisions/`, and the module names turned up words carrying three to five unrelated meanings each — `provider`, `tier`, `audit`, `source`, `recipe`, `seed`, `account`, `transaction` — with no recorded resolution for any of them.

This adds `CONTEXT.md`: a glossary of 58 terms, every one sourced from something real in the repository rather than invented, each with a one-or-two-sentence definition of what it *is* and an `_Avoid_` list. It also records the disagreements the mining found and says which side wins. `AGENTS.md` points agents at it, and the existing documentation-policy guard is extended to cover it.

## Changes

- **`CONTEXT.md` (new)** — 58 terms grouped for reading into ingestion, the warehouse, money, identity and review, investments, surfaces, privacy, verification, and extension. Followed by the relationships between them, 14 flagged ambiguities with a resolution each, and 3 open questions left explicitly unresolved rather than quietly dropped.
- **Single context, not a context map** — a bounded-context split would need the same word to mean different things *because of the subsystem*, and it does not: `account_id`, `source_type`, and `transaction_id` mean exactly one thing from extractor through MCP envelope. The real overloading is cross-cutting homonyms, which a `CONTEXT-MAP.md` would scatter rather than resolve.
- **Spec-versus-code disagreements resolved** — the largest is `Extractor`/`Loader` versus `Provider`: the Protocol docstring says it unified the two halves and `extension-contracts.md` uses Provider throughout, but the directory and class names still carry the old term. The glossary picks **Provider** and records that those internal names migrate as they are touched. Also `symmetry` → **Parity**, and `provenance` versus `lineage` kept as genuinely different mechanisms rather than collapsed.
- **`AGENTS.md` + `tests/test_documentation_policy.py`** — a short pointer under Shared Vocabulary, scoped so that renaming a shipped schema column, MCP tool, or CLI command stays a public-contract change rather than something the glossary authorizes. `CONTEXT.md` joins both the public-doc private-link ban and the agent-instruction retired-route ban.

## Test plan

- [x] `make check test` — 9,748 passed, 0 failed, 4 skipped; format, lint, and pyright clean
- [x] `uv run pytest tests/test_documentation_policy.py tests/moneybin/test_docs` — 232 passed against the final commit
- [x] Private-link guard proven by mutation, not by a passing run: appending a `private/` link made `test_public_docs_do_not_link_private` fail naming `CONTEXT.md`; reverted
- [x] Retired-route guard proven the same way: appending a prose route made `test_active_agent_instructions_do_not_route_to_retired_trackers_or_skills` fail naming `CONTEXT.md:445`; reverted
- [x] No real financial data — greps for institution names and for runs of three or more digits return nothing
- [x] Every factual claim checked against the schema, which caught several: `reports` holds only two of the four report kinds, `source_origin` is absent from merged core models and from `raw.ofx_institutions`, and the split-expanded line grain is not the same thing as a Split
- [ ] **Reviewer:** the last commit landed after the final adversarial review round — its claims are verified against the schema but have not been independently reviewed
- [ ] **Reviewer:** confirm the three open questions are the right ones to leave open, particularly whether **Actor** should have one vocabulary or two
