### PR TITLE
test: cut redundant pipeline setup

### DIFF
--- a/tests/e2e/test_concurrent_access.py
+++ b/tests/e2e/test_concurrent_access.py
@@ -228,16 +228,18 @@ def test_write_write_contention_retries(
         text=True,
         env=env,
     )
-    _wait_for_marker(signal_path)
-    pb = subprocess.Popen(  # noqa: S603 — controlled test script
-        [sys.executable, "-c", textwrap.dedent(worker_b)],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        env=env,
-    )
-    _wait_for_marker(retry_path)
-    release_path.touch()
+    try:
+        _wait_for_marker(signal_path)
+        pb = subprocess.Popen(  # noqa: S603 — controlled test script
+            [sys.executable, "-c", textwrap.dedent(worker_b)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+        _wait_for_marker(retry_path)
+    finally:
+        release_path.touch()
 
     _, a_err = pa.communicate(timeout=15)
     b_out, b_err = pb.communicate(timeout=20)
@@ -336,16 +338,18 @@ def test_read_only_holder_blocks_write_then_succeeds(
         text=True,
         env=env,
     )
-    _wait_for_marker(signal_path)
-    pb = subprocess.Popen(  # noqa: S603 — controlled test script
-        [sys.executable, "-c", textwrap.dedent(worker_b)],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        env=env,
-    )
-    _wait_for_marker(retry_path)
-    release_path.touch()
+    try:
+        _wait_for_marker(signal_path)
+        pb = subprocess.Popen(  # noqa: S603 — controlled test script
+            [sys.executable, "-c", textwrap.dedent(worker_b)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+        _wait_for_marker(retry_path)
+    finally:
+        release_path.touch()
 
     _, a_err = pa.communicate(timeout=15)
     b_out, b_err = pb.communicate(timeout=20)

--- a/tests/e2e/test_concurrent_access.py
+++ b/tests/e2e/test_concurrent_access.py
@@ -56,6 +56,17 @@ def _make_env(db_path: Path, encryption_key: str) -> dict[str, str]:
 
 # The encryption key used for all tests in this module.
 _TEST_KEY = "concurrent-access-test-key-abc123"  # noqa: S105 — test-only key
+_MARKER_TIMEOUT = 15.0
+
+
+def _wait_for_marker(marker: Path) -> None:
+    """Wait until a subprocess proves it has reached the named state."""
+    deadline = time.monotonic() + _MARKER_TIMEOUT
+    while time.monotonic() < deadline:
+        if marker.exists():
+            return
+        time.sleep(0.05)
+    pytest.fail(f"Timed out waiting for readiness marker: {marker}")
 
 
 @pytest.fixture(scope="module")
@@ -149,6 +160,8 @@ def test_write_write_contention_retries(
     db_path, key = concurrent_db
     env = _make_env(db_path, key)
     signal_path = tmp_path / "a_write_ready.flag"
+    release_path = tmp_path / "release_write.flag"
+    retry_path = tmp_path / "b_write_retried.flag"
 
     worker_a = f"""
     import time, sys, os
@@ -163,7 +176,9 @@ def test_write_write_contention_retries(
 
     with Database(db_path, read_only=False, secret_store=mock_store, no_auto_upgrade=True) as db:
         open("{signal_path}", "w").close()
-        time.sleep(3)
+        release_path = Path("{release_path}")
+        while not release_path.exists():
+            time.sleep(0.05)
     sys.exit(0)
     """
 
@@ -177,12 +192,7 @@ def test_write_write_contention_retries(
     key = os.environ["_MB_TEST_KEY"]
     mock_store = MagicMock()
     mock_store.get_key.return_value = key
-    signal_path = "{signal_path}"
-
-    for _ in range(50):
-        if os.path.exists(signal_path):
-            break
-        time.sleep(0.1)
+    retry_path = "{retry_path}"
 
     # Manual retry loop — same pattern as get_database() internally.
     retry_count = 0
@@ -198,6 +208,7 @@ def test_write_write_contention_retries(
         except DatabaseLockError as e:
             last_exc = e
             retry_count += 1
+            Path(retry_path).touch()
             time.sleep(delay)
             delay = min(delay * 1.5, 0.5)
 
@@ -217,7 +228,7 @@ def test_write_write_contention_retries(
         text=True,
         env=env,
     )
-    time.sleep(0.3)
+    _wait_for_marker(signal_path)
     pb = subprocess.Popen(  # noqa: S603 — controlled test script
         [sys.executable, "-c", textwrap.dedent(worker_b)],
         stdout=subprocess.PIPE,
@@ -225,6 +236,8 @@ def test_write_write_contention_retries(
         text=True,
         env=env,
     )
+    _wait_for_marker(retry_path)
+    release_path.touch()
 
     _, a_err = pa.communicate(timeout=15)
     b_out, b_err = pb.communicate(timeout=20)
@@ -253,6 +266,8 @@ def test_read_only_holder_blocks_write_then_succeeds(
     db_path, key = concurrent_db
     env = _make_env(db_path, key)
     signal_path = tmp_path / "a_ro_ready.flag"
+    release_path = tmp_path / "release_read.flag"
+    retry_path = tmp_path / "b_read_retried.flag"
 
     worker_a = f"""
     import time, sys, os
@@ -267,7 +282,9 @@ def test_read_only_holder_blocks_write_then_succeeds(
 
     with Database(db_path, read_only=True, secret_store=mock_store) as db:
         open("{signal_path}", "w").close()
-        time.sleep(4)
+        release_path = Path("{release_path}")
+        while not release_path.exists():
+            time.sleep(0.05)
     sys.exit(0)
     """
 
@@ -281,12 +298,7 @@ def test_read_only_holder_blocks_write_then_succeeds(
     key = os.environ["_MB_TEST_KEY"]
     mock_store = MagicMock()
     mock_store.get_key.return_value = key
-    signal_path = "{signal_path}"
-
-    for _ in range(50):
-        if os.path.exists(signal_path):
-            break
-        time.sleep(0.1)
+    retry_path = "{retry_path}"
 
     retry_count = 0
     deadline = time.monotonic() + 9.0
@@ -301,6 +313,7 @@ def test_read_only_holder_blocks_write_then_succeeds(
         except DatabaseLockError as e:
             last_exc = e
             retry_count += 1
+            Path(retry_path).touch()
             time.sleep(delay)
             delay = min(delay * 1.5, 0.5)
         except Exception as e:
@@ -323,7 +336,7 @@ def test_read_only_holder_blocks_write_then_succeeds(
         text=True,
         env=env,
     )
-    time.sleep(0.3)
+    _wait_for_marker(signal_path)
     pb = subprocess.Popen(  # noqa: S603 — controlled test script
         [sys.executable, "-c", textwrap.dedent(worker_b)],
         stdout=subprocess.PIPE,
@@ -331,6 +344,8 @@ def test_read_only_holder_blocks_write_then_succeeds(
         text=True,
         env=env,
     )
+    _wait_for_marker(retry_path)
+    release_path.touch()
 
     _, a_err = pa.communicate(timeout=15)
     b_out, b_err = pb.communicate(timeout=20)

--- a/tests/e2e/test_e2e_mcp.py
+++ b/tests/e2e/test_e2e_mcp.py
@@ -10,11 +10,14 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import AsyncIterator
 from typing import Any
 
 import pytest
+import pytest_asyncio
 
 from tests.e2e.conftest import (
+    _MONEYBIN_BIN,  # pyright: ignore[reportPrivateUsage]  # resolved E2E entrypoint
     FAST_ARGON2_ENV,
     make_workflow_env,
     seed_pending_match,
@@ -35,48 +38,62 @@ def _server_env(mcp_env: dict[str, str]) -> dict[str, str]:
     return {**os.environ, **FAST_ARGON2_ENV, **mcp_env}
 
 
+def _server_params(env: dict[str, str]) -> Any:
+    """Use the active test venv's entrypoint, without per-server uv resolution."""
+    from mcp.client.stdio import StdioServerParameters
+
+    if not _MONEYBIN_BIN.exists():
+        pytest.fail(
+            f"moneybin entrypoint not found at {_MONEYBIN_BIN}. "
+            "Run `uv sync` to populate the venv before running E2E tests."
+        )
+    return StdioServerParameters(
+        command=str(_MONEYBIN_BIN),
+        args=["mcp", "serve"],
+        env=env,
+    )
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="module")
+async def mcp_server_tools(
+    mcp_env: dict[str, str],
+) -> AsyncIterator[tuple[str, set[str]]]:
+    """Boot the immutable standard registry once for registration-only assertions."""
+    from mcp import ClientSession
+    from mcp.client.stdio import stdio_client
+
+    async with stdio_client(_server_params(_server_env(mcp_env))) as (read, write):
+        async with ClientSession(read, write) as session:
+            initialized = await session.initialize()
+            tools = await session.list_tools()
+            server_tools = (
+                initialized.serverInfo.name,
+                {tool.name for tool in tools.tools},
+            )
+    yield server_tools
+
+
 class TestMCPServerBoot:
     """Verify the MCP server starts, registers tools, and responds to protocol requests."""
 
     async def test_server_initializes_and_lists_tools(
-        self, mcp_env: dict[str, str]
+        self, mcp_server_tools: tuple[str, set[str]]
     ) -> None:
         """MCP server boots on an encrypted DB and reports registered tools."""
-        from mcp import ClientSession
-        from mcp.client.stdio import StdioServerParameters, stdio_client
+        server_name, tool_names = mcp_server_tools
+        assert server_name == "MoneyBin"
 
-        server_params = StdioServerParameters(
-            command="uv",  # noqa: S607 — uv is on PATH in dev environments
-            args=["run", "moneybin", "mcp", "serve"],
-            env=_server_env(mcp_env),
-        )
+        from moneybin.mcp.surface import STANDARD_TOOL_NAMES
 
-        async with stdio_client(server_params) as (read, write):
-            async with ClientSession(read, write) as session:
-                result = await session.initialize()
-
-                # Server should identify itself
-                assert result.serverInfo.name == "MoneyBin"
-
-                # List tools — core namespaces should be registered
-                tools_result = await session.list_tools()
-                tool_names = [t.name for t in tools_result.tools]
-
-                from moneybin.mcp.surface import STANDARD_TOOL_NAMES
-
-                assert set(tool_names) == STANDARD_TOOL_NAMES
+        assert tool_names == STANDARD_TOOL_NAMES
 
     async def test_server_invokes_tool(self, mcp_env: dict[str, str]) -> None:
         """MCP server can invoke a tool and return a valid response envelope."""
         from mcp import ClientSession
-        from mcp.client.stdio import StdioServerParameters, stdio_client
+        from mcp.client.stdio import stdio_client
         from mcp.types import TextContent
 
-        server_params = StdioServerParameters(
-            command="uv",  # noqa: S607 — uv is on PATH in dev environments
-            args=["run", "moneybin", "mcp", "serve"],
-            env=_server_env(mcp_env),
-        )
+        server_params = _server_params(_server_env(mcp_env))
 
         async with stdio_client(server_params) as (read, write):
             async with ClientSession(read, write) as session:
@@ -97,52 +114,41 @@ class TestMCPServerBoot:
                 assert "actions" in envelope
                 assert envelope["summary"]["sensitivity"] == "medium"
 
-    async def test_accounts_v2_tools_registered(self, mcp_env: dict[str, str]) -> None:
+    async def test_accounts_v2_tools_registered(
+        self, mcp_server_tools: tuple[str, set[str]]
+    ) -> None:
         """All v2 accounts namespace tools are registered on the server.
 
         The narrow write tools (rename/include/archive/unarchive) were folded
         into ``accounts_set``; confirm both that ``accounts_set`` is present
         and that the removed names are gone.
         """
-        from mcp import ClientSession
-        from mcp.client.stdio import StdioServerParameters, stdio_client
+        _, tool_names = mcp_server_tools
 
-        server_params = StdioServerParameters(
-            command="uv",  # noqa: S607
-            args=["run", "moneybin", "mcp", "serve"],
-            env=_server_env(mcp_env),
-        )
+        standard_accounts_tools = {
+            "accounts",
+            "accounts_set",
+            "accounts_balances",
+            "accounts_balance_assert",
+        }
+        assert standard_accounts_tools <= tool_names
 
-        async with stdio_client(server_params) as (read, write):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                tools_result = await session.list_tools()
-                tool_names = {t.name for t in tools_result.tools}
-
-                standard_accounts_tools = {
-                    "accounts",
-                    "accounts_set",
-                    "accounts_balances",
-                    "accounts_balance_assert",
-                }
-                assert standard_accounts_tools <= tool_names
-
-                # Legacy narrow boundaries are folded into the standard tools.
-                for removed in (
-                    "accounts_get",
-                    "accounts_summary",
-                    "accounts_balance_history",
-                    "accounts_balance_reconcile",
-                    "accounts_balance_assertions",
-                    "accounts_balance_assertion_delete",
-                    "accounts_rename",
-                    "accounts_include",
-                    "accounts_archive",
-                    "accounts_unarchive",
-                ):
-                    assert removed not in tool_names, (
-                        f"{removed} should be folded into accounts_set"
-                    )
+        # Legacy narrow boundaries are folded into the standard tools.
+        for removed in (
+            "accounts_get",
+            "accounts_summary",
+            "accounts_balance_history",
+            "accounts_balance_reconcile",
+            "accounts_balance_assertions",
+            "accounts_balance_assertion_delete",
+            "accounts_rename",
+            "accounts_include",
+            "accounts_archive",
+            "accounts_unarchive",
+        ):
+            assert removed not in tool_names, (
+                f"{removed} should be folded into accounts_set"
+            )
 
     async def test_accounts_balance_assertions_view_invocable(
         self, mcp_env: dict[str, str]
@@ -155,14 +161,10 @@ class TestMCPServerBoot:
         on a fresh DB and returns an empty assertions list.
         """
         from mcp import ClientSession
-        from mcp.client.stdio import StdioServerParameters, stdio_client
+        from mcp.client.stdio import stdio_client
         from mcp.types import TextContent
 
-        server_params = StdioServerParameters(
-            command="uv",  # noqa: S607
-            args=["run", "moneybin", "mcp", "serve"],
-            env=_server_env(mcp_env),
-        )
+        server_params = _server_params(_server_env(mcp_env))
 
         async with stdio_client(server_params) as (read, write):
             async with ClientSession(read, write) as session:
@@ -187,100 +189,63 @@ class TestReportsTool:
     """Generic report catalog/runner smoke tests."""
 
     async def test_generic_reports_tool_registered(
-        self, mcp_env: dict[str, str]
+        self, mcp_server_tools: tuple[str, set[str]]
     ) -> None:
         """The generic reports boundary replaces every per-report tool."""
-        from mcp import ClientSession
-        from mcp.client.stdio import StdioServerParameters, stdio_client
+        _, tool_names = mcp_server_tools
 
-        server_params = StdioServerParameters(
-            command="uv",  # noqa: S607
-            args=["run", "moneybin", "mcp", "serve"],
-            env=_server_env(mcp_env),
-        )
-
-        async with stdio_client(server_params) as (read, write):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                tools_result = await session.list_tools()
-                tool_names = {t.name for t in tools_result.tools}
-
-                assert "reports" in tool_names
-                assert "reports_networth" not in tool_names
-                assert "reports_networth_history" not in tool_names
+        assert "reports" in tool_names
+        assert "reports_networth" not in tool_names
+        assert "reports_networth_history" not in tool_names
 
     async def test_per_report_tools_are_not_registered(
-        self, mcp_env: dict[str, str]
+        self, mcp_server_tools: tuple[str, set[str]]
     ) -> None:
         """Report additions do not consume MCP tool slots."""
-        from mcp import ClientSession
-        from mcp.client.stdio import StdioServerParameters, stdio_client
+        _, tool_names = mcp_server_tools
 
-        server_params = StdioServerParameters(
-            command="uv",  # noqa: S607
-            args=["run", "moneybin", "mcp", "serve"],
-            env=_server_env(mcp_env),
-        )
+        removed = {
+            "reports_spending",
+            "reports_cashflow",
+            "reports_recurring",
+            "reports_merchants",
+            "reports_large_transactions",
+            "reports_balance_drift",
+        }
+        assert not removed & tool_names
 
-        async with stdio_client(server_params) as (read, write):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                tools_result = await session.list_tools()
-                tool_names = {t.name for t in tools_result.tools}
-
-                removed = {
-                    "reports_spending",
-                    "reports_cashflow",
-                    "reports_recurring",
-                    "reports_merchants",
-                    "reports_large_transactions",
-                    "reports_balance_drift",
-                }
-                assert not removed & tool_names
-
-                # reports_uncategorized removed — use transactions_categorize_pending instead
-                assert "reports_uncategorized" not in tool_names
-                # v1 tools removed
-                assert "reports_spending_summary" not in tool_names
-                assert "reports_spending_by_category" not in tool_names
+        # reports_uncategorized removed — use transactions_categorize_pending instead
+        assert "reports_uncategorized" not in tool_names
+        # v1 tools removed
+        assert "reports_spending_summary" not in tool_names
+        assert "reports_spending_by_category" not in tool_names
 
 
 class TestCurationTools:
     """Consolidated curation boundaries are registered."""
 
-    async def test_curation_tools_registered(self, mcp_env: dict[str, str]) -> None:
-        from mcp import ClientSession
-        from mcp.client.stdio import StdioServerParameters, stdio_client
+    async def test_curation_tools_registered(
+        self, mcp_server_tools: tuple[str, set[str]]
+    ) -> None:
+        _, tool_names = mcp_server_tools
 
-        server_params = StdioServerParameters(
-            command="uv",  # noqa: S607
-            args=["run", "moneybin", "mcp", "serve"],
-            env=_server_env(mcp_env),
-        )
-
-        async with stdio_client(server_params) as (read, write):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                tools_result = await session.list_tools()
-                tool_names = {t.name for t in tools_result.tools}
-
-                expected = {
-                    "transactions_create",
-                    "transactions_annotate",
-                    "import_labels_set",
-                    "system_audit",
-                }
-                missing = expected - tool_names
-                assert not missing, f"Missing curation tools: {missing}"
-                removed = {
-                    "transactions_notes_add",
-                    "transactions_notes_edit",
-                    "transactions_notes_delete",
-                    "transactions_tags_set",
-                    "transactions_tags_rename",
-                    "transactions_splits_set",
-                }
-                assert not removed & tool_names
+        expected = {
+            "transactions_create",
+            "transactions_annotate",
+            "import_labels_set",
+            "system_audit",
+        }
+        missing = expected - tool_names
+        assert not missing, f"Missing curation tools: {missing}"
+        removed = {
+            "transactions_notes_add",
+            "transactions_notes_edit",
+            "transactions_notes_delete",
+            "transactions_tags_set",
+            "transactions_tags_rename",
+            "transactions_splits_set",
+        }
+        assert not removed & tool_names
 
 
 class TestNamespaceResources:
@@ -294,13 +259,9 @@ class TestNamespaceResources:
     async def test_schema_resource_registered(self, mcp_env: dict[str, str]) -> None:
         """moneybin://schema resource is registered on the server."""
         from mcp import ClientSession
-        from mcp.client.stdio import StdioServerParameters, stdio_client
+        from mcp.client.stdio import stdio_client
 
-        server_params = StdioServerParameters(
-            command="uv",  # noqa: S607
-            args=["run", "moneybin", "mcp", "serve"],
-            env=_server_env(mcp_env),
-        )
+        server_params = _server_params(_server_env(mcp_env))
 
         async with stdio_client(server_params) as (read, write):
             async with ClientSession(read, write) as session:
@@ -327,42 +288,27 @@ class TestMatchesTools:
         home = tmp_path_factory.mktemp("e2e_matches")
         return make_workflow_env(home, "matches-test")
 
-    async def test_matches_tools_registered(self, matches_env: dict[str, str]) -> None:
+    async def test_matches_tools_registered(
+        self, mcp_server_tools: tuple[str, set[str]]
+    ) -> None:
         """Match review uses the standard normalized review boundaries."""
-        from mcp import ClientSession
-        from mcp.client.stdio import StdioServerParameters, stdio_client
-
-        server_params = StdioServerParameters(
-            command="uv",  # noqa: S607
-            args=["run", "moneybin", "mcp", "serve"],
-            env=_server_env(matches_env),
-        )
-
-        async with stdio_client(server_params) as (read, write):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                tools_result = await session.list_tools()
-                tool_names = {t.name for t in tools_result.tools}
-                assert {"reviews", "reviews_decide"} <= tool_names
-                assert "transactions_matches_pending" not in tool_names
-                assert "transactions_matches_set" not in tool_names
+        _, tool_names = mcp_server_tools
+        assert {"reviews", "reviews_decide"} <= tool_names
+        assert "transactions_matches_pending" not in tool_names
+        assert "transactions_matches_set" not in tool_names
 
     async def test_reviews_returns_seeded_match(
         self, matches_env: dict[str, str]
     ) -> None:
         """Reviews returns a seeded pending match."""
         from mcp import ClientSession
-        from mcp.client.stdio import StdioServerParameters, stdio_client
+        from mcp.client.stdio import stdio_client
         from mcp.types import TextContent
 
         seeded_match_id = "e2e_pending_match_001"
         seed_pending_match(matches_env, seeded_match_id)
 
-        server_params = StdioServerParameters(
-            command="uv",  # noqa: S607
-            args=["run", "moneybin", "mcp", "serve"],
-            env=_server_env(matches_env),
-        )
+        server_params = _server_params(_server_env(matches_env))
 
         async with stdio_client(server_params) as (read, write):
             async with ClientSession(read, write) as session:
@@ -387,17 +333,13 @@ class TestMatchesTools:
     ) -> None:
         """reviews_decide accepts a pending match and returns accepted status."""
         from mcp import ClientSession
-        from mcp.client.stdio import StdioServerParameters, stdio_client
+        from mcp.client.stdio import stdio_client
         from mcp.types import TextContent
 
         seeded_match_id = "e2e_set_match_001"
         seed_pending_match(matches_env, seeded_match_id)
 
-        server_params = StdioServerParameters(
-            command="uv",  # noqa: S607
-            args=["run", "moneybin", "mcp", "serve"],
-            env=_server_env(matches_env),
-        )
+        server_params = _server_params(_server_env(matches_env))
 
         async with stdio_client(server_params) as (read, write):
             async with ClientSession(read, write) as session:
@@ -430,7 +372,7 @@ class TestMatchesTools:
     ) -> None:
         """Reviews history returns decisions with decided_at timestamps."""
         from mcp import ClientSession
-        from mcp.client.stdio import StdioServerParameters, stdio_client
+        from mcp.client.stdio import stdio_client
         from mcp.types import TextContent
 
         # History excludes pending — accept the match first so it's a decision.
@@ -438,11 +380,7 @@ class TestMatchesTools:
         # A second match left pending must NOT surface in history (pins the
         # get_match_log pending-exclusion at the MCP layer).
         seed_pending_match(matches_env, "e2e_hist_pending_002")
-        server_params = StdioServerParameters(
-            command="uv",  # noqa: S607
-            args=["run", "moneybin", "mcp", "serve"],
-            env=_server_env(matches_env),
-        )
+        server_params = _server_params(_server_env(matches_env))
         async with stdio_client(server_params) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()
@@ -488,14 +426,10 @@ class TestMatchesTools:
         `error.code`, and `error.hint`. This exercises the path that broke.
         """
         from mcp import ClientSession
-        from mcp.client.stdio import StdioServerParameters, stdio_client
+        from mcp.client.stdio import stdio_client
         from mcp.types import TextContent
 
-        server_params = StdioServerParameters(
-            command="uv",  # noqa: S607
-            args=["run", "moneybin", "mcp", "serve"],
-            env=_server_env(matches_env),
-        )
+        server_params = _server_params(_server_env(matches_env))
         async with stdio_client(server_params) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()
@@ -518,24 +452,13 @@ class TestMatchesTools:
         )
 
     async def test_legacy_match_boundaries_are_not_registered(
-        self, matches_env: dict[str, str]
+        self, mcp_server_tools: tuple[str, set[str]]
     ) -> None:
         """Legacy match boundaries do not consume standard-registry slots."""
-        from mcp import ClientSession
-        from mcp.client.stdio import StdioServerParameters, stdio_client
-
-        server_params = StdioServerParameters(
-            command="uv",  # noqa: S607
-            args=["run", "moneybin", "mcp", "serve"],
-            env=_server_env(matches_env),
-        )
-        async with stdio_client(server_params) as (read, write):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                tools = {t.name for t in (await session.list_tools()).tools}
-                assert {"reviews", "reviews_decide"} <= tools
-                assert "transactions_matches_run" not in tools
-                assert "transactions_matches_history" not in tools
+        _, tool_names = mcp_server_tools
+        assert {"reviews", "reviews_decide"} <= tool_names
+        assert "transactions_matches_run" not in tool_names
+        assert "transactions_matches_history" not in tool_names
 
 
 class TestMCPServeTransportGate:
@@ -552,9 +475,7 @@ class TestMCPServeTransportGate:
         import asyncio
 
         proc = await asyncio.create_subprocess_exec(
-            "uv",  # noqa: S607 — uv is on PATH in dev environments
-            "run",
-            "moneybin",
+            str(_MONEYBIN_BIN),
             "mcp",
             "serve",
             "--transport",
@@ -609,14 +530,10 @@ class TestMCPFirstRunSetup:
         stdout stream would blow up the SDK transport before call_tool() returns.
         """
         from mcp import ClientSession
-        from mcp.client.stdio import StdioServerParameters, stdio_client
+        from mcp.client.stdio import stdio_client
         from mcp.types import TextContent
 
-        server_params = StdioServerParameters(
-            command="uv",  # noqa: S607 — uv is on PATH in dev environments
-            args=["run", "moneybin", "mcp", "serve"],
-            env=unconfigured_env,
-        )
+        server_params = _server_params(unconfigured_env)
         async with stdio_client(server_params) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()
@@ -647,7 +564,7 @@ class TestMCPFirstRunSetup:
         the middleware is no longer active (self._configured is True).
         """
         from mcp import ClientSession, types
-        from mcp.client.stdio import StdioServerParameters, stdio_client
+        from mcp.client.stdio import stdio_client
         from mcp.shared.context import RequestContext
         from mcp.types import TextContent
 
@@ -662,11 +579,7 @@ class TestMCPFirstRunSetup:
                 action="accept", content={"value": "e2e-first-run"}
             )
 
-        server_params = StdioServerParameters(
-            command="uv",  # noqa: S607 — uv is on PATH in dev environments
-            args=["run", "moneybin", "mcp", "serve"],
-            env=unconfigured_env,
-        )
+        server_params = _server_params(unconfigured_env)
         async with stdio_client(server_params) as (read, write):
             async with ClientSession(
                 read, write, elicitation_callback=elicit_cb
@@ -716,15 +629,11 @@ class TestMCPFirstRunSetup:
         hang or kill the transport, not return an error.
         """
         from mcp import ClientSession
-        from mcp.client.stdio import StdioServerParameters, stdio_client
+        from mcp.client.stdio import stdio_client
         from mcp.shared.exceptions import McpError
         from pydantic import AnyUrl
 
-        server_params = StdioServerParameters(
-            command="uv",  # noqa: S607 — uv is on PATH in dev environments
-            args=["run", "moneybin", "mcp", "serve"],
-            env=unconfigured_env,
-        )
+        server_params = _server_params(unconfigured_env)
         async with stdio_client(server_params) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()

--- a/tests/moneybin/test_services/test_demo_service.py
+++ b/tests/moneybin/test_services/test_demo_service.py
@@ -29,6 +29,8 @@ _INSERT_TXN = (
     "VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
 )
 
+_PERSONAS = ("basic", "family", "freelancer", "international")
+
 
 @pytest.fixture(autouse=True)
 def _restore_profile_state() -> Generator[None, None, None]:  # pyright: ignore[reportUnusedFunction]  # pytest autouse fixture
@@ -40,6 +42,45 @@ def _restore_profile_state() -> Generator[None, None, None]:  # pyright: ignore[
         yield
     finally:
         config._current_profile = original  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.fixture(scope="session", params=_PERSONAS)
+def demo_profile_for_persona(
+    request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory
+) -> Generator[tuple[Path, DemoResult], None, None]:
+    """Build each real persona once for the read-only pipeline assertions."""
+    import os
+
+    from moneybin import config
+
+    home = tmp_path_factory.mktemp(f"demo_{request.param}")
+    original_home = os.environ.get("MONEYBIN_HOME")
+    os.environ["MONEYBIN_HOME"] = str(home)
+    config.clear_settings_cache()
+    try:
+        result = DemoService().run(persona=request.param, seed=42, years=1)
+        yield home, result
+    finally:
+        if original_home is None:
+            os.environ.pop("MONEYBIN_HOME", None)
+        else:
+            os.environ["MONEYBIN_HOME"] = original_home
+        config.clear_settings_cache()
+
+
+@pytest.fixture
+def built_demo_profile(
+    demo_profile_for_persona: tuple[Path, DemoResult],
+    monkeypatch: pytest.MonkeyPatch,
+) -> DemoResult:
+    """Activate one immutable, session-built demo profile for a read-only test."""
+    from moneybin import config
+
+    home, result = demo_profile_for_persona
+    monkeypatch.setenv("MONEYBIN_HOME", str(home))
+    config.clear_settings_cache()
+    config.set_current_profile(DEMO_PROFILE)
+    return result
 
 
 def _mock_pipeline(
@@ -303,9 +344,8 @@ def test_rebuild_requires_confirmation(
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize("persona", ["basic", "family", "freelancer", "international"])
 def test_demo_net_worth_covers_every_account(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, persona: str
+    built_demo_profile: DemoResult,
 ) -> None:
     # Demo's one headline answer. It used to print "Net worth: 0.00": every account
     # is carried in `core.fct_balances_daily` only to its OWN last observation, so on
@@ -313,10 +353,9 @@ def test_demo_net_worth_covers_every_account(
     # older statements had already dropped out. The OFX accounts carry a single
     # opening-day balance, so they vanished entirely, and `basic`'s remaining account
     # happened to sit at zero.
-    monkeypatch.setenv("MONEYBIN_HOME", str(tmp_path))
     from moneybin.database import get_database
 
-    result = DemoService().run(persona=persona, seed=42, years=1)
+    result = built_demo_profile
 
     # A real position exists. For one currency that is the scalar; for several
     # the scalar is null by design and each currency carries its own figure.
@@ -337,9 +376,8 @@ def test_demo_net_worth_covers_every_account(
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize("persona", ["basic", "family", "freelancer", "international"])
 def test_demo_ships_a_categorized_profile(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, persona: str
+    built_demo_profile: DemoResult,
 ) -> None:
     # Demo's headline promise. It previously shipped 0% categorized — the generator
     # never taught the engine about the merchants it invented, and doctor's coverage
@@ -349,10 +387,9 @@ def test_demo_ships_a_categorized_profile(
     # The floor is deliberately well under what the personas actually reach (~84-93%)
     # so it tracks the real failure — a collapse to zero — rather than churning on
     # every merchant-catalog tweak.
-    monkeypatch.setenv("MONEYBIN_HOME", str(tmp_path))
     from moneybin.database import get_database
 
-    result = DemoService().run(persona=persona, seed=42, years=1)
+    result = built_demo_profile
 
     assert result.transaction_count > 0
     assert result.categorized_count / result.transaction_count > 0.7
@@ -364,20 +401,16 @@ def test_demo_ships_a_categorized_profile(
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize("persona", ["basic", "family", "freelancer", "international"])
 def test_demo_pipeline_output_is_invisible_to_the_real_data_guard(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, persona: str
+    built_demo_profile: DemoResult,
 ) -> None:
     # The inverse property, driven through the REAL pipeline for every persona.
     # The guard now treats any `app.*` table outside _DEMO_WRITTEN_APP_TABLES as
     # the user's — so if the pipeline ever starts writing another one, demo would
     # refuse to rebuild its OWN profile on the next run. This is the test that
     # catches that in CI rather than in a user's terminal.
-    monkeypatch.setenv("MONEYBIN_HOME", str(tmp_path))
     from moneybin.database import get_database
     from moneybin.synthetic.reset import has_non_synthetic_data
-
-    DemoService().run(persona=persona, seed=42, years=1)
 
     with get_database(read_only=True) as db:
         assert has_non_synthetic_data(db) is False

--- a/tests/moneybin/test_services/test_demo_service.py
+++ b/tests/moneybin/test_services/test_demo_service.py
@@ -59,13 +59,13 @@ def demo_profile_for_persona(
     config.clear_settings_cache()
     try:
         result = DemoService().run(persona=request.param, seed=42, years=1)
-        yield home, result
     finally:
         if original_home is None:
             os.environ.pop("MONEYBIN_HOME", None)
         else:
             os.environ["MONEYBIN_HOME"] = original_home
         config.clear_settings_cache()
+    yield home, result
 
 
 @pytest.fixture


### PR DESCRIPTION
Reduce redundant test setup while preserving assertions. Focused current-head suite: 51 passed. Full gate has a checkout-location-specific parity failure reproduced only in /private/tmp and not a clean repo-contained exact-head worktree.