### PR TITLE
perf: reuse migration schema template

### DIFF
--- a/tests/moneybin/conftest.py
+++ b/tests/moneybin/conftest.py
@@ -372,10 +372,10 @@ def db(
     object, schema, and per-test isolation are identical to a fresh build.
 
     Mark a test or module ``@pytest.mark.fresh_db`` to force a real per-test
-    schema build instead — required for tests whose *subject* is schema
-    creation, migration, or init (so they exercise the real mechanism rather
-    than a pre-baked copy). See ``test_template_copy_matches_fresh_build`` for
-    the invariant that keeps the two paths equivalent.
+    schema build instead — required when a test exercises schema creation,
+    automatic migration, or initialization itself. Individual migration tests
+    may use the template after reconstructing their pre-migration state; see
+    ``test_template_copy_matches_fresh_build`` for the equivalence invariant.
 
     Fast-path key constraint: the template is encrypted with the conftest
     default key (``"test-encryption-key-for-unit-tests"``). A module that

--- a/tests/moneybin/test_database/test_assume_initialized.py
+++ b/tests/moneybin/test_database/test_assume_initialized.py
@@ -134,21 +134,6 @@ def _catalog(db: Database) -> dict[str, object]:
     }
 
 
-def test_catalog_includes_indexes_and_comments(tmp_path: Path) -> None:
-    database = Database(
-        tmp_path / "test.duckdb",
-        secret_store=_store(),
-        no_auto_upgrade=True,
-        read_only=False,
-    )
-    try:
-        catalog = _catalog(database)
-        assert "indexes" in catalog
-        assert "catalog_comments" in catalog
-    finally:
-        database.close()
-
-
 def test_template_copy_matches_fresh_build(tmp_path: Path) -> None:
     # Build the copy artifacts first, so a failure here opens no connection.
     template = tmp_path / "template.duckdb"

--- a/tests/moneybin/test_database/test_assume_initialized.py
+++ b/tests/moneybin/test_database/test_assume_initialized.py
@@ -86,7 +86,7 @@ def test_assume_initialized_rejects_missing_file(tmp_path: Path) -> None:
 
 
 def _catalog(db: Database) -> dict[str, object]:
-    """Full schema fingerprint: tables, columns (+types), views, comments, constraints."""
+    """Full schema fingerprint, including indexes and catalog comments."""
     tables = db.execute(
         "SELECT schema_name, table_name, comment FROM duckdb_tables() "
         "ORDER BY schema_name, table_name"
@@ -96,8 +96,26 @@ def _catalog(db: Database) -> dict[str, object]:
         "FROM duckdb_columns() ORDER BY schema_name, table_name, column_name"
     ).fetchall()
     views = db.execute(
-        "SELECT schema_name, view_name FROM duckdb_views() "
+        "SELECT schema_name, view_name, comment FROM duckdb_views() "
         "ORDER BY schema_name, view_name"
+    ).fetchall()
+    indexes = db.execute(
+        "SELECT schema_name, index_name, table_name, is_unique, sql "
+        "FROM duckdb_indexes() "
+        "ORDER BY schema_name, index_name"
+    ).fetchall()
+    catalog_comments = db.execute(
+        "SELECT object_type, schema_name, object_name, comment FROM ("
+        "SELECT 'table' AS object_type, schema_name, table_name AS object_name, comment "
+        "FROM duckdb_tables() "
+        "UNION ALL "
+        "SELECT 'view' AS object_type, schema_name, view_name AS object_name, comment "
+        "FROM duckdb_views() "
+        "UNION ALL "
+        "SELECT 'index' AS object_type, schema_name, index_name AS object_name, comment "
+        "FROM duckdb_indexes()"
+        ") WHERE comment IS NOT NULL "
+        "ORDER BY object_type, schema_name, object_name"
     ).fetchall()
     # Constraints (PK/unique/check/not-null) — the dimension test_repo_metadata's
     # PK check relies on; included so schema drift in keys can't slip past.
@@ -110,8 +128,25 @@ def _catalog(db: Database) -> dict[str, object]:
         "tables": tables,
         "columns": columns,
         "views": views,
+        "indexes": indexes,
+        "catalog_comments": catalog_comments,
         "constraints": constraints,
     }
