### PR TITLE
Fix match_signals partial mask leaking serialized JSON tail

### DIFF
--- a/.claude/rules/reports.md
+++ b/.claude/rules/reports.md
@@ -120,10 +120,11 @@ complete, and fails the build if the two disagree.
 - **At CRITICAL, over-declaring is not automatically safe — the transform
   matters.** Below CRITICAL every transform is passthrough, so a higher tier is
   strictly more masking and tier alone decides. At CRITICAL it does not: all
-  four classes share `Tier.CRITICAL` but `ROUTING_NUMBER` and `UNRESOLVED` mask
-  **wholly** (`'021000021'` → `'*****'`) while `ACCOUNT_IDENTIFIER` and
-  `INSTITUTION_ACCOUNT_NUMBER` mask **partially** (`'021000021'` →
-  `'****0021'`). Runtime masking keys off the **declared** class, so declaring
+  five classes share `Tier.CRITICAL` but `ROUTING_NUMBER`, `UNRESOLVED`, and
+  `COMPOSITE_IDENTIFIER` mask **wholly** (`'021000021'` → `'*****'`) while
+  `ACCOUNT_IDENTIFIER` and `INSTITUTION_ACCOUNT_NUMBER` mask **partially**
+  (`'021000021'` → `'****0021'`). Runtime masking keys off the **declared**
+  class, so declaring
   `ACCOUNT_IDENTIFIER` for a column that derives to `ROUTING_NUMBER` publishes
   the real routing number's last four digits. **Never replace a whole-masking
   class with a partial-masking one.** The guard measures each class's strength

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2053,6 +2053,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   update.
 
 ### Security
