### PR TITLE
Single-source gold-key derivation

### DIFF
--- a/src/moneybin/matching/hashing.py
+++ b/src/moneybin/matching/hashing.py
@@ -3,7 +3,7 @@
 Gold keys are SHA-256 hashes truncated to 16 hex characters (64 bits),
 consistent with the content-hash ID strategy used elsewhere in MoneyBin.
 
-Unmatched records: SHA-256(source_type|source_transaction_id|account_id)
+Unmatched records: SHA-256(source_type|source_origin|source_account_key|source_transaction_id)
 Matched groups: SHA-256(sorted pipe-delimited contributing tuples)
 """
 
@@ -11,10 +11,13 @@ import hashlib
 
 
 def gold_key_unmatched(
-    source_type: str, source_transaction_id: str, account_id: str
+    source_type: str,
+    source_origin: str,
+    source_account_key: str,
+    source_transaction_id: str,
 ) -> str:
     """Generate a gold key for an unmatched (single-source) record."""
-    raw = f"{source_type}|{source_transaction_id}|{account_id}"
+    raw = f"{source_type}|{source_origin}|{source_account_key}|{source_transaction_id}"
     return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
 

--- a/src/moneybin/services/investment_service.py
+++ b/src/moneybin/services/investment_service.py
@@ -43,7 +43,6 @@ Correctness contracts implemented here (see
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import uuid
 from dataclasses import dataclass, field
@@ -58,6 +57,7 @@ from moneybin.investments.cost_basis import (
     AVERAGE_ELIGIBLE_SECURITY_TYPES,
     resolve_cost_basis_method,
 )
+from moneybin.matching.hashing import gold_key_unmatched
 from moneybin.metrics.registry import (
     INVESTMENT_EVENTS_RECORDED_TOTAL,
     PRICE_RESOLUTION_STATUS_TOTAL,
@@ -229,19 +229,6 @@ class SecurityResolutionError(UserError):
     ) -> None:
         """Store a user-safe message + code (``MUTATION_AMBIGUOUS`` on collision)."""
         super().__init__(message, code=code, hint=hint)
-
-
-def _predict_investment_gold_key(source_transaction_id: str, account_id: str) -> str:
-    """Content-hash the canonical ``investment_transaction_id`` at INSERT time.
-
-    Mirrors ``_predict_manual_gold_key`` in ``transaction_service`` — SHA256 over
-    the immutable source identity, truncated to 16 hex. The manual investment
-    staging model passes this id through unchanged (no matcher pipeline for
-    investments in v1), so the service is its sole author. Uniqueness rides on
-    the freshly-minted ``source_transaction_id``.
-    """
-    raw = f"{_SOURCE_TYPE}|{_SOURCE_ORIGIN}|{account_id}|{source_transaction_id}"
-    return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
 
 # ── Read-path result shapes ───────────────────────────────────────────────
@@ -1222,8 +1209,11 @@ class InvestmentService:
         multi-row / multi-event writes stay atomic.
         """
         source_transaction_id = "manual_" + uuid.uuid4().hex[:12]
