### PR TITLE
Extend the public-surface PII rule to PR text

### DIFF
--- a/.claude/rules/branching.md
+++ b/.claude/rules/branching.md
@@ -1,5 +1,5 @@
 ---
-description: "Branch prefix → PR label mapping, commit message style"
+description: "Branch prefix → PR label mapping, commit message style, account PII in public branch and PR text"
 ---
 
 # Branch Naming & PR Labels
@@ -8,18 +8,62 @@ description: "Branch prefix → PR label mapping, commit message style"
 
 `{type}/{kebab-case-summary}` — e.g., `feat/add-oauth-support`, `fix/null-pointer-auth`, `deps/bump-typer`.
 
-## Branch names are a public surface
+## Branch names, PR text, and comments are a public surface
 
-A branch name reaches origin, every PR URL, the reflog, and CI logs — all
-public. Never build one from real account data: an institution plus a last four
-is a linked pair, and a rename does not recall it. One such branch had to be
-force-deleted from origin with its history rewritten, and the worktree
-directory kept the name afterward.
+A branch name reaches origin, every PR URL, the reflog, and CI logs. A PR
+title, a PR body, a review comment, and a commit message reach the same places
+plus notification email. All of it is public, effectively permanent, and
+written by hand — `SanitizedLogFormatter` guards the log pipeline and nothing
+guards this. Never build any of it from real account data: an institution plus
+a last four is a linked pair, and a rename does not recall it. One such branch
+had to be force-deleted from origin with its history rewritten, and the
+worktree directory kept the name afterward. Editing a posted body is weaker
+still — GitHub keeps the prior revision in the body's edit history.
 
 Name the defect, not the account — `fix/cross-source-dedup-remediation`, never
 `fix/<bank>-<last-four>-…`. The same applies to worktree directory names, which
 the native mechanism derives from the branch. This rule file is public too:
 describe the shape, never paste the offending name as an example.
+
+### The log permitted list does not transfer
+
+AGENTS.md → Security bounds log output by `privacy-data-protection.md` §"What
+CAN appear", and that list permits **institution names and masked
+identifiers**. It permits them because a log line is machine-generated, locally
+scoped, and already filtered. Public text is none of those things, so that list
+is not the standard here. Keep all of the following out of a branch name, PR
+title, PR body, comment, or commit message:
+
+- An institution you actually bank with, linked to your own holdings. Naming
+  one impersonally is fine — as a parser's `<ORG>` value, a statement layout,
+  or a member of a class ("institutions that tokenize account numbers"). What
+  discloses is the link between a real institution and your own accounts or
+  profile, whatever the grammar carrying it: "two real accounts at
+  `<institution>`" and "validated against real accounts at `<institution>`"
+  disclose the same fact, and neither is possessive. Test for the link, not for
+  a word — no amount of surrounding verification detail makes it necessary.
+- A last four belonging to a real account, masked or bare — `****1234`,
+  `…1234`, `x1234` are the shapes. Masking is a display rule, not a licence to
+  publish.
+- A real account display name, nickname, or balance.
+- A real merchant, counterparty, or transaction description taken from your own
+  data.
+
+Synthetic values are the default for every example: `1234`, `5678`,
+`Vacation Fund …1111`. A real value never demonstrates a format better than a
+fabricated one does.
+
+### Verification evidence is where this leaks
+
+The diff is not the risk — the **Test plan** is. A verification line reports
+what you actually ran, and what you actually ran was a real profile. Report the
+shape instead of the holding: "a 3-year family-persona profile, two
+same-institution accounts, 2,886 transactions, no warning" carries the same
+evidentiary weight as naming the bank and none of the exposure. Counts, date
+spans, and pass/fail totals are fine; the identifying noun is what has to go.
+
+Scan the composed body before posting, not only the staged diff — the body is
+written from session context that no pre-commit check has ever seen.
 
 ## Type → Label Mapping
 

--- a/.claude/rules/branching.md
+++ b/.claude/rules/branching.md
@@ -1,5 +1,5 @@
 ---
