### PR TITLE
perf: batch categorization hot-path writes

### DIFF
--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -259,7 +259,8 @@ def _database_connections_block(db_path: Path) -> dict[str, Any]:
     # No separate exists() check: _writer_is_live opens the lock file and
     # returns False if it is absent, so an exists() guard would be a redundant,
     # TOCTOU-prone stat.
-    if _writer_is_live(lock_path):
+    writer_is_live = _writer_is_live(lock_path)
+    if writer_is_live:
         metadata = _read_writer_metadata(lock_path)
         if metadata is not None:
             writer_pid = metadata["pid"]
@@ -273,7 +274,7 @@ def _database_connections_block(db_path: Path) -> dict[str, Any]:
     # The lock probe above is sufficient to establish a healthy status; only
     # enumerate processes when diagnosing the live writer that needs a holder.
     readers: list[dict[str, Any]] = []
-    processes = find_blocking_processes(resolved) if writers else []
+    processes = find_blocking_processes(resolved) if writer_is_live else []
     for proc in processes:
         if writer_pid is not None and proc["pid"] == writer_pid:
             continue  # Avoid double-listing the writer as a reader

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -270,11 +270,11 @@ def _database_connections_block(db_path: Path) -> dict[str, Any]:
         # back to no writer entry — the lock-file payload is best-effort
         # observability, not a correctness contract.
 
-    # Process inspection takes roughly half a second on a healthy machine.
-    # The lock probe above is sufficient to establish a healthy status; only
-    # enumerate processes when diagnosing the live writer that needs a holder.
+    # A writer can time out and release the advisory lock while a DuckDB reader
+    # still blocks the next write, so recovery diagnostics must enumerate
+    # readers independently of the current writer-lock state.
     readers: list[dict[str, Any]] = []
-    processes = find_blocking_processes(resolved) if writer_is_live else []
+    processes = find_blocking_processes(resolved)
     for proc in processes:
         if writer_pid is not None and proc["pid"] == writer_pid:
             continue  # Avoid double-listing the writer as a reader

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -269,8 +269,12 @@ def _database_connections_block(db_path: Path) -> dict[str, Any]:
         # back to no writer entry — the lock-file payload is best-effort
         # observability, not a correctness contract.
 
+    # Process inspection takes roughly half a second on a healthy machine.
+    # The lock probe above is sufficient to establish a healthy status; only
+    # enumerate processes when diagnosing the live writer that needs a holder.
     readers: list[dict[str, Any]] = []