+- **`sql_query` no longer publishes the tail of a serialized JSON column as if
+  it were an account number's last four digits.**
+  `app.account_link_decisions.match_signals` — a JSON column holding the weak
+  signals behind a proposed account link (institution last-four, name
+  similarity) — was classified `ACCOUNT_IDENTIFIER`, whose mask keeps
+  `value[-4:]`. A JSON column reaches the masking transform as a serialized
+  `str`, so the four characters that survived were the tail of the JSON
+  text — closing punctuation plus whatever key happened to sort last — not a
+  real signal value, and which characters leaked depended on key order rather
+  than anything the declaration controlled. A new `COMPOSITE_IDENTIFIER` class
+  masks this and any future serialized/composite column WHOLE instead,
+  matching the precedent already set for two sibling JSON columns
+  (`raw.import_log.account_names`, `prep.int_transactions__matched
+  .match_group_id`). A regression test walks every JSON-typed `core.*`/`app.*`
+  column and fails if one is ever classified with a partial mask again. (#451)
 - **Six CVEs cleared, and the audit that missed two of them now sees every
   dependency group.** `cryptography` 49.0.0 → 50.0.0 (PYSEC-2026-3552), `pip`
   26.1.2 → 26.2.1 (PYSEC-2026-3721), and `pymdown-extensions` 10.21.3 → 11.0.2

--- a/docs/specs/privacy-data-classification.md
+++ b/docs/specs/privacy-data-classification.md
@@ -145,6 +145,7 @@ compares `duckdb_columns()` against `CLASSIFICATION` in both directions.
 
 | (schema, table) | column | class | justification |
 |---|---|---|---|
+| (app, account_link_decisions) | match_signals | COMPOSITE_IDENTIFIER | JSON weak-signal payload that may embed account digits (`institution_last4`). ACCOUNT_IDENTIFIER's partial mask would publish the tail of the *serialized JSON text* — whichever key sorts last — not the tail of a real value; COMPOSITE_IDENTIFIER masks WHOLE instead (issue #451). |
 | (app, account_settings) | archived, include_in_net_worth | TXN_TYPE | account-level state flags; no `BOOLEAN_FLAG` class exists, TXN_TYPE is the closest LOW-tier categorical bucket. Same applies to the mirror columns on `core.dim_accounts`. |
 | (app, account_settings) | display_name | USER_NOTE | user-supplied free-text label; treat as user input rather than institution-supplied metadata. Same on `core.dim_accounts`. |
 | (app, account_settings) | holder_category | TXN_TYPE | `'personal' / 'business' / 'joint'` — low-cardinality categorical classifier. Same on `core.dim_accounts`. |
@@ -417,7 +418,7 @@ Because both functions share the same `_TRANSFORMS` table, a change to how CRITI
 
 **This PR is redaction-only.** Specifically:
 
-- CRITICAL-tier columns (`ACCOUNT_IDENTIFIER`, `INSTITUTION_ACCOUNT_NUMBER`, `ROUTING_NUMBER`) are **always masked** in `sql_query` results, exactly as the typed tools mask them (account number → `****<last4>`, routing number → `*****`).
+- CRITICAL-tier columns (`ACCOUNT_IDENTIFIER`, `INSTITUTION_ACCOUNT_NUMBER`, `ROUTING_NUMBER`, `UNRESOLVED`, `COMPOSITE_IDENTIFIER`) are **always masked** in `sql_query` results, exactly as the typed tools mask them (account number → `****<last4>`, routing/unresolved/composite → `*****`).
 - HIGH/MEDIUM/LOW columns (amounts, descriptions, dates, categories) **pass through in the clear**, matching the current behavior of `transactions(account=..., start=..., end=..., merchant=..., category=..., min_amount=..., max_amount=..., text=..., limit=..., cursor=...)` and other typed tools.
 - There is **no consent gate** on `sql_query`. The consent enforcement gate is deferred project-wide. When the gate un-defers, `sql_query` will inherit it automatically because it routes column → class → `_TRANSFORMS`, the same path the typed surface uses.
 - There are **no degraded/refusal responses**. Those were explicitly dropped from the PR 4 scope.

--- a/docs/specs/reports-foundation.md
+++ b/docs/specs/reports-foundation.md
@@ -165,8 +165,8 @@ explicit inline reason**. CI fails unless every declared column is either
 derivation-matched **or** carries an explicit downgrade.
 
 The floor is ordered on **`(tier, mask strength)`**, not tier alone. Tier alone
-is insufficient at CRITICAL: all four CRITICAL classes share `Tier.CRITICAL`
-but `ROUTING_NUMBER`/`UNRESOLVED` mask wholly while
+is insufficient at CRITICAL: all five CRITICAL classes share `Tier.CRITICAL`
+but `ROUTING_NUMBER`/`UNRESOLVED`/`COMPOSITE_IDENTIFIER` mask wholly while
 `ACCOUNT_IDENTIFIER`/`INSTITUTION_ACCOUNT_NUMBER` mask partially
 (`"****" + value[-4:]`), and runtime masking keys off the **declared** class —
 so declaring `ACCOUNT_IDENTIFIER` where derivation says `ROUTING_NUMBER` sits

--- a/src/moneybin/privacy/redaction.py
+++ b/src/moneybin/privacy/redaction.py
@@ -100,11 +100,34 @@ def _mask_account_identifier(value: Any, _consent: ConsentSet | None) -> Any:
     return "****" + value[-4:] if len(value) >= 4 else "****"
 
 
-def _mask_routing_number(value: str | None, _consent: ConsentSet | None) -> str | None:
-    """ROUTING_NUMBER → constant ``"*****"`` (or ``None`` for nullable)."""
+def _mask_to_constant(value: Any) -> Any:
+    """Shared body for classes that mask WHOLE to ``"*****"`` (or ``None``).
+
+    ROUTING_NUMBER, COMPOSITE_IDENTIFIER, and UNRESOLVED all destroy the value
+    identically — the class distinction is *why* each is masked WHOLE, not
+    *how*. Kept as one body so the constant can't drift between the three call
+    sites; each keeps its own function name and docstring for that reason.
+    """
     if value is None:
         return None
     return "*****"
+
+
+def _mask_routing_number(value: str | None, _consent: ConsentSet | None) -> str | None:
+    """ROUTING_NUMBER → constant ``"*****"`` (or ``None`` for nullable)."""
+    return _mask_to_constant(value)
+
+
+def _mask_composite_identifier(value: Any, _consent: ConsentSet | None) -> Any:
+    """COMPOSITE_IDENTIFIER → constant ``"*****"`` (or ``None`` for nullable).
+
+    Whole, not the partial mask ACCOUNT_IDENTIFIER takes: this class covers
+    serialized/composite values (JSON, a packed multi-field string) where an
+    identifier fragment can land anywhere, so ``"****" + value[-4:]`` would
+    keep the tail of the serialization rather than the tail of any single
+    value inside it. See the class's ``taxonomy.py`` comment.
+    """
+    return _mask_to_constant(value)
 
 
 def _mask_unresolved(value: Any, _consent: ConsentSet | None) -> Any:
@@ -118,9 +141,7 @@ def _mask_unresolved(value: Any, _consent: ConsentSet | None) -> Any:
     ``_mask_account_identifier`` does) would raise ``TypeError`` on those and
     fail the query OPEN through the caller's error path.
     """
-    if value is None:
-        return None
-    return "*****"
+    return _mask_to_constant(value)
 
 
 def _passthrough(value: Any, _consent: ConsentSet | None) -> Any:
@@ -221,6 +242,7 @@ _TRANSFORMS: dict[DataClass, Any] = {
     DataClass.ACCOUNT_IDENTIFIER: _mask_account_identifier,
     DataClass.INSTITUTION_ACCOUNT_NUMBER: _mask_account_identifier,
     DataClass.ROUTING_NUMBER: _mask_routing_number,
+    DataClass.COMPOSITE_IDENTIFIER: _mask_composite_identifier,
     DataClass.UNRESOLVED: _mask_unresolved,
     # HIGH-tier — pass through in PR 2 (PR 3 adds bucketing).
     DataClass.BALANCE: _passthrough,
@@ -250,12 +272,12 @@ class MaskStrength(IntEnum):
 
     Tier says how *sensitive* a class is; strength says how *hard* its transform
     hides the value. The two are independent, and conflating them leaks: all
-    four CRITICAL classes share ``Tier.CRITICAL``, but ROUTING_NUMBER and
-    UNRESOLVED mask WHOLE while ACCOUNT_IDENTIFIER and
-    INSTITUTION_ACCOUNT_NUMBER mask PARTIAL (``"****" + value[-4:]``). Standing
-    a PARTIAL class in for a WHOLE one at the same tier publishes the last four
-    characters of a value the declaration does not describe — the same
-    order-dependence ``sql_lineage._combined_class`` collapses to
+    five CRITICAL classes share ``Tier.CRITICAL``, but ROUTING_NUMBER,
+    UNRESOLVED, and COMPOSITE_IDENTIFIER mask WHOLE while ACCOUNT_IDENTIFIER
+    and INSTITUTION_ACCOUNT_NUMBER mask PARTIAL (``"****" + value[-4:]``).
+    Standing a PARTIAL class in for a WHOLE one at the same tier publishes the
+    last four characters of a value the declaration does not describe — the
+    same order-dependence ``sql_lineage._combined_class`` collapses to
     ``FAIL_CLOSED_CLASS``, reached through the declaration path instead.
     """
 

