### PR TITLE
perf: skip redundant transform restate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1308,6 +1308,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   audit trail keeps it (#387).
 
 ### Fixed
+- **Transforming fresh data no longer repeats a full rebuild when the initial
+  SQLMesh plan already scheduled every FULL model.** A view-only model change
+  still triggers that rebuild when new raw data landed, so refreshed reports do
+  not miss the new rows. (#483)
+
 - **A non-finite amount no longer crashes a report, or prices as though it were
   a number.** A `NaN` in a money column left `format_money` through
   `amount < 0` as a raw `decimal.InvalidOperation` traceback rather than a

--- a/src/moneybin/services/transform_service.py
+++ b/src/moneybin/services/transform_service.py
@@ -12,6 +12,7 @@ import time
 from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import Protocol, cast
 
 import duckdb
 
@@ -70,6 +71,32 @@ _RAW_IMPORT_SCOPED: frozenset[str] = frozenset({
     "tabular_accounts",
     "tabular_transactions",
 })
+
+
+class _PlannedSnapshot(Protocol):
+    name: str
+    is_full: bool
+
+
+class _SnapshotInterval(Protocol):
+    snapshot_id: object
+
+
+class _InitialPlan(Protocol):
+    snapshots: dict[object, _PlannedSnapshot]
+    missing_intervals: Collection[_SnapshotInterval]
+
+
+def _plan_backfills_full_models(
+    plan: _InitialPlan, full_models: Collection[str]
+) -> bool:
+    """Return whether the initial SQLMesh plan schedules every FULL model."""
+    planned_full_models = {
+        plan.snapshots[interval.snapshot_id].name
+        for interval in plan.missing_intervals
+        if plan.snapshots[interval.snapshot_id].is_full
+    }
+    return set(full_models) <= planned_full_models
 
 
 def _build_raw_landing_scan(
@@ -290,16 +317,24 @@ class TransformService:
                     #      per-model cron cadence. (No incremental models exist
                     #      today, so this is currently a no-op — wired now so the
                     #      pipeline is correct when one lands.)
-                    #   3. restate FULL models only when step 1 made no changes.
-                    #      A fresh or changed plan already materializes them; with
-                    #      an unchanged plan, restatement forces the rebuild that
-                    #      picks up new raw rows. Scoped to is_full so INCREMENTAL
-                    #      models are NOT blanket-restated (that would reprocess
-                    #      all history and defeat incrementality).
+                    #   3. restate FULL models only when step 1 did not schedule
+                    #      every one. A plan may change only a VIEW or environment
+                    #      metadata, which does not rebuild FULL models; otherwise
+                    #      the restatement forces the rebuild that picks up new raw
+                    #      rows. Scoped to is_full so INCREMENTAL models are NOT
+                    #      blanket-restated (that would reprocess all history and
+                    #      defeat incrementality).
                     # DEPRECATED-WHEN: the first INCREMENTAL model lands — verify
                     # step 2 keeps it fresh and that it stays out of the restate
                     # set below.
-                    initial_plan = ctx.plan(auto_apply=True, no_prompts=True)
+                    initial_plan = ctx.plan(no_prompts=True)
+                    full_models = [
+                        name for name, model in ctx.models.items() if model.kind.is_full
+                    ]
+                    initial_plan_backfills_full_models = _plan_backfills_full_models(
+                        cast(_InitialPlan, initial_plan), full_models
+                    )
+                    ctx.apply(initial_plan)
                     # ctx.run() returns a CompletionStatus; unlike plan() it does
                     # NOT raise on scheduler/audit/model failure (SQLMesh's own
                     # CLI checks is_failure and raises "Run failed"). Surface a
@@ -309,10 +344,7 @@ class TransformService:
                     run_status = ctx.run(ignore_cron=True)
                     if run_status.is_failure:
                         raise RuntimeError("SQLMesh run reported a failure status")
-                    full_models = [
-                        name for name, model in ctx.models.items() if model.kind.is_full
-                    ]
-                    if full_models and not initial_plan.has_changes:
+                    if full_models and not initial_plan_backfills_full_models:
                         ctx.plan(
                             restate_models=full_models,
                             auto_apply=True,

--- a/src/moneybin/services/transform_service.py
+++ b/src/moneybin/services/transform_service.py
@@ -290,16 +290,16 @@ class TransformService:
                     #      per-model cron cadence. (No incremental models exist
                     #      today, so this is currently a no-op — wired now so the
                     #      pipeline is correct when one lands.)
-                    #   3. restate FULL models — a FULL model's interval is
-                    #      already "complete" after step 1, so run() skips it; only
-                    #      restatement forces the full rebuild that picks up new
-                    #      raw rows. Scoped to is_full so INCREMENTAL models are
-                    #      NOT blanket-restated (that would reprocess all history
-                    #      every refresh and defeat incrementality).
+                    #   3. restate FULL models only when step 1 made no changes.
+                    #      A fresh or changed plan already materializes them; with
+                    #      an unchanged plan, restatement forces the rebuild that
+                    #      picks up new raw rows. Scoped to is_full so INCREMENTAL
+                    #      models are NOT blanket-restated (that would reprocess
+                    #      all history and defeat incrementality).
                     # DEPRECATED-WHEN: the first INCREMENTAL model lands — verify
                     # step 2 keeps it fresh and that it stays out of the restate
                     # set below.
-                    ctx.plan(auto_apply=True, no_prompts=True)
+                    initial_plan = ctx.plan(auto_apply=True, no_prompts=True)
                     # ctx.run() returns a CompletionStatus; unlike plan() it does
                     # NOT raise on scheduler/audit/model failure (SQLMesh's own
                     # CLI checks is_failure and raises "Run failed"). Surface a
@@ -312,7 +312,7 @@ class TransformService:
                     full_models = [
                         name for name, model in ctx.models.items() if model.kind.is_full
                     ]
-                    if full_models:
+                    if full_models and not initial_plan.has_changes:
                         ctx.plan(
                             restate_models=full_models,
                             auto_apply=True,

--- a/tests/moneybin/test_services/test_transform_service.py
+++ b/tests/moneybin/test_services/test_transform_service.py
@@ -6,12 +6,19 @@ import logging
 from collections.abc import Callable, Generator
 from datetime import UTC, date, datetime
 from decimal import Decimal
+from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
 
 from moneybin.database import Database
-from moneybin.services.transform_service import TransformService, TransformStatus
+from moneybin.services.transform_service import (
+    TransformService,
+    TransformStatus,
+    _InitialPlan,  # pyright: ignore[reportPrivateUsage]  # direct predicate coverage
+    _plan_backfills_full_models,  # pyright: ignore[reportPrivateUsage]  # direct predicate coverage
+)
 from tests.moneybin.db_helpers import record_sqlmesh_apply
 
 # raw.import_log columns required by NOT NULL constraints. The table is
@@ -413,6 +420,41 @@ def test_unrebuilt_model_kinds_cover_every_symbolic_kind() -> None:
     )
 
     assert _SYMBOLIC_MODEL_KINDS <= _UNREBUILT_MODEL_KINDS
+
+
+@pytest.mark.parametrize(
+    ("planned_models", "expected"),
+    [
+        ((("core.first", True), ("core.second", True)), True),
+        ((("core.first", True), ("reports.view", False)), False),
+    ],
+)
+def test_plan_backfills_full_models_only_when_every_full_model_is_scheduled(
+    planned_models: tuple[tuple[str, bool], tuple[str, bool]], expected: bool
+) -> None:
+    """A partial FULL-model backfill must retain the later restate."""
+    snapshots = {
+        "first": SimpleNamespace(
+            name=planned_models[0][0], is_full=planned_models[0][1]
+        ),
+        "second": SimpleNamespace(
+            name=planned_models[1][0], is_full=planned_models[1][1]
+        ),
+    }
+    plan = SimpleNamespace(
+        snapshots=snapshots,
+        missing_intervals=[
+            SimpleNamespace(snapshot_id="first"),
+            SimpleNamespace(snapshot_id="second"),
+        ],
+    )
+
+    assert (
+        _plan_backfills_full_models(
+            cast(_InitialPlan, plan), {"core.first", "core.second"}
+        )
+        is expected
+    )
 
 
 def test_apply_returns_apply_result_shape(

--- a/tests/moneybin/test_services/test_transform_service.py
+++ b/tests/moneybin/test_services/test_transform_service.py
@@ -452,7 +452,8 @@ def test_apply_returns_apply_result_shape(
     assert result.applied is True
     assert result.duration_seconds >= 0
     assert result.error is None
-    fake_ctx.plan.assert_called_once_with(auto_apply=True, no_prompts=True)
+    fake_ctx.plan.assert_called_once_with(no_prompts=True)
+    fake_ctx.apply.assert_called_once_with(fake_ctx.plan.return_value)
 
 
 def test_a_failing_duration_metric_does_not_abort_a_completed_apply(

--- a/tests/moneybin/test_transform_apply_refresh.py
+++ b/tests/moneybin/test_transform_apply_refresh.py
@@ -14,6 +14,8 @@ after new raw rows updates the materialized dimension.
 from __future__ import annotations
 
 import logging
+from contextlib import contextmanager
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -86,6 +88,77 @@ def _insert_plaid_account(
     )
 
 
+def _write_restate_regression_models(root: Path, *, include_view_column: bool) -> None:
+    """Write a minimal project with one FULL model and one dependent VIEW."""
+    models = root / "models"
+    models.mkdir(parents=True, exist_ok=True)
+    (models / "items.sql").write_text(
+        """
+        MODEL (
+          name core.restate_items,
+          kind FULL,
+          grain id
+        );
+
+        SELECT id FROM raw.restate_items
+        """
+    )
+    view_model = """
+        MODEL (
+          name reports.restate_items,
+          kind VIEW
+        );
+
+        SELECT id FROM core.restate_items
+        """
+    if include_view_column:
+        view_model = """
+            MODEL (
+              name reports.restate_items,
+              kind VIEW
+            );
+
+            SELECT id, id AS copy_id FROM core.restate_items
+            """
+    (models / "items_view.sql").write_text(view_model)
+
+
+@pytest.mark.slow
+def test_apply_restates_full_models_after_a_view_only_plan_change(
+    db: Database, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A changed VIEW cannot suppress the FULL rebuild needed for new raw rows."""
+    sqlmesh_root = tmp_path / "sqlmesh"
+    _write_restate_regression_models(sqlmesh_root, include_view_column=False)
+
+    @contextmanager
+    def test_sqlmesh_context(database: Database):  # type: ignore[no-untyped-def]
+        with sqlmesh_context(database, sqlmesh_root=sqlmesh_root) as context:
+            yield context
+
+    def skip_refresh_views(_db: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "moneybin.services.transform_service.sqlmesh_context", test_sqlmesh_context
+    )
+    monkeypatch.setattr(
+        "moneybin.services.transform_service.refresh_views", skip_refresh_views
+    )
+    db.execute("CREATE TABLE raw.restate_items (id INTEGER)")
+    db.execute("INSERT INTO raw.restate_items VALUES (1)")
+    assert TransformService(db).apply().applied is True
+
+    _write_restate_regression_models(sqlmesh_root, include_view_column=True)
+    db.execute("INSERT INTO raw.restate_items VALUES (2)")
+
+    assert TransformService(db).apply().applied is True
+    assert db.execute("SELECT id FROM core.restate_items ORDER BY id").fetchall() == [
+        (1,),
+        (2,),
+    ]
+
+
 @pytest.mark.slow
 def test_apply_does_not_restate_after_a_fresh_plan(
     db: Database, monkeypatch: pytest.MonkeyPatch
@@ -113,7 +186,7 @@ def test_apply_does_not_restate_after_a_fresh_plan(
     result = TransformService(db).apply()
 
     assert result.applied, f"fresh apply failed: {result.error}"
-    assert plan_calls == [{"auto_apply": True, "no_prompts": True}]
+    assert plan_calls == [{"no_prompts": True}]
     assert db.execute("SELECT COUNT(*) FROM core.dim_accounts").fetchone() == (1,)
 
 

--- a/tests/moneybin/test_transform_apply_refresh.py
+++ b/tests/moneybin/test_transform_apply_refresh.py
@@ -14,8 +14,10 @@ after new raw rows updates the materialized dimension.
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import pytest
+from sqlmesh import Context
 
 from moneybin.database import Database, sqlmesh_context
 from moneybin.services.transform_service import TransformService
@@ -82,6 +84,37 @@ def _insert_plaid_account(
         """,  # noqa: S608  # test fixture, not executing user SQL
         [f"link-{native_key}", canonical_id, native_key, source_origin],
     )
+
+
+@pytest.mark.slow
+def test_apply_does_not_restate_after_a_fresh_plan(
+    db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fresh plan materializes FULL models without a follow-up restate."""
+    plan_calls: list[dict[str, object]] = []
+    original_plan = Context.plan
+
+    def record_plan(self: Context, *args: Any, **kwargs: Any) -> Any:
+        plan_calls.append(kwargs)
+        return original_plan(self, *args, **kwargs)
+
+    monkeypatch.setattr(Context, "plan", record_plan)
+    _insert_plaid_account(
+        db,
+        native_key="a-native-checking",
+        canonical_id="canonA00000001",
+        institution_name="Bank A",
+        account_type="depository",
+        mask="0000",
+        source_origin="item_a",
+        extracted_at="2026-06-01 12:00:00",
+    )
+
+    result = TransformService(db).apply()
+
+    assert result.applied, f"fresh apply failed: {result.error}"
+    assert plan_calls == [{"auto_apply": True, "no_prompts": True}]
+    assert db.execute("SELECT COUNT(*) FROM core.dim_accounts").fetchone() == (1,)
 
 
 @pytest.mark.slow

--- a/tests/moneybin/test_transform_apply_refresh.py
+++ b/tests/moneybin/test_transform_apply_refresh.py
@@ -113,13 +113,13 @@ def _write_restate_regression_models(root: Path, *, include_view_column: bool) -
         """
     if include_view_column:
         view_model = """
-            MODEL (
-              name reports.restate_items,
-              kind VIEW
-            );
+        MODEL (
+          name reports.restate_items,
+          kind VIEW
+        );
 
-            SELECT id, id AS copy_id FROM core.restate_items
-            """
+        SELECT id, id AS copy_id FROM core.restate_items
+        """
     (models / "items_view.sql").write_text(view_model)
 
 


### PR DESCRIPTION
## Summary

- avoid a duplicate transform restatement when the initial SQLMesh plan already backfills every FULL model
- preserve the restatement when a view-only plan coincides with newly landed raw data
- cover fresh, repeat-refresh, and view-only plan behavior using real SQLMesh contexts

## Verification

- `env UV_CACHE_DIR=/private/tmp/uv-cache make check`
- `env UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest -n 1 tests/moneybin/test_transform_apply_refresh.py tests/moneybin/test_services/test_transform_service.py -v`
- `env UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest -n 1 tests/integration/test_import_service_batch.py tests/integration/test_scenario_sync_dim_freshness.py -v`
- `env UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest -n 1 tests/e2e/test_e2e_mutating.py::TestTransformMutating::test_transform_apply tests/e2e/test_e2e_mutating.py::TestTransformMutating::test_refresh_runs_pipeline tests/e2e/test_e2e_mutating.py::TestTransformMutating::test_refresh_step_transform_only -v`
