### PR TITLE
Close the MCP keyset ordering-guard gap and consolidate paging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -877,7 +877,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   ordinary successful response; the `transactions`, `system_audit` and
   `reviews` MCP tools accepted such a cursor, and a date or timestamp written
   in a different-but-valid ISO spelling could slip one past the other paged
-  views too. Cursors MoneyBin mints are unaffected. (#498)
+  views too; cursors MoneyBin mints are unaffected. (#498)
 - **Account merge proposals no longer fire on a shared generated label alone,
   on either side of the comparison.** Two unrelated accounts whose *display
   name* was never set by a person or a source — both resolving to a bare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -893,9 +893,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `2025-01-01`, a `T` or a space before the time — and the spellings do not
   sort against each other the way the dates they denote sort, so a cursor
   pairing two of them could otherwise present a continuation that was ahead of
-  its snapshot in fact while appearing to be behind it. The `transactions`,
-  `system_audit` and `import_status` walks compare the normalized value, and a
-  timestamp carrying a UTC offset is refused rather than reinterpreted.
+  its snapshot in fact while appearing to be behind it. Every walk keyed on a
+  day or an instant now compares the normalized value: `transactions`,
+  `system_audit`, `import_status`, the `reviews` history and pending
+  categorization queues, and the `accounts_balances` history, assertions and
+  reconcile views. A timestamp carrying a UTC offset is refused rather than
+  reinterpreted, because an offset makes a string sort by its wall-clock
+  reading instead of its instant.
 - **Account merge proposals no longer fire on a shared generated label alone,
   on either side of the comparison.** Two unrelated accounts whose *display
   name* was never set by a person or a source — both resolving to a bare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -878,13 +878,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   predicate stops narrowing the page and widens it back to the rows page one
   gave — the duplicate arrives as an ordinary successful response, with no
   error to notice. Cursors are unsigned, so any caller can present one.
-  `transactions list` and the import-status view already rejected such a
-  cursor; the `transactions`, `system_audit` and `reviews` MCP tools accepted
-  it. The key-shape check and the ordering guard now live once in
-  `moneybin.protocol.pagination` beside the cursor codec, and every paged
-  surface — MCP and CLI alike — calls them, so a cursor one surface refuses
-  the others refuse too. Cursors MoneyBin itself mints are unaffected: no page
-  has ever produced an inverted pair.
+  `transactions list`, the account and balance views, and the import-status
+  view already rejected such a cursor; the `transactions`, `system_audit` and
+  `reviews` MCP tools accepted it. The key-shape check and the ordering guard
+  now live once in `moneybin.protocol.pagination` beside the cursor codec, and
+  every surface paging from a head snapshot — MCP and CLI alike — calls them,
+  so a cursor one refuses the others refuse too. The `investments`, `taxonomy`
+  and `privacy` views page the mirror convention, anchoring on the last row
+  rather than the first, and keep their own equivalent check. Cursors MoneyBin
+  itself mints are unaffected: no page has ever produced an inverted pair.
 - **Account merge proposals no longer fire on a shared generated label alone,
   on either side of the comparison.** Two unrelated accounts whose *display
   name* was never set by a person or a source — both resolving to a bare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -871,6 +871,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   known currency with an unknown one now withholds its market value instead of
   pricing the combined quantity at the known currency's close — the same guard
   that already withheld a position holding two different known currencies.
+- **A stale or forged pagination cursor no longer re-serves rows an earlier
+  page already returned.** A keyset cursor carries two keys: the snapshot that
+  froze the top of the walk, and the continuation key of the last row served.
+  When the continuation sorts *ahead* of the snapshot, the continuation
+  predicate stops narrowing the page and widens it back to the rows page one
+  gave — the duplicate arrives as an ordinary successful response, with no
+  error to notice. Cursors are unsigned, so any caller can present one.
+  `transactions list` and the import-status view already rejected such a
+  cursor; the `transactions`, `system_audit` and `reviews` MCP tools accepted
+  it. The key-shape check and the ordering guard now live once in
+  `moneybin.protocol.pagination` beside the cursor codec, and every paged
+  surface — MCP and CLI alike — calls them, so a cursor one surface refuses
+  the others refuse too. Cursors MoneyBin itself mints are unaffected: no page
+  has ever produced an inverted pair.
 - **Account merge proposals no longer fire on a shared generated label alone,
   on either side of the comparison.** Two unrelated accounts whose *display
   name* was never set by a person or a source — both resolving to a bare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -872,34 +872,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   pricing the combined quantity at the known currency's close — the same guard
   that already withheld a position holding two different known currencies.
 - **A stale or forged pagination cursor no longer re-serves rows an earlier
-  page already returned.** A keyset cursor carries two keys: the snapshot that
-  froze the top of the walk, and the continuation key of the last row served.
-  When the continuation sorts *ahead* of the snapshot, the continuation
-  predicate stops narrowing the page and widens it back to the rows page one
-  gave — the duplicate arrives as an ordinary successful response, with no
-  error to notice. Cursors are unsigned, so any caller can present one.
-  `transactions list`, the account and balance views, and the import-status
-  view already rejected such a cursor; the `transactions`, `system_audit` and
-  `reviews` MCP tools accepted it. The key-shape check and the ordering guard
-  now live once in `moneybin.protocol.pagination` beside the cursor codec, and
-  every surface paging from a head snapshot — MCP and CLI alike — calls them,
-  so a cursor one refuses the others refuse too. The `investments`, `taxonomy`
-  and `privacy` views page the mirror convention, anchoring on the last row
-  rather than the first, and keep their own equivalent check. Cursors MoneyBin
-  itself mints are unaffected: no page has ever produced an inverted pair.
-
-  A date or timestamp inside a cursor is now normalized before that check runs.
-  ISO 8601 spells one day or instant several ways — `20250101` and
-  `2025-01-01`, a `T` or a space before the time — and the spellings do not
-  sort against each other the way the dates they denote sort, so a cursor
-  pairing two of them could otherwise present a continuation that was ahead of
-  its snapshot in fact while appearing to be behind it. Every walk keyed on a
-  day or an instant now compares the normalized value: `transactions`,
-  `system_audit`, `import_status`, the `reviews` history and pending
-  categorization queues, and the `accounts_balances` history, assertions and
-  reconcile views. A timestamp carrying a UTC offset is refused rather than
-  reinterpreted, because an offset makes a string sort by its wall-clock
-  reading instead of its instant.
+  page already returned.** A continuation key that sorted ahead of its
+  snapshot widened the page back to page one and returned duplicates as an
+  ordinary successful response; the `transactions`, `system_audit` and
+  `reviews` MCP tools accepted such a cursor, and a date or timestamp written
+  in a different-but-valid ISO spelling could slip one past the other paged
+  views too. Cursors MoneyBin mints are unaffected. (#498)
 - **Account merge proposals no longer fire on a shared generated label alone,
   on either side of the comparison.** Two unrelated accounts whose *display
   name* was never set by a person or a source — both resolving to a bare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -887,6 +887,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   and `privacy` views page the mirror convention, anchoring on the last row
   rather than the first, and keep their own equivalent check. Cursors MoneyBin
   itself mints are unaffected: no page has ever produced an inverted pair.
+
+  A date or timestamp inside a cursor is now normalized before that check runs.
+  ISO 8601 spells one day or instant several ways — `20250101` and
+  `2025-01-01`, a `T` or a space before the time — and the spellings do not
+  sort against each other the way the dates they denote sort, so a cursor
+  pairing two of them could otherwise present a continuation that was ahead of
+  its snapshot in fact while appearing to be behind it. The `transactions`,
+  `system_audit` and `import_status` walks compare the normalized value, and a
+  timestamp carrying a UTC offset is refused rather than reinterpreted.
 - **Account merge proposals no longer fire on a shared generated label alone,
   on either side of the comparison.** Two unrelated accounts whose *display
   name* was never set by a person or a source — both resolving to a bare

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -33,7 +33,6 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 from datetime import date as _date
 from decimal import Decimal
-from functools import cmp_to_key
 from typing import Annotated, Any, Literal, cast
 
 from fastmcp import FastMCP
@@ -91,9 +90,10 @@ from moneybin.protocol.envelope import (
 )
 from moneybin.protocol.pagination import (
     KeysetPosition,
-    compare_keyset,
+    SortDirection,
     decode_keyset_cursor,
-    encode_keyset_cursor,
+    paginate_keyset,
+    validate_keyset_position,
 )
 from moneybin.services.account_links_service import (
     AccountLinkAcceptImpact,
@@ -118,6 +118,18 @@ from moneybin.services.identity_confirmation import (
 )
 from moneybin.services.mutation_context import current_operation_id
 from moneybin.services.refresh import RefreshResult
+
+# Display order of each paged accounts view's immutable keyset.
+_ACCOUNT_LIST_KEY_DIRECTIONS: tuple[SortDirection, ...] = ("asc",)
+_BALANCE_KEY_DIRECTIONS: dict[
+    Literal["latest", "history", "assertions", "reconcile"],
+    tuple[SortDirection, ...],
+] = {
+    "latest": ("asc",),
+    "history": ("asc", "asc"),
+    "assertions": ("asc", "desc"),
+    "reconcile": ("asc", "desc"),
+}
 
 # ─── Read tools (entity) ──────────────────────────────────────────────────
 
@@ -998,7 +1010,7 @@ def _coarse_position(
     tool: Literal["accounts", "accounts_balances"],
     view: str,
     filters: dict[str, object],
-    key_size: int,
+    directions: tuple[SortDirection, ...],
 ) -> KeysetPosition | None:
     """Decode one scope-bound cursor and validate its string key shape."""
     if cursor is None:
@@ -1014,16 +1026,11 @@ def _coarse_position(
             namespace=tool,
             scope={"filters": filters, "view": view},
         )
+        validate_keyset_position(
+            position, key_types=(str,) * len(directions), directions=directions
+        )
     except ValueError as exc:
         raise UserError("Invalid pagination cursor.", code=code) from exc
-    if (
-        len(position.snapshot) != key_size
-        or len(position.after) != key_size
-        or not all(
-            type(value) is str for value in (*position.snapshot, *position.after)
-        )
-    ):
-        raise UserError("Invalid pagination cursor.", code=code)
     return position
 
 
@@ -1044,44 +1051,18 @@ def _keyset_page[T](
         if tool == "accounts"
         else error_codes.ACCOUNT_BALANCE_CURSOR_INVALID
     )
-
-    def compare_rows(left: T, right: T) -> int:
-        return compare_keyset(key(left), key(right), directions)
-
-    ordered = sorted(rows, key=cmp_to_key(compare_rows))
-    if position is None:
-        if not ordered:
-            return [], None, 0
-        snapshot = key(ordered[0])
-        eligible = ordered
-        total_count = len(ordered)
-    else:
-        snapshot = cast(tuple[str, ...], position.snapshot)
-        after = cast(tuple[str, ...], position.after)
-        try:
-            if compare_keyset(after, snapshot, directions) < 0:
-                raise ValueError("continuation precedes snapshot")
-            eligible = [
-                row
-                for row in ordered
-                if compare_keyset(key(row), snapshot, directions) >= 0
-                and compare_keyset(key(row), after, directions) > 0
-            ]
-        except ValueError as exc:
-            raise UserError("Invalid pagination cursor.", code=code) from exc
-        total_count = position.total
-
-    page = eligible[:limit]
-    if len(eligible) <= limit or not page:
-        return page, None, total_count
-    next_cursor = encode_keyset_cursor(
-        namespace=tool,
-        scope={"filters": filters, "view": view},
-        snapshot=snapshot,
-        after=key(page[-1]),
-        total=total_count,
-    )
-    return page, next_cursor, total_count
+    try:
+        return paginate_keyset(
+            rows,
+            limit=limit,
+            key_of=key,
+            directions=directions,
+            namespace=tool,
+            scope={"filters": filters, "view": view},
+            position=position,
+        )
+    except ValueError as exc:
+        raise UserError("Invalid pagination cursor.", code=code) from exc
 
 
 def _account_candidates(payload: AccountListPayload) -> list[EntityCandidate]:
@@ -1237,7 +1218,7 @@ async def accounts_coarse(
             tool="accounts",
             view="list",
             filters=filters,
-            key_size=1,
+            directions=_ACCOUNT_LIST_KEY_DIRECTIONS,
         )
         response = await _run_account_read(
             accounts,
@@ -1252,7 +1233,7 @@ async def accounts_coarse(
             position=position,
             filters=filters,
             key=lambda row: (row.account_id,),
-            directions=("asc",),
+            directions=_ACCOUNT_LIST_KEY_DIRECTIONS,
         )
         payload = AccountsListView(rows=page)
         return _coarse_envelope(
@@ -1410,13 +1391,13 @@ async def accounts_balances_coarse(
         "start": start.isoformat() if start is not None else None,
         "threshold": str(threshold) if threshold is not None else None,
     }
-    key_size = 1 if view == "latest" else 2
+    directions = _BALANCE_KEY_DIRECTIONS[view]
     position = _coarse_position(
         cursor,
         tool="accounts_balances",
         view=view,
         filters=filters,
-        key_size=key_size,
+        directions=directions,
     )
     account_id = (
         await _resolve_account_reference(reference, include_closed=True)
@@ -1438,7 +1419,7 @@ async def accounts_balances_coarse(
             position=position,
             filters=filters,
             key=lambda row: (row.account_id,),
-            directions=("asc",),
+            directions=directions,
         )
         payload = AccountsBalancesLatestView(observations=page)
         contract_type = AccountsBalancesLatestView
@@ -1457,7 +1438,7 @@ async def accounts_balances_coarse(
             position=position,
             filters=filters,
             key=lambda row: (row.balance_date.isoformat(), row.account_id),
-            directions=("asc", "asc"),
+            directions=directions,
         )
         payload = AccountsBalancesHistoryView(observations=page)
         contract_type = AccountsBalancesHistoryView
@@ -1474,7 +1455,7 @@ async def accounts_balances_coarse(
             position=position,
             filters=filters,
             key=lambda row: (row.account_id, row.assertion_date.isoformat()),
-            directions=("asc", "desc"),
+            directions=directions,
         )
         payload = AccountsBalancesAssertionsView(assertions=page)
         contract_type = AccountsBalancesAssertionsView
@@ -1492,7 +1473,7 @@ async def accounts_balances_coarse(
             position=position,
             filters=filters,
             key=lambda row: (row.account_id, row.balance_date.isoformat()),
-            directions=("asc", "desc"),
+            directions=directions,
         )
         payload = AccountsBalancesReconcileView(observations=page)
         contract_type = AccountsBalancesReconcileView

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -89,6 +89,7 @@ from moneybin.protocol.envelope import (
     build_envelope,
 )
 from moneybin.protocol.pagination import (
+    InvalidKeysetCursorError,
     KeysetPosition,
     SortDirection,
     decode_keyset_cursor,
@@ -1061,7 +1062,7 @@ def _keyset_page[T](
             scope={"filters": filters, "view": view},
             position=position,
         )
-    except ValueError as exc:
+    except InvalidKeysetCursorError as exc:
         raise UserError("Invalid pagination cursor.", code=code) from exc
 
 

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -92,6 +92,8 @@ from moneybin.protocol.pagination import (
     InvalidKeysetCursorError,
     KeysetPosition,
     SortDirection,
+    canonical_iso_date,
+    canonicalize_keyset_element,
     decode_keyset_cursor,
     paginate_keyset,
     validate_keyset_position,
@@ -122,6 +124,14 @@ from moneybin.services.refresh import RefreshResult
 
 # Display order of each paged accounts view's immutable keyset.
 _ACCOUNT_LIST_KEY_DIRECTIONS: tuple[SortDirection, ...] = ("asc",)
+# Which key element of each balances view is a day. Rows render it with
+# `date.isoformat()`, so a cursor must be normalized to that one spelling
+# before it is ordered against them: ISO admits spellings whose text order
+# contradicts their chronological order.
+_BALANCE_DATE_INDEX: dict[
+    Literal["latest", "history", "assertions", "reconcile"], int | None
+] = {"latest": None, "history": 0, "assertions": 1, "reconcile": 1}
+
 _BALANCE_KEY_DIRECTIONS: dict[
     Literal["latest", "history", "assertions", "reconcile"],
     tuple[SortDirection, ...],
@@ -1012,6 +1022,7 @@ def _coarse_position(
     view: str,
     filters: dict[str, object],
     directions: tuple[SortDirection, ...],
+    date_index: int | None = None,
 ) -> KeysetPosition | None:
     """Decode one scope-bound cursor and validate its string key shape."""
     if cursor is None:
@@ -1027,6 +1038,10 @@ def _coarse_position(
             namespace=tool,
             scope={"filters": filters, "view": view},
         )
+        if date_index is not None:
+            position = canonicalize_keyset_element(
+                position, index=date_index, canonicalize=canonical_iso_date
+            )
         validate_keyset_position(
             position, key_types=(str,) * len(directions), directions=directions
         )
@@ -1399,6 +1414,7 @@ async def accounts_balances_coarse(
         view=view,
         filters=filters,
         directions=directions,
+        date_index=_BALANCE_DATE_INDEX[view],
     )
     account_id = (
         await _resolve_account_reference(reference, include_closed=True)

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -97,6 +97,7 @@ from moneybin.protocol.pagination import (
     decode_keyset_cursor,
     paginate_keyset,
     validate_keyset_position,
+    validate_keyset_shape,
 )
 from moneybin.services.account_links_service import (
     AccountLinkAcceptImpact,
@@ -1038,6 +1039,9 @@ def _coarse_position(
             namespace=tool,
             scope={"filters": filters, "view": view},
         )
+        # Shape before canonicalization: the temporal element is addressed by
+        # index, so a short forged key must be rejected before it is indexed.
+        validate_keyset_shape(position, key_types=(str,) * len(directions))
         if date_index is not None:
             position = canonicalize_keyset_element(
                 position, index=date_index, canonicalize=canonical_iso_date

--- a/src/moneybin/mcp/tools/import_tools.py
+++ b/src/moneybin/mcp/tools/import_tools.py
@@ -109,7 +109,9 @@ from moneybin.utils.file import file_sha256
 
 logger = logging.getLogger(__name__)
 
-# Display order of the imports section: `started_at DESC, import_id DESC`.
+# Display order of the imports section: `started_at DESC, import_id DESC`. The
+# third element is not a sort column but the frozen imports-section total the
+# cursor pins; its direction is inert because the pair below must be equal.
 _IMPORT_KEY_DIRECTIONS: tuple[SortDirection, ...] = ("desc", "desc", "asc")
 
 _IMPORT_STATUS_SECTION_ORDER: tuple[Literal["imports", "formats", "inbox"], ...] = (
@@ -1545,16 +1547,18 @@ def _import_status_position(
             namespace="import_status.imports",
             scope={"import_id": None, "sections": sections},
         )
-        # The third key element is the frozen non-imports section count, equal
-        # on both keys, so it never decides the ordering comparison.
+        # Validates arity first, so the indexing below is safe. The third key
+        # element is the frozen imports-section total rather than a sort
+        # column; a cursor whose two totals disagree is rejected outright
+        # below, so it never reaches a page having steered the comparison.
         validate_keyset_position(
             position, key_types=(str, str, int), directions=_IMPORT_KEY_DIRECTIONS
         )
         if (
             not position.snapshot[1]
             or not position.after[1]
-            or cast(int, position.snapshot[2]) < 0
             or position.snapshot[2] != position.after[2]
+            or cast(int, position.snapshot[2]) < 0
             or cast(int, position.snapshot[2]) > position.total
         ):
             raise ValueError("invalid import keyset shape")

--- a/src/moneybin/mcp/tools/import_tools.py
+++ b/src/moneybin/mcp/tools/import_tools.py
@@ -95,9 +95,10 @@ from moneybin.protocol.envelope import (
 )
 from moneybin.protocol.pagination import (
     KeysetPosition,
-    compare_keyset,
+    SortDirection,
     decode_keyset_cursor,
     encode_keyset_cursor,
+    validate_keyset_position,
 )
 from moneybin.services.import_confirmation import sign_convention_effect
 from moneybin.services.refresh_outcome import (
@@ -107,6 +108,9 @@ from moneybin.services.refresh_outcome import (
 from moneybin.utils.file import file_sha256
 
 logger = logging.getLogger(__name__)
+
+# Display order of the imports section: `started_at DESC, import_id DESC`.
+_IMPORT_KEY_DIRECTIONS: tuple[SortDirection, ...] = ("desc", "desc", "asc")
 
 _IMPORT_STATUS_SECTION_ORDER: tuple[Literal["imports", "formats", "inbox"], ...] = (
     "imports",
@@ -1541,33 +1545,21 @@ def _import_status_position(
             namespace="import_status.imports",
             scope={"import_id": None, "sections": sections},
         )
+        # The third key element is the frozen non-imports section count, equal
+        # on both keys, so it never decides the ordering comparison.
+        validate_keyset_position(
+            position, key_types=(str, str, int), directions=_IMPORT_KEY_DIRECTIONS
+        )
         if (
-            len(position.snapshot) != 3
-            or len(position.after) != 3
-            or not all(
-                isinstance(value, str)
-                for value in (
-                    position.snapshot[0],
-                    position.snapshot[1],
-                    position.after[0],
-                    position.after[1],
-                )
-            )
-            or not position.snapshot[1]
+            not position.snapshot[1]
             or not position.after[1]
-            or type(position.snapshot[2]) is not int
-            or type(position.after[2]) is not int
-            or position.snapshot[2] < 0
+            or cast(int, position.snapshot[2]) < 0
             or position.snapshot[2] != position.after[2]
-            or position.snapshot[2] > position.total
+            or cast(int, position.snapshot[2]) > position.total
         ):
             raise ValueError("invalid import keyset shape")
-        snapshot = cast(tuple[str, str], position.snapshot[:2])
-        after = cast(tuple[str, str], position.after[:2])
-        datetime.fromisoformat(snapshot[0])
-        datetime.fromisoformat(after[0])
-        if compare_keyset(snapshot, after, ("desc", "desc")) > 0:
-            raise ValueError("import continuation precedes its snapshot")
+        datetime.fromisoformat(cast(str, position.snapshot[0]))
+        datetime.fromisoformat(cast(str, position.after[0]))
         return position
     except ValueError as exc:
         raise UserError(

--- a/src/moneybin/mcp/tools/import_tools.py
+++ b/src/moneybin/mcp/tools/import_tools.py
@@ -96,6 +96,7 @@ from moneybin.protocol.envelope import (
 from moneybin.protocol.pagination import (
     KeysetPosition,
     SortDirection,
+    canonical_iso_timestamp,
     decode_keyset_cursor,
     encode_keyset_cursor,
     reject_inverted_keyset,
@@ -1534,14 +1535,6 @@ def import_formats() -> ResponseEnvelope[ImportFormatsPayload]:
     )
 
 
-def _canonical_import_timestamp(started_at: str) -> str:
-    """Return one import cursor timestamp in canonical space-separated ISO form."""
-    parsed = datetime.fromisoformat(started_at)
-    if parsed.tzinfo is not None:
-        raise ValueError("import cursor timestamp must be naive")
-    return parsed.isoformat(sep=" ")
-
-
 def _import_status_position(
     cursor: str | None,
     *,
@@ -1574,12 +1567,12 @@ def _import_status_position(
         # forged pair mixing them would otherwise pass the guard inverted.
         canonical = KeysetPosition(
             snapshot=(
-                _canonical_import_timestamp(cast(str, position.snapshot[0])),
+                canonical_iso_timestamp(cast(str, position.snapshot[0])),
                 position.snapshot[1],
                 position.snapshot[2],
             ),
             after=(
-                _canonical_import_timestamp(cast(str, position.after[0])),
+                canonical_iso_timestamp(cast(str, position.after[0])),
                 position.after[1],
                 position.after[2],
             ),

--- a/src/moneybin/mcp/tools/import_tools.py
+++ b/src/moneybin/mcp/tools/import_tools.py
@@ -98,7 +98,8 @@ from moneybin.protocol.pagination import (
     SortDirection,
     decode_keyset_cursor,
     encode_keyset_cursor,
-    validate_keyset_position,
+    reject_inverted_keyset,
+    validate_keyset_shape,
 )
 from moneybin.services.import_confirmation import sign_convention_effect
 from moneybin.services.refresh_outcome import (
@@ -1533,6 +1534,14 @@ def import_formats() -> ResponseEnvelope[ImportFormatsPayload]:
     )
 
 
+def _canonical_import_timestamp(started_at: str) -> str:
+    """Return one import cursor timestamp in canonical space-separated ISO form."""
+    parsed = datetime.fromisoformat(started_at)
+    if parsed.tzinfo is not None:
+        raise ValueError("import cursor timestamp must be naive")
+    return parsed.isoformat(sep=" ")
+
+
 def _import_status_position(
     cursor: str | None,
     *,
@@ -1551,9 +1560,7 @@ def _import_status_position(
         # element is the frozen imports-section total rather than a sort
         # column; a cursor whose two totals disagree is rejected outright
         # below, so it never reaches a page having steered the comparison.
-        validate_keyset_position(
-            position, key_types=(str, str, int), directions=_IMPORT_KEY_DIRECTIONS
-        )
+        validate_keyset_shape(position, key_types=(str, str, int))
         if (
             not position.snapshot[1]
             or not position.after[1]
@@ -1562,9 +1569,24 @@ def _import_status_position(
             or cast(int, position.snapshot[2]) > position.total
         ):
             raise ValueError("invalid import keyset shape")
-        datetime.fromisoformat(cast(str, position.snapshot[0]))
-        datetime.fromisoformat(cast(str, position.after[0]))
-        return position
+        # Canonicalize before ordering: two valid ISO spellings of one instant
+        # do not sort against each other the way the timestamps do, so a
+        # forged pair mixing them would otherwise pass the guard inverted.
+        canonical = KeysetPosition(
+            snapshot=(
+                _canonical_import_timestamp(cast(str, position.snapshot[0])),
+                position.snapshot[1],
+                position.snapshot[2],
+            ),
+            after=(
+                _canonical_import_timestamp(cast(str, position.after[0])),
+                position.after[1],
+                position.after[2],
+            ),
+            total=position.total,
+        )
+        reject_inverted_keyset(canonical, _IMPORT_KEY_DIRECTIONS)
+        return canonical
     except ValueError as exc:
         raise UserError(
             "Invalid import pagination cursor.",

--- a/src/moneybin/mcp/tools/reviews.py
+++ b/src/moneybin/mcp/tools/reviews.py
@@ -90,6 +90,7 @@ from moneybin.privacy.redaction import redact_typed
 from moneybin.privacy.taxonomy import Tier
 from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
 from moneybin.protocol.pagination import (
+    InvalidKeysetCursorError,
     KeysetPosition,
     KeysetScalar,
     SortDirection,
@@ -779,7 +780,7 @@ def _review_page(
             scope={"kind": kind, "status": status},
             position=position,
         )
-    except ValueError as exc:
+    except InvalidKeysetCursorError as exc:
         raise UserError(
             "Invalid review pagination cursor.",
             code=error_codes.REVIEW_CURSOR_INVALID,

--- a/src/moneybin/mcp/tools/reviews.py
+++ b/src/moneybin/mcp/tools/reviews.py
@@ -94,9 +94,13 @@ from moneybin.protocol.pagination import (
     KeysetPosition,
     KeysetScalar,
     SortDirection,
+    canonical_iso_date,
+    canonical_iso_timestamp,
+    canonicalize_keyset_element,
     decode_keyset_cursor,
     paginate_keyset,
-    validate_keyset_position,
+    reject_inverted_keyset,
+    validate_keyset_shape,
 )
 from moneybin.services.account_links_service import AccountLinksService
 from moneybin.services.account_resolution_types import UNNAMED_ACCOUNT_LABEL
@@ -148,13 +152,44 @@ def _review_position(
             namespace="reviews",
             scope={"kind": kind, "status": status},
         )
-        validate_keyset_position(position, key_types=types, directions=directions)
+        validate_keyset_shape(position, key_types=types)
+        canonical = _canonical_review_position(position, kind=kind, status=status)
+        reject_inverted_keyset(canonical, directions)
     except ValueError as exc:
         raise UserError(
             "Invalid review pagination cursor.",
             code=error_codes.REVIEW_CURSOR_INVALID,
         ) from exc
-    return position
+    return canonical
+
+
+def _canonical_review_position(
+    position: KeysetPosition,
+    *,
+    kind: ReviewQueueKind,
+    status: ReviewStatus,
+) -> KeysetPosition:
+    """Normalize this queue's leading temporal key, if it has one.
+
+    A history queue keys on the instant a decision was made; the pending
+    categorization queue keys on a transaction *day*. Canonicalizing one as the
+    other would rewrite the key into a spelling no row produces, so the page
+    would match nothing at all rather than mis-order — which is why the shape
+    is declared per queue here rather than guessed from the value.
+    """
+    if status == "history":
+        canonicalize = canonical_iso_timestamp
+    elif kind == "categorization":
+        canonicalize = canonical_iso_date
+    else:
+        return position
+
+    def normalize(value: str) -> str:
+        # `_review_ordering` substitutes "" for a row carrying no timestamp, so
+        # the empty key is one a page can mint and must survive normalization.
+        return value if value == "" else canonicalize(value)
+
+    return canonicalize_keyset_element(position, index=0, canonicalize=normalize)
 
 
 def _review_envelope[T](

--- a/src/moneybin/mcp/tools/reviews.py
+++ b/src/moneybin/mcp/tools/reviews.py
@@ -6,7 +6,6 @@ import asyncio
 import logging
 from dataclasses import dataclass, replace
 from decimal import Decimal
-from functools import cmp_to_key
 from typing import Annotated, Any, Literal, cast
 
 from fastmcp import FastMCP
@@ -94,9 +93,9 @@ from moneybin.protocol.pagination import (
     KeysetPosition,
     KeysetScalar,
     SortDirection,
-    compare_keyset,
     decode_keyset_cursor,
-    encode_keyset_cursor,
+    paginate_keyset,
+    validate_keyset_position,
 )
 from moneybin.services.account_links_service import AccountLinksService
 from moneybin.services.account_resolution_types import UNNAMED_ACCOUNT_LABEL
@@ -141,27 +140,19 @@ def _review_position(
     """Decode a keyset cursor and reject cross-queue or cross-status reuse."""
     if cursor is None:
         return None
+    types, directions = _review_key_contract(kind, status)
     try:
         position = decode_keyset_cursor(
             cursor,
             namespace="reviews",
             scope={"kind": kind, "status": status},
         )
+        validate_keyset_position(position, key_types=types, directions=directions)
     except ValueError as exc:
         raise UserError(
             "Invalid review pagination cursor.",
             code=error_codes.REVIEW_CURSOR_INVALID,
         ) from exc
-    types, _ = _review_key_contract(kind, status)
-    for key in (position.snapshot, position.after):
-        if len(key) != len(types) or any(
-            type(value) is not expected
-            for value, expected in zip(key, types, strict=True)
-        ):
-            raise UserError(
-                "Invalid review pagination cursor.",
-                code=error_codes.REVIEW_CURSOR_INVALID,
-            )
     return position
 
 
@@ -777,54 +768,23 @@ def _review_page(
     position: KeysetPosition | None,
 ) -> tuple[list[Any], str | None]:
     """Page one evolving queue without depending on live-list offsets."""
-    if not rows:
-        return [], None
     _, directions = _review_key_contract(kind, status)
-
-    def compare_rows(left: Any, right: Any) -> int:
-        left_key, _ = _review_ordering(kind, status, left)
-        right_key, _ = _review_ordering(kind, status, right)
-        return compare_keyset(left_key, right_key, directions)
-
-    ordered = sorted(rows, key=cmp_to_key(compare_rows))
-    if position is None:
-        snapshot, _ = _review_ordering(kind, status, ordered[0])
-        eligible = ordered
-    else:
-        snapshot = position.snapshot
-        try:
-            eligible = [
-                row
-                for row in ordered
-                if compare_keyset(
-                    _review_ordering(kind, status, row)[0],
-                    snapshot,
-                    directions,
-                )
-                >= 0
-                and compare_keyset(
-                    _review_ordering(kind, status, row)[0],
-                    position.after,
-                    directions,
-                )
-                > 0
-            ]
-        except ValueError as exc:
-            raise UserError(
-                "Invalid review pagination cursor.",
-                code=error_codes.REVIEW_CURSOR_INVALID,
-            ) from exc
-    page = eligible[:limit]
-    if len(eligible) <= limit or not page:
-        return page, None
-    after, _ = _review_ordering(kind, status, page[-1])
-    return page, encode_keyset_cursor(
-        namespace="reviews",
-        scope={"kind": kind, "status": status},
-        snapshot=snapshot,
-        after=after,
-        total=position.total if position is not None else len(ordered),
-    )
+    try:
+        page, next_cursor, _ = paginate_keyset(
+            rows,
+            limit=limit,
+            key_of=lambda row: _review_ordering(kind, status, row)[0],
+            directions=directions,
+            namespace="reviews",
+            scope={"kind": kind, "status": status},
+            position=position,
+        )
+    except ValueError as exc:
+        raise UserError(
+            "Invalid review pagination cursor.",
+            code=error_codes.REVIEW_CURSOR_INVALID,
+        ) from exc
+    return page, next_cursor
 
 
 def _review_count(

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -10,7 +10,6 @@ import logging
 import os
 import subprocess  # noqa: S404 — subprocess used for git rev-parse; static args only
 from collections.abc import Callable
-from datetime import datetime
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Annotated, Any, Literal, cast
@@ -73,6 +72,7 @@ from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
 from moneybin.protocol.pagination import (
     KeysetPosition,
     SortDirection,
+    canonical_iso_timestamp,
     decode_keyset_cursor,
     encode_keyset_cursor,
     reject_inverted_keyset,
@@ -966,10 +966,7 @@ def _canonical_audit_key(key: tuple[object, ...]) -> tuple[str, str]:
     occurred_at, row_id = cast(tuple[str, str], key)
     if not row_id:
         raise ValueError("audit cursor carries an empty id")
-    parsed = datetime.fromisoformat(occurred_at)
-    if parsed.tzinfo is not None:
-        raise ValueError("audit cursor timestamp must be naive")
-    return parsed.isoformat(sep=" "), row_id
+    return canonical_iso_timestamp(occurred_at), row_id
 
 
 def _audit_list_actions(

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -72,12 +72,17 @@ from moneybin.privacy.redaction import redact_typed
 from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
 from moneybin.protocol.pagination import (
     KeysetPosition,
+    SortDirection,
     decode_keyset_cursor,
     encode_keyset_cursor,
+    validate_keyset_position,
 )
 from moneybin.utils.db_processes import describe_process, find_blocking_processes
 
 logger = logging.getLogger(__name__)
+
+# Display order of both audit views: `ORDER BY occurred_at DESC, <id> DESC`.
+_AUDIT_KEY_DIRECTIONS: tuple[SortDirection, ...] = ("desc", "desc")
 
 _HEALTHY_STATUSES = frozenset({"healthy"})
 _DISCONNECTED_STATUSES = frozenset({"disconnected"})
@@ -931,23 +936,18 @@ def _audit_bounds(
     """Validate and narrow decoded audit keys to timestamp/id string pairs."""
     if position is None:
         return None, None
-    if (
-        len(position.snapshot) != 2
-        or len(position.after) != 2
-        or not all(
-            isinstance(value, str) for value in (*position.snapshot, *position.after)
-        )
-    ):
-        raise ValueError("invalid audit cursor")
-    snapshot = cast(tuple[str, str], position.snapshot)
-    after = cast(tuple[str, str], position.after)
     try:
-        datetime.fromisoformat(snapshot[0])
-        datetime.fromisoformat(after[0])
+        validate_keyset_position(
+            position, key_types=(str, str), directions=_AUDIT_KEY_DIRECTIONS
+        )
+        snapshot = cast(tuple[str, str], position.snapshot)
+        after = cast(tuple[str, str], position.after)
+        for occurred_at, row_id in (snapshot, after):
+            if not row_id:
+                raise ValueError("audit cursor carries an empty id")
+            datetime.fromisoformat(occurred_at)
     except ValueError as exc:
         raise ValueError("invalid audit cursor") from exc
-    if not snapshot[1] or not after[1]:
-        raise ValueError("invalid audit cursor")
     return (
         snapshot,
         after,

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -75,7 +75,8 @@ from moneybin.protocol.pagination import (
     SortDirection,
     decode_keyset_cursor,
     encode_keyset_cursor,
-    validate_keyset_position,
+    reject_inverted_keyset,
+    validate_keyset_shape,
 )
 from moneybin.utils.db_processes import describe_process, find_blocking_processes
 
@@ -937,21 +938,38 @@ def _audit_bounds(
     if position is None:
         return None, None
     try:
-        validate_keyset_position(
-            position, key_types=(str, str), directions=_AUDIT_KEY_DIRECTIONS
+        validate_keyset_shape(position, key_types=(str, str))
+        snapshot = _canonical_audit_key(position.snapshot)
+        after = _canonical_audit_key(position.after)
+        reject_inverted_keyset(
+            KeysetPosition(snapshot=snapshot, after=after, total=position.total),
+            _AUDIT_KEY_DIRECTIONS,
         )
-        snapshot = cast(tuple[str, str], position.snapshot)
-        after = cast(tuple[str, str], position.after)
-        for occurred_at, row_id in (snapshot, after):
-            if not row_id:
-                raise ValueError("audit cursor carries an empty id")
-            datetime.fromisoformat(occurred_at)
     except ValueError as exc:
         raise ValueError("invalid audit cursor") from exc
     return (
         snapshot,
         after,
     )
+
+
+def _canonical_audit_key(key: tuple[object, ...]) -> tuple[str, str]:
+    """Return one audit key with its timestamp in canonical space-separated ISO.
+
+    ``datetime.fromisoformat`` accepts both ``2025-06-01T01:00:00`` and
+    ``2025-06-01 02:00:00``; lexicographically the space form sorts behind the
+    ``T`` form even when it is the later instant, so comparing raw keys would
+    let a forged cursor mixing the two defeat the ordering guard. An offset
+    would break the same ordering, and every timestamp this log stores is
+    naive, so an aware one is refused rather than converted.
+    """
+    occurred_at, row_id = cast(tuple[str, str], key)
+    if not row_id:
+        raise ValueError("audit cursor carries an empty id")
+    parsed = datetime.fromisoformat(occurred_at)
+    if parsed.tzinfo is not None:
+        raise ValueError("audit cursor timestamp must be naive")
+    return parsed.isoformat(sep=" "), row_id
 
 
 def _audit_list_actions(

--- a/src/moneybin/mcp/tools/transactions.py
+++ b/src/moneybin/mcp/tools/transactions.py
@@ -76,6 +76,7 @@ from moneybin.services.transaction_service import (
     OperationalTransactionResult,
     TransactionGetResult,
     TransactionService,
+    transaction_keyset_bounds,
 )
 
 logger = logging.getLogger(__name__)
@@ -286,36 +287,13 @@ def _transaction_bounds(
     """Validate and narrow decoded transaction keys to date/id pairs."""
     if position is None:
         return None, None
-    if (
-        len(position.snapshot) != 2
-        or len(position.after) != 2
-        or not all(
-            isinstance(value, str) for value in (*position.snapshot, *position.after)
-        )
-    ):
-        raise UserError(
-            "Invalid pagination cursor.",
-            code=error_codes.TRANSACTION_CURSOR_INVALID,
-        )
-    snapshot = cast(tuple[str, str], position.snapshot)
-    after = cast(tuple[str, str], position.after)
     try:
-        date.fromisoformat(snapshot[0])
-        date.fromisoformat(after[0])
+        return transaction_keyset_bounds(position)
     except ValueError as exc:
         raise UserError(
             "Invalid pagination cursor.",
             code=error_codes.TRANSACTION_CURSOR_INVALID,
         ) from exc
-    if not snapshot[1] or not after[1]:
-        raise UserError(
-            "Invalid pagination cursor.",
-            code=error_codes.TRANSACTION_CURSOR_INVALID,
-        )
-    return (
-        snapshot,
-        after,
-    )
 
 
 def _transaction_period(start: date | None, end: date | None) -> str | None:

--- a/src/moneybin/protocol/pagination.py
+++ b/src/moneybin/protocol/pagination.py
@@ -16,6 +16,7 @@ import json
 import math
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from functools import cmp_to_key
 from typing import Literal, cast
 
 type KeysetScalar = str | int | float | bool | None
@@ -144,6 +145,94 @@ def build_keyset_page[T](
         snapshot=snapshot if snapshot is not None else key_of(page[0]),
         after=key_of(page[-1]),
         total=total,
+    )
+
+
+def validate_keyset_position(
+    position: KeysetPosition,
+    *,
+    key_types: tuple[type, ...],
+    directions: tuple[SortDirection, ...],
+) -> None:
+    """Reject a decoded position with a misshapen key or an inverted continuation.
+
+    Cursors are unsigned base64 JSON, so a caller can forge one no page ever
+    minted. An ``after`` that sorts *ahead* of its snapshot makes the
+    continuation predicate weaker than the snapshot predicate instead of
+    narrower, and the page re-serves rows page one already returned. Every
+    keyset surface calls this so that rejection is uniform.
+    """
+    for key in (position.snapshot, position.after):
+        if len(key) != len(key_types) or any(
+            type(value) is not expected
+            for value, expected in zip(key, key_types, strict=True)
+        ):
+            raise ValueError("invalid keyset cursor shape")
+    _reject_inverted_keyset(position, directions)
+
+
+def _reject_inverted_keyset(
+    position: KeysetPosition,
+    directions: tuple[SortDirection, ...],
+) -> None:
+    """Raise when the continuation key sorts ahead of the snapshot it continues."""
+    if compare_keyset(position.after, position.snapshot, directions) < 0:
+        raise ValueError("keyset continuation precedes its snapshot")
+
+
+def paginate_keyset[T](
+    rows: Sequence[T],
+    *,
+    limit: int,
+    key_of: Callable[[T], tuple[KeysetScalar, ...]],
+    directions: tuple[SortDirection, ...],
+    namespace: str,
+    scope: Mapping[str, object],
+    position: KeysetPosition | None,
+) -> tuple[list[T], str | None, int]:
+    """Sort a whole result set into display order and serve one keyset page.
+
+    The counterpart to :func:`build_keyset_page` for surfaces whose rows arrive
+    as a complete in-memory list rather than a SQL over-fetch: the snapshot
+    frozen on page one bounds the walk, so rows prepended mid-walk are excluded
+    and the total stays stable. Returns the page, its continuation, and the
+    total the walk is pinned to.
+    """
+
+    def compare_rows(left: T, right: T) -> int:
+        return compare_keyset(key_of(left), key_of(right), directions)
+
+    ordered = sorted(rows, key=cmp_to_key(compare_rows))
+    if position is None:
+        if not ordered:
+            return [], None, 0
+        snapshot = key_of(ordered[0])
+        eligible = ordered
+        total_count = len(ordered)
+    else:
+        _reject_inverted_keyset(position, directions)
+        snapshot = position.snapshot
+        eligible = [
+            row
+            for row in ordered
+            if compare_keyset(key_of(row), snapshot, directions) >= 0
+            and compare_keyset(key_of(row), position.after, directions) > 0
+        ]
+        total_count = position.total
+
+    page = eligible[:limit]
+    if len(eligible) <= limit or not page:
+        return page, None, total_count
+    return (
+        page,
+        encode_keyset_cursor(
+            namespace=namespace,
+            scope=scope,
+            snapshot=snapshot,
+            after=key_of(page[-1]),
+            total=total_count,
+        ),
+        total_count,
     )
 
 

--- a/src/moneybin/protocol/pagination.py
+++ b/src/moneybin/protocol/pagination.py
@@ -176,20 +176,41 @@ def validate_keyset_position(
     """
     if len(key_types) != len(directions):
         raise ValueError("key_types and directions describe different keys")
+    validate_keyset_shape(position, key_types=key_types)
+    reject_inverted_keyset(position, directions)
+
+
+def validate_keyset_shape(
+    position: KeysetPosition,
+    *,
+    key_types: tuple[type, ...],
+) -> None:
+    """Reject a decoded position whose keys are not the declared shape."""
     for key in (position.snapshot, position.after):
         if len(key) != len(key_types) or any(
             type(value) is not expected
             for value, expected in zip(key, key_types, strict=True)
         ):
             raise InvalidKeysetCursorError("invalid keyset cursor shape")
-    _reject_inverted_keyset(position, directions)
 
 
-def _reject_inverted_keyset(
+def reject_inverted_keyset(
     position: KeysetPosition,
     directions: tuple[SortDirection, ...],
 ) -> None:
-    """Raise when the continuation key sorts ahead of the snapshot it continues."""
+    """Raise when the continuation key sorts ahead of the snapshot it continues.
+
+    Compares the key values exactly as given, so a surface whose key is a
+    *temporal string* must canonicalize it before calling this. ``date`` and
+    ``datetime.fromisoformat`` each accept several spellings of one instant —
+    ``T`` or space separator, basic ``20250101`` or extended ``2025-01-02``,
+    with or without fractional seconds — and those spellings do not sort
+    against each other the way the database sorts the values they denote. A
+    forged cursor pairing two spellings would otherwise slip past this check
+    while still being inverted, which is the very bug the check exists to stop.
+    Surfaces with a temporal key therefore normalize first and pass the
+    canonical form to both this guard and the SQL predicate.
+    """
     if compare_keyset(position.after, position.snapshot, directions) < 0:
         raise InvalidKeysetCursorError("keyset continuation precedes its snapshot")
 
@@ -235,8 +256,8 @@ def paginate_keyset[T](
         eligible = ordered
         total_count = len(ordered)
     else:
-        _reject_inverted_keyset(position, directions)
         try:
+            reject_inverted_keyset(position, directions)
             eligible = [
                 row
                 for row in ordered

--- a/src/moneybin/protocol/pagination.py
+++ b/src/moneybin/protocol/pagination.py
@@ -219,9 +219,13 @@ def canonicalize_keyset_element(
     """
 
     def rewrite(key: tuple[KeysetScalar, ...]) -> tuple[KeysetScalar, ...]:
-        value = key[index]
-        if not isinstance(value, str):
+        # Fails closed on a short key rather than trusting the caller to have
+        # checked arity first: a forged cursor reaches this before any shape
+        # check a caller happens to run, and an IndexError escaping as a crash
+        # is exactly the outcome a cursor guard exists to prevent.
+        if index >= len(key) or not isinstance(key[index], str):
             raise InvalidKeysetCursorError("invalid keyset cursor shape")
+        value = cast(str, key[index])
         return (*key[:index], canonicalize(value), *key[index + 1 :])
 
     return KeysetPosition(

--- a/src/moneybin/protocol/pagination.py
+++ b/src/moneybin/protocol/pagination.py
@@ -148,6 +148,15 @@ def build_keyset_page[T](
     )
 
 
+class InvalidKeysetCursorError(ValueError):
+    """A decoded cursor no page could have minted.
+
+    Distinct from a bare ``ValueError`` so a surface can map a rejected cursor
+    to its caller-facing error without also swallowing a programming error —
+    an unorderable row key or a broken encode — raised from the same block.
+    """
+
+
 def validate_keyset_position(
     position: KeysetPosition,
     *,
@@ -159,15 +168,20 @@ def validate_keyset_position(
     Cursors are unsigned base64 JSON, so a caller can forge one no page ever
     minted. An ``after`` that sorts *ahead* of its snapshot makes the
     continuation predicate weaker than the snapshot predicate instead of
-    narrower, and the page re-serves rows page one already returned. Every
-    keyset surface calls this so that rejection is uniform.
+    narrower, and the page re-serves rows page one already returned.
+
+    Every surface paging from a *head* snapshot calls this, so that rejection
+    is uniform across them. It does not fit the tail-snapshot surfaces; see
+    :func:`paginate_keyset` for that distinction.
     """
+    if len(key_types) != len(directions):
+        raise ValueError("key_types and directions describe different keys")
     for key in (position.snapshot, position.after):
         if len(key) != len(key_types) or any(
             type(value) is not expected
             for value, expected in zip(key, key_types, strict=True)
         ):
-            raise ValueError("invalid keyset cursor shape")
+            raise InvalidKeysetCursorError("invalid keyset cursor shape")
     _reject_inverted_keyset(position, directions)
 
 
@@ -177,7 +191,7 @@ def _reject_inverted_keyset(
 ) -> None:
     """Raise when the continuation key sorts ahead of the snapshot it continues."""
     if compare_keyset(position.after, position.snapshot, directions) < 0:
-        raise ValueError("keyset continuation precedes its snapshot")
+        raise InvalidKeysetCursorError("keyset continuation precedes its snapshot")
 
 
 def paginate_keyset[T](
@@ -197,6 +211,17 @@ def paginate_keyset[T](
     frozen on page one bounds the walk, so rows prepended mid-walk are excluded
     and the total stays stable. Returns the page, its continuation, and the
     total the walk is pinned to.
+
+    This is the *head*-snapshot convention: the snapshot is the first row in
+    display order and the walk runs away from it. ``investments``, ``taxonomy``
+    and ``privacy`` page the mirror convention — the snapshot is the *last* row
+    and the walk runs back toward it — which is self-consistent rather than
+    unguarded, and is deliberately not folded in here: doing so would change
+    which rows their cursors select.
+
+    Raises :class:`InvalidKeysetCursorError` only for a cursor this page rejects.
+    A row key that cannot be ordered, or a failed encode, raises a plain
+    ``ValueError``: those are defects in the caller's rows, not in the cursor.
     """
 
     def compare_rows(left: T, right: T) -> int:
@@ -211,13 +236,16 @@ def paginate_keyset[T](
         total_count = len(ordered)
     else:
         _reject_inverted_keyset(position, directions)
+        try:
+            eligible = [
+                row
+                for row in ordered
+                if compare_keyset(key_of(row), position.snapshot, directions) >= 0
+                and compare_keyset(key_of(row), position.after, directions) > 0
+            ]
+        except ValueError as exc:
+            raise InvalidKeysetCursorError(str(exc)) from exc
         snapshot = position.snapshot
-        eligible = [
-            row
-            for row in ordered
-            if compare_keyset(key_of(row), snapshot, directions) >= 0
-            and compare_keyset(key_of(row), position.after, directions) > 0
-        ]
         total_count = position.total
 
     page = eligible[:limit]

--- a/src/moneybin/protocol/pagination.py
+++ b/src/moneybin/protocol/pagination.py
@@ -16,6 +16,7 @@ import json
 import math
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from datetime import date, datetime
 from functools import cmp_to_key
 from typing import Literal, cast
 
@@ -178,6 +179,56 @@ def validate_keyset_position(
         raise ValueError("key_types and directions describe different keys")
     validate_keyset_shape(position, key_types=key_types)
     reject_inverted_keyset(position, directions)
+
+
+def canonical_iso_date(value: str) -> str:
+    """Return the one extended-ISO spelling of a day that sorts as the day does."""
+    return date.fromisoformat(value).isoformat()
+
+
+def canonical_iso_timestamp(value: str) -> str:
+    """Return the one space-separated ISO spelling of an instant, or raise.
+
+    Space-separated because that is what ``str()`` on a database timestamp
+    produces, so a cursor this surface minted normalizes to itself unchanged.
+    An offset-bearing value is refused rather than converted: an offset suffix
+    makes the string sort by its wall-clock reading rather than its instant,
+    which is the same defect canonicalizing exists to remove, and every
+    timestamp these walks order is naive.
+    """
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is not None:
+        raise ValueError("keyset cursor timestamp must be naive")
+    return parsed.isoformat(sep=" ")
+
+
+def canonicalize_keyset_element(
+    position: KeysetPosition,
+    *,
+    index: int,
+    canonicalize: Callable[[str], str],
+) -> KeysetPosition:
+    """Return the position with one key element replaced by its canonical form.
+
+    Ordering is only sound when a key compares the way the value it denotes
+    compares. A temporal element breaks that on its own: ISO 8601 admits
+    several spellings of one day or instant whose text order contradicts their
+    chronological order, so a forged cursor pairing two spellings can look
+    like a valid continuation while being inverted. Every walk with a temporal
+    element routes through here before its keys are ordered or handed to SQL.
+    """
+
+    def rewrite(key: tuple[KeysetScalar, ...]) -> tuple[KeysetScalar, ...]:
+        value = key[index]
+        if not isinstance(value, str):
+            raise InvalidKeysetCursorError("invalid keyset cursor shape")
+        return (*key[:index], canonicalize(value), *key[index + 1 :])
+
+    return KeysetPosition(
+        snapshot=rewrite(position.snapshot),
+        after=rewrite(position.after),
+        total=position.total,
+    )
 
 
 def validate_keyset_shape(

--- a/src/moneybin/services/transaction_service.py
+++ b/src/moneybin/services/transaction_service.py
@@ -869,7 +869,10 @@ class TransactionService:
             key_of=lambda t: (t.transaction_date, t.transaction_id),
             namespace=_TRANSACTION_LIST_CURSOR,
             scope=scope,
-            snapshot=position.snapshot if position is not None else None,
+            # The canonical local, not position.snapshot: minting from the raw
+            # decoded value would carry a caller's non-canonical spelling into
+            # every later cursor instead of converging on one form.
+            snapshot=snapshot,
             total=total_count,
         )
 

--- a/src/moneybin/services/transaction_service.py
+++ b/src/moneybin/services/transaction_service.py
@@ -32,10 +32,12 @@ from moneybin.mcp.write_contracts import (
 )
 from moneybin.protocol.pagination import (
     KeysetPosition,
+    KeysetScalar,
     SortDirection,
     build_keyset_page,
     decode_keyset_cursor,
-    validate_keyset_position,
+    reject_inverted_keyset,
+    validate_keyset_shape,
 )
 from moneybin.repositories.transaction_notes_repo import TransactionNotesRepo
 from moneybin.repositories.transaction_splits_repo import TransactionSplitsRepo
@@ -82,16 +84,31 @@ def transaction_keyset_bounds(
     malformed: ``transaction_id > ''`` is true for every row, so the
     continuation silently re-serves rows the cursor claims to be past.
     """
-    validate_keyset_position(
-        position, key_types=(str, str), directions=TRANSACTION_KEY_DIRECTIONS
+    validate_keyset_shape(position, key_types=(str, str))
+    snapshot = _canonical_transaction_key(position.snapshot)
+    after = _canonical_transaction_key(position.after)
+    reject_inverted_keyset(
+        KeysetPosition(snapshot=snapshot, after=after, total=position.total),
+        TRANSACTION_KEY_DIRECTIONS,
     )
-    snapshot = cast("tuple[str, str]", position.snapshot)
-    after = cast("tuple[str, str]", position.after)
-    for day, transaction_id in (snapshot, after):
-        if not transaction_id:
-            raise ValueError("keyset cursor carries an empty transaction id")
-        date.fromisoformat(day)
     return snapshot, after
+
+
+def _canonical_transaction_key(
+    key: tuple[KeysetScalar, ...],
+) -> tuple[str, str]:
+    """Return one transaction key with its day in canonical extended ISO form.
+
+    ``date.fromisoformat`` accepts basic ``20250101`` as readily as extended
+    ``2025-01-02``, and those two spellings sort against each other backwards
+    from the dates they denote. Comparing raw keys would let a forged cursor
+    mixing the two pass the ordering guard while still being inverted, so the
+    day is normalized before it reaches either the guard or the SQL predicate.
+    """
+    day, transaction_id = cast("tuple[str, str]", key)
+    if not transaction_id:
+        raise ValueError("keyset cursor carries an empty transaction id")
+    return date.fromisoformat(day).isoformat(), transaction_id
 
 
 # Audit target prefixes (schema, table) for the audit events still emitted

--- a/src/moneybin/services/transaction_service.py
+++ b/src/moneybin/services/transaction_service.py
@@ -35,6 +35,7 @@ from moneybin.protocol.pagination import (
     KeysetScalar,
     SortDirection,
     build_keyset_page,
+    canonical_iso_date,
     decode_keyset_cursor,
     reject_inverted_keyset,
     validate_keyset_shape,
@@ -108,7 +109,7 @@ def _canonical_transaction_key(
     day, transaction_id = cast("tuple[str, str]", key)
     if not transaction_id:
         raise ValueError("keyset cursor carries an empty transaction id")
-    return date.fromisoformat(day).isoformat(), transaction_id
+    return canonical_iso_date(day), transaction_id
 
 
 # Audit target prefixes (schema, table) for the audit events still emitted

--- a/src/moneybin/services/transaction_service.py
+++ b/src/moneybin/services/transaction_service.py
@@ -32,10 +32,10 @@ from moneybin.mcp.write_contracts import (
 )
 from moneybin.protocol.pagination import (
     KeysetPosition,
-    KeysetScalar,
+    SortDirection,
     build_keyset_page,
-    compare_keyset,
     decode_keyset_cursor,
+    validate_keyset_position,
 )
 from moneybin.repositories.transaction_notes_repo import TransactionNotesRepo
 from moneybin.repositories.transaction_splits_repo import TransactionSplitsRepo
@@ -64,29 +64,34 @@ logger = logging.getLogger(__name__)
 _TRANSACTION_LIST_CURSOR = "transactions_list"
 
 # Display order of the keyset: `ORDER BY transaction_date DESC, transaction_id`.
-_TRANSACTION_KEY_DIRECTIONS: tuple[Literal["asc", "desc"], ...] = ("desc", "asc")
+TRANSACTION_KEY_DIRECTIONS: tuple[SortDirection, ...] = ("desc", "asc")
 
 
-def _is_transaction_key(key: tuple[KeysetScalar, ...]) -> bool:
-    """Validate a decoded cursor key before it reaches the SQL predicate.
+def transaction_keyset_bounds(
+    position: KeysetPosition,
+) -> tuple[tuple[str, str], tuple[str, str]]:
+    """Validate a decoded transaction cursor and narrow it to date/id pairs.
 
-    Cursors are unsigned base64 JSON, so a caller can forge one. Types alone
-    are not enough: a well-typed but non-ISO date reaches DuckDB and raises a
-    ConversionException, which ``classify_user_error`` does not recognize — the
-    caller gets a traceback instead of an envelope. An empty transaction_id is
-    worse than malformed: ``transaction_id > ''`` is true for every row, so the
+    Shared with the MCP ``transactions`` tool: both surfaces page the same
+    ``ORDER BY transaction_date DESC, transaction_id`` walk, so a key one
+    rejects the other must reject. Key shape and continuation order come from
+    ``validate_keyset_position``; what remains is what this key *means*. A
+    well-typed but non-ISO date reaches DuckDB and raises a ConversionException,
+    which ``classify_user_error`` does not recognize — the caller gets a
+    traceback instead of an envelope. An empty transaction_id is worse than
+    malformed: ``transaction_id > ''`` is true for every row, so the
     continuation silently re-serves rows the cursor claims to be past.
     """
-    if len(key) != 2 or not all(isinstance(part, str) for part in key):
-        return False
-    day, transaction_id = cast("tuple[str, str]", key)
-    if not transaction_id:
-        return False
-    try:
+    validate_keyset_position(
+        position, key_types=(str, str), directions=TRANSACTION_KEY_DIRECTIONS
+    )
+    snapshot = cast("tuple[str, str]", position.snapshot)
+    after = cast("tuple[str, str]", position.after)
+    for day, transaction_id in (snapshot, after):
+        if not transaction_id:
+            raise ValueError("keyset cursor carries an empty transaction id")
         date.fromisoformat(day)
-    except ValueError:
-        return False
-    return True
+    return snapshot, after
 
 
 # Audit target prefixes (schema, table) for the audit events still emitted
@@ -808,28 +813,16 @@ class TransactionService:
             uncategorized_only=uncategorized_only,
         )
         position: KeysetPosition | None = None
+        snapshot: tuple[str, str] | None = None
+        after: tuple[str, str] | None = None
         if cursor is not None:
             try:
                 position = decode_keyset_cursor(
                     cursor, namespace=_TRANSACTION_LIST_CURSOR, scope=scope
                 )
+                snapshot, after = transaction_keyset_bounds(position)
             except ValueError as e:
                 raise ValueError("invalid cursor") from e
-            if not _is_transaction_key(position.snapshot) or not _is_transaction_key(
-                position.after
-            ):
-                raise ValueError("invalid cursor")
-            # Both keys are well-formed on their own, but an `after` that sorts
-            # ahead of its snapshot makes the continuation predicate weaker
-            # than the snapshot predicate instead of narrower, re-serving rows
-            # page one already returned. Matches the accounts keyset path.
-            if (
-                compare_keyset(
-                    position.after, position.snapshot, _TRANSACTION_KEY_DIRECTIONS
-                )
-                < 0
-            ):
-                raise ValueError("invalid cursor")
 
         account_ids: list[str] | None = None
         if accounts:
@@ -848,12 +841,8 @@ class TransactionService:
             # page without a second count query.
             limit=limit + 1,
             offset=0,
-            snapshot=cast("tuple[str, str] | None", position.snapshot)
-            if position is not None
-            else None,
-            after=cast("tuple[str, str] | None", position.after)
-            if position is not None
-            else None,
+            snapshot=snapshot,
+            after=after,
         )
         total_count = position.total if position is not None else page.total_count
         transactions, next_cursor = build_keyset_page(

--- a/tests/moneybin/test_mcp/test_pagination.py
+++ b/tests/moneybin/test_mcp/test_pagination.py
@@ -308,3 +308,134 @@ def test_compare_keyset_supports_mixed_sort_directions() -> None:
         )
         > 0
     )
+
+
+def test_review_position_rejects_an_inversion_spelled_in_two_iso_forms() -> None:
+    """The history queue keys on an instant, so it needs the same guard.
+
+    `2025-06-01 02:00:00` is the later instant but sorts behind the `T` form as
+    raw text, so an uncanonicalized guard reads this pair as a continuation.
+    """
+    from moneybin.errors import UserError
+    from moneybin.mcp.tools.reviews import (
+        _review_position,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    cursor = encode_keyset_cursor(
+        namespace="reviews",
+        scope={"kind": "matches", "status": "history"},
+        snapshot=("2025-06-01T01:00:00", "dec-a"),
+        after=("2025-06-01 02:00:00", "dec-b"),
+        total=2,
+    )
+
+    with pytest.raises(UserError) as caught:
+        _review_position(cursor, kind="matches", status="history")
+
+    assert caught.value.code == "review_cursor_invalid"
+
+
+def test_review_position_keeps_the_empty_timestamp_a_page_can_mint() -> None:
+    """`_review_ordering` emits "" for a row with no timestamp; it must page."""
+    from moneybin.mcp.tools.reviews import (
+        _review_position,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    cursor = encode_keyset_cursor(
+        namespace="reviews",
+        scope={"kind": "matches", "status": "history"},
+        snapshot=("", "dec-a"),
+        after=("", "dec-b"),
+        total=2,
+    )
+
+    position = _review_position(cursor, kind="matches", status="history")
+
+    assert position is not None
+    assert position.snapshot == ("", "dec-a")
+
+
+def test_balance_position_rejects_an_inversion_spelled_in_two_iso_forms() -> None:
+    """The balances history walk keys on a day and needs the same guard.
+
+    Ascending by date, `20250601` is the earlier day and so sorts ahead of the
+    `2025-06-02` snapshot — inverted — yet as raw text it reads as behind it.
+    """
+    from moneybin.errors import UserError
+    from moneybin.mcp.tools.accounts import (
+        _BALANCE_KEY_DIRECTIONS,  # pyright: ignore[reportPrivateUsage]
+        _coarse_position,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    cursor = encode_keyset_cursor(
+        namespace="accounts_balances",
+        scope={"filters": {}, "view": "history"},
+        snapshot=("2025-06-02", "acct-a"),
+        after=("20250601", "acct-b"),
+        total=2,
+    )
+
+    with pytest.raises(UserError) as caught:
+        _coarse_position(
+            cursor,
+            tool="accounts_balances",
+            view="history",
+            filters={},
+            directions=_BALANCE_KEY_DIRECTIONS["history"],
+            date_index=0,
+        )
+
+    assert caught.value.code == "account_balance_cursor_invalid"
+
+
+def test_canonical_iso_timestamp_refuses_an_offset_bearing_value() -> None:
+    """An offset makes the string sort by wall clock rather than by instant.
+
+    `2025-06-01T09:00:00+09:00` is the earlier instant than a naive
+    `2025-06-01 05:00:00`, but sorts after it as text — the same contradiction
+    canonicalizing exists to remove, so the value is refused rather than
+    converted. Every timestamp these walks order is naive.
+    """
+    from moneybin.protocol.pagination import canonical_iso_timestamp
+
+    assert canonical_iso_timestamp("2025-06-01T05:00:00") == "2025-06-01 05:00:00"
+
+    with pytest.raises(ValueError, match="must be naive"):
+        canonical_iso_timestamp("2025-06-01T09:00:00+09:00")
+
+
+def test_audit_bounds_refuse_an_offset_bearing_timestamp() -> None:
+    """The audit walk refuses an aware cursor rather than reinterpreting it."""
+    from moneybin.mcp.tools.system import (
+        _audit_bounds,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    aware = KeysetPosition(
+        snapshot=("2025-06-01T09:00:00+09:00", "audit-a"),
+        after=("2025-06-01T10:00:00+09:00", "audit-b"),
+        total=2,
+    )
+
+    with pytest.raises(ValueError, match="invalid audit cursor"):
+        _audit_bounds(aware)
+
+
+def test_import_position_refuses_an_offset_bearing_timestamp() -> None:
+    """The import walk refuses an aware cursor for the same reason."""
+    from moneybin.errors import UserError
+    from moneybin.mcp.tools.import_tools import (
+        _import_status_position,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    cursor = encode_keyset_cursor(
+        namespace="import_status.imports",
+        scope={"import_id": None, "sections": ["imports"]},
+        snapshot=("2025-06-01T09:00:00+09:00", "imp_a", 1),
+        after=("2025-06-01T10:00:00+09:00", "imp_b", 1),
+        total=2,
+    )
+
+    with pytest.raises(UserError) as caught:
+        _import_status_position(cursor, sections=["imports"])
+
+    assert caught.value.code == "import_cursor_invalid"

--- a/tests/moneybin/test_mcp/test_pagination.py
+++ b/tests/moneybin/test_mcp/test_pagination.py
@@ -8,6 +8,7 @@ import json
 import pytest
 
 from moneybin.protocol.pagination import (
+    InvalidKeysetCursorError,
     KeysetPosition,
     compare_keyset,
     decode_keyset_cursor,
@@ -201,7 +202,7 @@ def test_paginate_keyset_freezes_the_snapshot_and_walks_without_repeats() -> Non
 def test_paginate_keyset_rejects_continuation_before_its_snapshot() -> None:
     inverted = KeysetPosition(snapshot=("b",), after=("a",), total=3)
 
-    with pytest.raises(ValueError, match="continuation precedes"):
+    with pytest.raises(InvalidKeysetCursorError, match="continuation precedes"):
         paginate_keyset(
             ["a", "b", "c"],
             limit=2,
@@ -211,6 +212,36 @@ def test_paginate_keyset_rejects_continuation_before_its_snapshot() -> None:
             scope={},
             position=inverted,
         )
+
+
+def test_paginate_keyset_does_not_blame_the_cursor_for_unorderable_rows() -> None:
+    """A first page carries no cursor, so its failure must not read as one.
+
+    Mixed-type keys make ``compare_keyset`` raise while sorting. That is a
+    defect in the caller's rows; reporting it as an invalid cursor would send
+    a caller chasing a cursor they never sent.
+    """
+    with pytest.raises(ValueError, match="not comparable") as caught:
+        paginate_keyset(
+            ["a", 1],
+            limit=2,
+            key_of=lambda row: (row,),
+            directions=("asc",),
+            namespace="reviews",
+            scope={},
+            position=None,
+        )
+
+    assert not isinstance(caught.value, InvalidKeysetCursorError)
+
+
+def test_validate_keyset_position_rejects_a_mismatched_contract() -> None:
+    """Declaring more key types than directions is a bug, not a bad cursor."""
+    position = KeysetPosition(snapshot=("a", "b"), after=("a", "c"), total=2)
+
+    with pytest.raises(ValueError, match="describe different keys") as caught:
+        validate_keyset_position(position, key_types=(str, str), directions=("asc",))
+    assert not isinstance(caught.value, InvalidKeysetCursorError)
 
 
 def test_compare_keyset_supports_mixed_sort_directions() -> None:

--- a/tests/moneybin/test_mcp/test_pagination.py
+++ b/tests/moneybin/test_mcp/test_pagination.py
@@ -12,6 +12,8 @@ from moneybin.protocol.pagination import (
     compare_keyset,
     decode_keyset_cursor,
     encode_keyset_cursor,
+    paginate_keyset,
+    validate_keyset_position,
 )
 
 
@@ -101,6 +103,114 @@ def test_keyset_cursor_rejects_non_finite_float_keys() -> None:
     ).decode()
     with pytest.raises(ValueError, match="invalid keyset cursor"):
         decode_keyset_cursor(cursor, namespace="reviews", scope={})
+
+
+def test_validate_keyset_position_rejects_continuation_before_its_snapshot() -> None:
+    """An `after` ahead of its snapshot re-serves rows page one already gave.
+
+    Rows sort `date DESC, id ASC`, so the newer date sorts *ahead*. The
+    snapshot predicate keeps rows at or below the snapshot and the `after`
+    predicate is supposed to narrow that further; inverted, it widens it back
+    to the whole first page.
+    """
+    inverted = KeysetPosition(
+        snapshot=("2026-07-18", "txn-b"),
+        after=("2026-07-19", "txn-a"),
+        total=2,
+    )
+
+    with pytest.raises(ValueError, match="continuation precedes"):
+        validate_keyset_position(
+            inverted, key_types=(str, str), directions=("desc", "asc")
+        )
+
+
+def test_validate_keyset_position_accepts_a_continuation_at_its_snapshot() -> None:
+    """A one-row first page mints `after == snapshot`; that is not inverted."""
+    boundary = KeysetPosition(
+        snapshot=("2026-07-19", "txn-a"),
+        after=("2026-07-19", "txn-a"),
+        total=2,
+    )
+
+    validate_keyset_position(boundary, key_types=(str, str), directions=("desc", "asc"))
+
+
+@pytest.mark.parametrize(
+    ("snapshot", "after", "key_types"),
+    [
+        (("2026-07-19",), ("2026-07-18",), (str, str)),
+        (("2026-07-19", 1), ("2026-07-18", 2), (str, str)),
+        ((True, "txn-a"), (True, "txn-b"), (int, str)),
+    ],
+    ids=["short-key", "wrong-scalar-type", "bool-is-not-int"],
+)
+def test_validate_keyset_position_rejects_keys_of_the_wrong_shape(
+    snapshot: tuple[object, ...],
+    after: tuple[object, ...],
+    key_types: tuple[type, ...],
+) -> None:
+    position = KeysetPosition(
+        snapshot=snapshot,  # type: ignore[arg-type]
+        after=after,  # type: ignore[arg-type]
+        total=2,
+    )
+
+    with pytest.raises(ValueError, match="invalid keyset cursor shape"):
+        validate_keyset_position(
+            position, key_types=key_types, directions=("asc",) * len(key_types)
+        )
+
+
+def _first_element(row: str) -> tuple[str]:
+    return (row,)
+
+
+def test_paginate_keyset_freezes_the_snapshot_and_walks_without_repeats() -> None:
+    """The frozen snapshot excludes a later prepend and preserves the total."""
+    page, cursor, total = paginate_keyset(
+        ["c", "a", "b"],
+        limit=2,
+        key_of=_first_element,
+        directions=("asc",),
+        namespace="reviews",
+        scope={},
+        position=None,
+    )
+
+    assert page == ["a", "b"]
+    assert total == 3
+    assert cursor is not None
+
+    position = decode_keyset_cursor(cursor, namespace="reviews", scope={})
+    second, next_cursor, second_total = paginate_keyset(
+        ["0", "c", "a", "b"],
+        limit=2,
+        key_of=_first_element,
+        directions=("asc",),
+        namespace="reviews",
+        scope={},
+        position=position,
+    )
+
+    assert second == ["c"]
+    assert next_cursor is None
+    assert second_total == 3
+
+
+def test_paginate_keyset_rejects_continuation_before_its_snapshot() -> None:
+    inverted = KeysetPosition(snapshot=("b",), after=("a",), total=3)
+
+    with pytest.raises(ValueError, match="continuation precedes"):
+        paginate_keyset(
+            ["a", "b", "c"],
+            limit=2,
+            key_of=_first_element,
+            directions=("asc",),
+            namespace="reviews",
+            scope={},
+            position=inverted,
+        )
 
 
 def test_compare_keyset_supports_mixed_sort_directions() -> None:

--- a/tests/moneybin/test_mcp/test_pagination.py
+++ b/tests/moneybin/test_mcp/test_pagination.py
@@ -439,3 +439,51 @@ def test_import_position_refuses_an_offset_bearing_timestamp() -> None:
         _import_status_position(cursor, sections=["imports"])
 
     assert caught.value.code == "import_cursor_invalid"
+
+
+def test_canonicalize_keyset_element_fails_closed_on_a_short_key() -> None:
+    """A forged short key must be refused, never crash on the index.
+
+    The temporal element is addressed by position, so a key with fewer
+    elements than the index reaches a raw `key[index]`. An IndexError is not a
+    ValueError, so it would escape every cursor handler and surface as a crash
+    instead of the refusal a forged cursor is supposed to get.
+    """
+    from moneybin.protocol.pagination import (
+        canonical_iso_date,
+        canonicalize_keyset_element,
+    )
+
+    short = KeysetPosition(snapshot=("acct-a",), after=("acct-b",), total=2)
+
+    with pytest.raises(InvalidKeysetCursorError, match="shape"):
+        canonicalize_keyset_element(short, index=1, canonicalize=canonical_iso_date)
+
+
+def test_balance_position_refuses_a_short_forged_key() -> None:
+    """The assertions view keys its day second, so a one-element key is short."""
+    from moneybin.errors import UserError
+    from moneybin.mcp.tools.accounts import (
+        _BALANCE_KEY_DIRECTIONS,  # pyright: ignore[reportPrivateUsage]
+        _coarse_position,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    cursor = encode_keyset_cursor(
+        namespace="accounts_balances",
+        scope={"filters": {}, "view": "assertions"},
+        snapshot=("acct-a",),
+        after=("acct-b",),
+        total=2,
+    )
+
+    with pytest.raises(UserError) as caught:
+        _coarse_position(
+            cursor,
+            tool="accounts_balances",
+            view="assertions",
+            filters={},
+            directions=_BALANCE_KEY_DIRECTIONS["assertions"],
+            date_index=1,
+        )
+
+    assert caught.value.code == "account_balance_cursor_invalid"

--- a/tests/moneybin/test_mcp/test_pagination.py
+++ b/tests/moneybin/test_mcp/test_pagination.py
@@ -235,6 +235,43 @@ def test_paginate_keyset_does_not_blame_the_cursor_for_unorderable_rows() -> Non
     assert not isinstance(caught.value, InvalidKeysetCursorError)
 
 
+def test_transaction_bounds_reject_an_inversion_spelled_in_two_iso_forms() -> None:
+    """Mixing ISO spellings must not smuggle an inverted continuation through.
+
+    `date.fromisoformat` accepts basic `20250101` and extended `2025-01-02`
+    alike, and those two sort against each other backwards from the days they
+    denote: as raw strings the later day looks like it sorts behind. The keys
+    are canonicalized before the ordering guard, so the comparison sees the
+    days DuckDB will see rather than the characters the caller chose.
+    """
+    from moneybin.services.transaction_service import transaction_keyset_bounds
+
+    inverted = KeysetPosition(
+        snapshot=("20250101", "txn_a"),
+        after=("2025-01-02", "txn_z"),
+        total=5,
+    )
+
+    with pytest.raises(InvalidKeysetCursorError, match="continuation precedes"):
+        transaction_keyset_bounds(inverted)
+
+
+def test_transaction_bounds_canonicalize_an_accepted_key() -> None:
+    """A valid basic-form day still pages, normalized to the extended form."""
+    from moneybin.services.transaction_service import transaction_keyset_bounds
+
+    snapshot, after = transaction_keyset_bounds(
+        KeysetPosition(
+            snapshot=("20250102", "txn_a"),
+            after=("2025-01-01", "txn_z"),
+            total=5,
+        )
+    )
+
+    assert snapshot == ("2025-01-02", "txn_a")
+    assert after == ("2025-01-01", "txn_z")
+
+
 def test_validate_keyset_position_rejects_a_mismatched_contract() -> None:
     """Declaring more key types than directions is a bug, not a bad cursor."""
     position = KeysetPosition(snapshot=("a", "b"), after=("a", "c"), total=2)

--- a/tests/moneybin/test_mcp/test_review.py
+++ b/tests/moneybin/test_mcp/test_review.py
@@ -717,6 +717,41 @@ async def test_review_cursor_snapshot_excludes_prepends_and_preserves_total() ->
     assert first.summary.total_count == second.summary.total_count == 2
 
 
+async def test_review_cursor_rejects_continuation_before_its_snapshot() -> None:
+    """`after` may never sort ahead of the snapshot it continues.
+
+    The forged key is well-shaped — a float and a string, exactly the matches
+    queue contract — so only the ordering guard can reject it. Confidence sorts
+    DESC, so 1.0 sorts ahead of the 0.9 snapshot page one froze, the `> after`
+    filter stops narrowing anything, and the page re-serves match-a.
+    """
+    from moneybin.protocol.pagination import encode_keyset_cursor
+
+    rows = [_pending_match("match-a"), _pending_match("match-b")]
+    with patch(
+        "moneybin.mcp.tools.reviews.MatchingService.get_pending",
+        return_value=rows,
+    ):
+        first = await reviews_coarse(kind="matches", status="pending", limit=1)
+        assert [row.decision_id for row in first.data.rows] == ["match-a"]
+
+        response = await reviews_coarse(
+            kind="matches",
+            status="pending",
+            limit=1,
+            cursor=encode_keyset_cursor(
+                namespace="reviews",
+                scope={"kind": "matches", "status": "pending"},
+                snapshot=(0.9, "match-a"),
+                after=(1.0, "match-z"),
+                total=2,
+            ),
+        )
+
+    assert response.error is not None
+    assert response.error.code == "review_cursor_invalid"
+
+
 async def test_review_cursor_validates_key_shape_when_queue_is_empty() -> None:
     from moneybin.protocol.pagination import encode_keyset_cursor
 

--- a/tests/moneybin/test_mcp/test_system_tools.py
+++ b/tests/moneybin/test_mcp/test_system_tools.py
@@ -552,6 +552,47 @@ async def test_system_audit_history_continuation_ignores_newer_operation() -> No
     assert second.summary.total_count == 3
 
 
+async def test_system_audit_coarse_rejects_continuation_before_its_snapshot(
+    mcp_db: object,
+) -> None:
+    """`after` may never sort ahead of the snapshot it continues.
+
+    The forged key carries two well-formed ISO timestamps and non-empty ids, so
+    only the ordering guard can reject it. Events sort newest-first, so a
+    far-future `after` sorts ahead of the snapshot page one froze and the
+    continuation predicate stops excluding anything the snapshot already admits.
+    """
+    from moneybin.protocol.pagination import (
+        decode_keyset_cursor,
+        encode_keyset_cursor,
+    )
+
+    _make_tag_op("inverted-a")
+    _make_tag_op("inverted-b")
+    first = await system_audit_coarse(view="events", limit=1)
+    assert first.next_cursor is not None
+    position = decode_keyset_cursor(
+        first.next_cursor,
+        namespace="system_audit",
+        scope={"view": "events"},
+    )
+
+    response = await system_audit_coarse(
+        view="events",
+        limit=1,
+        cursor=encode_keyset_cursor(
+            namespace="system_audit",
+            scope={"view": "events"},
+            snapshot=position.snapshot,
+            after=("2999-01-01T00:00:00", "audit-forged"),
+            total=position.total,
+        ),
+    )
+
+    assert response.error is not None
+    assert response.error.code == "infra_invalid_input"
+
+
 async def test_system_audit_coarse_rejects_malformed_and_cross_view_cursors(
     mcp_db: object,
 ) -> None:

--- a/tests/moneybin/test_mcp/test_system_tools.py
+++ b/tests/moneybin/test_mcp/test_system_tools.py
@@ -593,6 +593,37 @@ async def test_system_audit_coarse_rejects_continuation_before_its_snapshot(
     assert response.error.code == "infra_invalid_input"
 
 
+async def test_system_audit_coarse_rejects_an_inversion_spelled_in_two_iso_forms(
+    mcp_db: object,
+) -> None:
+    """A later instant written with a space separator is still inverted.
+
+    `datetime.fromisoformat` accepts both `2025-06-01T01:00:00` and
+    `2025-06-01 02:00:00`, and as raw strings the space form sorts behind the
+    `T` form even though it is the later instant — so an uncanonicalized guard
+    would accept this pair and re-serve rows the caller already has.
+    """
+    from moneybin.protocol.pagination import encode_keyset_cursor
+
+    _make_tag_op("spelling-a")
+    _make_tag_op("spelling-b")
+
+    response = await system_audit_coarse(
+        view="events",
+        limit=1,
+        cursor=encode_keyset_cursor(
+            namespace="system_audit",
+            scope={"view": "events"},
+            snapshot=("2025-06-01T01:00:00", "audit-a"),
+            after=("2025-06-01 02:00:00", "audit-b"),
+            total=2,
+        ),
+    )
+
+    assert response.error is not None
+    assert response.error.code == "infra_invalid_input"
+
+
 async def test_system_audit_coarse_rejects_malformed_and_cross_view_cursors(
     mcp_db: object,
 ) -> None:

--- a/tests/moneybin/test_mcp/test_transactions_get.py
+++ b/tests/moneybin/test_mcp/test_transactions_get.py
@@ -366,6 +366,45 @@ async def test_transactions_coarse_rejects_continuation_before_its_snapshot() ->
 
 
 @pytest.mark.unit
+async def test_transactions_coarse_rejects_an_inversion_spelled_in_two_iso_forms() -> (
+    None
+):
+    """A basic-form snapshot must not let a later extended-form day through.
+
+    As raw strings `2025-06-02` sorts behind `20250601`, so an uncanonicalized
+    ordering guard reads this pair as a valid continuation even though the
+    continuation day is the later one — re-serving txn_1 and txn_2.
+    """
+    from moneybin.protocol.pagination import encode_keyset_cursor
+
+    _insert_transactions()
+
+    response = await transactions_coarse(
+        account="ACC001",
+        limit=1,
+        cursor=encode_keyset_cursor(
+            namespace="transactions",
+            scope={
+                "account": "acc001",
+                "category": None,
+                "end": None,
+                "max_amount": None,
+                "merchant": None,
+                "min_amount": None,
+                "start": None,
+                "text": None,
+            },
+            snapshot=("20250601", "txn_1"),
+            after=("2025-06-02", "txn_0"),
+            total=2,
+        ),
+    )
+
+    assert response.error is not None
+    assert response.error.code == "transaction_cursor_invalid"
+
+
+@pytest.mark.unit
 async def test_transactions_coarse_cursor_is_bound_to_filters(
     mcp_db: object,
 ) -> None:

--- a/tests/moneybin/test_mcp/test_transactions_get.py
+++ b/tests/moneybin/test_mcp/test_transactions_get.py
@@ -323,6 +323,49 @@ async def test_transaction_continuation_keeps_initial_total_after_tail_insert() 
 
 
 @pytest.mark.unit
+async def test_transactions_coarse_rejects_continuation_before_its_snapshot() -> None:
+    """`after` may never sort ahead of the snapshot it continues.
+
+    Both keys are individually well-formed — two strings, ISO dates, non-empty
+    ids — so only the ordering guard can reject this. Rows sort
+    `transaction_date DESC, transaction_id ASC`, so the far-future `after` sorts
+    ahead of the snapshot page one froze. That makes the continuation predicate
+    weaker than the snapshot predicate rather than narrower, and the page
+    re-serves txn_1, which page one already returned. Cursors are unsigned, so
+    this is a reachable forgery; `TransactionService.get` already rejects it.
+    """
+    from moneybin.protocol.pagination import encode_keyset_cursor
+
+    _insert_transactions()
+    first = await transactions_coarse(account="ACC001", limit=1)
+    assert [row.transaction_id for row in first.data.transactions] == ["txn_1"]
+
+    response = await transactions_coarse(
+        account="ACC001",
+        limit=1,
+        cursor=encode_keyset_cursor(
+            namespace="transactions",
+            scope={
+                "account": "acc001",
+                "category": None,
+                "end": None,
+                "max_amount": None,
+                "merchant": None,
+                "min_amount": None,
+                "start": None,
+                "text": None,
+            },
+            snapshot=("2025-06-01", "txn_1"),
+            after=("2025-12-31", "txn_0"),
+            total=2,
+        ),
+    )
+
+    assert response.error is not None
+    assert response.error.code == "transaction_cursor_invalid"
+
+
+@pytest.mark.unit
 async def test_transactions_coarse_cursor_is_bound_to_filters(
     mcp_db: object,
 ) -> None:

--- a/tests/moneybin/test_services/test_transaction_get.py
+++ b/tests/moneybin/test_services/test_transaction_get.py
@@ -367,6 +367,55 @@ class TestTransactionGet:
             service.get(limit=2, cursor=forged)
 
     @pytest.mark.unit
+    def test_continuation_cursor_converges_on_the_canonical_day_spelling(
+        self, txn_db: Database
+    ) -> None:
+        """A minted cursor carries the canonical day, not the caller's spelling.
+
+        `date.fromisoformat` accepts basic `20260415` as readily as extended
+        `2026-04-15`. Both name the same day, so this cursor is valid and pages
+        normally — but if the continuation it mints echoed the caller's
+        spelling back, that spelling would ride along through every later page
+        instead of the walk settling on one form.
+        """
+        from moneybin.protocol.pagination import (
+            decode_keyset_cursor,
+            encode_keyset_cursor,
+        )
+        from moneybin.services.transaction_service import (
+            _TRANSACTION_LIST_CURSOR,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        service = TransactionService(txn_db)
+        scope = service._get_cursor_scope(  # pyright: ignore[reportPrivateUsage]
+            accounts=None,
+            date_from=None,
+            date_to=None,
+            categories=None,
+            amount_min=None,
+            amount_max=None,
+            description=None,
+            uncategorized_only=False,
+        )
+        basic_form = encode_keyset_cursor(
+            namespace=_TRANSACTION_LIST_CURSOR,
+            scope=scope,
+            snapshot=("20260415", "T2"),
+            after=("20260415", "T2"),
+            total=4,
+        )
+
+        result = service.get(limit=1, cursor=basic_form)
+
+        assert result.next_cursor is not None
+        continuation = decode_keyset_cursor(
+            result.next_cursor,
+            namespace=_TRANSACTION_LIST_CURSOR,
+            scope=scope,
+        )
+        assert continuation.snapshot == ("2026-04-15", "T2")
+
+    @pytest.mark.unit
     def test_continuation_that_precedes_its_snapshot_is_rejected(
         self, txn_db: Database
     ) -> None:


### PR DESCRIPTION
Closes MB-41.

## Summary

**The issue predicted one unguarded MCP surface. There are three:** `transactions`, `system_audit`, and `reviews`. MB-41 named the `transactions` tool; verifying the claim against current code turned up the same gap in `system_audit`'s cursor validator and in `reviews`' page engine. All three are fixed here, and each has its own end-to-end test.

A keyset cursor carries two keys: the `snapshot` that froze the top of the walk, and the `after` continuation key of the last row served. A page is `key >= snapshot AND key > after`. When `after` sorts **ahead** of `snapshot` in display order, `key > after` admits everything `key >= snapshot` already admits — so the continuation stops narrowing and widens back to page one, re-serving rows the caller already has. It arrives as an ordinary `status: ok` envelope with nothing to notice. Cursors are unsigned base64 JSON, so any caller can present such a pair.

`TransactionService.get()` (the CLI `transactions list` path) and `import_status` rejected it. The `transactions`, `system_audit`, and `reviews` MCP tools did not. `docs/specs/mcp-architecture.md` already promises the continuation "neither skips nor duplicates" — the code was in violation of its own spec on three surfaces.

The cause is duplication: the typed cursor validator was pasted at four sites and the ordering guard travelled with only two of them, and two near-identical full-sort page engines (`accounts.py`, `reviews.py`) each carried their own copy of the windowing logic — one with the guard, one without. Fixing the three surfaces individually would have left the same shape free to drift again, so the guard now has one home.

## Changes

**Two primitives beside the cursor codec in `moneybin/protocol/pagination.py`.** `validate_keyset_position(position, *, key_types, directions)` does key shape plus the ordering guard in one place. `paginate_keyset(rows, ...)` is the in-memory counterpart to `build_keyset_page`: sort into display order, window behind the frozen snapshot, mint the continuation.

**Every paged surface consumes them.** `transactions.py`, `system.py` and `reviews.py` gain the guard they were missing; `import_tools.py`, `accounts.py` and `transaction_service.py` drop their local copies for the shared one. Each caller still raises its own error type and code — only the rules are shared.

**One transaction key validator instead of two.** `transaction_keyset_bounds` in `transaction_service.py` is now used by both the service `get()` path and the MCP `transactions` tool. They page the same `ORDER BY transaction_date DESC, transaction_id` walk, so a key one rejects the other must reject.

**`accounts_balances` reads its sort order from one table.** A per-view keyset-direction map replaces four repeated direction literals and the `key_size` derived beside them, so cursor validation and the page engine cannot disagree about a view's order.

**Temporal keys are canonicalized before they are ordered.** ISO 8601 spells one day or instant several ways — basic `20250101` and extended `2025-01-02`, a `T` or a space before the time — and those spellings do not sort against each other the way the values they denote sort. Comparing raw strings therefore let a forged cursor present a continuation that was *ahead* of its snapshot in fact while sorting behind it as text, which is this PR's own bug reached by a different construction. Review caught it; it reproduced against the function with no database:

```python
validate_keyset_position(
    KeysetPosition(snapshot=("20250101", "txn_a"), after=("2025-01-02", "txn_z"), total=5),
    key_types=(str, str), directions=("desc", "asc"),
)   # did not raise
```

Review named three walks. The rule is broader, so the fix sweeps every keyset for the shape rather than patching the sites that leaked — **eight walks** carry a temporal element: `transactions` (day), `system_audit` events and history (instant), `import_status` (instant), `reviews` history (instant), `reviews` pending categorization (**day**), and `accounts_balances` history, assertions and reconcile (day).

Both reviews queues were confirmed defeatable before anything changed: `compare_keyset(("2025-06-01 02:00:00","dec-b"), ("2025-06-01T01:00:00","dec-a"), directions)` returned `1` for `matches/history` and for `categorization/pending`.

The two reviews queues cannot share a canonicalizer, and that distinction is load-bearing: history keys on `decided_at` (an instant), pending categorization on `transaction.transaction_date` (a day). Canonicalizing either as the other rewrites the key into a spelling no row emits, so the page would match **nothing** rather than mis-order — an empty-page bug with no error. Each queue declares its own shape. The `""` that `_review_ordering` emits for a row with no timestamp is itself a key a page can mint, so it passes through untouched.

`validate_keyset_position` is now the composition of `validate_keyset_shape` and `reject_inverted_keyset`, so a surface with a temporal key can normalize between the two steps; there is still exactly one implementation of each check, and one of the canonicalization. Normalizing rather than rejecting non-canonical spellings matters: every legitimately minted audit cursor uses a space separator, because `str(datetime)` writes one where `.isoformat()` writes `T`, so a strict round-trip check would have rejected real cursors. A timestamp carrying a UTC offset is refused rather than reinterpreted — an offset breaks the same ordering, and these logs store naive values.

**A rejected cursor is now a distinct exception.** `InvalidKeysetCursorError` separates "this cursor is bad" from "these rows cannot be ordered" or "the encode failed". Without it the shared page engine's `try` would have widened over the in-memory sort, so an unorderable row on a **first page — which carries no cursor at all** — would have been reported to the caller as an invalid cursor. The two page-engine call sites now catch only the cursor error, and a `key_types`/`directions` length mismatch raises a plain `ValueError` so a wiring bug surfaces as a bug rather than as a per-caller user error.

## Background

This is not a cursor-contract change. The encoding, version, and namespace/scope binding are untouched. No cursor MoneyBin mints can carry an inverted pair — both page engines derive `after` from a row at or after the snapshot — so every cursor a caller holds today still decodes and still pages. Canonicalization is likewise a no-op on anything MoneyBin mints — every affected walk renders its row key with `date.isoformat()` or `str()`, which are already the canonical forms — so no cursor a page could previously produce is newly rejected. That claim is re-derived rather than restated: the evidence is the existing mint-then-page round-trip tests on each surface, which pass unchanged. What changes is that a cursor **no page ever minted** is now refused instead of silently serving duplicates.

`investments`, `taxonomy` and `privacy` were left alone deliberately. `_investment_page` freezes the *last* row of an ascending walk as its upper bound rather than the first as a lower bound — a self-consistent mirror of this contract, not a missing guard — and folding it in would change which rows its cursors select. That is a separate decision, not this bug.

## Test plan

Test-first. Each new test was watched red before the fix, and each red was the bug rather than an error: `transactions`, `system_audit` and `reviews` each returned a successful envelope with `returned_count=1, has_more=True` for a forged inverted cursor.

Every forged fixture is well-shaped for its surface — correct arity, correct scalar types, parseable ISO temporals, non-empty ids — so only the ordering guard can reject it. No other check on those paths can claim the refusal, which is what keeps each test pinned to the guard it names.

- `test_pagination.py` — the guard rejects an inverted position, accepts the `after == snapshot` boundary that a one-row first page legitimately mints, and rejects three wrong-shape keys (short key, wrong scalar type, `bool` presented where `int` is declared). `paginate_keyset` freezes its snapshot across a prepend, preserves the total, and rejects an inverted position.
- `test_transactions_get.py`, `test_review.py`, `test_system_tools.py` — one end-to-end forged-cursor rejection per newly guarded MCP surface, driven through the real tool.
- `test_pagination.py` also pins the two error-classification rules above: unorderable rows on a cursor-less first page raise a plain `ValueError` and specifically *not* `InvalidKeysetCursorError`, and a mismatched `key_types`/`directions` contract does the same.

Both bypassing pairs above are pinned as regression tests at the shared helper and at each of the three temporal surfaces, using the exact constructions review reproduced.

An adversarial pre-push review over the exact base-to-head range raised a documentation-accuracy MUST FIX — the CHANGELOG and a docstring both claimed *every* paged surface calls the shared guard, which the three tail-snapshot surfaces make false — plus the over-wide `try` and a wrong comment on the import cursor's third key element. All are fixed in this branch. It independently confirmed the `directions`-versus-`ORDER BY` pairing at every site, that no legitimately minted cursor is newly rejected, and that `total_count` semantics are identical to both replaced helpers.

Gates run repo-wide: `make format`, `make lint`, and a bare `uv run pyright` (0 errors; 3 pre-existing unrelated `reportlab` import warnings). `make test`: 10371 passed, 4 skipped, 2 failed. `make test-integration`: 561 passed, 0 failed. `uv run pytest tests/test_documentation_policy.py` for the CHANGELOG edit: 8 passed.

Neither unit failure is introduced by this diff, and both were investigated rather than assumed. `test_oauth_client.py::test_google_oauth_authorizes_with_the_shipped_client_id_and_secret_pair` is environmental: the developer shell has `MONEYBIN_GSHEET__OAUTH_CLIENT_ID` set without its paired secret, and the test constructs `MoneyBinSettings.model_validate({})`, which Pydantic Settings populates from the ambient environment. This diff touches no connector, config or settings code, and CI sets no such variable. `test_system_status_coarse_defaults_to_fixed_section_order` is load-dependent: it exceeded the 30s tool cap while two pytest processes ran concurrently, and passes in isolation and across its whole file (61 passed).

Reviewers should check that each surface's declared `directions` matches the `ORDER BY` its rows actually arrive in — that pairing is what the guard's correctness rests on.