-    for proc in find_blocking_processes(resolved):
+    processes = find_blocking_processes(resolved) if writers else []
+    for proc in processes:
         if writer_pid is not None and proc["pid"] == writer_pid:
             continue  # Avoid double-listing the writer as a reader
         readers.append({

--- a/src/moneybin/repositories/base.py
+++ b/src/moneybin/repositories/base.py
@@ -174,6 +174,33 @@ class BaseRepo:
         ).inc()
         return event
 
+    def _emit_audits(
+        self,
+        *,
+        action: str,
+        changes: list[
+            tuple[
+                tuple[str | None, str | None, str | None],
+                dict[str, Any] | None,
+                dict[str, Any] | None,
+            ]
+        ],
+        actor: str,
+        parent_audit_id: str | None = None,
+    ) -> list[AuditEvent]:
+        """Emit row-grain audits for a batch mutation with one database write."""
+        events = self._audit.record_audit_events(
+            action=action,
+            changes=changes,
+            actor=actor,
+            parent_audit_id=parent_audit_id,
+        )
+        if events:
+            app_mutation_audit_emitted_total.labels(
+                repository=self.repository, action=action
+            ).inc(len(events))
+        return events
+
     def _fetch_one(
         self,
         table_ref: TableRef,

--- a/src/moneybin/repositories/transaction_categories_repo.py
+++ b/src/moneybin/repositories/transaction_categories_repo.py
@@ -193,6 +193,110 @@ class TransactionCategoriesRepo(BaseRepo):
                 parent_audit_id=parent_audit_id,
             )
 
+    def upsert_guarded_many(
+        self,
+        categorizations: list[dict[str, Any]],
+        *,
+        actor: str,
+        parent_audit_id: str | None = None,
+        in_outer_txn: bool = False,
+    ) -> set[str]:
+        """Apply guarded engine categorizations with one write and row-grain audits."""
+        if not categorizations:
+            return set()
+        from moneybin.services.categorization._shared import (  # noqa: PLC0415
+            priority_case_sql,
+        )
+
+        transaction_ids = [str(item["transaction_id"]) for item in categorizations]
+        if len(set(transaction_ids)) != len(transaction_ids):
+            raise ValueError("batch categorization requires unique transaction_ids")
+        placeholders = ", ".join("?" for _ in transaction_ids)
+        columns = ", ".join(quote_ident(c) for c in _TRANSACTION_CATEGORIES_COLUMNS)
+        values = ", ".join(
+            "(?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?)" for _ in categorizations
+        )
+        params: list[Any] = []
+        for item in categorizations:
+            params.extend([
+                item["transaction_id"],
+                item["category"],
+                item["subcategory"],
+                item["category_id"],
+                item["categorized_by"],
+                item["merchant_id"],
+                item["rule_id"],
+                item["confidence"],
+                item["source_type"],
+            ])
+        excluded_priority = priority_case_sql("EXCLUDED.categorized_by")
+        existing_priority = priority_case_sql(
+            f"{TRANSACTION_CATEGORIES.full_name}.categorized_by"
+        )
+        with self._transaction(in_outer_txn=in_outer_txn):
+            before_rows = self._db.execute(
+                f"SELECT {columns} FROM {TRANSACTION_CATEGORIES.full_name} "  # noqa: S608  # TableRef + code-constant columns
+                f"WHERE transaction_id IN ({placeholders})",
+                transaction_ids,
+            ).fetchall()
+            before_by_id: dict[str, dict[str, Any]] = {
+                str(row[0]): dict(
+                    zip(_TRANSACTION_CATEGORIES_COLUMNS, row, strict=True)
+                )
+                for row in before_rows
+            }
+            wrote = self._db.execute(
+                f"""
+                INSERT INTO {TRANSACTION_CATEGORIES.full_name}
+                    (transaction_id, category, subcategory, category_id,
+                     categorized_at, categorized_by, merchant_id, rule_id,
+                     confidence, source_type)
+                VALUES {values}
+                ON CONFLICT (transaction_id) DO UPDATE SET
+                    category = EXCLUDED.category,
+                    subcategory = EXCLUDED.subcategory,
+                    category_id = EXCLUDED.category_id,
+                    categorized_at = EXCLUDED.categorized_at,
+                    categorized_by = EXCLUDED.categorized_by,
+                    merchant_id = EXCLUDED.merchant_id,
+                    rule_id = EXCLUDED.rule_id,
+                    confidence = EXCLUDED.confidence,
+                    source_type = EXCLUDED.source_type
+                WHERE {excluded_priority} <= {existing_priority}
+                RETURNING transaction_id
+                """,  # noqa: S608  # TableRef, CASE, and placeholder count are code controlled
+                params,
+            ).fetchall()
+            written_ids = {str(row[0]) for row in wrote}
+            if not written_ids:
+                return set()
+            written_placeholders = ", ".join("?" for _ in written_ids)
+            after_rows = self._db.execute(
+                f"SELECT {columns} FROM {TRANSACTION_CATEGORIES.full_name} "  # noqa: S608  # TableRef + code-constant columns
+                f"WHERE transaction_id IN ({written_placeholders})",
+                sorted(written_ids),
+            ).fetchall()
+            after_by_id: dict[str, dict[str, Any]] = {
+                str(row[0]): dict(
+                    zip(_TRANSACTION_CATEGORIES_COLUMNS, row, strict=True)
+                )
+                for row in after_rows
+            }
+            self._emit_audits(
+                action="category.set",
+                changes=[
+                    (
+                        (*self._audit_target, transaction_id),
+                        self._serialize_for_audit(before_by_id.get(transaction_id)),
+                        self._serialize_for_audit(after_by_id[transaction_id]),
+                    )
+                    for transaction_id in sorted(written_ids)
+                ],
+                actor=actor,
+                parent_audit_id=parent_audit_id,
+            )
+            return written_ids
+
     def clear(
         self,
         transaction_id: str,

--- a/src/moneybin/services/audit_service.py
+++ b/src/moneybin/services/audit_service.py
@@ -176,6 +176,82 @@ class AuditService:
             undoes_operation_id=undoes_operation_id,
         )
 
+    def record_audit_events(
+        self,
+        *,
+        action: str,
+        changes: list[
+            tuple[
+                tuple[str | None, str | None, str | None],
+                dict[str, Any] | None,
+                dict[str, Any] | None,
+            ]
+        ],
+        actor: str,
+        parent_audit_id: str | None = None,
+    ) -> list[AuditEvent]:
+        """Insert same-action audit rows with one multi-row statement.
+
+        Each change remains a separate audit row, so operation-level undo keeps
+        its existing row-grain behavior while batch writers avoid one round trip
+        per affected record.
+        """
+        if not changes:
+            return []
+        operation_id = current_operation_id()
+        events: list[AuditEvent] = []
+        params: list[Any] = []
+        for target, before, after in changes:
+            target_schema, target_table, target_id = target
+            audit_id = uuid.uuid4().hex
+            params.extend([
+                audit_id,
+                actor,
+                action,
+                target_schema,
+                target_table,
+                target_id,
+                json.dumps(before) if before is not None else None,
+                json.dumps(after) if after is not None else None,
+                parent_audit_id,
+                operation_id,
+                None,
+                False,
+                None,
+            ])
+            events.append(
+                AuditEvent(
+                    audit_id=audit_id,
+                    occurred_at="",
+                    actor=actor,
+                    action=action,
+                    target_schema=target_schema,
+                    target_table=target_table,
+                    target_id=target_id,
+                    before_value=before,
+                    after_value=after,
+                    parent_audit_id=parent_audit_id,
+                    operation_id=operation_id,
+                )
+            )
+        values = ", ".join(
+            "(" + ", ".join("?" for _ in range(13)) + ")" for _ in changes
+        )
+        self._db.conn.execute(
+            f"""
+            INSERT INTO app.audit_log (
+                audit_id, actor, action,
+                target_schema, target_table, target_id,
+                before_value, after_value, parent_audit_id, operation_id,
+                context_json, is_undo, undoes_operation_id
+            ) VALUES {values}
+            """,  # noqa: S608  # Placeholder count derives only from batch length
+            params,
+        )
+        audit_events_emitted_total.labels(action=action, actor=actor).inc(len(events))
+        logger.debug(f"audit_events count={len(events)} action={action} actor={actor}")
+        return events
+
     def list_events(
         self,
         *,

--- a/src/moneybin/services/categorization/applier.py
+++ b/src/moneybin/services/categorization/applier.py
@@ -1869,3 +1869,41 @@ class MatchApplier:
             src_attempted=categorized_by,
         ).inc()
         return WriteOutcome(written=False, skipped_reason="lower_priority_source")
+
+    def write_categorizations(
+        self, categorizations: list[dict[str, object]]
+    ) -> set[str]:
+        """Apply engine categorizations as one guarded, audited batch."""
+        if not categorizations:
+            return set()
+        prepared: list[dict[str, object]] = []
+        for categorization in categorizations:
+            categorized_by = str(categorization["categorized_by"])
+            if categorized_by not in SOURCE_PRIORITY:
+                raise ValueError(
+                    f"Unknown categorized_by={categorized_by!r}; "
+                    f"must be one of {sorted(SOURCE_PRIORITY)}"
+                )
+            prepared.append({
+                **categorization,
+                "category_id": resolve_category_id(
+                    self._db,
+                    str(categorization["category"]),
+                    cast("str | None", categorization["subcategory"]),
+                ),
+            })
+        written = self._tx_categories.upsert_guarded_many(prepared, actor="system")
+        for categorization in prepared:
+            transaction_id = str(categorization["transaction_id"])
+            if transaction_id in written:
+                continue
+            existing = self._db.execute(
+                f"SELECT categorized_by FROM {TRANSACTION_CATEGORIES.full_name} "  # noqa: S608  # TableRef + parameterized value
+                "WHERE transaction_id = ?",
+                [transaction_id],
+            ).fetchone()
+            CATEGORIZE_WRITE_SKIPPED_PRECEDENCE_TOTAL.labels(
+                src_existing=existing[0] if existing else "unknown",
+                src_attempted=str(categorization["categorized_by"]),
+            ).inc()
+        return written

--- a/src/moneybin/services/categorization/applier.py
+++ b/src/moneybin/services/categorization/applier.py
@@ -1877,6 +1877,7 @@ class MatchApplier:
         if not categorizations:
             return set()
         prepared: list[dict[str, object]] = []
+        category_ids: dict[tuple[str, str | None], str | None] = {}
         for categorization in categorizations:
             categorized_by = str(categorization["categorized_by"])
             if categorized_by not in SOURCE_PRIORITY:
@@ -1884,26 +1885,42 @@ class MatchApplier:
                     f"Unknown categorized_by={categorized_by!r}; "
                     f"must be one of {sorted(SOURCE_PRIORITY)}"
                 )