+
+
+def test_catalog_includes_indexes_and_comments(tmp_path: Path) -> None:
+    database = Database(
+        tmp_path / "test.duckdb",
+        secret_store=_store(),
+        no_auto_upgrade=True,
+        read_only=False,
+    )
+    try:
+        catalog = _catalog(database)
+        assert "indexes" in catalog
+        assert "catalog_comments" in catalog
+    finally:
+        database.close()
 
 
 def test_template_copy_matches_fresh_build(tmp_path: Path) -> None:

--- a/tests/moneybin/test_migration_v003.py
+++ b/tests/moneybin/test_migration_v003.py
@@ -1,11 +1,7 @@
 """Tests for V003: add import_id/source_type/source_origin to raw.ofx_* tables."""
 
-import pytest
-
 from moneybin.database import Database
 from moneybin.sql.migrations.V003__ofx_import_batch_columns import migrate
-
-pytestmark = pytest.mark.fresh_db
 
 
 class TestV003Migration:

--- a/tests/moneybin/test_migration_v007.py
+++ b/tests/moneybin/test_migration_v007.py
@@ -15,12 +15,8 @@ from __future__ import annotations
 
 import json
 
-import pytest
-
 from moneybin.database import Database
 from moneybin.sql.migrations.V007__transaction_curation import migrate
-
-pytestmark = pytest.mark.fresh_db
 
 
 def _drop_and_recreate_legacy_notes(db: Database) -> None:

--- a/tests/moneybin/test_migration_v008.py
+++ b/tests/moneybin/test_migration_v008.py
@@ -20,8 +20,6 @@ from tests.moneybin.migration_helpers import (
     run_migration,
 )
 
-pytestmark = pytest.mark.fresh_db
-
 
 def _reset_to_pre_v008_state(db: Database) -> None:
     """Reverse the V008 end-state: drop `exemplars`, restore raw_pattern NOT NULL."""