-        investment_transaction_id = _predict_investment_gold_key(
-            source_transaction_id, account_id
+        investment_transaction_id = gold_key_unmatched(
+            _SOURCE_TYPE,
+            _SOURCE_ORIGIN,
+            account_id,
+            source_transaction_id,
         )
         self._db.conn.execute(
             f"""

--- a/src/moneybin/services/transaction_service.py
+++ b/src/moneybin/services/transaction_service.py
@@ -20,6 +20,7 @@ from typing import Any, Literal, Protocol, cast
 from moneybin import error_codes
 from moneybin.database import Database
 from moneybin.errors import UserError
+from moneybin.matching.hashing import gold_key_unmatched
 from moneybin.mcp.write_contracts import (
     AnnotationRequest,
     NoteAdd,
@@ -105,26 +106,6 @@ def _state_digest(value: object) -> str:
     """Hash live preflight state without exposing annotation contents."""
     encoded = json.dumps(value, sort_keys=True, default=str, separators=(",", ":"))
     return hashlib.sha256(encoded.encode()).hexdigest()
-
-
-def _predict_manual_gold_key(source_transaction_id: str, account_id: str) -> str:
-    """Pre-compute the gold ``transaction_id`` the SQLMesh pipeline will assign.
-
-    Mirrors the unmatched-row branch of ``int_transactions__matched`` after the
-    ADR-015 / RD-2 re-key, which hashes the immutable source identity (NOT the
-    mutable canonical ``account_id``):
-    ``SUBSTRING(SHA256(source_type||'|'||source_origin||'|'||source_account_key||'|'||source_transaction_id), 1, 16)``.
-    For manual rows ``source_origin='user'`` and ``source_account_key`` is the
-    stored ``account_id``. Manual rows are exempt from the matcher (spec Req 6 /
-    Task 8) so this branch is the only one they hit. If either side of this hash
-    drifts from the SQL, the pre-attached user-category row will silently fail to
-    join in ``core.fct_transactions``.
-    """
-    raw = (
-        f"{_MANUAL_SOURCE_TYPE}|{_MANUAL_SOURCE_ORIGIN}|"
-        f"{account_id}|{source_transaction_id}"
-    )
-    return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
 
 @dataclass(frozen=True, slots=True)
@@ -1124,8 +1105,11 @@ class TransactionService:
         try:
             for entry in prepared:
                 source_transaction_id = "manual_" + uuid.uuid4().hex[:12]
-                transaction_id = _predict_manual_gold_key(
-                    source_transaction_id, entry["account_id"]
+                transaction_id = gold_key_unmatched(
+                    _MANUAL_SOURCE_TYPE,
+                    _MANUAL_SOURCE_ORIGIN,
+                    entry["account_id"],
+                    source_transaction_id,
                 )
                 # Persist the predicted ``transaction_id`` alongside the source
                 # id so the doctor ``orphan_app_state`` audit can join on it to
@@ -1133,7 +1117,7 @@ class TransactionService:
                 # row in the window between ``transactions_create`` and the
                 # next ``refresh_run`` (which materializes the row in
                 # ``core.fct_transactions``). Migration V026 added the column;
-                # the hash here mirrors ``_predict_manual_gold_key`` exactly.
+                # The canonical helper mirrors the SQLMesh unmatched-row hash.
                 self._db.conn.execute(
                     f"""
                     INSERT INTO {MANUAL_TRANSACTIONS.full_name} (

--- a/tests/moneybin/matching/test_hashing.py
+++ b/tests/moneybin/matching/test_hashing.py
@@ -7,25 +7,25 @@ class TestGoldKeyUnmatched:
     """Tests for gold_key_unmatched."""
 
     def test_deterministic(self) -> None:
-        key1 = gold_key_unmatched("csv", "abc123", "acct1")
-        key2 = gold_key_unmatched("csv", "abc123", "acct1")
+        key1 = gold_key_unmatched("csv", "export", "acct1", "abc123")
+        key2 = gold_key_unmatched("csv", "export", "acct1", "abc123")
         assert key1 == key2
 
     def test_length_is_16_hex(self) -> None:
-        key = gold_key_unmatched("ofx", "FITID001", "checking")
+        key = gold_key_unmatched("ofx", "institution", "checking", "FITID001")
         assert len(key) == 16
         assert all(c in "0123456789abcdef" for c in key)
 
     def test_different_inputs_produce_different_keys(self) -> None:
-        key1 = gold_key_unmatched("csv", "abc", "acct1")
-        key2 = gold_key_unmatched("ofx", "abc", "acct1")
+        key1 = gold_key_unmatched("csv", "export", "acct1", "abc")
+        key2 = gold_key_unmatched("ofx", "institution", "acct1", "abc")
         assert key1 != key2
 
     def test_pipe_delimited_input(self) -> None:
         import hashlib
 
-        expected = hashlib.sha256(b"csv|txn123|acct1").hexdigest()[:16]
-        assert gold_key_unmatched("csv", "txn123", "acct1") == expected
+        expected = hashlib.sha256(b"csv|export|acct1|txn123").hexdigest()[:16]
+        assert gold_key_unmatched("csv", "export", "acct1", "txn123") == expected
 
 
 class TestGoldKeyMatched:
@@ -54,7 +54,7 @@ class TestGoldKeyMatched:
 
     def test_different_from_unmatched(self) -> None:
         matched = gold_key_matched([("csv", "abc", "acct1"), ("ofx", "xyz", "acct1")])
-        unmatched_csv = gold_key_unmatched("csv", "abc", "acct1")
-        unmatched_ofx = gold_key_unmatched("ofx", "xyz", "acct1")
+        unmatched_csv = gold_key_unmatched("csv", "export", "acct1", "abc")
+        unmatched_ofx = gold_key_unmatched("ofx", "institution", "acct1", "xyz")
         assert matched != unmatched_csv
         assert matched != unmatched_ofx

--- a/tests/moneybin/test_dedup_integration.py
+++ b/tests/moneybin/test_dedup_integration.py
@@ -239,12 +239,32 @@ class TestEndToEndDedup:
         result2 = matcher2.run()
         assert result2.auto_merged >= 1
 
-    def test_gold_key_consistency(self) -> None:
+    def test_gold_key_consistency(self, db: Database) -> None:
         """Python and SQL gold key generation must produce identical results."""
-        py_key = gold_key_unmatched("csv", "txn123", "acct1")
+        source_type = "csv"
+        source_origin = "broker-export"
+        source_account_key = "source-account"
+        source_transaction_id = "txn123"
+        py_key = gold_key_unmatched(
+            source_type,
+            source_origin,
+            source_account_key,
+            source_transaction_id,
+        )
+        sql_key = db.execute(
+            """
+            SELECT SUBSTRING(SHA256(? || '|' || ? || '|' || ? || '|' || ?), 1, 16)
+            """,
+            [
+                source_type,
+                source_origin,
+                source_account_key,
+                source_transaction_id,
+            ],
+        ).fetchone()
 
-        assert len(py_key) == 16
-        assert all(c in "0123456789abcdef" for c in py_key)
+        assert sql_key is not None
+        assert py_key == sql_key[0]
 
         group_key = gold_key_matched([
             ("csv", "txn_csv", "acct1"),

--- a/tests/moneybin/test_mcp/test_investments_tools.py
+++ b/tests/moneybin/test_mcp/test_investments_tools.py
@@ -957,18 +957,28 @@ class TestInvestmentsRecord:
         _add_security(security_id="sec_1", ticker="AAPL")
         import moneybin.services.investment_service as svc_mod
 
-        # Patch the per-row gold-key fn to raise mid-batch — the injection point
-        # for a simulated infra failure inside the write transaction.
-        real = svc_mod._predict_investment_gold_key  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        # Patch the canonical per-row gold-key function to raise mid-batch — the
+        # injection point for a simulated infra failure inside the write transaction.
+        real = svc_mod.gold_key_unmatched
         calls = {"n": 0}
 
-        def _boom(source_transaction_id: str, account_id: str) -> str:
+        def _boom(
+            source_type: str,
+            source_origin: str,
+            source_account_key: str,
+            source_transaction_id: str,
+        ) -> str:
             calls["n"] += 1
             if calls["n"] == 2:  # fail on the second row's insert
                 raise RuntimeError("simulated infra failure mid-batch")
-            return real(source_transaction_id, account_id)
+            return real(
+                source_type,
+                source_origin,
+                source_account_key,
+                source_transaction_id,
+            )
 
-        monkeypatch.setattr(svc_mod, "_predict_investment_gold_key", _boom)
+        monkeypatch.setattr(svc_mod, "gold_key_unmatched", _boom)
 
         def _buy(day: str, amount: str) -> dict[str, object]:
             return {


### PR DESCRIPTION
## Summary

- Make the unmatched gold-key helper use the four immutable source-identity fields used by the SQL model.
- Route manual transaction and investment writes through that helper to eliminate duplicate Python implementations.
- Compare the Python helper with DuckDB's SQL expression in the integration test.

## Test plan

- `env UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/moneybin/matching/test_hashing.py tests/moneybin/test_dedup_integration.py tests/moneybin/test_services/test_transaction_service.py tests/moneybin/test_services/test_investment_service.py tests/moneybin/test_mcp/test_investments_tools.py -v`
- `env UV_CACHE_DIR=/private/tmp/uv-cache make check`
