### PR TITLE
Consolidate dim accounts SQLMesh tests

### DIFF
--- a/tests/moneybin/test_account_type_normalization.py
+++ b/tests/moneybin/test_account_type_normalization.py
@@ -20,6 +20,10 @@ materialize via sqlmesh, assert the projected dim columns.
 
 from __future__ import annotations
 
+import shutil
+from pathlib import Path
+from unittest.mock import MagicMock
+
 import pytest
 
 from moneybin.database import Database, sqlmesh_context
@@ -55,6 +59,7 @@ def _ofx_account(
     institution_org: str = "Vocab Bank",
     institution_fid: str = "fid-v",
     routing_number: str | None = "111000025",
+    source_origin: str,
 ) -> None:
     db.execute(
         """
@@ -63,14 +68,25 @@ def _ofx_account(
              institution_fid, source_file, source_type, source_origin,
              extracted_at, loaded_at)
         VALUES (?, ?, ?, ?, ?, '/tmp/v.ofx', 'ofx',
-                'vocab_ofx', '2024-01-01'::TIMESTAMP, '2024-01-01'::TIMESTAMP)
+                ?, '2024-01-01'::TIMESTAMP, '2024-01-01'::TIMESTAMP)
         """,  # noqa: S608  # test fixture
-        [native_key, routing_number, account_type, institution_org, institution_fid],
+        [
+            native_key,
+            routing_number,
+            account_type,
+            institution_org,
+            institution_fid,
+            source_origin,
+        ],
     )
 
 
 def _tabular_account(
-    db: Database, *, native_key: str, account_type: str | None
+    db: Database,
+    *,
+    native_key: str,
+    account_type: str | None,
+    source_origin: str,
 ) -> None:
     db.execute(
         """
@@ -79,10 +95,10 @@ def _tabular_account(
              source_file, source_type, source_origin, import_id,
              extracted_at, loaded_at)
         VALUES (?, 'Vocab Acct', ?, 'Vocab Bank', '/tmp/v.csv', 'csv',
-                'vocab_tab', 'imp-v-001', '2024-01-01'::TIMESTAMP,
+                ?, 'imp-v-001', '2024-01-01'::TIMESTAMP,
                 '2024-01-01'::TIMESTAMP)
         """,  # noqa: S608  # test fixture
-        [native_key, account_type],
+        [native_key, account_type, source_origin],
     )
 
 
@@ -93,6 +109,211 @@ def _dim_type(db: Database, account_id: str) -> tuple[str | None, str | None]:
     ).fetchone()
     assert row is not None, f"no core.dim_accounts row for {account_id!r}"
     return row[0], row[1]
+
+
+def _case_id(name: str) -> str:
+    return f"mb21_account_type_{name}"
+
+
+def _case_origin(name: str) -> str:
+    return f"mb21_account_type_{name}_origin"
+
+
+def _plaid_account(
+    db: Database,
+    *,
+    native_key: str,
+    account_type: str | None,
+    account_subtype: str | None = None,
+    institution_name: str | None = "Vocab Bank",
+    mask: str = "4242",
+    official_name: str | None = "Vocab Account",
+    source_origin: str,
+) -> None:
+    db.execute(
+        """
+        INSERT INTO raw.plaid_accounts
+            (account_id, account_type, account_subtype, institution_name, mask,
+             official_name, source_file, source_type, source_origin,
+             extracted_at, loaded_at)
+        VALUES (?, ?, ?, ?, ?, ?, 'plaid://mb21-account-type', 'plaid', ?,
+                '2024-01-01'::TIMESTAMP, '2024-01-01'::TIMESTAMP)
+        """,  # noqa: S608  # test fixture
+        [
+            native_key,
+            account_type,
+            account_subtype,
+            institution_name,
+            mask,
+            official_name,
+            source_origin,
+        ],
+    )
+
+
+@pytest.fixture(scope="module")
+def account_type_cases_template(
+    tmp_path_factory: pytest.TempPathFactory,
+    request: pytest.FixtureRequest,
+) -> Path:
+    """One materialization over independently namespaced account-type cases."""
+    secret_store = MagicMock()
+    secret_store.get_key.return_value = "test-encryption-key-for-unit-tests"
+    db = Database(
+        tmp_path_factory.mktemp("account_type_normalization") / "test.duckdb",
+        secret_store=secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
+    )
+    request.addfinalizer(db.close)
+
+    for raw_value in (
+        "CHECKING",
+        "SAVINGS",
+        "MONEYMRKT",
+        "CD",
+        "CREDITLINE",
+        "CREDITCARD",
+    ):
+        name = f"ofx_{raw_value.lower()}"
+        native = _case_id(f"{name}_native")
+        origin = _case_origin(name)
+        _ofx_account(
+            db, native_key=native, account_type=raw_value, source_origin=origin
+        )
+        _link(
+            db,
+            link_id=_case_id(f"{name}_link"),
+            account_id=_case_id(name),
+            ref_value=native,
+            source_type="ofx",
+            source_origin=origin,
+        )
+
+    for name, account_type in (
+        ("tabular_credit_card", "credit_card"),
+        ("tabular_unmapped", "Christmas Club"),
+        ("tabular_generic_credit", "credit"),
+    ):
+        native = _case_id(f"{name}_native")
+        origin = _case_origin(name)
+        _tabular_account(
+            db, native_key=native, account_type=account_type, source_origin=origin
+        )
+        _link(
+            db,
+            link_id=_case_id(f"{name}_link"),
+            account_id=_case_id(name),
+            ref_value=native,
+            source_type="csv",
+            source_origin=origin,
+        )
+
+    for name, suffix in (("typeless_a", "4387"), ("typeless_b", "3431")):
+        # ``dim_accounts`` derives last_four only from a numeric native account id.
+        # Keep that real input shape while the source origin and canonical id isolate
+        # this template case from every other row.
+        native = f"200111111111{suffix}"
+        origin = _case_origin(name)
+        _ofx_account(db, native_key=native, account_type=None, source_origin=origin)
+        _link(
+            db,
+            link_id=_case_id(f"{name}_link"),
+            account_id=_case_id(name),
+            ref_value=native,
+            source_type="ofx",
+            source_origin=origin,
+        )
+
+    for name, account_type, institution_org, institution_fid, routing_number in (
+        ("opaque_org", "CREDITCARD", "B1", "10898", "111000025"),
+        ("unknown_fid", "CHECKING", "SOME CREDIT UNION", "99999", "111000025"),
+        ("legacy_empty_type", "", "Vocab Bank", "fid-v", "111000025"),
+        ("legacy_empty_routing", "CREDITCARD", "Vocab Bank", "fid-v", ""),
+        ("subtype_override", "SAVINGS", "Vocab Bank", "fid-v", "111000025"),
+    ):
+        # The Chase display assertion needs the provider's numeric suffix in its
+        # native id; the source origin and canonical id still namespace this case.
+        native = "ofx-b1-4387" if name == "opaque_org" else _case_id(f"{name}_native")
+        origin = _case_origin(name)
+        _ofx_account(
+            db,
+            native_key=native,
+            account_type=account_type,
+            institution_org=institution_org,
+            institution_fid=institution_fid,
+            routing_number=routing_number,
+            source_origin=origin,
+        )
+        _link(
+            db,
+            link_id=_case_id(f"{name}_link"),
+            account_id=_case_id(name),
+            ref_value=native,
+            source_type="ofx",
+            source_origin=origin,
+        )
+
+    db.execute(
+        """
+        INSERT INTO app.account_settings (account_id, account_subtype, updated_at)
+        VALUES (?, 'money market', CURRENT_TIMESTAMP)
+        """,  # noqa: S608  # test fixture
+        [_case_id("subtype_override")],
+    )
+
+    for name, account_type, account_subtype, institution_name, official_name in (
+        ("plaid_unmapped", "crypto_wallet", None, "Novel Bank", "Novel"),
+        ("plaid_null", None, None, "Untyped Bank", "Untyped"),
+        ("plaid_blank_empty", "credit", "", "", ""),
+        ("plaid_blank_spaces", "credit", "   ", "   ", "   "),
+    ):
+        native = _case_id(f"{name}_native")
+        origin = _case_origin(name)
+        _plaid_account(
+            db,
+            native_key=native,
+            account_type=account_type,
+            account_subtype=account_subtype,
+            institution_name=institution_name,
+            official_name=official_name,
+            source_origin=origin,
+        )
+        _link(
+            db,
+            link_id=_case_id(f"{name}_link"),
+            account_id=_case_id(name),
+            ref_value=native,
+            source_type="plaid",
+            source_origin=origin,
+        )
+
+    with sqlmesh_context(db) as ctx:
+        ctx.plan(auto_apply=True, no_prompts=True)
+    db.close()
+    return db.path
+
+
+@pytest.fixture()
+def account_type_cases(
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+    account_type_cases_template: Path,
+) -> Database:
+    """An isolated planned snapshot for one account-type assertion case."""
+    path = tmp_path / "test.duckdb"
+    shutil.copy(account_type_cases_template, path)
+    secret_store = MagicMock()
+    secret_store.get_key.return_value = "test-encryption-key-for-unit-tests"
+    db = Database(
+        path,
+        secret_store=secret_store,
+        no_auto_upgrade=True,
+        assume_initialized=True,
+        read_only=False,
+    )
+    request.addfinalizer(db.close)
+    return db
 
 
 @pytest.mark.slow