--- a/src/moneybin/privacy/taxonomy.py
+++ b/src/moneybin/privacy/taxonomy.py
@@ -63,6 +63,20 @@ class DataClass(StrEnum):
     AGGREGATE = "aggregate"
     RECORD_ID = "record_id"
     TIMESTAMP_OBSERVABILITY = "timestamp_observability"
+    # A serialized/composite value (JSON, a packed multi-field string) that may
+    # embed identifier-class material at a position the declaration cannot
+    # pin down. CRITICAL and masked WHOLE, for the same reason UNRESOLVED is:
+    # a DuckDB JSON column reaches the redaction transform as `str`, so
+    # ACCOUNT_IDENTIFIER's `"****" + value[-4:]` would surface the tail of the
+    # SERIALIZED TEXT — whichever key happens to sort last — not the tail of
+    # any value inside it. Unlike UNRESOLVED, this IS a positive declaration:
+    # the column's shape and worst-case content are known, just not which
+    # bytes land in the last four. Use this instead of UNRESOLVED for a
+    # `CLASSIFICATION`/`core`+`app` column — UNRESOLVED there is the
+    # fail-closed marker for a column NOBODY classified, and declaring it
+    # explicitly would defeat the completeness tests that exist to catch that
+    # gap. Origin: match_signals (issue #451).
+    COMPOSITE_IDENTIFIER = "composite_identifier"
     # Not a classification — the absence of one. Assigned by the fail-closed
     # paths in ``sql_lineage`` / ``sql_query`` when a column reaches the user
     # WITHOUT lineage having positively established what it holds (an