-description: "Branch prefix → PR label mapping, commit message style, account PII in public branch and PR text"
+description: "Branch prefix → PR label mapping, commit message style, account PII in public branch, PR, and issue text"
 ---
 
 # Branch Naming & PR Labels
@@ -8,17 +8,24 @@ description: "Branch prefix → PR label mapping, commit message style, account 
 
 `{type}/{kebab-case-summary}` — e.g., `feat/add-oauth-support`, `fix/null-pointer-auth`, `deps/bump-typer`.
 
-## Branch names, PR text, and comments are a public surface
+## Branch names, PR and issue text, and comments are a public surface
 
 A branch name reaches origin, every PR URL, the reflog, and CI logs. A PR
-title, a PR body, a review comment, and a commit message reach the same places
-plus notification email. All of it is public, effectively permanent, and
-written by hand — `SanitizedLogFormatter` guards the log pipeline and nothing
-guards this. Never build any of it from real account data: an institution plus
-a last four is a linked pair, and a rename does not recall it. One such branch
-had to be force-deleted from origin with its history rewritten, and the
-worktree directory kept the name afterward. Editing a posted body is weaker
-still — GitHub keeps the prior revision in the body's edit history.
+title, a PR body, an issue title, an issue body, a review comment, and a commit
+message reach the same places plus notification email — and AGENTS.md routes
+public delivery status and implementation-ready work to this repository's
+issues, so an agent writes them routinely. All of it is public, effectively
+permanent, and written by hand — `SanitizedLogFormatter` guards the log
+pipeline and nothing guards this. Never build any of it from real user data: an
+institution plus a last four is a linked pair, and a rename does not recall it.
+One such branch had to be force-deleted from origin with its history rewritten,
+and the worktree directory kept the name afterward.
+
+Retraction is weaker than it looks, so the scan has to happen before posting.
+Editing a body leaves the prior revision in GitHub's edit history. Rewriting a
+branch is weaker still: a force-pushed-away commit stays fetchable by SHA
+through the commit URL and the REST commits API, so the leak survives a clean
+branch tip and a squash merge alike. Purging it takes GitHub Support, not Git.
 
 Name the defect, not the account — `fix/cross-source-dedup-remediation`, never
 `fix/<bank>-<last-four>-…`. The same applies to worktree directory names, which
@@ -32,22 +39,28 @@ CAN appear", and that list permits **institution names and masked
 identifiers**. It permits them because a log line is machine-generated, locally
 scoped, and already filtered. Public text is none of those things, so that list
 is not the standard here. Keep all of the following out of a branch name, PR
-title, PR body, comment, or commit message:
+title, PR body, issue title, issue body, comment, or commit message.
 