--- a/tests/moneybin/test_migration_v009.py
+++ b/tests/moneybin/test_migration_v009.py
@@ -20,8 +20,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V009__purge_redundant_table_migrations import migrate
 from tests.moneybin.migration_helpers import insert_rows, run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 _SCHEMA_MIGRATIONS_COLS = (
     "version",
     "filename",

--- a/tests/moneybin/test_migration_v010.py
+++ b/tests/moneybin/test_migration_v010.py
@@ -31,8 +31,6 @@ from tests.moneybin.migration_helpers import (
     run_migration,
 )
 
-pytestmark = pytest.mark.fresh_db
-
 
 def _reset_to_pre_v010_state(db: Database) -> None:
     """Reverse the V010 end-state so the migration has work to do.

--- a/tests/moneybin/test_migration_v011.py
+++ b/tests/moneybin/test_migration_v011.py
@@ -29,8 +29,6 @@ from tests.moneybin.migration_helpers import (
     run_migration,
 )
 
-pytestmark = pytest.mark.fresh_db
-
 
 def _reset_to_pre_v011_state(db: Database) -> None:
     """Drop the V011 `updated_at` column so the migration has work to do."""

--- a/tests/moneybin/test_migration_v012.py
+++ b/tests/moneybin/test_migration_v012.py
@@ -19,8 +19,6 @@ import pytest
 from moneybin.database import Database
 from moneybin.sql.migrations.V012__drop_merchant_overrides import migrate
 
-pytestmark = pytest.mark.fresh_db
-
 
 def _table_exists(db: Database, schema: str, table: str) -> bool:
     row = db.execute(

--- a/tests/moneybin/test_migration_v013.py
+++ b/tests/moneybin/test_migration_v013.py
@@ -22,8 +22,6 @@ from moneybin.sql.migrations.V013__add_content_hash_to_schema_migrations import 
 )
 from tests.moneybin.migration_helpers import column_exists, insert_rows, run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 _SEED_COLUMNS = ("version", "filename", "checksum", "success")
 
 

--- a/tests/moneybin/test_migration_v014.py
+++ b/tests/moneybin/test_migration_v014.py
@@ -22,8 +22,6 @@ from moneybin.sql.migrations.V014__add_category_id_columns import migrate
 from tests.moneybin.db_helpers import create_core_tables
 from tests.moneybin.migration_helpers import run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 
 @pytest.fixture()
 def v014_db(db: Database) -> Database:

--- a/tests/moneybin/test_migration_v015.py
+++ b/tests/moneybin/test_migration_v015.py
@@ -27,8 +27,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V015__relax_user_categories_text_unique import migrate
 from tests.moneybin.migration_helpers import run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 
 @pytest.fixture()
 def v015_db(db: Database) -> Database:

--- a/tests/moneybin/test_migration_v016.py
+++ b/tests/moneybin/test_migration_v016.py
@@ -18,8 +18,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V016__add_rule_id_to_proposed_rules import migrate
 from tests.moneybin.migration_helpers import run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 LINKED_PATTERN = "STARBUCKS"
 ORPHAN_PATTERN = "WHOLE_FOODS"
 PENDING_PATTERN = "TARGET"

--- a/tests/moneybin/test_migration_v019.py
+++ b/tests/moneybin/test_migration_v019.py
@@ -21,8 +21,6 @@ from moneybin.sql.migrations.V019__add_deleted_from_source_at_to_tabular import 
 )
 from tests.moneybin.migration_helpers import column_exists, run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 CSV_TXN_ID = "csv_aaaa11112222bbbb"
 TSV_TXN_ID = "tsv_cccc33334444dddd"
 EXCEL_TXN_ID = "xls_eeee55556666ffff"

--- a/tests/moneybin/test_migration_v020.py
+++ b/tests/moneybin/test_migration_v020.py
@@ -26,8 +26,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V020__create_app_gsheet_connections import migrate
 from tests.moneybin.migration_helpers import column_exists, run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 _ALL_COLUMNS: tuple[str, ...] = (
     "connection_id",
     "spreadsheet_id",

--- a/tests/moneybin/test_migration_v021.py
+++ b/tests/moneybin/test_migration_v021.py
@@ -27,8 +27,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V021__create_raw_gsheet_seeds import migrate
 from tests.moneybin.migration_helpers import column_exists, run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 _ALL_COLUMNS: tuple[str, ...] = (
     "connection_id",
     "spreadsheet_id",

--- a/tests/moneybin/test_migration_v022.py
+++ b/tests/moneybin/test_migration_v022.py
@@ -9,8 +9,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V022__create_app_ai_consent_grants import migrate
 from tests.moneybin.migration_helpers import column_exists, run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 _ALL_COLUMNS: tuple[str, ...] = (
     "grant_id",
     "feature_category",

--- a/tests/moneybin/test_migration_v023.py
+++ b/tests/moneybin/test_migration_v023.py
@@ -21,8 +21,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V023__add_operation_id_to_audit_log import migrate
 from tests.moneybin.migration_helpers import column_info, run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 # Realistic pre-spec audit rows: full 32-hex audit_ids, varied actors/targets.
 _LEGACY_ROWS: tuple[tuple[str, str, str], ...] = (
     ("a1b2c3d4e5f60718293a4b5c6d7e8f90", "cli", "note.add"),

--- a/tests/moneybin/test_migration_v024.py
+++ b/tests/moneybin/test_migration_v024.py
@@ -24,8 +24,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V024__add_undo_columns_to_audit_log import migrate
 from tests.moneybin.migration_helpers import column_info, run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 # Realistic pre-spec audit rows: full 32-hex audit_ids + their op group ids.
 _LEGACY_ROWS: tuple[tuple[str, str, str, str], ...] = (
     ("a1b2c3d4e5f60718293a4b5c6d7e8f90", "cli", "note.add", "op_" + "1" * 32),

--- a/tests/moneybin/test_migration_v026.py
+++ b/tests/moneybin/test_migration_v026.py
@@ -39,8 +39,6 @@ from moneybin.sql.migrations.V026__add_transaction_id_to_manual_transactions imp
 )
 from tests.moneybin.migration_helpers import column_exists, run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 
 def _expected_hash(source_transaction_id: str, account_id: str) -> str:
     """V026's frozen backfill hash: ``manual|source_transaction_id|account_id``.

--- a/tests/moneybin/test_migration_v030.py
+++ b/tests/moneybin/test_migration_v030.py
@@ -8,12 +8,8 @@ installs get them via this migration. Pure additive (`ADD COLUMN IF NOT EXISTS
 
 from __future__ import annotations
 
-import pytest
-
 from moneybin.database import Database
 from moneybin.sql.migrations.V030__add_plaid_transaction_fields import migrate
-
-pytestmark = pytest.mark.fresh_db
 
 _NEW_COLUMNS = [
     "original_description",

--- a/tests/moneybin/test_migration_v032.py
+++ b/tests/moneybin/test_migration_v032.py
@@ -24,8 +24,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V032__add_category_source_map_and_class import migrate
 from tests.moneybin.migration_helpers import column_exists, column_info, run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 _BRIDGE_COLUMNS = {
     "source_type",
     "source_category_code",

--- a/tests/moneybin/test_migration_v033.py
+++ b/tests/moneybin/test_migration_v033.py
@@ -18,8 +18,6 @@ from moneybin.sql.migrations.V033__add_transaction_categories_source_type import
 )
 from tests.moneybin.migration_helpers import column_exists, column_info, run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 _PRE_V033_DDL = """
     CREATE TABLE app.transaction_categories (
         transaction_id VARCHAR PRIMARY KEY,

--- a/tests/moneybin/test_migration_v034.py
+++ b/tests/moneybin/test_migration_v034.py
@@ -26,8 +26,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V034__add_investment_tables import migrate
 from tests.moneybin.migration_helpers import column_exists, run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 
 def _table_exists(db: Database, schema: str, table: str) -> bool:
     row = db.execute(

--- a/tests/moneybin/test_migration_v035.py
+++ b/tests/moneybin/test_migration_v035.py
@@ -26,8 +26,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V035__add_securities_created_by import migrate
 from tests.moneybin.migration_helpers import run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 _OLD_SHAPE = """
 CREATE TABLE app.securities (
     security_id VARCHAR NOT NULL PRIMARY KEY,

--- a/tests/moneybin/test_migration_v036.py
+++ b/tests/moneybin/test_migration_v036.py
@@ -5,15 +5,11 @@ from __future__ import annotations
 import json
 from typing import Any
 
-import pytest
-
 from moneybin.database import Database
 from moneybin.sql.migrations.V036__rename_iso_currency_code_to_currency_code import (
     migrate,
 )
 from tests.moneybin.migration_helpers import column_exists, insert_rows, run_migration
-
-pytestmark = pytest.mark.fresh_db
 
 _ROWS: list[tuple[str, str | None]] = [
     ("acct_checking01", "USD"),

--- a/tests/moneybin/test_migration_v037.py
+++ b/tests/moneybin/test_migration_v037.py
@@ -7,12 +7,8 @@ it is idempotent and needs no backfill.
 
 from __future__ import annotations
 
-import pytest
-
 from moneybin.database import Database
 from moneybin.sql.migrations.V037__add_currency_code_to_ofx_tables import migrate
-
-pytestmark = pytest.mark.fresh_db
 
 # The pre-V037 shape of raw.ofx_transactions/raw.ofx_balances (no currency_code).
 _PRE_V037_TRANSACTIONS_DDL = """

--- a/tests/moneybin/test_migration_v038.py
+++ b/tests/moneybin/test_migration_v038.py
@@ -9,14 +9,10 @@ idempotent and needs no backfill.
 
 from __future__ import annotations
 
-import pytest
-
 from moneybin.database import Database
 from moneybin.sql.migrations.V038__add_iso_currency_code_to_plaid_balances import (
     migrate,
 )
-
-pytestmark = pytest.mark.fresh_db
 
 _NEW_COLUMNS = ["iso_currency_code", "unofficial_currency_code"]
 

--- a/tests/moneybin/test_migration_v041.py
+++ b/tests/moneybin/test_migration_v041.py
@@ -9,8 +9,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V041__create_app_export_destinations import migrate
 from tests.moneybin.migration_helpers import run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 
 def test_v041_creates_export_destinations(db: Database) -> None:
     """The migration creates the exact cross-kind destination registry."""

--- a/tests/moneybin/test_migration_v042.py
+++ b/tests/moneybin/test_migration_v042.py
@@ -38,8 +38,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V042__widen_security_link_ref_kinds import migrate
 from tests.moneybin.migration_helpers import run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 _OLD_SHAPE = """
 CREATE TABLE app.security_links (
     link_id VARCHAR NOT NULL,

--- a/tests/moneybin/test_migration_v043.py
+++ b/tests/moneybin/test_migration_v043.py
@@ -24,8 +24,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V043__create_app_security_price_overrides import migrate
 from tests.moneybin.migration_helpers import run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 
 def _insert_override(
     db: Database,

--- a/tests/moneybin/test_migration_v044.py
+++ b/tests/moneybin/test_migration_v044.py
@@ -9,8 +9,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V044__create_app_profile_settings import migrate
 from tests.moneybin.migration_helpers import run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 _COLUMN_SHAPE_SQL = """
 SELECT column_name, data_type, is_nullable
   FROM information_schema.columns

--- a/tests/moneybin/test_migration_v045.py
+++ b/tests/moneybin/test_migration_v045.py
@@ -9,8 +9,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V045__create_app_user_reports import migrate
 from tests.moneybin.migration_helpers import run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 #: The columns a save must supply; everything else carries a default.
 _REQUIRED = (
     "report_id",

--- a/tests/moneybin/test_migration_v046.py
+++ b/tests/moneybin/test_migration_v046.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-import pytest
-
 from moneybin.database import Database
 from moneybin.loaders import import_log
 from moneybin.sql.migrations.V046__add_file_sha256_to_import_log import migrate
 from tests.moneybin.migration_helpers import run_migration
-
-pytestmark = pytest.mark.fresh_db
 
 _COLUMN_SHAPE_SQL = """
 SELECT column_name, data_type, is_nullable

--- a/tests/moneybin/test_migration_v047.py
+++ b/tests/moneybin/test_migration_v047.py
@@ -19,8 +19,6 @@ from moneybin.sql.migrations.V047__add_fitid_repaired_to_ofx_transactions import
 )
 from tests.moneybin.migration_helpers import column_exists, run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 
 def _insert_pre_migration_row(
     db: Database,

--- a/tests/moneybin/test_migration_v048.py
+++ b/tests/moneybin/test_migration_v048.py
@@ -24,8 +24,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V048__create_raw_exchange_rates import migrate
 from tests.moneybin.migration_helpers import run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 
 def _insert_rate(
     db: Database,

--- a/tests/moneybin/test_migration_v049.py
+++ b/tests/moneybin/test_migration_v049.py
@@ -23,8 +23,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V049__create_app_exchange_rate_overrides import migrate
 from tests.moneybin.migration_helpers import run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 
 def _insert_override(
     db: Database,

--- a/tests/moneybin/test_migration_v050.py
+++ b/tests/moneybin/test_migration_v050.py
@@ -15,8 +15,6 @@ from moneybin.database import Database
 from moneybin.sql.migrations.V050__add_plaid_account_identity_fields import migrate
 from tests.moneybin.migration_helpers import column_exists, insert_rows, run_migration
 
-pytestmark = pytest.mark.fresh_db
-
 _PRE_MIGRATION_COLUMNS = (
     "account_id",
     "account_type",

--- a/tests/moneybin/test_migrations.py
+++ b/tests/moneybin/test_migrations.py
@@ -20,9 +20,8 @@ from moneybin.migrations import (
 )
 from tests.moneybin.test_cli.test_message_hygiene import names_an_internal_dependency
 
-pytestmark = pytest.mark.fresh_db
 
-
+@pytest.mark.fresh_db
 class TestMigrationSchema:
     """Verify migration tracking tables are created by init_schemas."""
 


### PR DESCRIPTION
## Summary

- Harden the template-copy equivalence invariant to compare indexes and catalog comments.
- Reuse the validated schema template for migration-runner and V0NN migration tests.

## Verification

- Focused migration suite: 303 passed in 12.79s (base: 302 passed in 31.62s).
- Changed-file adversarial review: 300 passed.
- Full unit gate: 10,114 passed, 4 skipped; one unrelated parity failure reproduces on the exact base commit.