@@ -110,72 +331,49 @@ def _dim_type(db: Database, account_id: str) -> tuple[str | None, str | None]:
     ],
 )
 def test_ofx_account_type_normalizes_to_canonical_vocabulary(
-    db: Database, raw_value: str, expected_type: str, expected_subtype: str
+    account_type_cases: Database,
+    raw_value: str,
+    expected_type: str,
+    expected_subtype: str,
 ) -> None:
     """OFX <ACCTTYPE> spellings collapse to the canonical set, keeping detail in subtype."""
-    native = f"ofx-{raw_value.lower()}"
-    canonical = f"canon-{raw_value.lower()}"[:15]
-    _ofx_account(db, native_key=native, account_type=raw_value)
-    _link(
-        db,
-        link_id=f"lnk-{raw_value.lower()}"[:12],
-        account_id=canonical,
-        ref_value=native,
-        source_type="ofx",
-        source_origin="vocab_ofx",
+    assert _dim_type(account_type_cases, _case_id(f"ofx_{raw_value.lower()}")) == (
+        expected_type,
+        expected_subtype,
     )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    assert _dim_type(db, canonical) == (expected_type, expected_subtype)
 
 
 @pytest.mark.slow
-def test_tabular_free_text_account_type_normalizes(db: Database) -> None:
+def test_tabular_free_text_account_type_normalizes(
+    account_type_cases: Database,
+) -> None:
     """A CSV column mapping writes free text; it must land in the canonical set too."""
-    _tabular_account(db, native_key="tab-cc", account_type="credit_card")
-    _link(
-        db,
-        link_id="lnk-tab-cc",
-        account_id="canon-tab-cc",
-        ref_value="tab-cc",
-        source_type="csv",
-        source_origin="vocab_tab",
+    assert _dim_type(account_type_cases, _case_id("tabular_credit_card")) == (
+        "credit",
+        "credit card",
     )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    assert _dim_type(db, "canon-tab-cc") == ("credit", "credit card")
 
 
 @pytest.mark.slow
-def test_unmapped_account_type_is_null_not_guessed(db: Database) -> None:
+def test_unmapped_account_type_is_null_not_guessed(
+    account_type_cases: Database,
+) -> None:
     """An unrecognized spelling yields NULL type, preserving the original in subtype.
 
     NULL is the honest answer and it is also the useful one: the dim's merge
     skips NULLs, so a stronger source can still supply the type. Defaulting to
     'other' would out-rank that real value on recency.
     """
-    _tabular_account(db, native_key="tab-weird", account_type="Christmas Club")
-    _link(
-        db,
-        link_id="lnk-tab-wd",
-        account_id="canon-tab-wd",
-        ref_value="tab-weird",
-        source_type="csv",
-        source_origin="vocab_tab",
+    assert _dim_type(account_type_cases, _case_id("tabular_unmapped")) == (
+        None,
+        "christmas club",
     )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    assert _dim_type(db, "canon-tab-wd") == (None, "christmas club")
 
 
 @pytest.mark.slow
-def test_typeless_accounts_stay_distinguishable_by_last_four(db: Database) -> None:
+def test_typeless_accounts_stay_distinguishable_by_last_four(
+    account_type_cases: Database,
+) -> None:
     """Two typeless accounts at one institution must not share a display_name.
 
     The COALESCE chain assumed account_type was always present: with it NULL,
@@ -183,27 +381,11 @@ def test_typeless_accounts_stay_distinguishable_by_last_four(db: Database) -> No
     falls through to the bare institution name, so every card at one bank
     renders identically. last_four is what distinguishes them.
     """
-    for native, canonical, link in (
-        ("2001111111114387", "canon-typeless-a", "lnk-tl-a"),
-        ("2001111111113431", "canon-typeless-b", "lnk-tl-b"),
-    ):
-        _ofx_account(db, native_key=native, account_type=None)
-        _link(
-            db,
-            link_id=link,
-            account_id=canonical,
-            ref_value=native,
-            source_type="ofx",
-            source_origin="vocab_ofx",
-        )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    rows = db.execute(
+    rows = account_type_cases.execute(
         "SELECT account_id, display_name FROM core.dim_accounts "
-        "WHERE account_id IN ('canon-typeless-a', 'canon-typeless-b') "
-        "ORDER BY account_id"
+        "WHERE account_id IN (?, ?) "
+        "ORDER BY account_id",
+        [_case_id("typeless_a"), _case_id("typeless_b")],
     ).fetchall()
     names = [r[1] for r in rows]
 
@@ -218,7 +400,7 @@ def test_typeless_accounts_stay_distinguishable_by_last_four(db: Database) -> No
 
 @pytest.mark.slow
 def test_opaque_ofx_org_code_resolves_to_a_readable_institution_name(
-    db: Database,
+    account_type_cases: Database,
 ) -> None:
     """<ORG> is a routing code, not a name — resolve the display name by FID.
 
@@ -226,28 +408,9 @@ def test_opaque_ofx_org_code_resolves_to_a_readable_institution_name(
     (3000). Aliasing <ORG> straight through showed users "B1" in a column
     documented as the human-readable institution name.
     """
-    _ofx_account(
-        db,
-        native_key="ofx-b1-4387",
-        account_type="CREDITCARD",
-        institution_org="B1",
-        institution_fid="10898",
-    )
-    _link(
-        db,
-        link_id="lnk-b1-1",
-        account_id="canon-b1-4387",
-        ref_value="ofx-b1-4387",
-        source_type="ofx",
-        source_origin="vocab_ofx",
-    )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    row = db.execute(
+    row = account_type_cases.execute(
         "SELECT institution_name, display_name FROM core.dim_accounts WHERE account_id = ?",
-        ["canon-b1-4387"],
+        [_case_id("opaque_org")],
     ).fetchone()
     assert row is not None
     assert row[0] == "Chase", f"expected the FID to resolve a name, got {row[0]!r}"
@@ -255,37 +418,20 @@ def test_opaque_ofx_org_code_resolves_to_a_readable_institution_name(
 
 
 @pytest.mark.slow
-def test_unknown_fid_falls_back_to_the_raw_org(db: Database) -> None:
+def test_unknown_fid_falls_back_to_the_raw_org(account_type_cases: Database) -> None:
     """An institution absent from the registry keeps its <ORG> — never blank."""
-    _ofx_account(
-        db,
-        native_key="ofx-unknown-1",
-        account_type="CHECKING",
-        institution_org="SOME CREDIT UNION",
-        institution_fid="99999",
-    )
-    _link(
-        db,
-        link_id="lnk-unk-1",
-        account_id="canon-unknown-1",
-        ref_value="ofx-unknown-1",
-        source_type="ofx",
-        source_origin="vocab_ofx",
-    )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    row = db.execute(
+    row = account_type_cases.execute(
         "SELECT institution_name FROM core.dim_accounts WHERE account_id = ?",
-        ["canon-unknown-1"],
+        [_case_id("unknown_fid")],
     ).fetchone()
     assert row is not None
     assert row[0] == "SOME CREDIT UNION"
 
 
 @pytest.mark.slow
-def test_legacy_empty_string_account_type_normalizes_to_null(db: Database) -> None:
+def test_legacy_empty_string_account_type_normalizes_to_null(
+    account_type_cases: Database,
+) -> None:
     """Rows imported before the extractor fix hold '', not NULL.
 
     The extractor now writes NULL for an absent <ACCTTYPE>, but raw rows
@@ -293,24 +439,13 @@ def test_legacy_empty_string_account_type_normalizes_to_null(db: Database) -> No
     treat those as absent too, or the subtype fallback (LOWER(account_type))
     just relocates the empty string into account_subtype.
     """
-    _ofx_account(db, native_key="ofx-legacy-empty", account_type="")
-    _link(
-        db,
-        link_id="lnk-legacy-1",
-        account_id="canon-legacy-em",
-        ref_value="ofx-legacy-empty",
-        source_type="ofx",
-        source_origin="vocab_ofx",
-    )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    assert _dim_type(db, "canon-legacy-em") == (None, None)
+    assert _dim_type(account_type_cases, _case_id("legacy_empty_type")) == (None, None)
 
 
 @pytest.mark.slow
-def test_unmapped_plaid_type_resolves_to_null_not_a_default(db: Database) -> None:
+def test_unmapped_plaid_type_resolves_to_null_not_a_default(
+    account_type_cases: Database,
+) -> None:
     """An unrecognized Plaid type must resolve to NULL, like every other source.
 
     A non-NULL default looks safer than NULL here and is not. core.fct_balances
@@ -321,30 +456,9 @@ def test_unmapped_plaid_type_resolves_to_null_not_a_default(db: Database) -> Non
     test_plaid_null_account_type_dropped — this test pins the staging half so a
     future "helpful" fallback cannot reintroduce it from above.
     """
-    db.execute(
-        """
-        INSERT INTO raw.plaid_accounts
-            (account_id, account_type, account_subtype, institution_name, mask,
-             official_name, source_file, source_type, source_origin,
-             extracted_at, loaded_at)
-        VALUES ('plaid-novel', 'crypto_wallet', NULL, 'Novel Bank', '4242',
-                'Novel', 'plaid://novel', 'plaid', 'novel_inst',
-                '2024-01-01'::TIMESTAMP, '2024-01-01'::TIMESTAMP)
-        """  # noqa: S608  # test fixture
+    account_type, account_subtype = _dim_type(
+        account_type_cases, _case_id("plaid_unmapped")
     )
-    _link(
-        db,
-        link_id="lnk-plaid-nv",
-        account_id="canon-plaid-nv",
-        ref_value="plaid-novel",
-        source_type="plaid",
-        source_origin="novel_inst",
-    )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    account_type, account_subtype = _dim_type(db, "canon-plaid-nv")
     assert account_type is None, (
         f"expected NULL, got {account_type!r} — a non-NULL default lets "
         "fct_balances sign an unsignable balance as an asset"
@@ -356,7 +470,9 @@ def test_unmapped_plaid_type_resolves_to_null_not_a_default(db: Database) -> Non
 
 
 @pytest.mark.slow
-def test_mapped_alias_without_a_finer_subtype_stays_null(db: Database) -> None:
+def test_mapped_alias_without_a_finer_subtype_stays_null(
+    account_type_cases: Database,
+) -> None:
     """A registry hit with no finer subtype must yield NULL, not the raw alias.
 
     `CREDIT` maps to account_type 'credit' with a blank account_subtype, so
@@ -365,52 +481,25 @@ def test_mapped_alias_without_a_finer_subtype_stays_null(db: Database) -> None:
     by recency alone, a later generic import would then silently downgrade an
     existing 'credit card' to 'credit' and regress display_name.
     """
-    _tabular_account(db, native_key="tab-generic", account_type="credit")
-    _link(
-        db,
-        link_id="lnk-tab-gen",
-        account_id="canon-tab-gen",
-        ref_value="tab-generic",
-        source_type="csv",
-        source_origin="vocab_tab",
+    assert _dim_type(account_type_cases, _case_id("tabular_generic_credit")) == (
+        "credit",
+        None,
     )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    assert _dim_type(db, "canon-tab-gen") == ("credit", None)
 
 
 @pytest.mark.slow
-def test_display_name_honors_a_user_subtype_override(db: Database) -> None:
+def test_display_name_honors_a_user_subtype_override(
+    account_type_cases: Database,
+) -> None:
     """display_name must render the same subtype the subtype column reports.
 
     The output column is COALESCE(s.account_subtype, w.account_subtype), but the
     display chain read only the pre-override merged value — so overriding the
     subtype without also setting a display_name made the two disagree.
     """
-    _ofx_account(db, native_key="ofx-override-1", account_type="SAVINGS")
-    _link(
-        db,
-        link_id="lnk-ovr-1",
-        account_id="canon-override-1",
-        ref_value="ofx-override-1",
-        source_type="ofx",
-        source_origin="vocab_ofx",
-    )
-    db.execute(
-        """
-        INSERT INTO app.account_settings (account_id, account_subtype, updated_at)
-        VALUES ('canon-override-1', 'money market', CURRENT_TIMESTAMP)
-        """  # noqa: S608  # test fixture
-    )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    row = db.execute(
+    row = account_type_cases.execute(
         "SELECT account_subtype, display_name FROM core.dim_accounts WHERE account_id = ?",
-        ["canon-override-1"],
+        [_case_id("subtype_override")],
     ).fetchone()
     assert row is not None
     assert row[0] == "money market"
@@ -420,7 +509,7 @@ def test_display_name_honors_a_user_subtype_override(db: Database) -> None:
 
 
 @pytest.mark.slow
-def test_genuinely_null_plaid_type_stays_null(db: Database) -> None:
+def test_genuinely_null_plaid_type_stays_null(account_type_cases: Database) -> None:
     """A NULL Plaid account_type is distinct from an unmapped one — both stay NULL.
 
     `SyncAccount.account_type` is `str | None`, so NULL is reachable rather than
@@ -429,30 +518,7 @@ def test_genuinely_null_plaid_type_stays_null(db: Database) -> None:
     asset. Pairs with test_unmapped_plaid_type_resolves_to_null_not_a_default:
     the two inputs differ, the required outcome does not.
     """
-    db.execute(
-        """
-        INSERT INTO raw.plaid_accounts
-            (account_id, account_type, account_subtype, institution_name, mask,
-             official_name, source_file, source_type, source_origin,
-             extracted_at, loaded_at)
-        VALUES ('plaid-untyped', NULL, NULL, 'Untyped Bank', '7777',
-                'Untyped', 'plaid://untyped', 'plaid', 'untyped_inst',
-                '2024-01-01'::TIMESTAMP, '2024-01-01'::TIMESTAMP)
-        """  # noqa: S608  # test fixture
-    )
-    _link(
-        db,
-        link_id="lnk-plaid-un",
-        account_id="canon-plaid-un",
-        ref_value="plaid-untyped",
-        source_type="plaid",
-        source_origin="untyped_inst",
-    )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    account_type, _ = _dim_type(db, "canon-plaid-un")
+    account_type, _ = _dim_type(account_type_cases, _case_id("plaid_null"))
     assert account_type is None, (
         f"expected NULL, got {account_type!r} — fct_balances would then sign an "
         "unsignable balance as a positive asset"
@@ -460,7 +526,9 @@ def test_genuinely_null_plaid_type_stays_null(db: Database) -> None:
 
 
 @pytest.mark.slow
-def test_legacy_empty_string_routing_number_normalizes_to_null(db: Database) -> None:
+def test_legacy_empty_string_routing_number_normalizes_to_null(
+    account_type_cases: Database,
+) -> None:
     """routing_number has the same legacy-'' failure mode as account_type.
 
     A credit-card statement's <CCACCTFROM> never carries <BANKID>, so pre-fix
@@ -471,24 +539,9 @@ def test_legacy_empty_string_routing_number_normalizes_to_null(db: Database) -> 
     NULL and lets the stale '' win permanently. Verified live: both real Chase
     cards carried routing_number='' in core.dim_accounts before this guard.
     """
-    _ofx_account(
-        db, native_key="ofx-legacy-rn", account_type="CREDITCARD", routing_number=""
-    )
-    _link(
-        db,
-        link_id="lnk-legacy-rn",
-        account_id="canon-legacy-rn",
-        ref_value="ofx-legacy-rn",
-        source_type="ofx",
-        source_origin="vocab_ofx",
-    )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    row = db.execute(
+    row = account_type_cases.execute(
         "SELECT routing_number FROM core.dim_accounts WHERE account_id = ?",
-        ["canon-legacy-rn"],
+        [_case_id("legacy_empty_routing")],
     ).fetchone()
     assert row is not None
     assert row[0] is None, f"expected NULL, got {row[0]!r} — the '' leak persists"
@@ -496,7 +549,9 @@ def test_legacy_empty_string_routing_number_normalizes_to_null(db: Database) -> 
 
 @pytest.mark.slow
 @pytest.mark.parametrize("blank", ["", "   "])
-def test_blank_plaid_text_fields_normalize_to_null(db: Database, blank: str) -> None:
+def test_blank_plaid_text_fields_normalize_to_null(
+    account_type_cases: Database, blank: str
+) -> None:
     """Blank Plaid text columns must reach core as NULL, not ''.
 
     `COALESCE` only replaces NULL, so a '' subtype short-circuits the registry
@@ -504,34 +559,11 @@ def test_blank_plaid_text_fields_normalize_to_null(db: Database, blank: str) -> 
     in display_name's concat, yielding a malformed leading-space label. Same
     empty-string-vs-NULL class this PR fixes for OFX, on the Plaid side.
     """
-    db.execute(
-        """
-        INSERT INTO raw.plaid_accounts
-            (account_id, account_type, account_subtype, institution_name, mask,
-             official_name, source_file, source_type, source_origin,
-             extracted_at, loaded_at)
-        VALUES ('plaid-blank', 'credit', ?, ?, '4242', ?,
-                'plaid://blank', 'plaid', 'blank_inst',
-                '2024-01-01'::TIMESTAMP, '2024-01-01'::TIMESTAMP)
-        """,  # noqa: S608  # test fixture
-        [blank, blank, blank],
-    )
-    _link(
-        db,
-        link_id="lnk-plaid-bl",
-        account_id="canon-plaid-bl",
-        ref_value="plaid-blank",
-        source_type="plaid",
-        source_origin="blank_inst",
-    )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    row = db.execute(
+    name = "plaid_blank_empty" if blank == "" else "plaid_blank_spaces"
+    row = account_type_cases.execute(
         "SELECT account_subtype, institution_name, official_name, display_name "
         "FROM core.dim_accounts WHERE account_id = ?",
-        ["canon-plaid-bl"],
+        [_case_id(name)],
     ).fetchone()
     assert row is not None
     assert row[0] is None, f"blank subtype survived as {row[0]!r}"

--- a/tests/moneybin/test_dim_accounts_merge.py
+++ b/tests/moneybin/test_dim_accounts_merge.py
@@ -17,12 +17,20 @@ materialize via sqlmesh and assert the projected dim columns.
 
 from __future__ import annotations
 
+import shutil
+from pathlib import Path
+from unittest.mock import MagicMock
+
 import pytest
 
 from moneybin.database import Database, sqlmesh_context
 from moneybin.services.account_resolution_types import UNNAMED_ACCOUNT_LABEL
 
 pytestmark = pytest.mark.integration
+
+
+def _case_id(name: str) -> str:
+    return f"mb21_dim_accounts_{name}"
 
 
 def _insert_accepted_source_native(
@@ -114,9 +122,9 @@ def _insert_tabular_account(
 
 def _seed_shared_canonical_ofx_and_tabular(db: Database) -> str:
     """Seed OFX (with routing) + a later tabular row (no routing) sharing one canonical id."""
-    canonical_id = "canonshared0001"
-    ofx_native = "ofx-acctid-shr01"
-    tab_native = "tab-acctid-shr01"
+    canonical_id = _case_id("shared")
+    ofx_native = _case_id("shared_ofx_native")
+    tab_native = _case_id("shared_tabular_native")
 
     # OFX: earlier, carries the routing number.
     _insert_ofx_account(
@@ -126,14 +134,15 @@ def _seed_shared_canonical_ofx_and_tabular(db: Database) -> str:
         institution_org="Shared Bank OFX",
         account_type="CHECKING",
         extracted_at="2024-01-01 00:00:00",
+        source_origin=_case_id("shared_ofx_origin"),
     )
     _insert_accepted_source_native(
         db,
-        link_id="link-ofx-shr",
+        link_id=_case_id("shared_ofx_link"),
         account_id=canonical_id,
         ref_value=ofx_native,
         source_type="ofx",
-        source_origin="test_bank_ofx",
+        source_origin=_case_id("shared_ofx_origin"),
     )
 
     # Tabular: later, no routing (tabular staging always projects routing NULL).
@@ -144,30 +153,196 @@ def _seed_shared_canonical_ofx_and_tabular(db: Database) -> str:
         institution_name="Shared Bank CSV",
         account_type="checking",
         extracted_at="2024-06-01 00:00:00",
+        source_origin=_case_id("shared_tabular_origin"),
     )
     _insert_accepted_source_native(
         db,
-        link_id="link-tab-shr",
+        link_id=_case_id("shared_tabular_link"),
         account_id=canonical_id,
         ref_value=tab_native,
         source_type="csv",
-        source_origin="test_bank_tab",
+        source_origin=_case_id("shared_tabular_origin"),
     )
     return canonical_id
 
 
+@pytest.fixture(scope="module")
+def dim_accounts_cases_template(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Path:
+    """One materialization over independently namespaced dim-account cases."""
+    secret_store = MagicMock()
+    secret_store.get_key.return_value = "test-encryption-key-for-unit-tests"
+    db = Database(
+        tmp_path_factory.mktemp("dim_accounts_merge") / "test.duckdb",
+        secret_store=secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
+    )
+    try:
+        _seed_shared_canonical_ofx_and_tabular(db)
+
+        _insert_tabular_account(
+            db,
+            native_key=_case_id("unlinked_native"),
+            account_name="Orphan Checking",
+            institution_name="Orphan Bank",
+            account_type="checking",
+            extracted_at="2024-02-01 00:00:00",
+            source_origin=_case_id("unlinked_origin"),
+        )
+
+        slug_canonical_id = _case_id("institution_slug")
+        slug_ofx_native = _case_id("institution_slug_ofx_native")
+        slug_tabular_native = _case_id("institution_slug_tabular_native")
+        _insert_ofx_account(
+            db,
+            native_key=slug_ofx_native,
+            routing_number="123000220",
+            institution_org="USB",
+            account_type="CHECKING",
+            extracted_at="2024-01-01 00:00:00",
+            institution_fid="5950",
+            source_origin=_case_id("institution_slug_ofx_origin"),
+        )
+        _insert_accepted_source_native(
+            db,
+            link_id=_case_id("institution_slug_ofx_link"),
+            account_id=slug_canonical_id,
+            ref_value=slug_ofx_native,
+            source_type="ofx",
+            source_origin=_case_id("institution_slug_ofx_origin"),
+        )
+        _insert_tabular_account(
+            db,
+            native_key=slug_tabular_native,
+            account_name="Shared Checking",
+            institution_name="Shared Bank CSV",
+            account_type="checking",
+            extracted_at="2024-06-01 00:00:00",
+            source_origin=_case_id("institution_slug_tabular_origin"),
+        )
+        _insert_accepted_source_native(
+            db,
+            link_id=_case_id("institution_slug_tabular_link"),
+            account_id=slug_canonical_id,
+            ref_value=slug_tabular_native,
+            source_type="csv",
+            source_origin=_case_id("institution_slug_tabular_origin"),
+        )
+
+        last_four_canonical_id = _case_id("ofx_last_four")
+        last_four_native = "123456784267"
+        _insert_ofx_account(
+            db,
+            native_key=last_four_native,
+            routing_number="121000248",
+            institution_org="WELLS FARGO",
+            account_type="CHECKING",
+            extracted_at="2024-01-01 00:00:00",
+            source_origin=_case_id("ofx_last_four_origin"),
+        )
+        _insert_accepted_source_native(
+            db,
+            link_id=_case_id("ofx_last_four_link"),
+            account_id=last_four_canonical_id,
+            ref_value=last_four_native,
+            source_type="ofx",
+            source_origin=_case_id("ofx_last_four_origin"),
+        )
+
+        unnameable_native = "471166339912"
+        _insert_tabular_account(
+            db,
+            native_key=unnameable_native,
+            account_name="Row With No Bank Fields",
+            institution_name=None,
+            account_type=None,
+            extracted_at="2024-03-01 00:00:00",
+            source_origin=_case_id("unnameable_origin"),
+        )
+
+        nameless_canonical_id = _case_id("nameless")
+        nameless_native = _case_id("nameless_native")
+        _insert_tabular_account(
+            db,
+            native_key=nameless_native,
+            account_name="Row With No Bank Fields",
+            institution_name=None,
+            account_type=None,
+            extracted_at="2024-03-01 00:00:00",
+            source_origin=_case_id("nameless_origin"),
+        )
+        _insert_accepted_source_native(
+            db,
+            link_id=_case_id("nameless_link"),
+            account_id=nameless_canonical_id,
+            ref_value=nameless_native,
+            source_type="csv",
+            source_origin=_case_id("nameless_origin"),
+        )
+
+        _insert_tabular_account(
+            db,
+            native_key=_case_id("last_four_only_native"),
+            account_name="Row With No Bank Fields",
+            institution_name=None,
+            account_type=None,
+            account_number="9876554521",
+            extracted_at="2024-03-01 00:00:00",
+            source_origin=_case_id("last_four_only_origin"),
+        )
+        _insert_tabular_account(
+            db,
+            native_key=_case_id("subtype_last_four_native"),
+            account_name="Row With No Bank Fields",
+            institution_name=None,
+            account_type="CHECKING",
+            account_number="9876554521",
+            extracted_at="2024-03-01 00:00:00",
+            source_origin=_case_id("subtype_last_four_origin"),
+        )
+
+        with sqlmesh_context(db) as ctx:
+            ctx.plan(auto_apply=True, no_prompts=True)
+        return db.path
+    finally:
+        db.close()
+
+
+@pytest.fixture()
+def dim_accounts_cases(
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+    dim_accounts_cases_template: Path,
+) -> Database:
+    """An isolated, writable copy of the shared planned baseline."""
+    path = tmp_path / "test.duckdb"
+    shutil.copy(dim_accounts_cases_template, path)
+    path.chmod(0o600)
+    secret_store = MagicMock()
+    secret_store.get_key.return_value = "test-encryption-key-for-unit-tests"
+    db = Database(
+        path,
+        secret_store=secret_store,
+        no_auto_upgrade=True,
+        assume_initialized=True,
+        read_only=False,
+    )
+    request.addfinalizer(db.close)
+    return db
+
+
 @pytest.mark.slow
-def test_dim_accounts_no_null_clobber(db: Database) -> None:
+def test_dim_accounts_no_null_clobber(dim_accounts_cases: Database) -> None:
     """A later tabular row (routing NULL) must NOT null the OFX routing_number.
 
     Old last-write-wins (ROW_NUMBER ORDER BY extracted_at DESC) would pick the
     later tabular row and emit routing_number = NULL. The per-field merge keeps
     the OFX value.
     """
-    canonical_id = _seed_shared_canonical_ofx_and_tabular(db)
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
+    db = dim_accounts_cases
+    canonical_id = _case_id("shared")
 
     row = db.execute(
         "SELECT routing_number, institution_fid FROM core.dim_accounts WHERE account_id = ?",
@@ -184,12 +359,12 @@ def test_dim_accounts_no_null_clobber(db: Database) -> None:
 
 
 @pytest.mark.slow
-def test_dim_accounts_collapses_sources_to_one_row(db: Database) -> None:
+def test_dim_accounts_collapses_sources_to_one_row(
+    dim_accounts_cases: Database,
+) -> None:
     """OFX + CSV rows sharing one canonical id collapse to exactly one dim row."""
-    canonical_id = _seed_shared_canonical_ofx_and_tabular(db)
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
+    db = dim_accounts_cases
+    canonical_id = _case_id("shared")
 
     count = db.execute(
         "SELECT COUNT(*) FROM core.dim_accounts WHERE account_id = ?",
@@ -200,23 +375,15 @@ def test_dim_accounts_collapses_sources_to_one_row(db: Database) -> None:
 
 
 @pytest.mark.slow
-def test_dim_accounts_unlinked_account_keyed_by_source_native(db: Database) -> None:
+def test_dim_accounts_unlinked_account_keyed_by_source_native(
+    dim_accounts_cases: Database,
+) -> None:
     """An unlinked account (canonical id NULL) stays distinct under its source-native key."""
-    native_key = "tab-unlinked-0001"
-    _insert_tabular_account(
-        db,
-        native_key=native_key,
-        account_name="Orphan Checking",
-        institution_name="Orphan Bank",
-        account_type="checking",
-        extracted_at="2024-02-01 00:00:00",
-    )
+    db = dim_accounts_cases
+    native_key = _case_id("unlinked_native")
     # Deliberately NO app.account_links row. stg does NOT project a NULL
     # account_id — it COALESCEs the source-native key in itself — so the row
     # reaches the dim keyed by native_key and grain_key passes it through.
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
 
     rows = db.execute(
         "SELECT account_id FROM core.dim_accounts WHERE account_id = ?",
@@ -237,7 +404,7 @@ def test_dim_accounts_unlinked_account_keyed_by_source_native(db: Database) -> N
 
 @pytest.mark.slow
 def test_a_resolved_institution_slug_outranks_later_unresolved_text(
-    db: Database,
+    dim_accounts_cases: Database,
 ) -> None:
     """A registry-resolved slug must survive a later source that only has raw text.
 
@@ -258,49 +425,8 @@ def test_a_resolved_institution_slug_outranks_later_unresolved_text(
     deliberately absent from seeds.institutions — a registered spelling would
     resolve and the two branches would agree.
     """
-    canonical_id = "canoninstslug01"
-    ofx_native = "ofx-acctid-inst1"
-    tab_native = "tab-acctid-inst1"
-
-    # OFX: earlier, FID 5950 resolves through seeds.institutions to 'us_bank'.
-    _insert_ofx_account(
-        db,
-        native_key=ofx_native,
-        routing_number="123000220",
-        institution_org="USB",
-        account_type="CHECKING",
-        extracted_at="2024-01-01 00:00:00",
-        institution_fid="5950",
-    )
-    _insert_accepted_source_native(
-        db,
-        link_id="link-ofx-inst",
-        account_id=canonical_id,
-        ref_value=ofx_native,
-        source_type="ofx",
-        source_origin="test_bank_ofx",
-    )
-
-    # Tabular: later, and its institution text matches no registry spelling.
-    _insert_tabular_account(
-        db,
-        native_key=tab_native,
-        account_name="Shared Checking",
-        institution_name="Shared Bank CSV",
-        account_type="checking",
-        extracted_at="2024-06-01 00:00:00",
-    )
-    _insert_accepted_source_native(
-        db,
-        link_id="link-tab-inst",
-        account_id=canonical_id,
-        ref_value=tab_native,
-        source_type="csv",
-        source_origin="test_bank_tab",
-    )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
+    db = dim_accounts_cases
+    canonical_id = _case_id("institution_slug")
 
     row = db.execute(
         "SELECT institution_slug FROM core.dim_accounts WHERE account_id = ?",
@@ -315,33 +441,16 @@ def test_a_resolved_institution_slug_outranks_later_unresolved_text(
 
 
 @pytest.mark.slow
-def test_last_four_derived_for_ofx_without_account_settings(db: Database) -> None:
+def test_last_four_derived_for_ofx_without_account_settings(
+    dim_accounts_cases: Database,
+) -> None:
     """OFX account without app.account_settings gets last_four derived from ACCTID digits.
 
     Verifies the Decision 8 capture layer: last_four is derived from source fields
     (OFX source_account_key) when no user-set app.account_settings row exists.
     """
-    canonical_id = "canonofxlast401"
-    ofx_native = "123456784267"  # ACCTID ending 4267
-    _insert_ofx_account(
-        db,
-        native_key=ofx_native,
-        routing_number="121000248",
-        institution_org="WELLS FARGO",
-        account_type="CHECKING",
-        extracted_at="2024-01-01 00:00:00",
-    )
-    _insert_accepted_source_native(
-        db,
-        link_id="link-ofx-last4",
-        account_id=canonical_id,
-        ref_value=ofx_native,
-        source_type="ofx",
-        source_origin="test_bank_ofx",
-    )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
+    db = dim_accounts_cases
+    canonical_id = _case_id("ofx_last_four")
 
     row = db.execute(
         "SELECT last_four, display_name FROM core.dim_accounts WHERE account_id = ?",
@@ -354,7 +463,7 @@ def test_last_four_derived_for_ofx_without_account_settings(db: Database) -> Non
 
 @pytest.mark.slow
 def test_an_unnameable_unlinked_account_is_not_named_by_its_source_key(
-    db: Database,
+    dim_accounts_cases: Database,
 ) -> None:
     """The terminal display_name branch never emits a source-native key.
 
@@ -365,23 +474,11 @@ def test_an_unnameable_unlinked_account_is_not_named_by_its_source_key(
     number in a column the taxonomy declares USER_NOTE, and from there into
     reports.* as account_name. The label degrades instead.
     """
+    db = dim_accounts_cases
     native_key = "471166339912"  # digits, as a real ACCTID would be
-    _insert_tabular_account(
-        db,
-        native_key=native_key,
-        # account_name is NOT NULL in raw and the dim's tabular CTE never
-        # selects it, so it cannot reach display_name either way.
-        account_name="Row With No Bank Fields",
-        institution_name=None,
-        account_type=None,
-        extracted_at="2024-03-01 00:00:00",
-    )
     # Deliberately NO app.account_links row. stg COALESCEs the source-native
     # key into account_id itself, so the row reaches the dim keyed by
     # native_key -- which is exactly what the terminal label must not print.
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
 
     row = db.execute(
         "SELECT display_name FROM core.dim_accounts WHERE account_id = ?",
@@ -399,7 +496,7 @@ def test_an_unnameable_unlinked_account_is_not_named_by_its_source_key(
 
 @pytest.mark.slow
 def test_the_terminal_label_omits_the_id_even_when_the_id_is_safe(
-    db: Database,
+    dim_accounts_cases: Database,
 ) -> None:
     """A linked account with nothing to name it is unnamed too, not id-labelled.
 
@@ -412,27 +509,8 @@ def test_the_terminal_label_omits_the_id_even_when_the_id_is_safe(
     silently break. Dropping the id outright is fail-closed by construction.
     The label it costs applied to no account.
     """
-    canonical_id = "canonnameless01"
-    native_key = "tab-nameless-001"
-    _insert_tabular_account(
-        db,
-        native_key=native_key,
-        account_name="Row With No Bank Fields",
-        institution_name=None,
-        account_type=None,
-        extracted_at="2024-03-01 00:00:00",
-    )
-    _insert_accepted_source_native(
-        db,
-        link_id="link-tab-nameless",
-        account_id=canonical_id,
-        ref_value=native_key,
-        source_type="csv",
-        source_origin="test_bank_tab",
-    )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
+    db = dim_accounts_cases
+    canonical_id = _case_id("nameless")
 
     row = db.execute(
         "SELECT display_name FROM core.dim_accounts WHERE account_id = ?",
@@ -450,7 +528,7 @@ def test_the_terminal_label_omits_the_id_even_when_the_id_is_safe(
 
 @pytest.mark.slow
 def test_a_last_four_alone_names_an_account_the_sentinel_would_have_taken(
-    db: Database,
+    dim_accounts_cases: Database,
 ) -> None:
     """A last four outranks the sentinel: it is the discriminator, and it is safe.
 
@@ -464,22 +542,11 @@ def test_a_last_four_alone_names_an_account_the_sentinel_would_have_taken(
     masked fragment the confirm flow already prints as evidence and the dim
     already publishes in its own column, so naming by it discloses nothing new.
     """
-    _insert_tabular_account(
-        db,
-        native_key="tab-lastfour-only",
-        account_name="Row With No Bank Fields",
-        institution_name=None,
-        account_type=None,
-        account_number="9876554521",
-        extracted_at="2024-03-01 00:00:00",
-    )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
+    db = dim_accounts_cases
 
     row = db.execute(
         "SELECT display_name FROM core.dim_accounts WHERE account_id = ?",
-        ["tab-lastfour-only"],
+        [_case_id("last_four_only_native")],
     ).fetchone()
     assert row is not None, "account missing from core.dim_accounts"
     assert row[0] == "…4521"
@@ -490,7 +557,7 @@ def test_a_last_four_alone_names_an_account_the_sentinel_would_have_taken(
 
 @pytest.mark.slow
 def test_a_subtype_with_no_institution_still_keeps_its_last_four(
-    db: Database,
+    dim_accounts_cases: Database,
 ) -> None:
     """The subtype arm gained a last four for the same reason the top arm has one.
 
@@ -500,22 +567,11 @@ def test_a_subtype_with_no_institution_still_keeps_its_last_four(
     supposed to name the account instead guaranteed a collision. This mirrors
     the institution arms, where the with-last-four variant precedes the without.
     """
-    _insert_tabular_account(
-        db,
-        native_key="tab-subtype-lastfour",
-        account_name="Row With No Bank Fields",
-        institution_name=None,
-        account_type="CHECKING",
-        account_number="9876554521",
-        extracted_at="2024-03-01 00:00:00",
-    )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
+    db = dim_accounts_cases
 
     row = db.execute(
         "SELECT display_name FROM core.dim_accounts WHERE account_id = ?",
-        ["tab-subtype-lastfour"],
+        [_case_id("subtype_last_four_native")],
     ).fetchone()
     assert row is not None, "account missing from core.dim_accounts"
     assert row[0] == "checking …4521"

--- a/tests/moneybin/test_stg_security_prices.py
+++ b/tests/moneybin/test_stg_security_prices.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import shutil
 from decimal import Decimal
+from pathlib import Path
+from unittest.mock import MagicMock
 
 import duckdb
 import pytest
@@ -69,51 +72,374 @@ def _accept_link(
     )
 
 
-@pytest.mark.slow
-def test_bound_key_resolves_to_the_canonical_security(db: Database) -> None:
-    _insert_price(db, key="sec_vti", close="214.55")
-    _accept_link(db, key="sec_vti", canonical_id="canonvti0000001")
+@pytest.fixture(scope="module")
+def security_price_cases_template(
+    tmp_path_factory: pytest.TempPathFactory,
+    request: pytest.FixtureRequest,
+) -> Path:
+    """One encrypted, planned baseline over independent staging-price cases."""
+    secret_store = MagicMock()
+    secret_store.get_key.return_value = "test-encryption-key-for-unit-tests"
+    db = Database(
+        tmp_path_factory.mktemp("stg_security_prices") / "test.duckdb",
+        secret_store=secret_store,
+        no_auto_upgrade=True,
+        read_only=False,
+    )
+    request.addfinalizer(db.close)
 
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
+    try:
+        _insert_price(
+            db,
+            key="mb21_bound_key",
+            close="214.55",
+            origin="mb21_bound",
+        )
+        _accept_link(
+            db,
+            key="mb21_bound_key",
+            canonical_id="mb21_bound_security",
+            link_id="mb21_bound_link",
+        )
+
+        _insert_price(
+            db,
+            key="mb21_unbound_key",
+            close="10.00",
+            origin="mb21_unbound",
+        )
+
+        _insert_price(
+            db,
+            key="mb21_reversed_key",
+            close="214.55",
+            origin="mb21_reversed",
+        )
+        _accept_link(
+            db,
+            key="mb21_reversed_key",
+            canonical_id="mb21_reversed_security",
+            link_id="mb21_reversed_link",
+        )
+        db.execute(
+            "UPDATE app.security_links SET status = 'reversed' "
+            "WHERE link_id = 'mb21_reversed_link'"
+        )
+
+        mapping = _ref_kind_mapping()
+        for index, (source, ref_kind) in enumerate(sorted(mapping.items())):
+            key = f"mb21_mapped_{source}"
+            _insert_price(
+                db,
+                key=key,
+                close="100.00",
+                source=source,
+                origin=f"mb21_mapped_{source}",
+            )
+            _accept_link(
+                db,
+                key=key,
+                canonical_id=f"mb21_mapped_{index:011d}",
+                ref_kind=ref_kind,
+                source_type=source,
+                link_id=f"mb21_mapped_link_{source}",
+            )
+
+        _insert_price(
+            db,
+            key="mb21_unmapped_key",
+            close="214.55",
+            source="yahoo",
+            origin="mb21_unmapped",
+        )
+        _accept_link(
+            db,
+            key="mb21_unmapped_key",
+            canonical_id="mb21_unmapped_security",
+            source_type="yahoo",
+            link_id="mb21_unmapped_link",
+        )
+
+        _insert_price(
+            db,
+            key="mb21_positive_key",
+            close="214.55",
+            origin="mb21_non_positive",
+        )
+
+        _insert_price(
+            db,
+            key="mb21_auto_earlier_key",
+            close="180.00",
+            source="tiingo",
+            origin="mb21_auto_earlier",
+            price_date="2026-07-10",
+        )
+        _accept_link(
+            db,
+            key="mb21_auto_earlier_key",
+            canonical_id="mb21_auto_earlier_security",
+            ref_kind="tiingo_ticker",
+            source_type="tiingo",
+            link_id="mb21_auto_earlier_link",
+        )
+        _retire_link(
+            db,
+            key="mb21_auto_earlier_key",
+            on="2026-07-15",
+            link_id="mb21_auto_earlier_link",
+        )
+
+        _insert_price(
+            db,
+            key="mb21_auto_later_key",
+            close="180.00",
+            source="tiingo",
+            origin="mb21_auto_later",
+            price_date="2026-07-10",
+        )
+        _insert_price(
+            db,
+            key="mb21_auto_later_key",
+            close="9.99",
+            source="tiingo",
+            origin="mb21_auto_later",
+            price_date="2026-07-20",
+        )
+        _accept_link(
+            db,
+            key="mb21_auto_later_key",
+            canonical_id="mb21_auto_later_security",
+            ref_kind="tiingo_ticker",
+            source_type="tiingo",
+            link_id="mb21_auto_later_link",
+        )
+        _retire_link(
+            db,
+            key="mb21_auto_later_key",
+            on="2026-07-15",
+            link_id="mb21_auto_later_link",
+        )
+
+        _insert_price(
+            db,
+            key="mb21_recycled_key",
+            close="180.00",
+            source="tiingo",
+            origin="mb21_recycled",
+            price_date="2026-07-10",
+        )
+        _insert_price(
+            db,
+            key="mb21_recycled_key",
+            close="9.99",
+            source="tiingo",
+            origin="mb21_recycled",
+            price_date="2026-07-20",
+        )
+        _accept_link(
+            db,
+            key="mb21_recycled_key",
+            canonical_id="mb21_recycled_old_security",
+            ref_kind="tiingo_ticker",
+            source_type="tiingo",
+            link_id="mb21_recycled_old_link",
+            decided_on="2026-07-01",
+        )
+        _retire_link(
+            db,
+            key="mb21_recycled_key",
+            on="2026-07-15",
+            link_id="mb21_recycled_old_link",
+        )
+        _accept_link(
+            db,
+            key="mb21_recycled_key",
+            canonical_id="mb21_recycled_new_security",
+            ref_kind="tiingo_ticker",
+            source_type="tiingo",
+            link_id="mb21_recycled_new_link",
+            decided_on="2026-07-16",
+        )
+
+        _insert_price(
+            db,
+            key="mb21_twice_key",
+            close="180.00",
+            source="tiingo",
+            origin="mb21_twice",
+            price_date="2026-07-10",
+        )
+        _insert_price(
+            db,
+            key="mb21_twice_key",
+            close="9.99",
+            source="tiingo",
+            origin="mb21_twice",
+            price_date="2026-07-20",
+        )
+        _accept_link(
+            db,
+            key="mb21_twice_key",
+            canonical_id="mb21_twice_security",
+            ref_kind="tiingo_ticker",
+            source_type="tiingo",
+            link_id="mb21_twice_first_link",
+            decided_on="2026-07-01",
+        )
+        _retire_link(
+            db, key="mb21_twice_key", on="2026-07-15", link_id="mb21_twice_first_link"
+        )
+        _accept_link(
+            db,
+            key="mb21_twice_key",
+            canonical_id="mb21_twice_security",
+            ref_kind="tiingo_ticker",
+            source_type="tiingo",
+            link_id="mb21_twice_second_link",
+            decided_on="2026-07-16",
+        )
+        _retire_link(
+            db, key="mb21_twice_key", on="2026-07-25", link_id="mb21_twice_second_link"
+        )
+
+        _insert_price(
+            db,
+            key="mb21_user_handover_key",
+            close="180.00",
+            source="tiingo",
+            origin="mb21_user_handover",
+            price_date="2026-07-10",
+        )
+        _insert_price(
+            db,
+            key="mb21_user_handover_key",
+            close="9.99",
+            source="tiingo",
+            origin="mb21_user_handover",
+            price_date="2026-07-20",
+        )
+        _accept_link(
+            db,
+            key="mb21_user_handover_key",
+            canonical_id="mb21_user_handover_rejected",
+            ref_kind="tiingo_ticker",
+            source_type="tiingo",
+            link_id="mb21_user_handover_rejected_link",
+            decided_on="2026-07-01",
+        )
+        _retire_link(
+            db,
+            key="mb21_user_handover_key",
+            on="2026-07-15",
+            by="user",
+            link_id="mb21_user_handover_rejected_link",
+        )
+        _accept_link(
+            db,
+            key="mb21_user_handover_key",
+            canonical_id="mb21_user_handover_rightful",
+            ref_kind="tiingo_ticker",
+            source_type="tiingo",
+            link_id="mb21_user_handover_rightful_link",
+            decided_on="2026-07-16",
+        )
+
+        _insert_price(
+            db,
+            key="mb21_user_reversed_key",
+            close="180.00",
+            source="tiingo",
+            origin="mb21_user_reversed",
+            price_date="2026-07-10",
+        )
+        _accept_link(
+            db,
+            key="mb21_user_reversed_key",
+            canonical_id="mb21_user_reversed_security",
+            ref_kind="tiingo_ticker",
+            source_type="tiingo",
+            link_id="mb21_user_reversed_link",
+        )
+        _retire_link(
+            db,
+            key="mb21_user_reversed_key",
+            on="2026-07-15",
+            by="user",
+            link_id="mb21_user_reversed_link",
+        )
+
+        with sqlmesh_context(db) as ctx:
+            ctx.plan(auto_apply=True, no_prompts=True)
+        return db.path
+    finally:
+        db.close()
+
+
+@pytest.fixture()
+def security_price_cases(
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+    security_price_cases_template: Path,
+) -> Database:
+    """An isolated, writable copy of the shared planned baseline."""
+    path = tmp_path / "test.duckdb"
+    shutil.copy(security_price_cases_template, path)
+    secret_store = MagicMock()
+    secret_store.get_key.return_value = "test-encryption-key-for-unit-tests"
+    db = Database(
+        path,
+        secret_store=secret_store,
+        no_auto_upgrade=True,
+        assume_initialized=True,
+        read_only=False,
+    )
+    request.addfinalizer(db.close)
+    return db
+
+
+def test_bound_key_resolves_to_the_canonical_security(
+    security_price_cases: Database,
+) -> None:
+    db = security_price_cases
 
     row = db.execute(
-        "SELECT security_id, close FROM prep.stg_security_prices"
+        "SELECT security_id, close FROM prep.stg_security_prices "
+        "WHERE security_id = 'mb21_bound_security'"
     ).fetchone()
-    assert row == ("canonvti0000001", Decimal("214.5500000000"))
+    assert row == ("mb21_bound_security", Decimal("214.5500000000"))
 
 
-@pytest.mark.slow
 def test_unresolved_key_stays_in_raw_and_is_absent_from_staging(
-    db: Database,
+    security_price_cases: Database,
 ) -> None:
     """The observation is not dropped — it appears once its security resolves."""
-    _insert_price(db, key="sec_unbound", close="10.00")
+    db = security_price_cases
 
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    staged = db.execute("SELECT COUNT(*) FROM prep.stg_security_prices").fetchone()
+    staged = db.execute(
+        "SELECT COUNT(*) FROM prep.stg_security_prices "
+        "WHERE source_origin = 'mb21_unbound'"
+    ).fetchone()
     assert staged is not None and staged[0] == 0
-    stored = db.execute("SELECT COUNT(*) FROM raw.security_prices").fetchone()
+    stored = db.execute(
+        "SELECT COUNT(*) FROM raw.security_prices WHERE source_origin = 'mb21_unbound'"
+    ).fetchone()
     assert stored is not None and stored[0] == 1
 
 
-@pytest.mark.slow
-def test_reversed_link_does_not_resolve(db: Database) -> None:
-    _insert_price(db, key="sec_vti", close="214.55")
-    _accept_link(db, key="sec_vti", canonical_id="canonvti0000001")
-    db.execute("UPDATE app.security_links SET status = 'reversed'")
+def test_reversed_link_does_not_resolve(security_price_cases: Database) -> None:
+    db = security_price_cases
 
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    row = db.execute("SELECT COUNT(*) FROM prep.stg_security_prices").fetchone()
+    row = db.execute(
+        "SELECT COUNT(*) FROM prep.stg_security_prices "
+        "WHERE source_origin = 'mb21_reversed'"
+    ).fetchone()
     assert row is not None and row[0] == 0
 
 
-@pytest.mark.slow
-def test_every_mapped_source_resolves_end_to_end(db: Database) -> None:
+def test_every_mapped_source_resolves_end_to_end(
+    security_price_cases: Database,
+) -> None:
     """Every source the ref_kind CASE maps must actually reach staging.
 
     The mapped set is read from the model file, so this test grows itself: adding
@@ -129,25 +455,14 @@ def test_every_mapped_source_resolves_end_to_end(db: Database) -> None:
     leaves the CASE untouched and this test unchanged — see
     test_price_service.py::test_every_source_the_service_writes_resolves_in_staging.
     """
+    db = security_price_cases
     mapping = _ref_kind_mapping()
-    for index, (source, ref_kind) in enumerate(sorted(mapping.items())):
-        key = f"sec_{source}"
-        _insert_price(db, key=key, close="100.00", source=source)
-        _accept_link(
-            db,
-            key=key,
-            canonical_id=f"canon{index:011d}",
-            ref_kind=ref_kind,
-            source_type=source,
-        )
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
 
     resolved = {
         row[0]
         for row in db.execute(
-            "SELECT source_type FROM prep.stg_security_prices"
+            "SELECT source_type FROM prep.stg_security_prices "
+            "WHERE source_origin LIKE 'mb21_mapped_%'"
         ).fetchall()
     }
     assert resolved == set(mapping), (
@@ -157,8 +472,9 @@ def test_every_mapped_source_resolves_end_to_end(db: Database) -> None:
     )
 
 
-@pytest.mark.slow
-def test_an_unmapped_source_is_dropped_permanently_not_deferred(db: Database) -> None:
+def test_an_unmapped_source_is_dropped_permanently_not_deferred(
+    security_price_cases: Database,
+) -> None:
     """A source the ref_kind CASE does not map is discarded silently and forever.
 
     This is the finding the COVERAGE block in the model documents, pinned as behavior.
@@ -182,23 +498,23 @@ def test_an_unmapped_source_is_dropped_permanently_not_deferred(db: Database) ->
         f"{unmapped!r} now has a ref_kind mapping; pick a source with no adapter behind "
         f"it, or this test silently stops covering the drop it names"
     )
-    _insert_price(db, key="yahoo_vti", close="214.55", source=unmapped)
-    _accept_link(db, key="yahoo_vti", canonical_id="canonvti0000001")
+    db = security_price_cases
 
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    staged = db.execute("SELECT COUNT(*) FROM prep.stg_security_prices").fetchone()
+    staged = db.execute(
+        "SELECT COUNT(*) FROM prep.stg_security_prices "
+        "WHERE source_origin = 'mb21_unmapped'"
+    ).fetchone()
     assert staged is not None and staged[0] == 0, "an unmapped source must not resolve"
-    stored = db.execute("SELECT COUNT(*) FROM raw.security_prices").fetchone()
+    stored = db.execute(
+        "SELECT COUNT(*) FROM raw.security_prices WHERE source_origin = 'mb21_unmapped'"
+    ).fetchone()
     assert stored is not None and stored[0] == 1, (
         "the row survives in raw — but unlike an unbound security it will never "
         "reappear downstream, because the failure is in the mapping, not the binding"
     )
 
 
-@pytest.mark.slow
-def test_non_positive_close_is_rejected(db: Database) -> None:
+def test_non_positive_close_is_rejected(security_price_cases: Database) -> None:
     """A zero or negative close is rejected at the raw write boundary by CHECK (close > 0).
 
     The guard lives on the append-only raw table, not as a downstream staging filter: a
@@ -206,11 +522,23 @@ def test_non_positive_close_is_rejected(db: Database) -> None:
     squatting on the primary key where — the table being append-only — it could never be
     corrected. A valid positive close still inserts.
     """
-    _insert_price(db, key="sec_vti", close="214.55", price_date="2026-07-15")
+    db = security_price_cases
     with pytest.raises(duckdb.ConstraintException):
-        _insert_price(db, key="sec_vti", close="0.0", price_date="2026-07-16")
+        _insert_price(
+            db,
+            key="mb21_positive_key",
+            close="0.0",
+            origin="mb21_non_positive",
+            price_date="2026-07-16",
+        )
     with pytest.raises(duckdb.ConstraintException):
-        _insert_price(db, key="sec_vti", close="-5.00", price_date="2026-07-17")
+        _insert_price(
+            db,
+            key="mb21_positive_key",
+            close="-5.00",
+            origin="mb21_non_positive",
+            price_date="2026-07-17",
+        )
 
 
 def _retire_link(
@@ -232,9 +560,8 @@ def _retire_link(
     )
 
 
-@pytest.mark.slow
 def test_an_auto_retired_link_still_resolves_its_earlier_observations(
-    db: Database,
+    security_price_cases: Database,
 ) -> None:
     """A renamed ticker must not erase the series stored under the old symbol.
 
@@ -244,29 +571,18 @@ def test_an_auto_retired_link_still_resolves_its_earlier_observations(
     entire pre-rename history out of prep and therefore out of core, on an
     ordinary corporate action and with no error.
     """
-    _insert_price(
-        db, key="FB", close="180.00", source="tiingo", price_date="2026-07-10"
-    )
-    _accept_link(
-        db,
-        key="FB",
-        canonical_id="canonmeta000001",
-        ref_kind="tiingo_ticker",
-        source_type="tiingo",
-    )
-    _retire_link(db, key="FB", on="2026-07-15")
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
+    db = security_price_cases
 
     row = db.execute(
-        "SELECT security_id, close FROM prep.stg_security_prices"
+        "SELECT security_id, close FROM prep.stg_security_prices "
+        "WHERE security_id = 'mb21_auto_earlier_security'"
     ).fetchone()
-    assert row == ("canonmeta000001", Decimal("180.0000000000"))
+    assert row == ("mb21_auto_earlier_security", Decimal("180.0000000000"))
 
 
-@pytest.mark.slow
-def test_an_auto_retired_link_does_not_claim_later_observations(db: Database) -> None:
+def test_an_auto_retired_link_does_not_claim_later_observations(
+    security_price_cases: Database,
+) -> None:
     """The retired key stops resolving the moment it is retired.
 
     Tickers get recycled — the rename that freed FB also frees it for whoever
@@ -275,45 +591,32 @@ def test_an_auto_retired_link_does_not_claim_later_observations(db: Database) ->
     different company's series: the exact failure retiring the binding existed
     to prevent.
     """
-    _insert_price(
-        db, key="FB", close="180.00", source="tiingo", price_date="2026-07-10"
-    )
-    _insert_price(db, key="FB", close="9.99", source="tiingo", price_date="2026-07-20")
-    _accept_link(
-        db,
-        key="FB",
-        canonical_id="canonmeta000001",
-        ref_kind="tiingo_ticker",
-        source_type="tiingo",
-    )
-    _retire_link(db, key="FB", on="2026-07-15")
-
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
+    db = security_price_cases
 
     dates = [
         str(row[0])
         for row in db.execute(
-            "SELECT price_date FROM prep.stg_security_prices ORDER BY price_date"
+            "SELECT price_date FROM prep.stg_security_prices "
+            "WHERE security_id = 'mb21_auto_later_security' ORDER BY price_date"
         ).fetchall()
     ]
     assert dates == ["2026-07-10"]
 
 
-def _owners(db: Database) -> list[tuple[str, str]]:
+def _owners(db: Database, origin: str) -> list[tuple[str, str]]:
     """Every (security, date) pair staging resolves, so a double claim shows up."""
     return [
         (str(row[0]), str(row[1]))
         for row in db.execute(
             "SELECT security_id, price_date FROM prep.stg_security_prices "
-            "ORDER BY price_date, security_id"
+            "WHERE source_origin = ? ORDER BY price_date, security_id",
+            [origin],
         ).fetchall()
     ]
 
 
-@pytest.mark.slow
 def test_a_recycled_key_does_not_claim_the_previous_owners_history(
-    db: Database,
+    security_price_cases: Database,
 ) -> None:
     """The new owner of a freed ticker owns it from the handover, not from birth.
 
@@ -323,41 +626,17 @@ def test_a_recycled_key_does_not_claim_the_previous_owners_history(
     history. Asserting the whole (security, date) set rather than a count is
     what makes the duplicate visible.
     """
-    _insert_price(
-        db, key="FB", close="180.00", source="tiingo", price_date="2026-07-10"
-    )
-    _insert_price(db, key="FB", close="9.99", source="tiingo", price_date="2026-07-20")
-    _accept_link(
-        db,
-        key="FB",
-        canonical_id="canonmeta000001",
-        ref_kind="tiingo_ticker",
-        source_type="tiingo",
-        link_id="link_fb_old",
-        decided_on="2026-07-01",
-    )
-    _retire_link(db, key="FB", on="2026-07-15", link_id="link_fb_old")
-    _accept_link(
-        db,
-        key="FB",
-        canonical_id="canonnewco00001",
-        ref_kind="tiingo_ticker",
-        source_type="tiingo",
-        link_id="link_fb_new",
-        decided_on="2026-07-16",
-    )
+    db = security_price_cases
 
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    assert _owners(db) == [
-        ("canonmeta000001", "2026-07-10"),
-        ("canonnewco00001", "2026-07-20"),
+    assert _owners(db, "mb21_recycled") == [
+        ("mb21_recycled_old_security", "2026-07-10"),
+        ("mb21_recycled_new_security", "2026-07-20"),
     ]
 
 
-@pytest.mark.slow
-def test_a_key_retired_twice_resolves_each_interval_once(db: Database) -> None:
+def test_a_key_retired_twice_resolves_each_interval_once(
+    security_price_cases: Database,
+) -> None:
     """Two retirements on one key partition its history; they must not overlap.
 
     A ticker can move away and come back, leaving one security holding two
@@ -366,42 +645,17 @@ def test_a_key_retired_twice_resolves_each_interval_once(db: Database) -> None:
     link's rows and the security's own history doubles under it — invisible in
     a count of distinct securities, and wrong in every valuation.
     """
-    _insert_price(
-        db, key="FB", close="180.00", source="tiingo", price_date="2026-07-10"
-    )
-    _insert_price(db, key="FB", close="9.99", source="tiingo", price_date="2026-07-20")
-    _accept_link(
-        db,
-        key="FB",
-        canonical_id="canonmeta000001",
-        ref_kind="tiingo_ticker",
-        source_type="tiingo",
-        link_id="link_fb_first",
-        decided_on="2026-07-01",
-    )
-    _retire_link(db, key="FB", on="2026-07-15", link_id="link_fb_first")
-    _accept_link(
-        db,
-        key="FB",
-        canonical_id="canonmeta000001",
-        ref_kind="tiingo_ticker",
-        source_type="tiingo",
-        link_id="link_fb_second",
-        decided_on="2026-07-16",
-    )
-    _retire_link(db, key="FB", on="2026-07-25", link_id="link_fb_second")
+    db = security_price_cases
 
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    assert _owners(db) == [
-        ("canonmeta000001", "2026-07-10"),
-        ("canonmeta000001", "2026-07-20"),
+    assert _owners(db, "mb21_twice") == [
+        ("mb21_twice_security", "2026-07-10"),
+        ("mb21_twice_security", "2026-07-20"),
     ]
 
 
-@pytest.mark.slow
-def test_a_user_reversal_hands_the_next_owner_the_whole_series(db: Database) -> None:
+def test_a_user_reversal_hands_the_next_owner_the_whole_series(
+    security_price_cases: Database,
+) -> None:
     """A rejection transfers nothing, so it must not bound the next owner below.
 
     The user's reversal says the pairing was never real. The closes stored under
@@ -410,61 +664,27 @@ def test_a_user_reversal_hands_the_next_owner_the_whole_series(db: Database) -> 
     `reversed_by`, not on `status` alone. This is the case that separates the
     two: an arm keyed on `status = 'reversed'` passes every other test here.
     """
-    _insert_price(
-        db, key="FB", close="180.00", source="tiingo", price_date="2026-07-10"
-    )
-    _insert_price(db, key="FB", close="9.99", source="tiingo", price_date="2026-07-20")
-    _accept_link(
-        db,
-        key="FB",
-        canonical_id="canonmeta000001",
-        ref_kind="tiingo_ticker",
-        source_type="tiingo",
-        link_id="link_fb_rejected",
-        decided_on="2026-07-01",
-    )
-    _retire_link(db, key="FB", on="2026-07-15", by="user", link_id="link_fb_rejected")
-    _accept_link(
-        db,
-        key="FB",
-        canonical_id="canonnewco00001",
-        ref_kind="tiingo_ticker",
-        source_type="tiingo",
-        link_id="link_fb_rightful",
-        decided_on="2026-07-16",
-    )
+    db = security_price_cases
 
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    assert _owners(db) == [
-        ("canonnewco00001", "2026-07-10"),
-        ("canonnewco00001", "2026-07-20"),
+    assert _owners(db, "mb21_user_handover") == [
+        ("mb21_user_handover_rightful", "2026-07-10"),
+        ("mb21_user_handover_rightful", "2026-07-20"),
     ]
 
 
-@pytest.mark.slow
-def test_a_user_reversed_link_resolves_nothing(db: Database) -> None:
+def test_a_user_reversed_link_resolves_nothing(
+    security_price_cases: Database,
+) -> None:
     """A rejection is a judgement, not bookkeeping, so its prices must drop.
 
     Paired with the auto-retirement tests deliberately: an arm written to admit
     every `reversed` row passes those and fails this one, and it would restore
     exactly the valuation the user reversed the binding to reject.
     """
-    _insert_price(
-        db, key="FB", close="180.00", source="tiingo", price_date="2026-07-10"
-    )
-    _accept_link(
-        db,
-        key="FB",
-        canonical_id="canonmeta000001",
-        ref_kind="tiingo_ticker",
-        source_type="tiingo",
-    )
-    _retire_link(db, key="FB", on="2026-07-15", by="user")
+    db = security_price_cases
 
-    with sqlmesh_context(db) as ctx:
-        ctx.plan(auto_apply=True, no_prompts=True)
-
-    staged = db.execute("SELECT COUNT(*) FROM prep.stg_security_prices").fetchone()
+    staged = db.execute(
+        "SELECT COUNT(*) FROM prep.stg_security_prices "
+        "WHERE source_origin = 'mb21_user_reversed'"
+    ).fetchone()
     assert staged is not None and staged[0] == 0


### PR DESCRIPTION
## Summary

Consolidates SQLMesh setup in `test_dim_accounts_merge.py` into one encrypted, namespaced template database and isolated per-test snapshots.

All nine behaviors remain, including last-four display and no-full-account-number privacy guards. The file now makes one real initial plan.

## Verification

- `env UV_CACHE_DIR=/private/tmp/uv-cache UV_NO_SYNC=1 uv run pytest tests/moneybin/test_dim_accounts_merge.py -n0 -v` — 9 passed (17.63s)
- `env UV_CACHE_DIR=/private/tmp/uv-cache UV_NO_SYNC=1 make check test` — formatting, lint, and Pyright passed; 10,163 passed, 1 known MCP capability-parity failure, 4 skipped (135.31s)
- Fresh independent exact-range review (`947a91a2..2549c25d`) — CLEAR

## Stacking

Base: `perf/mb-21-consolidate-stg-security-prices` (PR #478). This PR changes only `tests/moneybin/test_dim_accounts_merge.py`.