+            category_key = (
+                str(categorization["category"]),
+                cast("str | None", categorization["subcategory"]),
+            )
+            if category_key not in category_ids:
+                category_ids[category_key] = resolve_category_id(
+                    self._db, *category_key
+                )
             prepared.append({
                 **categorization,
-                "category_id": resolve_category_id(
-                    self._db,
-                    str(categorization["category"]),
-                    cast("str | None", categorization["subcategory"]),
-                ),
+                "category_id": category_ids[category_key],
             })
         written = self._tx_categories.upsert_guarded_many(prepared, actor="system")
+        skipped_ids = sorted(
+            str(categorization["transaction_id"])
+            for categorization in prepared
+            if str(categorization["transaction_id"]) not in written
+        )
+        existing_by_id: dict[str, str] = {}
+        if skipped_ids:
+            placeholders = ", ".join("?" for _ in skipped_ids)
+            existing_by_id = {
+                str(transaction_id): str(categorized_by)
+                for transaction_id, categorized_by in self._db.execute(
+                    f"SELECT transaction_id, categorized_by "
+                    f"FROM {TRANSACTION_CATEGORIES.full_name} "
+                    f"WHERE transaction_id IN ({placeholders})",  # noqa: S608  # TableRef + parameterized values
+                    skipped_ids,
+                ).fetchall()
+            }
         for categorization in prepared:
             transaction_id = str(categorization["transaction_id"])
             if transaction_id in written:
                 continue
