### PR TITLE
Ship the Google Sheets OAuth client ID in code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1164,6 +1164,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   audit trail keeps it (#387).
 
 ### Fixed
+- **Google Sheets connects without a Google Cloud Console detour.** The
+  connector shipped without an OAuth client of its own, so `moneybin gsheet
+  auth` on a fresh install refused outright — "Google Sheets OAuth client ID is
+  not configured" — until you registered your own Google Cloud project, roughly
+  the fifteen minutes of console clicking the feature had been designed to
+  spare you. MoneyBin now ships its own public client ID, which is how desktop
+  OAuth is meant to work: an installed app cannot keep a secret, so the
+  security rests on PKCE and a loopback redirect rather than on the identifier
+  being hidden. Point `MONEYBIN_GSHEET__OAUTH_CLIENT_ID` at your own project to
+  use its API quota instead, or set it empty to disable the connector. (#452)
 - **An account with nothing to identify it now reads `Unnamed account`, not
   `Account <id>`.** `core.dim_accounts.display_name` ended its fallback chain
   with the account's grain key, which for an account imported before the

--- a/src/moneybin/config.py
+++ b/src/moneybin/config.py
@@ -453,7 +453,7 @@ class SyncConfig(BaseModel):
 # Public installed-app OAuth client. Native apps are public clients (RFC 8252)
 # and cannot hold a secret, so PKCE and the loopback redirect carry the security
 # and this ships in source — a wheel contains no dotenv to read it from.
-# connect-gsheet.md "Design decisions"; a wrong-field copy would land in
+# connect-gsheet.md "Design rationale"; a wrong-field copy would land in
 # SyncConfig.oauth_client_id, which is the unrelated Auth0 client.
 GSHEET_PUBLIC_OAUTH_CLIENT_ID = (
     "719646616923-nteho06cqo7lfprmtvmsnpk6842m5lfp.apps.googleusercontent.com"

--- a/src/moneybin/config.py
+++ b/src/moneybin/config.py
@@ -450,17 +450,28 @@ class SyncConfig(BaseModel):
     )
 
 
+# Public installed-app OAuth client. Native apps are public clients (RFC 8252)
+# and cannot hold a secret, so PKCE and the loopback redirect carry the security
+# and this ships in source — a wheel contains no dotenv to read it from.
+# connect-gsheet.md "Design decisions"; a wrong-field copy would land in
+# SyncConfig.oauth_client_id, which is the unrelated Auth0 client.
+GSHEET_PUBLIC_OAUTH_CLIENT_ID = (
+    "719646616923-nteho06cqo7lfprmtvmsnpk6842m5lfp.apps.googleusercontent.com"
+)
+
+
 class GSheetSettings(BaseModel):
     """Configuration for the Google Sheets connector."""
 
     model_config = ConfigDict(frozen=True)
 
     oauth_client_id: str = Field(
-        default="",
+        default=GSHEET_PUBLIC_OAUTH_CLIENT_ID,
         description=(
             "OAuth 2.0 client ID for the installed-app Google OAuth flow. "
-            "Empty disables the connector; set via "
-            "MONEYBIN_GSHEET__OAUTH_CLIENT_ID."
+            "Defaults to MoneyBin's public client; override with "
+            "MONEYBIN_GSHEET__OAUTH_CLIENT_ID to use your own Google Cloud "
+            "project. Empty disables the connector."
         ),
     )
     api_timeout_seconds: float = Field(

--- a/tests/moneybin/test_config.py
+++ b/tests/moneybin/test_config.py
@@ -200,3 +200,20 @@ def test_auto_rule_guard_defaults() -> None:
     assert s.auto_rule_min_contains_length == 4
     assert s.auto_rule_broad_match_min == 20
     assert s.auto_rule_broad_match_factor == 10
+
+
+@pytest.mark.unit
+def test_gsheet_oauth_client_id_ships_embedded_by_default() -> None:
+    """The Sheets connector authorizes on a fresh install with no dotenv.
+
+    connect-gsheet.md ships a public installed-app client ID (PKCE, no
+    secret) so a pip user never touches Google Cloud Console. SyncConfig
+    carries a same-named Auth0 field; embedding must not land there.
+    """
+    from moneybin.config import GSHEET_PUBLIC_OAUTH_CLIENT_ID, MoneyBinSettings
+
+    settings = MoneyBinSettings()
+
+    assert settings.gsheet.oauth_client_id == GSHEET_PUBLIC_OAUTH_CLIENT_ID
+    assert GSHEET_PUBLIC_OAUTH_CLIENT_ID.endswith(".apps.googleusercontent.com")
+    assert settings.sync.oauth_client_id is None


### PR DESCRIPTION
## Summary

`GSheetSettings.oauth_client_id` defaulted to `""`, and `GoogleOAuthClient.authorize()` refuses outright when it is empty, so a fresh install could not connect a Google Sheet until the user stood up their own Google Cloud project — the 15 minutes of console setup that `docs/specs/connect-gsheet.md` explicitly set out to avoid. The spec calls for an "embedded public client ID, no client secret" in three places (lines 50, 75, 559); the code had drifted from it.

A wheel ships no dotenv, so the default has to live in source to reach a `pip install` user at all. Embedding is safe because installed apps are public clients that cannot hold a secret (RFC 8252) — the security comes from PKCE plus the loopback redirect, not from the ID being unguessable. Both escape hatches are preserved: an explicit empty string still disables the connector, and `MONEYBIN_GSHEET__OAUTH_CLIENT_ID` still overrides the default for anyone wanting their own Google Cloud project and isolated API quota.

## Test plan

- [x] `test_gsheet_oauth_client_id_ships_embedded_by_default` — new; written first and watched fail with `ImportError` on the missing constant before the default existed. Also asserts `settings.sync.oauth_client_id is None`, since `SyncConfig` carries a same-named Auth0 field that a wrong-field edit would silently land in.
- [x] `test_google_oauth_authorize_raises_when_client_id_empty` — pre-existing, still green: an explicitly empty value still disables the connector.
- [x] Full suite: 9,749 passed, 4 skipped, 0 failed. `ruff` clean, `pyright` 0 errors.
- [ ] Reviewer: confirm the embedded client is a **Desktop app** OAuth client, not a Web application — the flow sends `client_secret: ""` with a `127.0.0.1` redirect, which only a Desktop client accepts.