@@ -106,6 +120,7 @@ _TIER_BY_CLASS: dict[DataClass, Tier] = {
     DataClass.AGGREGATE: Tier.LOW,
     DataClass.RECORD_ID: Tier.LOW,
     DataClass.TIMESTAMP_OBSERVABILITY: Tier.LOW,
+    DataClass.COMPOSITE_IDENTIFIER: Tier.CRITICAL,
     DataClass.UNRESOLVED: Tier.CRITICAL,
     DataClass.FLOORED: Tier.LOW,
 }
@@ -137,9 +152,13 @@ CLASSIFICATION: dict[tuple[str, str], dict[str, DataClass]] = {
         "match_reason": DataClass.USER_NOTE,
         # Unlike match_decisions.match_signals (scores), this carries weak-signal
         # values that include account digits (institution_last4) — masked, not the
-        # LOW-tier AGGREGATE passthrough. JSON masking is coarse here; the typed
-        # accounts_links surface (M1S.5) presents signals with structured masking.
-        "match_signals": DataClass.ACCOUNT_IDENTIFIER,
+        # LOW-tier AGGREGATE passthrough. COMPOSITE_IDENTIFIER, not
+        # ACCOUNT_IDENTIFIER: a DuckDB JSON column reaches the transform as `str`,
+        # so ACCOUNT_IDENTIFIER's partial mask would surface the tail of the
+        # SERIALIZED JSON TEXT, not of any signal value (issue #451). Whole-masking
+        # costs only the rendered value here; the typed accounts_links surface
+        # (M1S.5) presents signals with structured masking.
+        "match_signals": DataClass.COMPOSITE_IDENTIFIER,
         "provisional_account_id": DataClass.RECORD_ID,
         # Frozen alongside candidate_display_name above; same reasoning.
         "provisional_display_name": DataClass.USER_NOTE,

--- a/src/moneybin/reports/_framework/execute.py
+++ b/src/moneybin/reports/_framework/execute.py
@@ -463,7 +463,7 @@ def masked_columns(output_classes: Mapping[str, DataClass]) -> tuple[str, ...]:
     """The columns whose class masks their value, in declaration order.
 
     Measured from the class's own transform rather than from a tier comparison:
-    all four CRITICAL classes share a tier but two of them mask only partially,
+    all five CRITICAL classes share a tier but two of them mask only partially,
     and below CRITICAL every transform is passthrough except FLOORED. The
     transform is what the reader actually sees.
     """

--- a/tests/moneybin/test_privacy/test_redaction.py
+++ b/tests/moneybin/test_privacy/test_redaction.py
@@ -101,6 +101,32 @@ def test_institution_account_number_uses_last_four_pattern() -> None:
     assert out.last_four == "****4242"
 
 
+def test_composite_identifier_masked_to_constant() -> None:
+    """WHOLE mask — a partial mask would publish the tail of a serialized blob.
+
+    ``account_link_decisions.match_signals`` reaches this transform as a DuckDB
+    JSON column cast to ``str``: ``"****" + value[-4:]`` would keep the tail of
+    the serialized JSON text, not the tail of any single signal value.
+    """
+    (masked,) = redact_records(
+        [{"n": '{"institution_last4": "9940"}'}],
+        {"n": DataClass.COMPOSITE_IDENTIFIER},
+        consent=None,
+    )
+    assert masked["n"] == "*****"
+
+
+def test_composite_identifier_none_passes_through() -> None:
+    (masked,) = redact_records(
+        [{"n": None}], {"n": DataClass.COMPOSITE_IDENTIFIER}, consent=None
+    )
+    assert masked["n"] is None
+
+
+def test_composite_identifier_measures_whole() -> None:
+    assert mask_strength(DataClass.COMPOSITE_IDENTIFIER) is MaskStrength.WHOLE
+
+
 @pytest.mark.parametrize(
     "value", [4, Decimal("4"), True, b"4021", ("4", "0"), Decimal("40.21")]
 )

--- a/tests/privacy/test_classification_completeness.py
+++ b/tests/privacy/test_classification_completeness.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import pytest
 
 from moneybin.database import Database
+from moneybin.privacy.redaction import MaskStrength, mask_strength
 from moneybin.privacy.sql_lineage import reports_class_map
 from moneybin.privacy.taxonomy import CLASSIFICATION, DataClass
 
@@ -20,6 +21,17 @@ def _live_columns(db: Database) -> set[tuple[str, str, str]]:
         SELECT schema_name, table_name, column_name
         FROM duckdb_columns()
         WHERE schema_name IN ('core', 'app')
+        """
+    ).fetchall()
+    return {(str(s), str(t), str(c)) for s, t, c in rows}
+
+
+def _live_json_columns(db: Database) -> set[tuple[str, str, str]]:
+    rows = db.execute(
+        """
+        SELECT schema_name, table_name, column_name
+        FROM duckdb_columns()
+        WHERE schema_name IN ('core', 'app') AND data_type = 'JSON'
         """
     ).fetchall()
     return {(str(s), str(t), str(c)) for s, t, c in rows}
@@ -87,4 +99,26 @@ def test_unresolved_is_never_declared_as_a_column_class() -> None:
         + "\n".join(f"  {d}" for d in sorted(declared))
         + "\nIt is the fail-closed marker for columns lineage could not "
         "resolve. Classify these columns properly instead."
+    )
+
+
+def test_no_json_column_takes_a_partial_mask(populated_db: Database) -> None:
+    """Regression guard: a JSON column must never take a PARTIAL-masking class.
+
+    A JSON column reaches the redaction transform as ``str`` (DuckDB casts
+    it), so a PARTIAL mask keeps the tail of the *serialized text* — whichever
+    key happens to sort last, not any value inside it. See issue #451.
+    """
+    offenders = [
+        f"{schema}.{table}.{col} -> {dc.value}"
+        for schema, table, col in sorted(_live_json_columns(populated_db))
+        for dc in [CLASSIFICATION.get((schema, table), {}).get(col)]
+        if dc is not None and mask_strength(dc) is MaskStrength.PARTIAL
+    ]
+    assert not offenders, (
+        "JSON columns classified with a PARTIAL-masking DataClass — this "
+        "publishes the tail of the serialized JSON text, not a real value's "
+        "tail:\n"
+        + "\n".join(f"  {o}" for o in offenders)
+        + "\nUse a WHOLE-masking class instead (see DataClass.COMPOSITE_IDENTIFIER)."
     )

--- a/tests/privacy/test_report_class_derivation.py
+++ b/tests/privacy/test_report_class_derivation.py
@@ -458,7 +458,7 @@ def test_declared_classes_match_derivation() -> None:
     ``_declaration_is_safe`` — **tier, then mask strength**, not class
     identity. Over-declaring is safe below CRITICAL except over ``FLOORED``
     (every other transform there is passthrough) and not automatically safe
-    at CRITICAL, where the four classes share a tier and differ in transform;
+    at CRITICAL, where the five classes share a tier and differ in transform;
     see that helper. Only a declaration
     that masks strictly more weakly than derivation requires an explicit,
     reasoned ``class_downgrades`` entry.

--- a/tests/privacy/test_report_class_derivation.py
+++ b/tests/privacy/test_report_class_derivation.py
@@ -383,7 +383,7 @@ def _declaration_is_safe(declared: DataClass, derived: DataClass) -> bool:
 
     Ordered on ``(tier, mask_strength)`` lexicographically. Tier alone is NOT
     sufficient, and the gap it leaves is the whole reason this helper exists:
-    all four CRITICAL classes share ``Tier.CRITICAL`` but do not share a
+    all five CRITICAL classes share ``Tier.CRITICAL`` but do not share a
     transform, so a tier-only comparison rates ACCOUNT_IDENTIFIER (masks
     PARTIAL, ``"****" + value[-4:]``) an adequate stand-in for ROUTING_NUMBER
     (masks WHOLE). Runtime masking keys off the DECLARED class, so that

--- a/tests/privacy/test_taxonomy.py
+++ b/tests/privacy/test_taxonomy.py
@@ -22,6 +22,10 @@ def test_record_id_is_low() -> None:
     assert DataClass.RECORD_ID.tier is Tier.LOW
 
 
+def test_composite_identifier_is_critical() -> None:
+    assert DataClass.COMPOSITE_IDENTIFIER.tier is Tier.CRITICAL
+
+
 def test_floored_is_low() -> None:
     """Pinned: Task 6's query gate keys off this tier to consent-gate raw/prep.
 


### PR DESCRIPTION
## Summary

`app.account_link_decisions.match_signals` is a JSON column holding the weak signals behind a proposed account link (institution last-four, name similarity), and it was classified `DataClass.ACCOUNT_IDENTIFIER`, whose mask is `"****" + value[-4:]`. DuckDB hands a JSON column to the redaction transform as a plain `str`, so the four characters that survived were the tail of the *serialized JSON text* — closing punctuation plus whichever key happened to sort last — not a real signal value, and which characters leaked depended on key order rather than anything the declaration controlled. Live example from the issue: `{"institution_last4": "0001", ...}` masked to `****01"}`.

`DataClass.UNRESOLVED` already solves this exact problem for two sibling composite columns (`raw.import_log.account_names`, `prep.int_transactions__matched.match_group_id`), but `UNRESOLVED` is explicitly forbidden inside `CLASSIFICATION` (the `core`/`app` registry) — declaring it there would defeat the completeness test that catches columns nobody classified. This adds a new `DataClass.COMPOSITE_IDENTIFIER`: a CRITICAL-tier, WHOLE-masking class for serialized/composite values that may embed identifier material at a position the declaration can't pin down, and reclassifies `match_signals` to it.

A regression test (`test_no_json_column_takes_a_partial_mask`) walks every live JSON-typed `core.*`/`app.*` column via `duckdb_columns()` and fails if any is ever classified with a partial mask again — confirmed it reproduces the original bug when reverted against the pre-fix classification.

## Test plan

- [x] `uv run pytest tests/privacy/ tests/moneybin/test_privacy/` — 772 passed
- [x] `make lint` and `uv run pyright` (repo-wide) — clean
- [x] `make test` (full suite) — 9,762 passed, 1 skipped-unrelated pre-existing failure (a local env-var override of a gsheet OAuth config default, confirmed unrelated), 4 skipped
- [x] `/code-review medium --fix` pass — deduplicated the three whole-mask transform bodies into a shared helper, fixed four stale "four CRITICAL classes" docstring counts
- [x] Isolated adversarial pre-push review (fresh agent, base→head diff only) — `clear`, and independently re-derived the exact leak (`****40"}`) against a live DuckDB connection, then reverted the classification in-memory and confirmed the new regression test catches it

## Related

Closes #451