-            existing = self._db.execute(
-                f"SELECT categorized_by FROM {TRANSACTION_CATEGORIES.full_name} "  # noqa: S608  # TableRef + parameterized value
-                "WHERE transaction_id = ?",
-                [transaction_id],
-            ).fetchone()
             CATEGORIZE_WRITE_SKIPPED_PRECEDENCE_TOTAL.labels(
-                src_existing=existing[0] if existing else "unknown",
+                src_existing=existing_by_id.get(transaction_id, "unknown"),
                 src_attempted=str(categorization["categorized_by"]),
             ).inc()
         return written

--- a/src/moneybin/services/categorization/orchestrator.py
+++ b/src/moneybin/services/categorization/orchestrator.py
@@ -651,7 +651,7 @@ class CategorizationOrchestrator:
         if not uncategorized:
             return set()
 
-        applied: set[str] = set()
+        categorizations: list[dict[str, object]] = []
         for row in uncategorized:
             match = CategorizationMatcher.match_first_rule(
                 rules,
@@ -666,16 +666,18 @@ class CategorizationOrchestrator:
             categorized_by: CategorizedBy = (
                 "auto_rule" if created_by == "auto_rule" else "rule"
             )
-            outcome = self._applier.write_categorization(
-                transaction_id=row.transaction_id,
-                category=category,
-                subcategory=subcategory,
-                categorized_by=categorized_by,
-                rule_id=rule_id,
-                confidence=1.0,
-            )
-            if outcome.written:
-                applied.add(row.transaction_id)
+            categorizations.append({
+                "transaction_id": row.transaction_id,
+                "category": category,
+                "subcategory": subcategory,
+                "categorized_by": categorized_by,
+                "merchant_id": None,
+                "rule_id": rule_id,
+                "confidence": 1.0,
+                "source_type": "internal",
+            })
+
+        applied = self._applier.write_categorizations(categorizations)
 
         if applied:
             _engine_counts_logger.info(
@@ -754,7 +756,7 @@ class CategorizationOrchestrator:
             m.merchant_id: (m.category, m.subcategory) for m in merchants
         }
 
-        categorized_count = 0
+        categorizations: list[dict[str, object]] = []
         for row in uncategorized:
             txn_id = row.transaction_id
             # Spec Decision 3 rung 2: match the provider merchant_name too, not just
@@ -834,16 +836,18 @@ class CategorizationOrchestrator:
             # deferred to rules / LLM / Tier-2b).
             if category is None:
                 continue
-            outcome = self._applier.write_categorization(
-                transaction_id=txn_id,
-                category=category,
-                subcategory=subcategory,
-                categorized_by=categorized_by,
-                merchant_id=merchant_id,
-                confidence=1.0,
-            )
-            if outcome.written:
-                categorized_count += 1
+            categorizations.append({
+                "transaction_id": txn_id,
+                "category": category,
+                "subcategory": subcategory,
+                "categorized_by": categorized_by,
+                "merchant_id": merchant_id,
+                "rule_id": None,
+                "confidence": 1.0,
+                "source_type": "internal",
+            })
+
+        categorized_count = len(self._applier.write_categorizations(categorizations))
 
         if categorized_count:
             _engine_counts_logger.info(
@@ -985,7 +989,7 @@ class CategorizationOrchestrator:
         Returns the number of rows actually written (post-gate, post-priority
         guard).
         """
-        count = 0
+        categorizations: list[dict[str, object]] = []
         for txn_id, category, subcategory, level, merchant_id in rows:
             confidence = plaid_confidence_to_numeric(level)
             if confidence is None:
@@ -1001,20 +1005,22 @@ class CategorizationOrchestrator:
                     source_type="plaid", reason="below_gate", trigger=trigger
                 ).inc()
                 continue
-            outcome = self._applier.write_categorization(
-                transaction_id=txn_id,
-                category=category,
-                subcategory=subcategory,
-                categorized_by="provider_native",
-                merchant_id=merchant_id,
-                source_type="plaid",
-                confidence=confidence,
-            )
-            if outcome.written:
-                count += 1
-                CATEGORIZE_PROVIDER_NATIVE_TOTAL.labels(
-                    source_type="plaid", trigger=trigger
-                ).inc()
+            categorizations.append({
+                "transaction_id": txn_id,
+                "category": category,
+                "subcategory": subcategory,
+                "categorized_by": "provider_native",
+                "merchant_id": merchant_id,
+                "rule_id": None,
+                "confidence": confidence,
+                "source_type": "plaid",
+            })
+
+        count = len(self._applier.write_categorizations(categorizations))
+        for _ in range(count):
+            CATEGORIZE_PROVIDER_NATIVE_TOTAL.labels(
+                source_type="plaid", trigger=trigger
+            ).inc()
 
         if count:
             _engine_counts_logger.info(

--- a/tests/moneybin/test_mcp/test_system_status_db_connections.py
+++ b/tests/moneybin/test_mcp/test_system_status_db_connections.py
@@ -232,13 +232,14 @@ def test_block_tolerates_corrupted_lock_file_while_held(tmp_path: Path) -> None:
         patch(
             "moneybin.mcp.tools.system.find_blocking_processes",
             return_value=[],
-        ),
+        ) as find_processes,
     ):
         # Overwrite the held lock file's contents in place (same inode, so the
         # holder's fcntl lock is unaffected) with invalid JSON.
         lock_path.write_text("not-json{{")
         block = _database_connections_block(db_path)
     assert block["writers"] == []
+    find_processes.assert_called_once_with(db_path.resolve())
 
 
 def test_block_tolerates_non_dict_json_while_held(tmp_path: Path) -> None:
@@ -255,11 +256,12 @@ def test_block_tolerates_non_dict_json_while_held(tmp_path: Path) -> None:
         patch(
             "moneybin.mcp.tools.system.find_blocking_processes",
             return_value=[],
-        ),
+        ) as find_processes,
     ):
         lock_path.write_text("null")
         block = _database_connections_block(db_path)
     assert block["writers"] == []
+    find_processes.assert_called_once_with(db_path.resolve())
 
 
 def test_read_writer_metadata_retries_transient_empty_read(

--- a/tests/moneybin/test_mcp/test_system_status_db_connections.py
+++ b/tests/moneybin/test_mcp/test_system_status_db_connections.py
@@ -81,15 +81,18 @@ def test_block_sanitizes_reader_command_to_friendly_name(tmp_path: Path) -> None
     """
     db_path = tmp_path / "status.duckdb"
     db_path.touch()
-    with patch(
-        "moneybin.mcp.tools.system.find_blocking_processes",
-        return_value=[
-            {
-                "pid": 9999,
-                "command": "python",
-                "cmdline": "/home/alice/secret/run.py --token abc123",
-            }
-        ],
+    with (
+        _holding_write_lock(db_path),
+        patch(
+            "moneybin.mcp.tools.system.find_blocking_processes",
+            return_value=[
+                {
+                    "pid": 9999,
+                    "command": "python",
+                    "cmdline": "/home/alice/secret/run.py --token abc123",
+                }
+            ],
+        ),
     ):
         block = _database_connections_block(db_path)
     assert len(block["readers"]) == 1
@@ -125,18 +128,26 @@ def test_block_omits_stale_lock_file_when_no_writer_holds(tmp_path: Path) -> Non
     assert block["writers"] == []
 
 
-def test_block_reports_readers_from_lsof(tmp_path: Path) -> None:
+def test_block_reports_readers_from_lsof_when_diagnosing_a_writer(
+    tmp_path: Path,
+) -> None:
     db_path = tmp_path / "status.duckdb"
     db_path.touch()
-    # No lock file -> no writers; lsof returns one reader.
-    with patch(
-        "moneybin.mcp.tools.system.find_blocking_processes",
-        return_value=[
-            {"pid": 9999, "command": "python", "cmdline": "moneybin reports spending"}
-        ],
+    with (
+        _holding_write_lock(db_path),
+        patch(
+            "moneybin.mcp.tools.system.find_blocking_processes",
+            return_value=[
+                {
+                    "pid": 9999,
+                    "command": "python",
+                    "cmdline": "moneybin reports spending",
+                }
+            ],
+        ),
     ):
         block = _database_connections_block(db_path)
-    assert block["writers"] == []
+    assert len(block["writers"]) == 1
     assert len(block["readers"]) == 1
     assert block["readers"][0]["pid"] == 9999
 
@@ -198,6 +209,17 @@ def test_block_returns_empty_when_no_lock_file_and_no_lsof_output(
     ):
         block = _database_connections_block(db_path)
     assert block == {"writers": [], "readers": []}
+
+
+def test_block_defers_lsof_when_no_writer_holds_lock(tmp_path: Path) -> None:
+    """Healthy status avoids the expensive process enumeration subprocess."""
+    db_path = tmp_path / "status.duckdb"
+    db_path.touch()
+    with patch("moneybin.mcp.tools.system.find_blocking_processes") as find_processes:
+        block = _database_connections_block(db_path)
+
+    assert block == {"writers": [], "readers": []}
+    find_processes.assert_not_called()
 
 
 def test_block_tolerates_corrupted_lock_file_while_held(tmp_path: Path) -> None:

--- a/tests/moneybin/test_mcp/test_system_status_db_connections.py
+++ b/tests/moneybin/test_mcp/test_system_status_db_connections.py
@@ -211,15 +211,27 @@ def test_block_returns_empty_when_no_lock_file_and_no_lsof_output(
     assert block == {"writers": [], "readers": []}
 
 
-def test_block_defers_lsof_when_no_writer_holds_lock(tmp_path: Path) -> None:
-    """Healthy status avoids the expensive process enumeration subprocess."""
+def test_block_reports_readers_without_live_writer(tmp_path: Path) -> None:
+    """A released writer lock must not hide the reader blocking the next write."""
     db_path = tmp_path / "status.duckdb"
     db_path.touch()
-    with patch("moneybin.mcp.tools.system.find_blocking_processes") as find_processes:
+    with patch(
+        "moneybin.mcp.tools.system.find_blocking_processes",
+        return_value=[
+            {
+                "pid": 9999,
+                "command": "python",
+                "cmdline": "moneybin reports spending",
+            }
+        ],
+    ) as find_processes:
         block = _database_connections_block(db_path)
 
-    assert block == {"writers": [], "readers": []}
-    find_processes.assert_not_called()
+    assert block == {
+        "writers": [],
+        "readers": [{"pid": 9999, "command": "moneybin reports"}],
+    }
+    find_processes.assert_called_once_with(db_path.resolve())
 
 
 def test_block_tolerates_corrupted_lock_file_while_held(tmp_path: Path) -> None:

--- a/tests/moneybin/test_repositories/test_transaction_categories_repo.py
+++ b/tests/moneybin/test_repositories/test_transaction_categories_repo.py
@@ -312,6 +312,24 @@ def test_upsert_guarded_many_preserves_precedence_and_row_grain_audits(
         assert json.loads(audit[5])["transaction_id"] == transaction_id
 
 
+def test_upsert_guarded_many_rejects_duplicate_transaction_ids(db: Database) -> None:
+    repo = TransactionCategoriesRepo(db)
+    categorization = {
+        "transaction_id": "duplicate",
+        "category": "Dining",
+        "subcategory": None,
+        "category_id": None,
+        "categorized_by": "rule",
+        "merchant_id": None,
+        "rule_id": "r1",
+        "confidence": 1.0,
+        "source_type": "internal",
+    }
+
+    with pytest.raises(ValueError, match="unique transaction_ids"):
+        repo.upsert_guarded_many([categorization, categorization], actor="system")
+
+
 # ---------------------------------------------------------------------------
 # clear + delete_by_rule
 # ---------------------------------------------------------------------------

--- a/tests/moneybin/test_repositories/test_transaction_categories_repo.py
+++ b/tests/moneybin/test_repositories/test_transaction_categories_repo.py
@@ -252,10 +252,10 @@ def test_upsert_guarded_many_preserves_precedence_and_row_grain_audits(
     database_calls = 0
     execute = db.execute
 
-    def count_execute(*args: object, **kwargs: object) -> object:
+    def count_execute(query: str, params: list[Any] | None = None) -> Any:
         nonlocal database_calls
         database_calls += 1
-        return execute(*args, **kwargs)
+        return execute(query, params)
 
     monkeypatch.setattr(db, "execute", count_execute)
     written = repo.upsert_guarded_many(

--- a/tests/moneybin/test_repositories/test_transaction_categories_repo.py
+++ b/tests/moneybin/test_repositories/test_transaction_categories_repo.py
@@ -11,6 +11,7 @@ import json
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
 from prometheus_client import REGISTRY
 
 from moneybin.database import Database
@@ -221,6 +222,94 @@ def test_upsert_guarded_overwrites_lower_priority_existing(db: Database) -> None
         ["txn6"],
     ).fetchone()
     assert row == ("B", "rule")
+
+
+def test_upsert_guarded_many_preserves_precedence_and_row_grain_audits(
+    db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One batched engine write retains each changed row's undo image."""
+    repo = TransactionCategoriesRepo(db)
+    repo.set(
+        "protected",
+        category="Dining",
+        subcategory=None,
+        category_id=None,
+        categorized_by="user",
+        actor="cli",
+    )
+    repo.upsert_guarded(
+        "replaceable",
+        category="Old",
+        subcategory=None,
+        category_id=None,
+        categorized_by="ai",
+        merchant_id=None,
+        rule_id=None,
+        confidence=None,
+        actor="system",
+    )
+
+    database_calls = 0
+    execute = db.execute
+
+    def count_execute(*args: object, **kwargs: object) -> object:
+        nonlocal database_calls
+        database_calls += 1
+        return execute(*args, **kwargs)
+
+    monkeypatch.setattr(db, "execute", count_execute)
+    written = repo.upsert_guarded_many(
+        [
+            {
+                "transaction_id": "protected",
+                "category": "Blocked",
+                "subcategory": None,
+                "category_id": None,
+                "categorized_by": "rule",
+                "merchant_id": None,
+                "rule_id": "r1",
+                "confidence": 1.0,
+                "source_type": "internal",
+            },
+            {
+                "transaction_id": "replaceable",
+                "category": "New",
+                "subcategory": None,
+                "category_id": None,
+                "categorized_by": "rule",
+                "merchant_id": None,
+                "rule_id": "r1",
+                "confidence": 1.0,
+                "source_type": "internal",
+            },
+            {
+                "transaction_id": "new",
+                "category": "Fresh",
+                "subcategory": None,
+                "category_id": None,
+                "categorized_by": "rule",
+                "merchant_id": "m1",
+                "rule_id": "r1",
+                "confidence": 1.0,
+                "source_type": "internal",
+            },
+        ],
+        actor="system",
+    )
+
+    assert written == {"replaceable", "new"}
+    # One read of the before image, one guarded multi-row upsert, and one read
+    # of after images; the matching row-grain audit insert is one direct
+    # multi-row connection write. Per-record persistence would make nine
+    # wrapper calls for this three-row batch.
+    assert database_calls == 3
+    assert db.execute(
+        "SELECT category FROM app.transaction_categories WHERE transaction_id = 'protected'"
+    ).fetchone() == ("Dining",)
+    for transaction_id in written:
+        audit = _audit_rows_for(db, transaction_id)[-1]
+        assert audit[0] == "category.set"
+        assert json.loads(audit[5])["transaction_id"] == transaction_id
 
 
 # ---------------------------------------------------------------------------

--- a/tests/moneybin/test_services/test_categorization_service_writes.py
+++ b/tests/moneybin/test_services/test_categorization_service_writes.py
@@ -9,7 +9,7 @@ service-layer behavior independently.
 from __future__ import annotations
 
 import logging
-from typing import cast
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -1466,6 +1466,101 @@ class TestWriteCategorizationSourceType:
         ).fetchone()
         assert row is not None
         assert row[0] == "internal"
+
+
+class TestBatchCategorizationWrites:
+    """Batch categorization avoids repeated lookup and diagnostic queries."""
+
+    def test_reuses_category_resolution_for_matching_taxonomy_pairs(
+        self, applier: MatchApplier, db: Database, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _insert_txn(db, "batch-cache-1")
+        _insert_txn(db, "batch-cache-2")
+        resolved: list[tuple[str, str | None]] = []
+
+        def resolve_once(
+            _db: Database, category: str, subcategory: str | None
+        ) -> str | None:
+            resolved.append((category, subcategory))
+            return None
+
+        monkeypatch.setattr(
+            "moneybin.services.categorization.applier.resolve_category_id",
+            resolve_once,
+        )
+
+        written = applier.write_categorizations([
+            {
+                "transaction_id": "batch-cache-1",
+                "category": "Dining",
+                "subcategory": None,
+                "categorized_by": "rule",
+                "merchant_id": None,
+                "rule_id": "r1",
+                "confidence": 1.0,
+                "source_type": "internal",
+            },
+            {
+                "transaction_id": "batch-cache-2",
+                "category": "Dining",
+                "subcategory": None,
+                "categorized_by": "rule",
+                "merchant_id": None,
+                "rule_id": "r1",
+                "confidence": 1.0,
+                "source_type": "internal",
+            },
+        ])
+
+        assert written == {"batch-cache-1", "batch-cache-2"}
+        assert resolved == [("Dining", None)]
+
+    def test_batches_precedence_skip_diagnostics(
+        self, applier: MatchApplier, db: Database, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for transaction_id in ("batch-skip-1", "batch-skip-2"):
+            _insert_txn(db, transaction_id)
+            applier.write_categorization(
+                transaction_id=transaction_id,
+                category="Protected",
+                subcategory=None,
+                categorized_by="user",
+            )
+
+        database_calls = 0
+        execute = db.execute
+
+        def count_execute(query: str, params: list[Any] | None = None) -> Any:
+            nonlocal database_calls
+            database_calls += 1
+            return execute(query, params)
+
+        monkeypatch.setattr(db, "execute", count_execute)
+        written = applier.write_categorizations([
+            {
+                "transaction_id": "batch-skip-1",
+                "category": "Attempt",
+                "subcategory": None,
+                "categorized_by": "ai",
+                "merchant_id": None,
+                "rule_id": None,
+                "confidence": 0.5,
+                "source_type": "internal",
+            },
+            {
+                "transaction_id": "batch-skip-2",
+                "category": "Attempt",
+                "subcategory": None,
+                "categorized_by": "ai",
+                "merchant_id": None,
+                "rule_id": None,
+                "confidence": 0.5,
+                "source_type": "internal",
+            },
+        ])
+
+        assert written == set()
+        assert database_calls == 4
 
 
 def test_taxonomy_target_batch_rolls_back_late_failure(


### PR DESCRIPTION
# Summary

- Batch guarded categorization writes and their row-grain audits through the existing repository and transaction boundaries.
- Preserve reader contention diagnostics after a writer releases its advisory lock, so recovery can identify a remaining DuckDB reader.

# Changes

- Preserve categorization precedence, per-record audit/undo images, partial-failure behavior, and metrics while reducing repeated database calls.
- Reuse taxonomy resolution within each batch and fetch precedence-skip diagnostics once per batch.
- Add regression coverage for duplicate batch keys, query counts, precedence, row-grain audit records, and reader diagnostics after a released writer lock.

# Test plan

- `env UV_CACHE_DIR=/private/tmp/uv-cache make check`
- `env UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/moneybin/test_mcp/test_system_status_db_connections.py tests/moneybin/test_repositories/test_transaction_categories_repo.py -n0 -v` (24 passed)
- `env UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/moneybin/test_services/test_categorization_service_writes.py tests/moneybin/test_services/test_categorization_service.py -n0 -v` (206 passed)
- `env UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/moneybin/matching/test_engine.py tests/moneybin/matching/test_transfer_integration.py -n0 -v` (68 passed)