-- An institution you actually bank with, linked to your own holdings. Naming
-  one impersonally is fine — as a parser's `<ORG>` value, a statement layout,
-  or a member of a class ("institutions that tokenize account numbers"). What
-  discloses is the link between a real institution and your own accounts or
-  profile, whatever the grammar carrying it: "two real accounts at
-  `<institution>`" and "validated against real accounts at `<institution>`"
-  disclose the same fact, and neither is possessive. Test for the link, not for
-  a word — no amount of surrounding verification detail makes it necessary.
+"Real" throughout means it came out of the user's data — a live profile, a real
+session, a connected account. It never means the reader's: the agent applying
+this rule banks nowhere, so a test written as "an institution *you* bank with"
+excludes every institution and passes everything.
+
+- A real institution the user banks with, linked to their holdings. Naming an
+  institution impersonally is fine — as a parser's `<ORG>` value, a statement
+  layout, or a member of a class ("institutions that tokenize account
+  numbers"). What discloses is the link between a real institution and the
+  user's accounts or profile, whatever the grammar carrying it: "two real
+  accounts at `<institution>`" and "validated against real accounts at
+  `<institution>`" disclose the same fact, and neither is possessive. Test for
+  the link, not for a word — no amount of surrounding verification detail makes
+  it necessary.
 - A last four belonging to a real account, masked or bare — `****1234`,
   `…1234`, `x1234` are the shapes. Masking is a display rule, not a licence to
   publish.
 - A real account display name, nickname, or balance.
-- A real merchant, counterparty, or transaction description taken from your own
-  data.
+- A real merchant, counterparty, or transaction description taken from the
+  user's data.
 
 Synthetic values are the default for every example: `1234`, `5678`,
 `Vacation Fund …1111`. A real value never demonstrates a format better than a
@@ -56,8 +69,8 @@ fabricated one does.
 ### Verification evidence is where this leaks
 
 The diff is not the risk — the **Test plan** is. A verification line reports
-what you actually ran, and what you actually ran was a real profile. Report the
-shape instead of the holding: "a 3-year family-persona profile, two
+what the run actually touched, and what it touched was a real profile. Report
+the shape instead of the holding: "a 3-year family-persona profile, two
 same-institution accounts, 2,886 transactions, no warning" carries the same
 evidentiary weight as naming the bank and none of the exposure. Counts, date
 spans, and pass/fail totals are fine; the identifying noun is what has to go.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,7 @@ Security-critical parameters (crypto cost factors, key lengths, salt sizes) defi
 
 - **Encryption at rest**: AES-256-GCM on all DuckDB databases. See [`privacy-data-protection.md`](docs/specs/privacy-data-protection.md).
 - **No PII or financial data in logs.** The permitted list is `privacy-data-protection.md` §"What CAN appear" — record counts, entity ids, masked identifiers, category labels and institution names, status codes and operation names, and file paths (never file contents). Nothing outside it. One exception: an account label already reduced to its masked form (`****1098`) may appear in a refusal message, because a caller who passed several keys cannot otherwise tell which one was rejected. That mask is digit-pattern based, so it fires only on keys carrying five or more digits — a shorter key reaches the refusal, and the log, verbatim. Treat that as a known gap, not as licence to widen the exception. See `.claude/rules/identifiers.md` → "Account identifiers".
+- **Public text is stricter than logs.** Branch names, PR titles and bodies, review comments, and commit messages pass through no sanitizer and are effectively permanent. The log list above does *not* transfer: it permits institution names and masked identifiers, which are exactly what must never identify a real holding in public. See `.claude/rules/branching.md` → "Branch names, PR text, and comments are a public surface".
 - **Parameterized SQL** with `?` placeholders. See `.claude/rules/security.md` for full standards.
 
 ## Rules Index
@@ -193,6 +194,6 @@ Files in `.claude/rules/` auto-load via `paths:` frontmatter — path-scoped loa
 | Rule | Covers |
 |------|--------|
 | `design-principles.md` | Durable path selection: one-way-door classifier, public-contract trigger list, the agent protocol, coherence rule. Depth — post-launch contract evolution, the milestone addressing scheme (`M{phase}{letter}.{n}` — append, don't reinvent), what it does NOT mean, the ADR bar: `.claude/references/design-principles-depth.md` |
-| `branching.md` | Branch prefix → PR label mapping, commit message style |
+| `branching.md` | Branch prefix → PR label mapping, commit message style, account PII in public branch and PR text |
 | `sandboxing.md` | Bash invocation patterns: single commands, allowlisted pipelines, structured-output filtering, policy denials |
 | `agent-experience.md` | Required agent-experience report whenever you interact with MoneyBin's MCP server in a session |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ Security-critical parameters (crypto cost factors, key lengths, salt sizes) defi
 
 - **Encryption at rest**: AES-256-GCM on all DuckDB databases. See [`privacy-data-protection.md`](docs/specs/privacy-data-protection.md).
 - **No PII or financial data in logs.** The permitted list is `privacy-data-protection.md` §"What CAN appear" — record counts, entity ids, masked identifiers, category labels and institution names, status codes and operation names, and file paths (never file contents). Nothing outside it. One exception: an account label already reduced to its masked form (`****1098`) may appear in a refusal message, because a caller who passed several keys cannot otherwise tell which one was rejected. That mask is digit-pattern based, so it fires only on keys carrying five or more digits — a shorter key reaches the refusal, and the log, verbatim. Treat that as a known gap, not as licence to widen the exception. See `.claude/rules/identifiers.md` → "Account identifiers".
-- **Public text is stricter than logs.** Branch names, PR titles and bodies, review comments, and commit messages pass through no sanitizer and are effectively permanent. The log list above does *not* transfer: it permits institution names and masked identifiers, which are exactly what must never identify a real holding in public. See `.claude/rules/branching.md` → "Branch names, PR text, and comments are a public surface".
+- **Public text is stricter than logs.** Branch names, PR and issue titles and bodies, review comments, and commit messages pass through no sanitizer and are effectively permanent. The log list above does *not* transfer: it permits institution names and masked identifiers, which are exactly what must never identify a real holding in public. See `.claude/rules/branching.md` → "Branch names, PR and issue text, and comments are a public surface".
 - **Parameterized SQL** with `?` placeholders. See `.claude/rules/security.md` for full standards.
 
 ## Rules Index
@@ -194,6 +194,6 @@ Files in `.claude/rules/` auto-load via `paths:` frontmatter — path-scoped loa
 | Rule | Covers |
 |------|--------|
 | `design-principles.md` | Durable path selection: one-way-door classifier, public-contract trigger list, the agent protocol, coherence rule. Depth — post-launch contract evolution, the milestone addressing scheme (`M{phase}{letter}.{n}` — append, don't reinvent), what it does NOT mean, the ADR bar: `.claude/references/design-principles-depth.md` |
-| `branching.md` | Branch prefix → PR label mapping, commit message style, account PII in public branch and PR text |
+| `branching.md` | Branch prefix → PR label mapping, commit message style, account PII in public branch, PR, and issue text |
 | `sandboxing.md` | Bash invocation patterns: single commands, allowlisted pipelines, structured-output filtering, policy denials |
 | `agent-experience.md` | Required agent-experience report whenever you interact with MoneyBin's MCP server in a session |


### PR DESCRIPTION
## Summary

`.claude/rules/branching.md` already said a branch name is a public surface that must never carry real account data. A PR title, a PR body, a review comment, and a commit message reach the same places — origin, the PR URL, CI logs, notification email — pass through no sanitizer, and are effectively permanent. No rule said so. This generalizes the section to cover all of them.

The concrete gap: a merged PR's Test plan described its verification run by naming the institution behind a real profile. Nothing in the rules forbade it, and the log rule arguably permitted it.

## Background

AGENTS.md → Security bounds log output by `privacy-data-protection.md` §"What CAN appear", and that list permits institution names and masked identifiers. It can, because a log line is machine-generated, locally scoped, and already passed through `SanitizedLogFormatter`. Widening that bullet to "in logs or PRs" would therefore have authorized in a public body exactly what has to stay out of one. The rule instead states that the list does not transfer, and AGENTS.md gets a separate Security bullet routing to it.

Placement is `branching.md` rather than `shipping.md` because `branching.md` has no `paths:` frontmatter and loads every session, while `shipping.md` is scoped to `CHANGELOG.md`, `README.md`, `docs/roadmap.md`, `docs/features.md`, and `docs/specs/INDEX.md` — so it would not be in context while a body is being written, which is the moment the rule has to fire.

The new section also names the Test plan as the recurring leak path. The diff is scanned before a commit; the body is composed afterwards, out of session context that no staged-diff scan ever saw.

## Test plan

- [x] `uv run pytest tests/test_documentation_policy.py -q` — 8 passed, 0 failed. That is the gate AGENTS.md names for an agent-instruction and docs diff.
- [x] Verified the placement premise instead of assuming it: `branching.md` frontmatter carries `description:` only, so it is always loaded; `shipping.md` carries the five-path `paths:` list quoted above.
- [x] Sized the problem before writing the rule — scanned the bodies of the last 60 PRs for the patterns the new section names. Every masked-digit hit was either a bolded test count (`**9663 passed**`) or a synthetic example (`1234`, `5678`, `****1098`); the single dollar amount was synthetic; three bodies named an institution, two of them legitimately (a parser's `<ORG>` value, a statement layout). One did not, which is the case above.
- Reviewers should confirm every example in the new section is synthetic. This rule file is public, so a real value inside it would be the exact failure it describes.

## Related

Companion change in the `commit-push-pr` skill adds the mechanism: scan the drafted title and body before presenting them, and defer to the repository's own instructions for what counts as sensitive.
