### PR TITLE
Fix sql_query rejecting reads with write keywords in literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1164,6 +1164,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   audit trail keeps it (#387).
 
 ### Fixed
+- **`sql_query` no longer refuses a read-only `SELECT` for a write keyword
+  inside a quoted string.** `SELECT 'export' AS probe` was rejected as though
+  it were a real `EXPORT` statement — one character away, `SELECT 'expor' AS
+  control` was always accepted, because the write-operation guard scanned raw
+  query text with no regard for string literals. It now masks literal
+  contents (via sqlglot's tokenizer) before matching, so ordinary words like
+  `export`, `update`, or `create` inside a string no longer trip it. This
+  unblocks `... WHERE action LIKE 'export%'` against `app.audit_log`, the
+  documented way to find an export's audit trail from the agent-safe SQL
+  surface (#447).
+
 - **A denied keychain read is no longer reported as a missing key.** macOS
   reports a sandbox-denied keychain read identically to a genuinely absent
   item (`errSecItemNotFound`), so three call sites each guessed differently:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1165,15 +1165,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - **`sql_query` no longer refuses a read-only `SELECT` for a write keyword
-  inside a quoted string.** `SELECT 'export' AS probe` was rejected as though
-  it were a real `EXPORT` statement — one character away, `SELECT 'expor' AS
-  control` was always accepted, because the write-operation guard scanned raw
-  query text with no regard for string literals. It now masks literal
-  contents (via sqlglot's tokenizer) before matching, so ordinary words like
-  `export`, `update`, or `create` inside a string no longer trip it. This
-  unblocks `... WHERE action LIKE 'export%'` against `app.audit_log`, the
-  documented way to find an export's audit trail from the agent-safe SQL
-  surface (#447).
+  that isn't actually a write.** `SELECT 'export' AS probe` was rejected as
+  though it were a real `EXPORT` statement — one character away,
+  `SELECT 'expor' AS control` was always accepted, because the write-operation
+  guard scanned raw query text with no regard for where the word appeared. It
+  now checks the parsed SQL's structure instead of its text: a word matters
+  only when it produces an actual write statement (`INSERT`, `UPDATE`,
+  `DROP`, etc.), never when it merely appears inside a string literal (any
+  quoting style), a quoted identifier, or a `--` comment. This unblocks
+  `... WHERE action LIKE 'export%'` against `app.audit_log`, the documented
+  way to find an export's audit trail from the agent-safe SQL surface (#447).
 
 - **A denied keychain read is no longer reported as a missing key.** macOS
   reports a sandbox-denied keychain read identically to a genuinely absent

--- a/src/moneybin/privacy/sql_query.py
+++ b/src/moneybin/privacy/sql_query.py
@@ -24,7 +24,10 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import duckdb
+import sqlglot
 from sqlglot import exp
+from sqlglot.errors import TokenError
+from sqlglot.tokenizer_core import TokenType
 
 from moneybin import error_codes
 from moneybin.database import Database
@@ -124,11 +127,39 @@ _READ_ONLY_PREFIXES = re.compile(
     re.IGNORECASE,
 )
 
-# Patterns that indicate write operations (even inside CTEs)
+# Patterns that indicate write operations (even inside CTEs). Matched against
+# the string-literal-masked text (`_mask_string_literals`) below, not the raw
+# query: a real DML/DDL keyword is never inside a quoted literal, so masking
+# only removes false positives (`SELECT 'export' AS probe`) and cannot hide an
+# actual write.
 _WRITE_PATTERNS = re.compile(
     r"\b(INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|TRUNCATE|REPLACE|MERGE|COPY|ATTACH|DETACH|EXPORT|IMPORT)\b",
     re.IGNORECASE,
 )
+
+
+def _mask_string_literals(sql: str) -> str:
+    """Blank the contents of every string literal, quotes included.
+
+    An ordinary word inside a quoted literal (``'export'``, ``'update'``) is
+    data, not a keyword, but a text-only regex can't tell the difference.
+    Uses sqlglot's tokenizer rather than a bespoke quote scanner so an escaped
+    quote (``'it''s'``) doesn't end the literal early.
+
+    Falls back to the original text on a tokenize failure — genuinely
+    malformed SQL still reaches the same "could not parse" error a few lines
+    later in the normal parse step, just without this mask applied first.
+    """
+    try:
+        tokens = sqlglot.tokenize(sql, read="duckdb")
+    except TokenError:
+        return sql
+    masked = sql
+    string_tokens = [t for t in tokens if t.token_type is TokenType.STRING]
+    for token in sorted(string_tokens, key=lambda t: t.start, reverse=True):
+        span = token.end - token.start + 1
+        masked = masked[: token.start] + " " * span + masked[token.end + 1 :]
+    return masked
 
 
 def validate_read_only_query(sql: str) -> str | None:
@@ -171,7 +202,7 @@ def validate_read_only_query(sql: str) -> str | None:
             "Queries must read from database tables only."
         )
 
-    if _WRITE_PATTERNS.search(stripped):
+    if _WRITE_PATTERNS.search(_mask_string_literals(stripped)):
         return (
             "Write operations (INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, etc.) "
             "are not allowed."

--- a/src/moneybin/privacy/sql_query.py
+++ b/src/moneybin/privacy/sql_query.py
@@ -24,10 +24,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import duckdb
-import sqlglot
 from sqlglot import exp
-from sqlglot.errors import TokenError
-from sqlglot.tokenizer_core import TokenType
 
 from moneybin import error_codes
 from moneybin.database import Database
@@ -127,39 +124,43 @@ _READ_ONLY_PREFIXES = re.compile(
     re.IGNORECASE,
 )
 
-# Patterns that indicate write operations (even inside CTEs). Matched against
-# the string-literal-masked text (`_mask_string_literals`) below, not the raw
-# query: a real DML/DDL keyword is never inside a quoted literal, so masking
-# only removes false positives (`SELECT 'export' AS probe`) and cannot hide an
-# actual write.
-_WRITE_PATTERNS = re.compile(
-    r"\b(INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|TRUNCATE|REPLACE|MERGE|COPY|ATTACH|DETACH|EXPORT|IMPORT)\b",
-    re.IGNORECASE,
+# Concrete sqlglot expression types for every write operation this gate
+# refuses (even nested inside a CTE). Structural, not textual: a query is
+# checked by what it PARSES to, so an ordinary word that merely LOOKS like a
+# keyword — inside a string literal (`'export'`, `e'export'`, `$$export$$`),
+# a quoted identifier (`"update"`), or a `-- comment` — can never trip this,
+# because none of those produce one of these node types. `find_all` walks the
+# whole tree, so a write buried in a CTE or a semicolon-separated second
+# statement is still caught (`SELECT 1; DROP TABLE x` verified).
+#
+# `EXPORT DATABASE`, `IMPORT DATABASE`, and bare `REPLACE INTO` have no
+# dedicated sqlglot node for the duckdb dialect (`REPLACE INTO` isn't even
+# valid DuckDB syntax — only `INSERT OR REPLACE INTO`, which parses as
+# `exp.Insert`) and are not covered here. That's safe: each is a top-level-only
+# statement DuckDB's own grammar refuses anywhere but the start of a query
+# (verified: `WITH x AS (SELECT 1) EXPORT DATABASE 'dir'` is a DuckDB parser
+# error, not a valid nested form), so `_READ_ONLY_PREFIXES` above already
+# refuses it as a bare statement before this check would run. The same holds
+# for DDL sqlglot falls back to a generic `exp.Command` for (e.g. `ALTER
+# SEQUENCE ... RESTART`, `DROP TYPE`, `CREATE TYPE ... AS ENUM`) — verified
+# each is likewise rejected by DuckDB when following `WITH x AS (SELECT 1)`.
+_WRITE_EXPRESSION_TYPES = (
+    exp.Insert,
+    exp.Update,
+    exp.Delete,
+    exp.Create,
+    exp.Drop,
+    exp.Alter,
+    exp.TruncateTable,
+    exp.Merge,
+    exp.Copy,
+    exp.Attach,
+    exp.Detach,
 )
 
 
-def _mask_string_literals(sql: str) -> str:
-    """Blank the contents of every string literal, quotes included.
-
-    An ordinary word inside a quoted literal (``'export'``, ``'update'``) is
-    data, not a keyword, but a text-only regex can't tell the difference.
-    Uses sqlglot's tokenizer rather than a bespoke quote scanner so an escaped
-    quote (``'it''s'``) doesn't end the literal early.
-
-    Falls back to the original text on a tokenize failure — genuinely
-    malformed SQL still reaches the same "could not parse" error a few lines
-    later in the normal parse step, just without this mask applied first.
-    """
-    try:
-        tokens = sqlglot.tokenize(sql, read="duckdb")
-    except TokenError:
-        return sql
-    masked = sql
-    string_tokens = [t for t in tokens if t.token_type is TokenType.STRING]
-    for token in sorted(string_tokens, key=lambda t: t.start, reverse=True):
-        span = token.end - token.start + 1
-        masked = masked[: token.start] + " " * span + masked[token.end + 1 :]
-    return masked
+def _contains_write_operation(tree: exp.Expr) -> bool:
+    return next(tree.find_all(*_WRITE_EXPRESSION_TYPES), None) is not None
 
 
 def validate_read_only_query(sql: str) -> str | None:
@@ -202,7 +203,15 @@ def validate_read_only_query(sql: str) -> str | None:
             "Queries must read from database tables only."
         )
 
-    if _WRITE_PATTERNS.search(_mask_string_literals(stripped)):
+    # A parse error here is not this gate's to report: return None and let the
+    # caller's own parse surface it with its own error code. Both remaining
+    # checks need the parsed tree, so parse once (cached) and reuse it.
+    try:
+        tree = parse_cached(stripped)
+    except SqlParseError:
+        return None
+
+    if _contains_write_operation(tree):
         return (
             "Write operations (INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, etc.) "
             "are not allowed."
@@ -211,13 +220,8 @@ def validate_read_only_query(sql: str) -> str | None:
     # Every statement in `SELECT 1; SELECT routing_number FROM ...` is
     # individually a legal read, so none of the checks above fire — but DuckDB
     # returns the LAST statement's rows while classification reads the first.
-    # A parse error here is not this gate's to report: return None and let the
-    # caller's parse surface it with its own error code.
-    try:
-        if is_multi_statement(parse_cached(stripped)):
-            return "Queries must be one statement; remove the extra ';'-separated SQL."
-    except SqlParseError:
-        return None
+    if is_multi_statement(tree):
+        return "Queries must be one statement; remove the extra ';'-separated SQL."
 
     return None
 

--- a/src/moneybin/privacy/sql_query.py
+++ b/src/moneybin/privacy/sql_query.py
@@ -133,17 +133,29 @@ _READ_ONLY_PREFIXES = re.compile(
 # whole tree, so a write buried in a CTE or a semicolon-separated second
 # statement is still caught (`SELECT 1; DROP TABLE x` verified).
 #
+# Only 8 of these are reachable nested inside a CTE under sqlglot's own
+# grammar (verified): Insert, Update, Delete, Create, Drop, Attach, Detach,
+# Merge. TruncateTable, Alter, and Copy are NOT — `WITH x AS (TRUNCATE TABLE
+# y) SELECT 1 FROM x` (and the ALTER/COPY equivalents) is a sqlglot
+# `ParseError`, so those three can only ever appear as a bare top-level
+# statement, which `_READ_ONLY_PREFIXES` above already refuses before this
+# check runs. They stay in the tuple as defense-in-depth against that prefix
+# check ever loosening, not because this check currently reaches them.
+#
 # `EXPORT DATABASE`, `IMPORT DATABASE`, and bare `REPLACE INTO` have no
-# dedicated sqlglot node for the duckdb dialect (`REPLACE INTO` isn't even
-# valid DuckDB syntax — only `INSERT OR REPLACE INTO`, which parses as
-# `exp.Insert`) and are not covered here. That's safe: each is a top-level-only
-# statement DuckDB's own grammar refuses anywhere but the start of a query
-# (verified: `WITH x AS (SELECT 1) EXPORT DATABASE 'dir'` is a DuckDB parser
-# error, not a valid nested form), so `_READ_ONLY_PREFIXES` above already
-# refuses it as a bare statement before this check would run. The same holds
-# for DDL sqlglot falls back to a generic `exp.Command` for (e.g. `ALTER
-# SEQUENCE ... RESTART`, `DROP TYPE`, `CREATE TYPE ... AS ENUM`) — verified
-# each is likewise rejected by DuckDB when following `WITH x AS (SELECT 1)`.
+# dedicated sqlglot node for the duckdb dialect at all (`REPLACE INTO` isn't
+# even valid DuckDB syntax — only `INSERT OR REPLACE INTO`, which parses as
+# `exp.Insert`) and are not in this tuple. That's safe for the same structural
+# reason: each is a top-level-only statement DuckDB's own grammar refuses
+# anywhere but the start of a query (verified: `WITH x AS (SELECT 1) EXPORT
+# DATABASE 'dir'` is a DuckDB parser error, not a valid nested form) — a bare
+# occurrence is refused above by `_READ_ONLY_PREFIXES`, and a WITH-prefixed
+# attempt fails to parse at all, which this function defers to the caller
+# (see the `except SqlParseError` below) and `execute_sql_query`'s own parse
+# then reports as `sql_invalid_query`. The same holds for DDL sqlglot falls
+# back to a generic `exp.Command` for (e.g. `ALTER SEQUENCE ... RESTART`,
+# `DROP TYPE`, `CREATE TYPE ... AS ENUM`) — verified each is likewise rejected
+# by DuckDB when following `WITH x AS (SELECT 1)`.
 _WRITE_EXPRESSION_TYPES = (
     exp.Insert,
     exp.Update,
@@ -160,7 +172,7 @@ _WRITE_EXPRESSION_TYPES = (
 
 
 def _contains_write_operation(tree: exp.Expr) -> bool:
-    return next(tree.find_all(*_WRITE_EXPRESSION_TYPES), None) is not None
+    return any(tree.find_all(*_WRITE_EXPRESSION_TYPES))
 
 
 def validate_read_only_query(sql: str) -> str | None:
@@ -205,7 +217,11 @@ def validate_read_only_query(sql: str) -> str | None:
 
     # A parse error here is not this gate's to report: return None and let the
     # caller's own parse surface it with its own error code. Both remaining
-    # checks need the parsed tree, so parse once (cached) and reuse it.
+    # checks need the parsed tree, so parse once here and reuse it for both —
+    # `execute_sql_query` parses again on its own (unstripped) copy of the
+    # query text, a separate `parse_cached` cache entry whenever the query
+    # carries leading/trailing whitespace; this only dedupes the two checks
+    # in this function.
     try:
         tree = parse_cached(stripped)
     except SqlParseError:

--- a/tests/privacy/test_sql_query.py
+++ b/tests/privacy/test_sql_query.py
@@ -585,6 +585,83 @@ def test_real_write_keyword_still_rejected_alongside_string_literal() -> None:
     assert "Write operations" in error
 
 
+@pytest.mark.parametrize(
+    "sql",
+    [
+        pytest.param("WITH x AS (CREATE TABLE y (a INT)) SELECT 1 FROM x", id="create"),
+        pytest.param("WITH x AS (DROP TABLE y) SELECT 1 FROM x", id="drop"),
+        pytest.param("WITH x AS (ATTACH 'y.db' AS y) SELECT 1 FROM x", id="attach"),
+        pytest.param("WITH x AS (DETACH y) SELECT 1 FROM x", id="detach"),
+        pytest.param(
+            "WITH x AS (MERGE INTO t USING s ON t.id = s.id "
+            "WHEN MATCHED THEN UPDATE SET x = s.x) SELECT 1 FROM x",
+            id="merge",
+        ),
+    ],
+)
+def test_write_type_nested_in_cte_is_independently_isolated(sql: str) -> None:
+    """Each AST write-node type the guard checks is exercised on its own.
+
+    A bare top-level write statement (e.g. ``DROP TABLE t``) is already
+    refused by the read-only-prefix check before the AST write check ever
+    runs, so a fixture using only bare statements would still pass even with
+    the corresponding entry deleted from ``_WRITE_EXPRESSION_TYPES`` — the
+    "fixture trips two guards, isolates neither" trap this repo's testing.md
+    documents. Nesting each write inside a CTE forces the prefix check to
+    pass, so only the structural write check can be what refuses it.
+
+    INSERT and UPDATE already have their own CTE-nested tests above.
+    TruncateTable, Alter, and Copy are absent here because DuckDB's own
+    grammar (via sqlglot) refuses to parse any of them as a CTE body at all —
+    verified, each raises a ``ParseError`` rather than reaching this check in
+    either a bare or nested position, so no isolating fixture is
+    constructible for them; they stay in the checked tuple purely as
+    defense-in-depth (see the module comment on `_WRITE_EXPRESSION_TYPES`).
+    """
+    error = validate_read_only_query(sql)
+    assert error is not None
+    assert "Write operations" in error
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        pytest.param("EXPORT DATABASE 'dir'", id="export-bare"),
+        pytest.param("IMPORT DATABASE 'dir'", id="import-bare"),
+        pytest.param(
+            "REPLACE INTO core.fct_transactions VALUES (1)", id="replace-bare"
+        ),
+        pytest.param(
+            "WITH x AS (SELECT 1) EXPORT DATABASE 'dir'", id="export-with-prefixed"
+        ),
+        pytest.param(
+            "WITH x AS (SELECT 1) IMPORT DATABASE 'dir'", id="import-with-prefixed"
+        ),
+        pytest.param(
+            "WITH x AS (SELECT 1) REPLACE INTO core.fct_transactions VALUES (1)",
+            id="replace-with-prefixed",
+        ),
+    ],
+)
+def test_keywords_with_no_dedicated_ast_node_are_still_refused(
+    sql: str, populated_db: Database
+) -> None:
+    """EXPORT/IMPORT DATABASE and bare REPLACE INTO are refused end to end.
+
+    These three have no dedicated sqlglot node for the duckdb dialect, so
+    `_WRITE_EXPRESSION_TYPES` deliberately doesn't name them (see the module
+    comment). Pins that the rest of the pipeline still refuses every shape
+    regardless: a bare statement fails the read-only-prefix check, and a
+    WITH-prefixed attempt is a genuine DuckDB syntax error (a CTE body must be
+    a SELECT) that fails to parse — `validate_read_only_query` defers a parse
+    failure to the caller, and `execute_sql_query`'s own parse then raises
+    `sql_invalid_query`.
+    """
+    with pytest.raises(UserError) as ei:
+        execute_sql_query(populated_db, sql, max_rows=10)
+    assert ei.value.code == error_codes.SQL_INVALID_QUERY
+
+
 def test_audit_log_export_action_query_executes(populated_db: Database) -> None:
     """``... WHERE action LIKE 'export%'`` against ``app.audit_log`` returns rows.
 

--- a/tests/privacy/test_sql_query.py
+++ b/tests/privacy/test_sql_query.py
@@ -501,6 +501,84 @@ def test_write_query_raises(populated_db: Database) -> None:
     assert ei.value.code == error_codes.SQL_INVALID_QUERY
 
 
+# Every keyword `_WRITE_PATTERNS` blocks, lowercased the way the issue's
+# repro used them — the regex is case-insensitive either way.
+_WRITE_KEYWORDS = [
+    "insert",
+    "update",
+    "delete",
+    "drop",
+    "create",
+    "alter",
+    "truncate",
+    "replace",
+    "merge",
+    "copy",
+    "attach",
+    "detach",
+    "export",
+    "import",
+]
+
+
+@pytest.mark.parametrize("keyword", _WRITE_KEYWORDS)
+def test_write_keyword_inside_string_literal_is_not_rejected(keyword: str) -> None:
+    """A write keyword occurring only inside a quoted literal is not a write.
+
+    Regression test for #447: ``_WRITE_PATTERNS`` scanned raw query text, so
+    ``SELECT 'export' AS probe`` was refused as though it contained a real
+    ``EXPORT`` statement — one character away, ``SELECT 'expor' AS control``
+    was always accepted. The bug was scanning quoted content at all, not
+    anything specific to the word "export".
+    """
+    assert validate_read_only_query(f"SELECT '{keyword}' AS probe") is None
+
+
+def test_write_keyword_inside_string_literal_with_escaped_quote() -> None:
+    """An escaped quote (``''``) inside the literal must not end it early.
+
+    A naive quote-splitting mask would treat ``it''s`` as closing after
+    ``it`` and reopening before ``s``, which un-masks ``update`` between them.
+    """
+    assert validate_read_only_query("SELECT 'it''s time to update' AS note") is None
+
+
+def test_real_write_keyword_still_rejected_alongside_masked_literal() -> None:
+    """Masking a literal must not blind the guard to a REAL write elsewhere.
+
+    The query is a legal read-only prefix (``WITH ...``) carrying a write
+    verb in the CTE body, plus an unrelated masked literal — proving the mask
+    only removes false positives from quoted text, not detection of an
+    actual write.
+    """
+    error = validate_read_only_query(
+        "WITH x AS (UPDATE core.fct_transactions SET amount = 1) "
+        "SELECT 'export' AS probe FROM x"
+    )
+    assert error is not None
+    assert "Write operations" in error
+
+
+def test_audit_log_export_action_query_executes(populated_db: Database) -> None:
+    """``... WHERE action LIKE 'export%'`` against ``app.audit_log`` returns rows.
+
+    The motivating case from #447: this exact shape was refused before the
+    fix because ``'export%'`` contains the blocked ``EXPORT`` keyword inside a
+    string literal, masking the real binder/execution behavior entirely.
+    """
+    populated_db.execute(
+        "INSERT INTO app.audit_log (audit_id, actor, action, operation_id) "
+        "VALUES (?, ?, ?, ?)",
+        ["audit_test_1", "system", "export.run", "op_test_1"],
+    )
+    result = execute_sql_query(
+        populated_db,
+        "SELECT action FROM app.audit_log WHERE action LIKE 'export%'",
+        max_rows=10,
+    )
+    assert result.records == [{"action": "export.run"}]
+
+
 def test_multi_statement_query_is_rejected() -> None:
     """Two statements in one string are refused before any classification.
 

--- a/tests/privacy/test_sql_query.py
+++ b/tests/privacy/test_sql_query.py
@@ -501,8 +501,8 @@ def test_write_query_raises(populated_db: Database) -> None:
     assert ei.value.code == error_codes.SQL_INVALID_QUERY
 
 
-# Every keyword `_WRITE_PATTERNS` blocks, lowercased the way the issue's
-# repro used them — the regex is case-insensitive either way.
+# Every keyword the old text-scanning guard blocked, lowercased the way the
+# issue's repro used them — write detection is case-insensitive either way.
 _WRITE_KEYWORDS = [
     "insert",
     "update",
@@ -525,31 +525,57 @@ _WRITE_KEYWORDS = [
 def test_write_keyword_inside_string_literal_is_not_rejected(keyword: str) -> None:
     """A write keyword occurring only inside a quoted literal is not a write.
 
-    Regression test for #447: ``_WRITE_PATTERNS`` scanned raw query text, so
-    ``SELECT 'export' AS probe`` was refused as though it contained a real
-    ``EXPORT`` statement — one character away, ``SELECT 'expor' AS control``
-    was always accepted. The bug was scanning quoted content at all, not
-    anything specific to the word "export".
+    Regression test for #447: the write-operation guard used to scan raw
+    query text, so ``SELECT 'export' AS probe`` was refused as though it
+    contained a real ``EXPORT`` statement — one character away,
+    ``SELECT 'expor' AS control`` was always accepted. The bug was scanning
+    quoted content at all, not anything specific to the word "export". The
+    guard now checks the parsed AST's expression types instead of matching
+    text, so a word appearing in a position sqlglot never resolves to a write
+    node (a literal, an identifier, a comment) cannot trip it.
     """
     assert validate_read_only_query(f"SELECT '{keyword}' AS probe") is None
 
 
 def test_write_keyword_inside_string_literal_with_escaped_quote() -> None:
-    """An escaped quote (``''``) inside the literal must not end it early.
+    """An escaped quote (``''``) inside the literal is still just data.
 
-    A naive quote-splitting mask would treat ``it''s`` as closing after
-    ``it`` and reopening before ``s``, which un-masks ``update`` between them.
+    Pins that the shared parser (also used for schema/lineage resolution)
+    tokenizes ``it''s`` as one literal rather than ending it early at the
+    first apostrophe, which would otherwise un-mask ``update`` between them.
     """
     assert validate_read_only_query("SELECT 'it''s time to update' AS note") is None
 
 
-def test_real_write_keyword_still_rejected_alongside_masked_literal() -> None:
-    """Masking a literal must not blind the guard to a REAL write elsewhere.
+@pytest.mark.parametrize(
+    "sql",
+    [
+        pytest.param("SELECT e'export' AS probe", id="escape-string"),
+        pytest.param("SELECT $$export$$ AS probe", id="dollar-quoted-string"),
+        pytest.param('SELECT "export" FROM t', id="double-quoted-identifier"),
+        pytest.param("SELECT 1 -- export this later", id="trailing-comment"),
+    ],
+)
+def test_write_keyword_outside_a_string_literal_is_not_rejected(sql: str) -> None:
+    """A write keyword in a non-literal quoted/commented position is not a write.
 
-    The query is a legal read-only prefix (``WITH ...``) carrying a write
-    verb in the CTE body, plus an unrelated masked literal — proving the mask
-    only removes false positives from quoted text, not detection of an
-    actual write.
+    DuckDB has more ways to carry the text "export" without writing anything:
+    an escape string (``e'...'``), a dollar-quoted string (``$$...$$``), a
+    double-quoted identifier (a column literally named ``export``), and a
+    ``--`` comment. None of these produce a write-type AST node, so the
+    AST-based guard passes all four (verified against the real ``duckdb``
+    engine that each is valid, keyword-free SQL).
+    """
+    assert validate_read_only_query(sql) is None
+
+
+def test_real_write_keyword_still_rejected_alongside_string_literal() -> None:
+    """A quoted literal elsewhere must not blind the guard to a REAL write.
+
+    The query is a legal read-only prefix (``WITH ...``) carrying a write verb
+    in the CTE body, plus an unrelated string literal that also happens to
+    contain a write keyword — proving the AST check only reacts to an actual
+    write-type node, not to the word appearing anywhere in the text.
     """
     error = validate_read_only_query(
         "WITH x AS (UPDATE core.fct_transactions SET amount = 1) "

--- a/tests/privacy/test_sql_query.py
+++ b/tests/privacy/test_sql_query.py
@@ -588,6 +588,10 @@ def test_real_write_keyword_still_rejected_alongside_string_literal() -> None:
 @pytest.mark.parametrize(
     "sql",
     [
+        pytest.param(
+            "WITH x AS (INSERT INTO y VALUES (1)) SELECT 1 FROM x", id="insert"
+        ),
+        pytest.param("WITH x AS (DELETE FROM y) SELECT 1 FROM x", id="delete"),
         pytest.param("WITH x AS (CREATE TABLE y (a INT)) SELECT 1 FROM x", id="create"),
         pytest.param("WITH x AS (DROP TABLE y) SELECT 1 FROM x", id="drop"),
         pytest.param("WITH x AS (ATTACH 'y.db' AS y) SELECT 1 FROM x", id="attach"),
@@ -610,7 +614,8 @@ def test_write_type_nested_in_cte_is_independently_isolated(sql: str) -> None:
     documents. Nesting each write inside a CTE forces the prefix check to
     pass, so only the structural write check can be what refuses it.
 
-    INSERT and UPDATE already have their own CTE-nested tests above.
+    UPDATE already has its own CTE-nested test above
+    (``test_real_write_keyword_still_rejected_alongside_string_literal``).
     TruncateTable, Alter, and Copy are absent here because DuckDB's own
     grammar (via sqlglot) refuses to parse any of them as a CTE body at all —
     verified, each raises a ``ParseError`` rather than reaching this check in


### PR DESCRIPTION
## Summary

`sql_query` refused a read-only `SELECT` whenever a DML/DDL keyword like `export` or `update` appeared inside a string literal, a quoted identifier, or a comment — the write-operation guard scanned raw query text instead of what the query actually parsed to, so `SELECT 'export' AS probe` was rejected as though it contained a real `EXPORT` statement while `SELECT 'expor' AS control` (one character different) always worked. The guard now checks the parsed SQL's structure: a query is refused only when it actually contains a write-statement AST node (`INSERT`, `UPDATE`, `DROP`, etc.), anywhere in the tree including nested in a CTE, never when a write-shaped word merely appears in a literal, identifier, or comment position. This unblocks the motivating case — `... WHERE action LIKE 'export%'` against `app.audit_log`, the documented way to find an export's audit trail from the agent-safe SQL surface.

The fix went through two rounds of pre-push adversarial review. The first caught that an initial text-masking approach (blank out string-literal spans before matching) still missed DuckDB's other ways to carry the same text without writing anything — escape strings (`e'...'`), dollar-quoted strings (`$$...$$`), double-quoted identifiers, and `--` comments — which is what led to the AST-based redesign below. The second caught that the new check's coverage wasn't fully isolated by tests, and that one comment overstated a safety argument; both are addressed here.

Out of scope: `_FILE_ACCESS_FUNCTIONS` and `_QUOTED_TABLE_SCAN` in the same file still scan raw text and can be tripped by a keyword-shaped string literal (e.g. `SELECT 'read_csv(x.csv)' AS probe` is wrongly refused) — the same defect class as this issue, but a distinct pair of gates with their own threat model (one sibling, `_URL_SCHEME_PATTERNS`, deliberately matches literal content by design, per its own test). Flagging as a candidate follow-up rather than expanding this fix's blast radius.

## Changes

- `src/moneybin/privacy/sql_query.py`: replace the raw-text `_WRITE_PATTERNS` regex with `_contains_write_operation`, which walks the already-parsed sqlglot AST for concrete write-statement node types (`Insert`, `Update`, `Delete`, `Create`, `Drop`, `Alter`, `TruncateTable`, `Merge`, `Copy`, `Attach`, `Detach`). `validate_read_only_query` now parses once and reuses the tree for both the write check and the existing multi-statement check.
- `tests/privacy/test_sql_query.py`: regression tests for every previously-blocked keyword inside a string literal (plus escape/dollar-quoted strings, double-quoted identifiers, and comments), CTE-nesting isolation tests for each AST node type the guard checks, and end-to-end pinning tests confirming `EXPORT DATABASE`/`IMPORT DATABASE`/bare `REPLACE INTO` — which have no dedicated sqlglot node — are still refused via the read-only-prefix check or the parse step.
- `CHANGELOG.md`: user-facing entry under Fixed.

## Test plan

- `uv run pytest tests/privacy/test_sql_query.py -v` — 160 tests, all passing (149 pre-existing + 11 new).
- `make check test` — full suite green (format/lint/pyright clean; the only failures are two confirmed pre-existing/unrelated: a Google Sheets OAuth client-ID fixture mismatch already failing on `main`, and a source-checkout-commit test that only fails from a timing race against a commit landing mid-run in this same worktree, confirmed passing in isolation).
- Manually verified every case from the issue's repro and the review's findings against the real `duckdb` engine: `e'export'`/`$$export$$`/`"update"` (quoted identifier)/`-- export` (comment) all execute cleanly and are no longer refused; a real write nested in a CTE alongside an unrelated string literal is still refused; `EXPORT DATABASE`/`IMPORT DATABASE`/`REPLACE INTO` remain refused both bare and when `WITH`-prefixed.

## Related

Closes #447
