### PR TITLE
Point the gsheet OAuth client at MoneyBin's own project

### DIFF
--- a/src/moneybin/config.py
+++ b/src/moneybin/config.py
@@ -455,8 +455,10 @@ class SyncConfig(BaseModel):
 # and this ships in source — a wheel contains no dotenv to read it from.
 # connect-gsheet.md "Design rationale"; a wrong-field copy would land in
 # SyncConfig.oauth_client_id, which is the unrelated Auth0 client.
+# Must stay in MoneyBin's own Google Cloud project — the consent screen shows
+# that project's app name, so a borrowed client asks users to trust a stranger.
 GSHEET_PUBLIC_OAUTH_CLIENT_ID = (
-    "719646616923-nteho06cqo7lfprmtvmsnpk6842m5lfp.apps.googleusercontent.com"
+    "756678783976-ld203ch19knsc2th5b6sc7mm5tq3dtpd.apps.googleusercontent.com"
 )
 
 


### PR DESCRIPTION
## Summary

Follow-up to #452, which embedded a public installed-app OAuth client so the Sheets connector would work on a fresh `pip install`. The mechanism was right; the credential was not. The embedded ID belonged to an **unrelated Google Cloud project**, which broke it two ways:

1. **The consent screen showed the wrong app name.** Google renders the *owning project's* name, so users were asked to grant an unrelated application read access to their financial spreadsheets — the exact shape of a phishing prompt, at the highest-trust moment in the connector.
2. **Its tester allowlist refused everyone.** Authorization failed with `403 access_denied` for anyone not on that project's test-user list.

So #452 moved a fresh install from "fails with a MoneyBin config error" to "fails with a Google 403." This swaps in a client from MoneyBin's own project and records at the constant why the owning project matters, since nothing in the code made that visible:

```
# Must stay in MoneyBin's own Google Cloud project — the consent screen shows
# that project's app name, so a borrowed client asks users to trust a stranger.
```

Reproduced live via the MCP `gsheet_connect` auth flow against the running server (build `f2b4bc95`), which is how the defect surfaced.

## Why no CHANGELOG entry

#452 is still under `Unreleased`, so no released version ever carried the broken ID and no user could have hit it. Its existing bullet — "MoneyBin now ships its own public client ID" — becomes true with this commit. A `Fixed` entry here would document a bug that never reached anyone.

## Test plan

- [x] `make check test` — 9,749 passed, 4 skipped, 0 failed; ruff clean; pyright 0 errors (3 known pre-existing `reportlab` warnings).
- [x] `test_gsheet_oauth_client_id_ships_embedded_by_default` passes, confirmed by exact node id.
- [ ] **Live authorization against a real Google Sheet** — the check that actually distinguishes a valid client from an invalid one, and the gate `connect-gsheet.md:924` requires. Runs after merge, once the MCP server restarts on this commit.

**Note on test coverage, stated plainly:** the unit test asserts the default is wired through to `settings.gsheet.oauth_client_id`. It cannot verify the credential belongs to the right Google project — no offline test can, which is why this defect passed a green suite in #452. Pinning the project number would restate the constant while looking like protection. The live authorization above is the only real check.

## Reviewer verification (console, not code)

Confirm on the new project that the client is a **Desktop app** type (not Web application — the flow sends an empty `client_secret` to a `127.0.0.1` redirect), and that the consent screen carries MoneyBin's own app name.

Google verification itself remains deferred to M3H per `connect-gsheet.md:49,559,890`; shipping pre-launch in testing/unverified mode is an accepted decision, not a regression.
