### PR TITLE
Distinguish a denied keychain read from a missing key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1177,7 +1177,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   one existence-aware hint instead: `db init` only when no database file
   exists yet, otherwise `db unlock` or the `MONEYBIN_DATABASE__ENCRYPTION_KEY`
   env var — which needs no further keychain access, exactly what may be
-  unavailable (#419).
+  unavailable (#419, PR #453).
 
 - **An account with nothing to identify it now reads `Unnamed account`, not
   `Account <id>`.** `core.dim_accounts.display_name` ended its fallback chain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1164,6 +1164,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   audit trail keeps it (#387).
 
 ### Fixed
+- **A denied keychain read is no longer reported as a missing key.** macOS
+  reports a sandbox-denied keychain read identically to a genuinely absent
+  item (`errSecItemNotFound`), so three call sites each guessed differently:
+  `db shell`/`db query` said the database was locked, opening the database
+  said the encryption key was missing and to run `db init` — even against a
+  database that already existed, contradicting its own hint one line below —
+  and `db unlock` asked whether `--passphrase` mode was ever used.
+  `SecretStore.get_key()` now raises a distinct `SecretUnavailableError` when
+  the keychain backend itself can tell a denied read apart from a routine
+  miss (e.g. a locked Linux secret service); every call site routes through
+  one existence-aware hint instead: `db init` only when no database file
+  exists yet, otherwise `db unlock` or the `MONEYBIN_DATABASE__ENCRYPTION_KEY`
+  env var — which needs no further keychain access, exactly what may be
+  unavailable (#419).
+
 - **An account with nothing to identify it now reads `Unnamed account`, not
   `Account <id>`.** `core.dim_accounts.display_name` ended its fallback chain
   with the account's grain key, which for an account imported before the

--- a/docs/specs/architecture-shared-primitives.md
+++ b/docs/specs/architecture-shared-primitives.md
@@ -494,7 +494,7 @@ Two narrow naming changes rode along with this spec landing — both shipped. Re
 ### Source files (primitives)
 
 - `src/moneybin/database.py` — `Database`, `get_database`, `init_db`, `sqlmesh_context`, `interrupt_and_reset_database`.
-- `src/moneybin/secrets.py` — `SecretStore`, `SecretNotFoundError`, `SecretStorageUnavailableError`.
+- `src/moneybin/secrets.py` — `SecretStore`, `SecretNotFoundError`, `SecretUnavailableError`, `SecretStorageUnavailableError`.
 - `src/moneybin/config.py` — `MoneyBinSettings` and nested config sections.
 - `src/moneybin/tables.py` — `TableRef` constants and the `INTERFACE_TABLES` derivation.
 - `src/moneybin/staleness.py` — `resolve_threshold_days`, `is_stale`, `SECURITY_TYPE_STALENESS_DAYS`; the observation-age vocabulary shared by every valuation domain (see "Observation staleness" below).

--- a/docs/specs/privacy-data-protection.md
+++ b/docs/specs/privacy-data-protection.md
@@ -102,7 +102,13 @@ duration of the shell session.
 11. A `SecretStore` class centralizes all local secret management. It is the only
     module that imports `keyring`. Three operations:
     - **`get_key(name)`**: OS keychain → `MONEYBIN_{NAME}` env var →
-      `SecretNotFoundError`. Used for encryption keys (database, e2e).
+      `SecretNotFoundError`. If the keychain backend itself reports the read as
+      denied/locked rather than a routine miss (e.g. a locked Linux secret
+      service), raises `SecretUnavailableError` instead — a subclass of
+      `SecretNotFoundError`, so existing catch sites are unaffected. macOS
+      cannot distinguish a denied read from a missing key at the OS level
+      (moneybin#419), so this only fires on backends that can. Used for
+      encryption keys (database, e2e).
     - **`set_key(name, value)` / `delete_key(name)`**: Write to / clear from OS
       keychain. Used by CLI commands (`db init`, `db lock`, `db unlock`,
       `db key rotate`) to manage key lifecycle. SecretStore does not own the
@@ -448,6 +454,9 @@ this spec — the CLI is the primary interface for infrastructure concerns.
 - **`get_key` env fallback:** keychain miss + `MONEYBIN_{NAME}` set → returns env var.
 - **`get_key` missing:** both miss → raises `SecretNotFoundError` with actionable
   instructions.
+- **`get_key` denied:** keychain backend reports the read as denied/locked
+  (e.g. `keyring.errors.KeyringLocked`) → raises `SecretUnavailableError`
+  (subclass of `SecretNotFoundError`), distinct from a routine miss.
 - **`get_env`:** env var set → returns value. Missing → raises `SecretNotFoundError`.
 - **`set_key` / `delete_key`:** writes to / clears from keychain (mock keyring in
   tests).

--- a/src/moneybin/cli/commands/db.py
+++ b/src/moneybin/cli/commands/db.py
@@ -63,11 +63,20 @@ def _load_encryption_key() -> Generator[str, None, None]:
     beyond the yield.
     """
     from moneybin.database import database_key_error_hint  # noqa: PLC0415
-    from moneybin.secrets import SecretNotFoundError, SecretStore  # noqa: PLC0415
+    from moneybin.secrets import (  # noqa: PLC0415
+        SecretNotFoundError,
+        SecretStore,
+        SecretUnavailableError,
+    )
 
     store = SecretStore()
     try:
         key = store.get_key("DATABASE__ENCRYPTION_KEY")
+    except SecretUnavailableError:
+        logger.error(
+            f"❌ OS keychain denied access to the key. {database_key_error_hint()}"
+        )
+        raise typer.Exit(1) from None
     except SecretNotFoundError:
         logger.error(f"❌ Key not found. {database_key_error_hint()}")
         raise typer.Exit(1) from None
@@ -238,12 +247,18 @@ def _run_duckdb_cli(
         logger.info("💡 Install from: https://duckdb.org/docs/installation/")
         raise typer.Exit(1)
 
-    from moneybin.secrets import SecretNotFoundError
+    from moneybin.database import database_key_error_hint
+    from moneybin.secrets import SecretNotFoundError, SecretUnavailableError
 
     try:
         init_script = _create_init_script(db_path)
+    except SecretUnavailableError:
+        logger.error(
+            f"❌ OS keychain denied access to the key. {database_key_error_hint()}"
+        )
+        raise typer.Exit(1) from None
     except SecretNotFoundError:
-        logger.error("❌ Database is locked — run 'moneybin db unlock' first")
+        logger.error(f"❌ Key not found. {database_key_error_hint()}")
         raise typer.Exit(1) from None
 
     try:
@@ -658,9 +673,24 @@ def db_unlock() -> None:
     try:
         salt_b64 = store.get_key(SALT_NAME)
     except SecretNotFoundError:
-        logger.error(
-            "❌ No passphrase salt found. Was this database created with --passphrase mode?"
-        )
+        if not settings.database.path.exists():
+            logger.error(
+                "❌ No passphrase salt found — no database exists yet. "
+                "Run 'moneybin db init --passphrase' to create one."
+            )
+        else:
+            # The database exists but the salt couldn't be read — genuinely
+            # ambiguous (see #419): could mean --passphrase mode was never
+            # used, or that this environment (sandboxed, headless, or CI)
+            # denies keychain access outright, which looks identical.
+            logger.error(
+                "❌ No passphrase salt found in keychain or env var, but "
+                "the database already exists. This can mean it wasn't "
+                "created with --passphrase mode, or that this environment "
+                "denies keychain access. If you know the raw encryption "
+                "key, set MONEYBIN_DATABASE__ENCRYPTION_KEY to open the "
+                "database directly, bypassing the salt entirely."
+            )
         raise typer.Exit(1) from None
 
     try:

--- a/src/moneybin/cli/commands/db.py
+++ b/src/moneybin/cli/commands/db.py
@@ -254,11 +254,12 @@ def _run_duckdb_cli(
         init_script = _create_init_script(db_path)
     except SecretUnavailableError:
         logger.error(
-            f"❌ OS keychain denied access to the key. {database_key_error_hint()}"
+            f"❌ OS keychain denied access to the key. "
+            f"{database_key_error_hint(db_path)}"
         )
         raise typer.Exit(1) from None
     except SecretNotFoundError:
-        logger.error(f"❌ Key not found. {database_key_error_hint()}")
+        logger.error(f"❌ Key not found. {database_key_error_hint(db_path)}")
         raise typer.Exit(1) from None
 
     try:
@@ -669,7 +670,11 @@ def db_unlock() -> None:
     settings = get_settings()
     store = SecretStore()
 
-    # Retrieve the stored salt
+    # Retrieve the stored salt. Deliberately not split into a separate
+    # SecretUnavailableError branch like the other two call sites: even a
+    # confirmed denial doesn't resolve the ambiguity here, since the salt
+    # could equally be absent because auto-key mode (not --passphrase) was
+    # used — the hedge below covers both regardless of which was raised.
     try:
         salt_b64 = store.get_key(SALT_NAME)
     except SecretNotFoundError:

--- a/src/moneybin/connectors/sync_auth.py
+++ b/src/moneybin/connectors/sync_auth.py
@@ -16,7 +16,7 @@ from moneybin import error_codes
 from moneybin.connectors.sync_client import SyncClient
 from moneybin.connectors.sync_errors import SyncAPIError, SyncAuthError
 from moneybin.errors import UserError
-from moneybin.secrets import SecretNotFoundError, SecretStore
+from moneybin.secrets import SecretNotFoundError, SecretStore, SecretUnavailableError
 
 _AUTH_SESSIONS_KEY = "SYNC__AUTH_SESSIONS"
 _LOCK_FILE_MODE = 0o600
@@ -287,6 +287,11 @@ class SyncAuthService:
     def _load_collection(self) -> dict[str, _StoredAuthSession]:
         try:
             raw = self._secrets.get_key(_AUTH_SESSIONS_KEY)
+        except SecretUnavailableError:
+            # A denied read is not "no sessions yet" — treating it that way
+            # would let a later save silently overwrite real sessions that
+            # simply couldn't be read (moneybin#419).
+            raise
         except SecretNotFoundError:
             return {}
         payload = cast(dict[str, dict[str, object]], json.loads(raw))

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -50,6 +50,7 @@ from moneybin.secrets import (
     SecretNotFoundError,
     SecretStorageUnavailableError,
     SecretStore,
+    SecretUnavailableError,
 )
 
 logger = logging.getLogger(__name__)
@@ -575,11 +576,18 @@ class Database:
         else:
             try:
                 encryption_key = store.get_key(_KEY_NAME)
+            except SecretUnavailableError as e:
+                # More specific than the branch below: the keychain backend
+                # itself reported the read as denied, not a routine miss.
+                raise DatabaseKeyError(
+                    "Cannot open database — the OS keychain denied the "
+                    "encryption-key read (locked or restricted), not "
+                    "because the key is missing."
+                ) from e
             except SecretNotFoundError as e:
                 raise DatabaseKeyError(
-                    f"Cannot open database — encryption key not found. "
-                    f"Run 'moneybin db init' to create a new database, or set "
-                    f"MONEYBIN_{_KEY_NAME} for CI/headless environments."
+                    f"Cannot open database — encryption key not found in "
+                    f"keychain or env var MONEYBIN_{_KEY_NAME}."
                 ) from e
             if secret_store is None:
                 _cached_encryption_key = encryption_key
@@ -1163,21 +1171,32 @@ def invalidate_encryption_key_cache() -> None:
 
 
 def database_key_error_hint() -> str:
-    """Return the appropriate hint for a DatabaseKeyError.
+    """Return the appropriate hint for a keychain-backed secret read failure.
 
-    Checks whether the database file exists to distinguish first-run
-    (need ``db init``) from locked (need ``db unlock``).
+    Checks whether the database file exists to distinguish first-run (need
+    ``db init``) from an existing database whose key could not be read. The
+    latter is genuinely ambiguous on platforms with no distinguishing OS
+    signal: a denied keychain read and a missing key raise the identical
+    exception, since macOS reports both as "item not found" to a process the
+    sandbox denies (moneybin#419). The hint always includes a recovery path
+    that doesn't need further keychain access, since that's exactly what may
+    be unavailable.
 
     Returns:
         A hint string with the correct recovery command.
     """
     try:
         db_path = get_settings().database.path
-        if db_path.exists():
-            return "💡 Run 'moneybin db unlock' to unlock the database first"
-        return "💡 Run 'moneybin db init' to create the database first"
     except Exception:  # noqa: BLE001 — fallback if settings can't load
         return "💡 Run 'moneybin db init' to create the database"
+    if not db_path.exists():
+        return "💡 Run 'moneybin db init' to create the database first"
+    return (
+        "💡 Run 'moneybin db unlock' if the keychain is simply locked, or "
+        f"set MONEYBIN_{_KEY_NAME} if this environment (sandboxed, "
+        "headless, or CI) denies keychain access outright — a denied read "
+        "looks identical to a missing key"
+    )
 
 
 def _lock_error_message(db_path: "Path", max_wait: float) -> str:

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -581,8 +581,8 @@ class Database:
                 # itself reported the read as denied, not a routine miss.
                 raise DatabaseKeyError(
                     "Cannot open database — the OS keychain denied the "
-                    "encryption-key read (locked or restricted), not "
-                    "because the key is missing."
+                    "encryption-key read (locked or restricted), so "
+                    "whether the key exists could not be determined."
                 ) from e
             except SecretNotFoundError as e:
                 raise DatabaseKeyError(
@@ -1170,7 +1170,7 @@ def invalidate_encryption_key_cache() -> None:
     _cached_encryption_key = None
 
 
-def database_key_error_hint() -> str:
+def database_key_error_hint(db_path: Path | None = None) -> str:
     """Return the appropriate hint for a keychain-backed secret read failure.
 
     Checks whether the database file exists to distinguish first-run (need
@@ -1182,13 +1182,22 @@ def database_key_error_hint() -> str:
     that doesn't need further keychain access, since that's exactly what may
     be unavailable.
 
+    Args:
+        db_path: The database path actually being opened, if the caller has
+            already resolved one (e.g. a ``--database`` override). Falls
+            back to the active profile's configured path when omitted —
+            using the profile default here for a caller that resolved a
+            different path can recommend ``db init`` against a database
+            that already exists at the caller's chosen path.
+
     Returns:
         A hint string with the correct recovery command.
     """
-    try:
-        db_path = get_settings().database.path
-    except Exception:  # noqa: BLE001 — fallback if settings can't load
-        return "💡 Run 'moneybin db init' to create the database"
+    if db_path is None:
+        try:
+            db_path = get_settings().database.path
+        except Exception:  # noqa: BLE001 — fallback if settings can't load
+            return "💡 Run 'moneybin db init' to create the database"
     if not db_path.exists():
         return "💡 Run 'moneybin db init' to create the database first"
     return (
@@ -1669,15 +1678,33 @@ def init_db(
             hash_len=argon2_hash_len,
         )
         # Save previous keys so we can roll back if DB open fails
-        # (e.g., db_path already encrypted with a different key).
+        # (e.g., db_path already encrypted with a different key). A denied
+        # read must NOT be treated as "no previous secret" — the rollback
+        # below deletes whatever wasn't captured here, so silently reading
+        # a denial as absence would let a real key get overwritten and then
+        # deleted on rollback, permanently losing access (moneybin#419).
         prev_key: str | None = None
         prev_salt: str | None = None
         try:
             prev_key = store.get_key(_KEY_NAME)
+        except SecretUnavailableError as e:
+            raise DatabaseKeyError(
+                "Cannot initialize database — the OS keychain denied the "
+                "encryption-key read (locked or restricted), so whether a "
+                "key already exists could not be determined. Refusing to "
+                "overwrite it; retry once the keychain is accessible."
+            ) from e
         except SecretNotFoundError:
             pass
         try:
             prev_salt = store.get_key(SALT_NAME)
+        except SecretUnavailableError as e:
+            raise DatabaseKeyError(
+                "Cannot initialize database — the OS keychain denied the "
+                "passphrase-salt read (locked or restricted), so whether a "
+                "salt already exists could not be determined. Refusing to "
+                "overwrite it; retry once the keychain is accessible."
+            ) from e
         except SecretNotFoundError:
             pass
 
@@ -1726,7 +1753,21 @@ def init_db(
         # is unset) or generate a fresh one.
         db_existed = db_path.exists()
         key_was_persisted_now = False
-        if store.has_keychain_entry(_KEY_NAME):
+        try:
+            key_already_present = store.has_keychain_entry(_KEY_NAME)
+        except SecretUnavailableError as e:
+            # A denied read must NOT be treated as "no existing key" — doing
+            # so would mint and persist a fresh key over one that couldn't
+            # be read, then delete it on rollback if the (now-mismatched)
+            # database fails to open (moneybin#419).
+            raise DatabaseKeyError(
+                "Cannot initialize database — the OS keychain denied the "
+                "encryption-key read (locked or restricted), so whether a "
+                "key already exists could not be determined. Refusing to "
+                "overwrite it; retry once the keychain is accessible, or "
+                f"set MONEYBIN_{_KEY_NAME} to bypass the keychain."
+            ) from e
+        if key_already_present:
             logger.debug("Using existing encryption key")
         else:
             key_from_env = False
@@ -1734,6 +1775,15 @@ def init_db(
                 encryption_key = store.get_key(_KEY_NAME)
                 key_from_env = True
                 logger.debug("Persisting env-provided encryption key to keychain")
+            except SecretUnavailableError as e:
+                raise DatabaseKeyError(
+                    "Cannot initialize database — the OS keychain denied "
+                    "the encryption-key read (locked or restricted), so "
+                    "whether a key already exists could not be determined. "
+                    "Refusing to overwrite it; retry once the keychain is "
+                    f"accessible, or set MONEYBIN_{_KEY_NAME} to bypass "
+                    "the keychain."
+                ) from e
             except SecretNotFoundError:
                 encryption_key = secrets_mod.token_hex(32)
                 logger.debug("Auto-generated encryption key stored in OS keychain")

--- a/src/moneybin/secrets.py
+++ b/src/moneybin/secrets.py
@@ -56,6 +56,19 @@ class SecretNotFoundError(Exception):
     """Raised when a secret cannot be found in keychain or environment."""
 
 
+class SecretUnavailableError(SecretNotFoundError):
+    """Raised when the OS keychain reports a read as denied, not missing.
+
+    Subclasses ``SecretNotFoundError`` so every existing ``except
+    SecretNotFoundError`` call site keeps working unchanged — this only lets
+    a caller that wants to react more precisely catch it first. Most
+    platforms can't actually raise this: macOS reports a sandbox-denied read
+    identically to a missing item (``errSecItemNotFound``), so this fires
+    only where the keyring backend itself distinguishes the two (e.g. a
+    locked Linux secret service, or an explicit macOS keychain ACL denial).
+    """
+
+
 class SecretStorageUnavailableError(Exception):
     """Raised when no OS keyring backend is available to persist a secret.
 
@@ -103,15 +116,24 @@ class SecretStore:
             The secret value.
 
         Raises:
+            SecretUnavailableError: If the keychain backend reports the read
+                as denied/locked (rather than a routine miss) and no env var
+                fallback is set.
             SecretNotFoundError: If the secret is not in keychain or env var.
         """
         # Try OS keychain first; missing backend (headless CI, minimal
         # containers) is treated as a keychain miss so the env-var fallback
-        # below can satisfy the read.
+        # below can satisfy the read. A denied/locked keychain is tracked
+        # separately from a routine miss — env var fallback still applies,
+        # but if that's also unset we can raise a more specific error.
+        denied = False
         try:
             value = keyring.get_password(self._service, name)
         except keyring.errors.NoKeyringError:  # type: ignore[reportAttributeAccessIssue]  # keyring stubs omit errors submodule
             value = None
+        except keyring.errors.KeyringLocked:  # type: ignore[reportAttributeAccessIssue]  # keyring stubs omit errors submodule
+            value = None
+            denied = True
         if value is not None:
             return value
 
@@ -121,6 +143,13 @@ class SecretStore:
         if value is not None:
             return value
 
+        if denied:
+            raise SecretUnavailableError(
+                f"Secret '{name}' could not be read — the OS keychain "
+                f"denied access (locked or restricted), not because the "
+                f"secret is missing. Set env var {env_var} to bypass the "
+                f"keychain."
+            )
         raise SecretNotFoundError(
             f"Secret '{name}' not found. Set it via OS keychain "
             f"(moneybin db init) or env var {env_var}."

--- a/src/moneybin/secrets.py
+++ b/src/moneybin/secrets.py
@@ -146,9 +146,9 @@ class SecretStore:
         if denied:
             raise SecretUnavailableError(
                 f"Secret '{name}' could not be read — the OS keychain "
-                f"denied access (locked or restricted), not because the "
-                f"secret is missing. Set env var {env_var} to bypass the "
-                f"keychain."
+                f"denied access (locked or restricted), so whether the "
+                f"secret exists could not be determined. Set env var "
+                f"{env_var} to bypass the keychain."
             )
         raise SecretNotFoundError(
             f"Secret '{name}' not found. Set it via OS keychain "
@@ -185,11 +185,23 @@ class SecretStore:
         from "key is only available via env var fallback" — e.g. ``init_db``
         needs to persist env-provided keys so the DB stays openable after
         the env var is unset.
+
+        Raises:
+            SecretUnavailableError: If the keychain backend reports the read
+                as denied/locked rather than a routine miss. A caller must
+                not treat this the same as "no entry" — proceeding as if
+                absent risks overwriting an entry that could not be read.
         """
         try:
             return keyring.get_password(self._service, name) is not None
         except keyring.errors.NoKeyringError:  # type: ignore[reportAttributeAccessIssue]  # keyring stubs omit errors submodule
             return False
+        except keyring.errors.KeyringLocked as e:  # type: ignore[reportAttributeAccessIssue]  # keyring stubs omit errors submodule
+            raise SecretUnavailableError(
+                f"Secret '{name}' could not be checked — the OS keychain "
+                f"denied access (locked or restricted), so whether an "
+                f"entry exists could not be determined."
+            ) from e
 
     def set_key(self, name: str, value: str) -> None:
         """Store a secret in the OS keychain.

--- a/tests/moneybin/connectors/test_sync_auth.py
+++ b/tests/moneybin/connectors/test_sync_auth.py
@@ -28,9 +28,12 @@ class _PatchedKeyring:
         self.values: dict[tuple[str, str], str] = {}
         self.lock = threading.Lock()
         self.fail_next_write = False
+        self.deny_reads = False
 
     def get_password(self, service: str, name: str) -> str | None:
         with self.lock:
+            if self.deny_reads:
+                raise keyring.errors.KeyringLocked
             return self.values.get((service, name))
 
     def set_password(self, service: str, name: str, value: str) -> None:
@@ -229,6 +232,49 @@ def test_begin_retains_only_sixteen_newest_terminal_sessions(
     assert all(
         collection[session_id]["device_code"] is None for session_id in terminal_ids
     )
+
+
+def test_begin_refuses_when_existing_sessions_cannot_be_read(
+    patched_keyring: _PatchedKeyring,
+    tmp_path: Path,
+) -> None:
+    """A denied read of the existing collection must not read as "no sessions".
+
+    Proceeding would let the new session's persist silently overwrite real
+    pending/active sessions that merely couldn't be read (see #419).
+    """
+    from moneybin.secrets import SecretUnavailableError
+
+    patched_keyring.values[("moneybin-alice", "SYNC__AUTH_SESSIONS")] = json.dumps({
+        "syncauth_existing": _stored_session(
+            "syncauth_existing",
+            status="pending",
+            expiration=datetime(2026, 7, 19, tzinfo=UTC) + timedelta(minutes=10),
+            device_code="existing-device-code",
+        )
+    })
+    patched_keyring.deny_reads = True
+    client = MagicMock()
+    client.begin_login.return_value = _challenge()
+    service = _service(
+        client=client,
+        store=SecretStore(profile="alice"),
+        lock_path=tmp_path / "alice.sync-auth",
+    )
+
+    with pytest.raises(SecretUnavailableError):
+        service.begin()
+
+    # The pre-existing collection must be untouched, not overwritten.
+    stored = patched_keyring.values[("moneybin-alice", "SYNC__AUTH_SESSIONS")]
+    assert json.loads(stored) == {
+        "syncauth_existing": _stored_session(
+            "syncauth_existing",
+            status="pending",
+            expiration=datetime(2026, 7, 19, tzinfo=UTC) + timedelta(minutes=10),
+            device_code="existing-device-code",
+        )
+    }
 
 
 def test_begin_retains_new_session_and_only_fifteen_other_pending_sessions(

--- a/tests/moneybin/test_cli/test_db_commands.py
+++ b/tests/moneybin/test_cli/test_db_commands.py
@@ -31,6 +31,19 @@ def _make_settings_mock(db_path: Path, mocker: Any) -> MagicMock:
     )
 
 
+def _make_settings_mock_for_hint(db_path: Path, mocker: Any) -> MagicMock:
+    """Like `_make_settings_mock`, but also patches database.py's own binding.
+
+    `database_key_error_hint()` resolves `get_settings` via the module-level
+    `from moneybin.config import get_settings` in database.py — a separate
+    bound name that patching `moneybin.config.get_settings` alone does not
+    reach, since that import already ran at collection time.
+    """
+    mock_settings = _make_settings_mock(db_path, mocker).return_value
+    mocker.patch("moneybin.database.get_settings", return_value=mock_settings)
+    return mock_settings
+
+
 class TestShellCommand:
     """Tests for 'moneybin db shell'."""
 
@@ -459,6 +472,63 @@ class TestQueryCommand:
         result = runner.invoke(app, ["query", "SELECT 1"])
         assert result.exit_code == 1
 
+    def test_query_locked_database_offers_unlock_and_env_var_never_db_init(
+        self,
+        runner: CliRunner,
+        mocker: Any,
+        mock_duckdb_cli: MagicMock,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The message names both recovery paths, never the dangerous db init.
+
+        A denied keychain read and a missing key raise the same exception
+        (see #419) — against an existing database file, suggesting `db init`
+        first is the dangerous case the issue was filed about.
+        """
+        from moneybin.secrets import SecretNotFoundError
+
+        test_db = tmp_path / "test.duckdb"
+        test_db.touch()
+        _make_settings_mock_for_hint(test_db, mocker)
+        mocker.patch(
+            "moneybin.cli.commands.db._create_init_script",
+            side_effect=SecretNotFoundError("locked"),
+        )
+
+        with caplog.at_level("INFO"):
+            result = runner.invoke(app, ["query", "SELECT 1"])
+
+        assert result.exit_code == 1
+        assert "db unlock" in caplog.text
+        assert "MONEYBIN_DATABASE__ENCRYPTION_KEY" in caplog.text
+        assert "db init" not in caplog.text
+
+    def test_query_denied_keychain_message_is_confident_not_a_hedge(
+        self,
+        runner: CliRunner,
+        mocker: Any,
+        mock_duckdb_cli: MagicMock,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """SecretUnavailableError names the OS denial, not a generic miss."""
+        from moneybin.secrets import SecretUnavailableError
+
+        test_db = tmp_path / "test.duckdb"
+        test_db.touch()
+        _make_settings_mock_for_hint(test_db, mocker)
+        mocker.patch(
+            "moneybin.cli.commands.db._create_init_script",
+            side_effect=SecretUnavailableError("denied"),
+        )
+
+        with caplog.at_level("INFO"):
+            result = runner.invoke(app, ["query", "SELECT 1"])
+
+        assert result.exit_code == 1
+        assert "denied" in caplog.text
+
 
 class TestDbInitCommand:
     """Tests for 'moneybin db init'."""
@@ -573,6 +643,56 @@ class TestDbUnlockCommand:
         result = runner.invoke(app, ["unlock"], input="anypassphrase\n")
 
         assert result.exit_code == 1
+
+    def test_unlock_no_salt_on_fresh_install_points_at_db_init(
+        self,
+        runner: CliRunner,
+        mocker: Any,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """No database at all — the salt miss is unambiguous: run db init."""
+        from moneybin.secrets import SecretNotFoundError
+
+        mock_store = MagicMock()
+        mock_store.get_key.side_effect = SecretNotFoundError("no salt")
+        mocker.patch("moneybin.secrets.SecretStore", return_value=mock_store)
+        _make_settings_mock(tmp_path / "never-created.duckdb", mocker)
+
+        with caplog.at_level("INFO"):
+            result = runner.invoke(app, ["unlock"], input="anypassphrase\n")
+
+        assert result.exit_code == 1
+        assert "db init --passphrase" in caplog.text
+        assert "MONEYBIN_DATABASE__ENCRYPTION_KEY" not in caplog.text
+
+    def test_unlock_no_salt_on_existing_database_names_env_denial(
+        self,
+        runner: CliRunner,
+        mocker: Any,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Database already exists — a denied read looks identical to a missing salt.
+
+        Offers the env-var route (which needs no further keychain access)
+        instead of only "was this created with --passphrase mode?" (see #419).
+        """
+        from moneybin.secrets import SecretNotFoundError
+
+        mock_store = MagicMock()
+        mock_store.get_key.side_effect = SecretNotFoundError("no salt")
+        mocker.patch("moneybin.secrets.SecretStore", return_value=mock_store)
+        existing = tmp_path / "moneybin.duckdb"
+        existing.write_bytes(b"")
+        _make_settings_mock(existing, mocker)
+
+        with caplog.at_level("INFO"):
+            result = runner.invoke(app, ["unlock"], input="anypassphrase\n")
+
+        assert result.exit_code == 1
+        assert "already exists" in caplog.text
+        assert "MONEYBIN_DATABASE__ENCRYPTION_KEY" in caplog.text
 
     def test_unlock_database_not_found_deletes_key_and_exits_1(
         self, runner: CliRunner, mocker: Any, tmp_path: Path
@@ -790,6 +910,22 @@ class TestDbKeyCommand:
 
         result = runner.invoke(app, ["key", "show"])
         assert result.exit_code == 1
+
+    def test_key_fails_with_confident_message_when_keychain_denied(
+        self, runner: CliRunner, mocker: Any, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """SecretUnavailableError names the OS denial, not a generic miss (#419)."""
+        from moneybin.secrets import SecretUnavailableError
+
+        mock_store = MagicMock()
+        mock_store.get_key.side_effect = SecretUnavailableError("denied")
+        mocker.patch("moneybin.secrets.SecretStore", return_value=mock_store)
+
+        with caplog.at_level("INFO"):
+            result = runner.invoke(app, ["key", "show"])
+
+        assert result.exit_code == 1
+        assert "denied" in caplog.text
 
 
 class TestDbBackupCommand:

--- a/tests/moneybin/test_database.py
+++ b/tests/moneybin/test_database.py
@@ -309,6 +309,125 @@ class TestDatabaseKeyErrorHint:
 
         assert "db init" in database_key_error_hint()
 
+    def test_explicit_db_path_overrides_profile_settings(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """An explicit db_path wins over the profile's configured path.
+
+        A caller that resolved its own path (e.g. a `--database` override)
+        must not have the hint re-derive a different, possibly-nonexistent
+        path from settings and wrongly recommend db init (see #419).
+        """
+        from moneybin.database import database_key_error_hint
+
+        settings = MagicMock()
+        settings.database.path = tmp_path / "never-created.duckdb"
+        mocker.patch("moneybin.database.get_settings", return_value=settings)
+
+        selected = tmp_path / "explicit.duckdb"
+        selected.write_bytes(b"")
+
+        hint = database_key_error_hint(selected)
+
+        assert "db unlock" in hint
+        assert "db init" not in hint
+
+
+class TestInitDb:
+    """init_db() — refuses to overwrite an ambiguously-unreadable secret (see #419)."""
+
+    def test_passphrase_mode_refuses_when_prev_key_read_denied(
+        self, db_dir: Path
+    ) -> None:
+        """A denied prev_key read must not be treated as "no previous key".
+
+        Proceeding would overwrite the real key with a freshly-derived one,
+        then delete it on rollback if the (now-mismatched) database fails to
+        open — permanently losing access.
+        """
+        from moneybin.database import init_db
+        from moneybin.secrets import SecretUnavailableError
+
+        store = MagicMock()
+        store.get_key.side_effect = SecretUnavailableError("denied")
+        db_path = db_dir / "moneybin.duckdb"
+        db_path.write_bytes(b"pre-existing-encrypted-content")
+
+        with pytest.raises(DatabaseKeyError, match="denied"):
+            init_db(
+                db_path,
+                passphrase="test-passphrase",  # noqa: S106  # test fixture, not a real credential
+                secret_store=store,
+            )
+
+        store.set_key.assert_not_called()
+        store.delete_key.assert_not_called()
+
+    def test_passphrase_mode_refuses_when_prev_salt_read_denied(
+        self, db_dir: Path
+    ) -> None:
+        """Same refusal for the salt read, which is checked separately."""
+        from moneybin.database import SALT_NAME, init_db
+        from moneybin.secrets import SecretNotFoundError, SecretUnavailableError
+
+        def get_key(name: str) -> str:
+            if name == SALT_NAME:
+                raise SecretUnavailableError("denied")
+            raise SecretNotFoundError("no prior key")
+
+        store = MagicMock()
+        store.get_key.side_effect = get_key
+        db_path = db_dir / "moneybin.duckdb"
+        db_path.write_bytes(b"pre-existing-encrypted-content")
+
+        with pytest.raises(DatabaseKeyError, match="denied"):
+            init_db(
+                db_path,
+                passphrase="test-passphrase",  # noqa: S106  # test fixture, not a real credential
+                secret_store=store,
+            )
+
+        store.set_key.assert_not_called()
+
+    def test_auto_key_mode_refuses_when_existence_check_denied(
+        self, db_dir: Path
+    ) -> None:
+        """has_keychain_entry() reporting denial must not read as "absent".
+
+        Proceeding would mint and persist a fresh random key over one that
+        couldn't be read, then delete it on rollback.
+        """
+        from moneybin.database import init_db
+        from moneybin.secrets import SecretUnavailableError
+
+        store = MagicMock()
+        store.has_keychain_entry.side_effect = SecretUnavailableError("denied")
+        db_path = db_dir / "moneybin.duckdb"
+        db_path.write_bytes(b"pre-existing-encrypted-content")
+
+        with pytest.raises(DatabaseKeyError, match="denied"):
+            init_db(db_path, secret_store=store)
+
+        store.set_key.assert_not_called()
+
+    def test_auto_key_mode_refuses_when_key_read_denied_after_absent_check(
+        self, db_dir: Path
+    ) -> None:
+        """A denial surfacing only on the get_key() fallback still refuses."""
+        from moneybin.database import init_db
+        from moneybin.secrets import SecretUnavailableError
+
+        store = MagicMock()
+        store.has_keychain_entry.return_value = False
+        store.get_key.side_effect = SecretUnavailableError("denied")
+        db_path = db_dir / "moneybin.duckdb"
+        db_path.write_bytes(b"pre-existing-encrypted-content")
+
+        with pytest.raises(DatabaseKeyError, match="denied"):
+            init_db(db_path, secret_store=store)
+
+        store.set_key.assert_not_called()
+
 
 class TestDatabaseOperations:
     """Database.execute(), .sql(), .conn property."""

--- a/tests/moneybin/test_database.py
+++ b/tests/moneybin/test_database.py
@@ -220,6 +220,25 @@ class TestDatabaseInit:
         with pytest.raises(DatabaseKeyError, match="encryption key"):
             Database(db_path, secret_store=store, read_only=False)
 
+    def test_raises_database_key_error_with_denied_message_when_keychain_denied(
+        self, db_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A denied keychain read gets a confident message, not a generic miss.
+
+        Distinguishes the two exceptions SecretStore can raise (see #419):
+        SecretUnavailableError means the OS reported the read as denied, so
+        the message says so instead of implying the key is simply absent.
+        """
+        import moneybin.database as db_module
+        from moneybin.secrets import SecretUnavailableError
+
+        monkeypatch.setattr(db_module, "_cached_encryption_key", None)
+        store = MagicMock()
+        store.get_key.side_effect = SecretUnavailableError("denied")
+        db_path = db_dir / "moneybin.duckdb"
+        with pytest.raises(DatabaseKeyError, match="denied"):
+            Database(db_path, secret_store=store, read_only=False)
+
     def test_read_only_missing_file_does_not_consult_secret_store(
         self, db_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -234,6 +253,61 @@ class TestDatabaseInit:
             Database(db_path, read_only=True, secret_store=store)
 
         store.get_key.assert_not_called()
+
+
+class TestDatabaseKeyErrorHint:
+    """database_key_error_hint() — existence-aware recovery hint (see #419)."""
+
+    def test_fresh_install_points_at_db_init_only(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """No database file at all — the only unambiguous case: run db init."""
+        from moneybin.database import database_key_error_hint
+
+        settings = MagicMock()
+        settings.database.path = tmp_path / "never-created.duckdb"
+        mocker.patch("moneybin.database.get_settings", return_value=settings)
+
+        hint = database_key_error_hint()
+
+        assert "db init" in hint
+        assert "db unlock" not in hint
+
+    def test_existing_database_hints_both_unlock_and_env_var_never_db_init(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """File exists — ambiguous: offer db unlock AND the keychain-free env var.
+
+        Never leads with db init against a database that already holds data
+        (the dangerous suggestion #419 was filed about), and always includes a
+        path that works even when this environment denies keychain access
+        outright.
+        """
+        from moneybin.database import database_key_error_hint
+
+        existing = tmp_path / "moneybin.duckdb"
+        existing.write_bytes(b"")
+        settings = MagicMock()
+        settings.database.path = existing
+        mocker.patch("moneybin.database.get_settings", return_value=settings)
+
+        hint = database_key_error_hint()
+
+        assert "db unlock" in hint
+        assert "MONEYBIN_DATABASE__ENCRYPTION_KEY" in hint
+        assert "db init" not in hint
+
+    def test_settings_load_failure_falls_back_to_db_init(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Settings can't load at all — degrade to the safest default."""
+        from moneybin.database import database_key_error_hint
+
+        mocker.patch(
+            "moneybin.database.get_settings", side_effect=RuntimeError("no profile")
+        )
+
+        assert "db init" in database_key_error_hint()
 
 
 class TestDatabaseOperations:

--- a/tests/moneybin/test_secrets.py
+++ b/tests/moneybin/test_secrets.py
@@ -170,3 +170,36 @@ class TestSetAndDeleteKey:
             )
             with pytest.raises(SecretNotFoundError, match="not found in keychain"):
                 store.delete_key("DATABASE__ENCRYPTION_KEY")
+
+
+class TestHasKeychainEntry:
+    """SecretStore.has_keychain_entry() — existence check, ignores env vars."""
+
+    def test_returns_true_when_entry_present(self) -> None:
+        store = SecretStore(profile="alice")
+        with patch("moneybin.secrets.keyring") as mock_kr:
+            mock_kr.get_password.return_value = "existing-value"
+            assert store.has_keychain_entry("DATABASE__ENCRYPTION_KEY") is True
+
+    def test_returns_false_when_no_keyring_backend(self) -> None:
+        store = SecretStore(profile="alice")
+        with patch("moneybin.secrets.keyring") as mock_kr:
+            mock_kr.errors.NoKeyringError = type("NoKeyringError", (Exception,), {})
+            mock_kr.get_password.side_effect = mock_kr.errors.NoKeyringError(
+                "no backend"
+            )
+            assert store.has_keychain_entry("DATABASE__ENCRYPTION_KEY") is False
+
+    def test_raises_secret_unavailable_when_keychain_locked(self) -> None:
+        """A denied read is distinct from "no entry" (see #419).
+
+        The caller must not treat it as absence, since doing so risks
+        overwriting an entry that merely couldn't be read.
+        """
+        store = SecretStore(profile="alice")
+        with patch("moneybin.secrets.keyring") as mock_kr:
+            mock_kr.errors.NoKeyringError = type("NoKeyringError", (Exception,), {})
+            mock_kr.errors.KeyringLocked = type("KeyringLocked", (Exception,), {})
+            mock_kr.get_password.side_effect = mock_kr.errors.KeyringLocked("denied")
+            with pytest.raises(SecretUnavailableError, match="denied"):
+                store.has_keychain_entry("DATABASE__ENCRYPTION_KEY")

--- a/tests/moneybin/test_secrets.py
+++ b/tests/moneybin/test_secrets.py
@@ -8,6 +8,7 @@ from moneybin.secrets import (
     SecretNotFoundError,
     SecretStorageUnavailableError,
     SecretStore,
+    SecretUnavailableError,
 )
 
 
@@ -44,6 +45,41 @@ class TestGetKey:
             mock_kr.get_password.return_value = None
             with pytest.raises(SecretNotFoundError, match="DATABASE__ENCRYPTION_KEY"):
                 store.get_key("DATABASE__ENCRYPTION_KEY")
+
+    def test_raises_secret_unavailable_when_keychain_locked(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Keychain reports the read as denied (not a miss) — a distinct error.
+
+        A locked/restricted keychain is not the same condition as a routine
+        miss: the OS is telling us the secret may well exist. See #419.
+        """
+        monkeypatch.delenv("MONEYBIN_DATABASE__ENCRYPTION_KEY", raising=False)
+        store = SecretStore()
+        with patch("moneybin.secrets.keyring") as mock_kr:
+            mock_kr.errors.NoKeyringError = type("NoKeyringError", (Exception,), {})
+            mock_kr.errors.KeyringLocked = type("KeyringLocked", (Exception,), {})
+            mock_kr.get_password.side_effect = mock_kr.errors.KeyringLocked("denied")
+            with pytest.raises(SecretUnavailableError, match="denied"):
+                store.get_key("DATABASE__ENCRYPTION_KEY")
+
+    def test_secret_unavailable_error_is_a_secret_not_found_error(self) -> None:
+        """Subclassing keeps every existing `except SecretNotFoundError:` working."""
+        assert issubclass(SecretUnavailableError, SecretNotFoundError)
+
+    def test_falls_back_to_env_var_when_keychain_locked(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A locked keychain doesn't block a working env var fallback."""
+        monkeypatch.setenv("MONEYBIN_DATABASE__ENCRYPTION_KEY", "secret-from-env")
+        store = SecretStore()
+        with patch("moneybin.secrets.keyring") as mock_kr:
+            mock_kr.errors.NoKeyringError = type("NoKeyringError", (Exception,), {})
+            mock_kr.errors.KeyringLocked = type("KeyringLocked", (Exception,), {})
+            mock_kr.get_password.side_effect = mock_kr.errors.KeyringLocked("denied")
+            result = store.get_key("DATABASE__ENCRYPTION_KEY")
+
+        assert result == "secret-from-env"
 
 
 class TestGetEnv:


### PR DESCRIPTION
## Summary
- macOS reports a sandbox-denied keychain read identically to a genuinely absent item (`errSecItemNotFound`), so `db.py`, `database.py`, and `db unlock`'s salt lookup each guessed differently — one said "locked", one said the key was missing and to run `db init` even against a database that already existed (contradicting its own hint), one asked whether `--passphrase` mode was ever used.
- `SecretStore.get_key()` now raises a distinct `SecretUnavailableError` when the keychain backend itself can tell a denied read apart from a routine miss (e.g. a locked Linux secret service) — a subclass of `SecretNotFoundError`, so every existing catch site keeps working unchanged.
- All three call sites now route through one existence-aware hint (`database_key_error_hint()`): `db init` only when no database file exists yet, otherwise `db unlock` or the `MONEYBIN_DATABASE__ENCRYPTION_KEY` env var — which needs no further keychain access, exactly what may be unavailable.
- Updated `docs/specs/privacy-data-protection.md` and `architecture-shared-primitives.md` to document the new exception, and added a CHANGELOG entry.

Closes #419.

## Test plan
- [x] `uv run ruff format --check` / `uv run ruff check` on all changed files
- [x] `uv run pyright` (bare, repo-wide)
- [x] `make check test` (format, lint, type-check, full suite)
- [x] New unit tests: `SecretStore.get_key()` denied-vs-missing (`test_secrets.py`), `Database.__init__` + `database_key_error_hint()` (`test_database.py`), CLI message assertions for `db query`, `db unlock`, `db key show` (`test_db_commands.py`)
