### PR TITLE
Derive price-source dispatch and ranking from one registry

### DIFF
--- a/docs/specs/investments-price-feeds.md
+++ b/docs/specs/investments-price-feeds.md
@@ -635,7 +635,8 @@ deterministic-resolution requirement.
 | 4 | `coingecko` | A settled public close; ranked below tiingo only to break ties, since the two never cover the same security. |
 | 5 | `trade_implied` | An execution price reflects one order's size and spread. |
 
-A new adapter takes the next free rank. Where two providers disagree on the same
+A new adapter appends the next free rank to `seeds.price_source_map`. Where
+two providers disagree on the same
 date the rank picks one deterministically and `system doctor` reports the
 disagreement — resolution stays stable, and the conflict stays visible.
 
@@ -647,34 +648,42 @@ Both are cheap to honour and expensive to discover late.
   both hold a row, which silently revalues `core.dim_holdings.market_value` and
   the C.3 daily series. The code change is one line either way; the consequence
   is not. Reordering is a deliberate, announced revaluation, not a refactor.
-- **A retired provider's `source_type` mapping stays forever.** Because
+- **A retired provider's registry row stays forever.** Because
   `raw.security_prices` is append-only, a provider's rows outlive the decision to
   stop fetching from it — and `prep.stg_security_prices` resolves each row through
-  a per-`source_type` `ref_kind` CASE with an INNER JOIN. Deleting a retired
-  source's arm of that CASE therefore discards every historical row it wrote,
-  silently and unrecoverably. Retiring a provider means ceasing to *write*, never
-  removing its mapping or its `ref_kind`.
+  the `ref_kind` its `seeds.price_source_map` row declares, with an INNER JOIN.
+  Deleting a retired source's row therefore discards every historical row it wrote,
+  silently and unrecoverably. Retiring a provider means clearing its
+  `security_types` so nothing routes to it, never removing the row or its
+  `ref_kind`.
 
-  **Three guards cover this, because no one of them sees every direction.**
+  **One registry, then three guards over what it cannot see.**
+
+  `seeds.price_source_map` is the single declaration: one CSV row supplies the
+  `ref_kind` `prep.stg_security_prices` joins on, the `source_rank`
+  `core.fct_security_prices` orders by, and — through `moneybin.price_sources` —
+  the adapter routing, `feed_ref_kind`, and feed-key set that `PriceService` and
+  `SecurityLinksService` dispatch on. The C.2 failure mode is therefore structural
+  rather than guarded: a writer cannot ship ahead of its mapping, because
+  declaring the source declares both.
 
   `tests/moneybin/test_stg_security_prices.py::test_every_mapped_source_resolves_end_to_end`
-  derives its source list by parsing the CASE out of the model file, so adding an
-  arm without widening the `ref_kind` CHECK fails loudly. It cannot see a removed
-  arm (removing one merely shrinks the set it iterates), nor a writer that ships
-  ahead of its mapping — in both cases the CASE is what changed or failed to
-  change, and this test reads only the CASE.
+  iterates the registry and asserts each mapped source resolves end to end, so
+  adding a row without widening the `ref_kind` CHECK fails loudly. It cannot see a
+  *deleted* row — removing one merely shrinks the set it iterates — which is what
+  `tests/moneybin/test_price_sources.py` pins, along with the shipped rank order.
 
   `tests/moneybin/test_services/test_price_service.py::test_every_source_the_service_writes_resolves_in_staging`
-  watches the opposite direction: every `source_type` `PriceService` writes must
-  appear in the CASE, spelled with the same `ref_kind` the service binds. This is
-  the guard that was missing when C.2's writer shipped one commit ahead of its
-  mapping, leaving every `tiingo` and `coingecko` row it wrote discarded.
+  watches the remaining direction: every source the service routes to must carry a
+  `ref_kind`. The shared helper additionally fails if `prep.stg_security_prices`
+  stops JOINing the registry or restates a `CASE p.source_type` beside it, so the
+  mapping cannot quietly fork back into two places.
 
   `investment_price_disagreement`'s sibling `investment_unmapped_price_source`
   closes the run-time half: any `source_type` present in `raw.security_prices`
   with an accepted binding whose rows still never reach staging. It covers rows
-  already written and sources no Python constant names — including a retired
-  provider whose arm someone deletes.
+  already written and sources no registry row names — including a retired
+  provider whose row someone deletes.
 
 **Freshness dominates rank.** An override applies to one
 `(security_id, price_date, quote_currency)`. Within that date it beats every

--- a/docs/specs/moneybin-doctor.md
+++ b/docs/specs/moneybin-doctor.md
@@ -164,13 +164,13 @@ while CoinGecko's is a 00:00 UTC close, so a volatile day separates two correct
 figures by more than a percent.
 
 **`investment_unmapped_price_source` detects a mapping failure without parsing
-the model's SQL.** `prep.stg_security_prices` resolves each `source_type` to a
-`ref_kind` through a CASE and INNER JOINs on the result, so an unmapped source
-makes the CASE return NULL, the comparison UNKNOWN, and the join drop the row —
-with no error and no counter. That drop is permanent rather than deferred:
+the model's SQL.** `prep.stg_security_prices` takes each `source_type`'s
+`ref_kind` from `seeds.price_source_map` and INNER JOINs on the result, so a
+source absent from that registry — or carrying no `ref_kind` — matches nothing
+and the join drops the row, with no error and no counter. That drop is permanent rather than deferred:
 unlike an unresolved binding, which waits in raw and reappears once its security
 binds, no number of later accepted bindings will ever surface it, because the
-failure is in the mapping rather than the binding.
+failure is in the registry rather than the binding.
 
 The check separates those two conditions with an accepted-binding join. A row it
 reports already has an accepted binding whose `source_type` and `ref_value`
@@ -181,11 +181,12 @@ resolver has minted a canonical security.
 
 This check exists because the failure it describes shipped: C.2 added a writer
 for `tiingo` and `coingecko` rows one commit ahead of the staging mapping, and
-every row written in between was discarded silently. A build-time guard in
-`tests/moneybin/test_services/test_price_service.py` now asserts every
-`source_type` `PriceService` writes appears in the CASE; this check is the
-run-time half, covering rows already written and sources no Python constant
-names.
+every row written in between was discarded silently. That particular split is
+now structural rather than guarded — `seeds.price_source_map` declares the
+source PriceService dispatches on and the `ref_kind` staging joins in one row,
+so declaring either declares both. This check remains the run-time half, and it
+is the only one that covers rows already written and a registry row someone
+deletes.
 
 ### Dropped invariant
 

--- a/src/moneybin/mcp/tools/investments.py
+++ b/src/moneybin/mcp/tools/investments.py
@@ -52,6 +52,7 @@ from moneybin.mcp.confirmation import (
 )
 from moneybin.mcp.decorator import mcp_tool
 from moneybin.mcp.privacy import Sensitivity, tier_to_sensitivity
+from moneybin.price_sources import FEED_KEY_REF_KINDS
 from moneybin.privacy.introspection import extract_data_classes
 from moneybin.privacy.payloads.investments import (
     InvestmentEventsPayload,
@@ -89,8 +90,7 @@ from moneybin.services.entity_reference import (
     resolve_entity_reference,
 )
 from moneybin.services.investment_service import InvestmentService
-from moneybin.services.security_links_service import (  # noqa: I001
-    _FEED_KEY_REF_KINDS,  # pyright: ignore[reportPrivateUsage]  # the routing set
+from moneybin.services.security_links_service import (
     SecurityLinkAcceptImpact,
     SecurityLinksService,
 )
@@ -667,7 +667,7 @@ def _load_pending_proposal(decision_id: str) -> _MergeProposal:
         for group in groups:
             for candidate in group.candidates:
                 if candidate.decision_id == decision_id:
-                    is_feed_key = group.ref_kind in _FEED_KEY_REF_KINDS
+                    is_feed_key = group.ref_kind in FEED_KEY_REF_KINDS
                     if is_feed_key:
                         # accept_impact answers "what does this merge touch", and
                         # raises when no accepted binding exists to move. A feed
@@ -850,7 +850,7 @@ def _apply_accept(
     with get_database(read_only=False) as db:
         service = SecurityLinksService(db, actor="mcp")
         decision = service.decision_by_id(decision_id)
-        if decision is not None and str(decision["ref_kind"]) in _FEED_KEY_REF_KINDS:
+        if decision is not None and str(decision["ref_kind"]) in FEED_KEY_REF_KINDS:
             # The merge branch's verify_accept re-derives the MERGE impact; a
             # feed-key bind has no such impact, but it still has a blast radius —
             # the sibling candidates its accept auto-rejects — and that radius is

--- a/src/moneybin/price_sources.py
+++ b/src/moneybin/price_sources.py
@@ -1,0 +1,146 @@
+"""The price-source registry, loaded from the seed SQLMesh materializes.
+
+One declaration — ``sqlmesh/models/seeds/price_source_map.csv`` — read two ways.
+``prep.stg_security_prices`` and ``core.fct_security_prices`` join the seeded
+table; everything Python dispatches on reads this module. The CSV is parsed
+here rather than queried from ``seeds.price_source_map`` because adapter
+routing has to work before any transform has ever run, and because a registry
+that could disagree with itself between the two readers would restore the split
+it exists to remove.
+
+Why the CSV is canonical and not a Python literal: the SQL models cannot import
+Python, and the failure this registry ends is a source declared on one side and
+missing from the other. See the seed model's header for what each column means
+and for the two rules — append ranks, never delete a row — that outlive any one
+adapter.
+"""
+
+from __future__ import annotations
+
+import csv
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+_SEEDS_DIR: Final = Path(__file__).parent / "sqlmesh" / "models" / "seeds"
+
+REGISTRY_CSV: Final = _SEEDS_DIR / "price_source_map.csv"
+SEED_MODEL_SQL: Final = _SEEDS_DIR / "price_source_map.sql"
+
+_SECURITY_TYPE_SEPARATOR: Final = "|"
+
+
+FEED_KEY_ROLE: Final = "feed_key"
+
+
+@dataclass(frozen=True, slots=True)
+class PriceSource:
+    """One source a resolved close can carry."""
+
+    source_type: str
+    source_rank: int
+    ref_kind: str | None
+    ref_role: str | None
+    security_types: frozenset[str]
+
+    @property
+    def feed_ref_kind(self) -> str:
+        """The ref_kind, for a source that resolves through ``app.security_links``.
+
+        Narrows the optional at the call sites that only ever hold a provider
+        source, so a derived source reaching one fails here instead of writing
+        a NULL ref_kind into a binding no join can match.
+        """
+        if self.ref_kind is None:
+            raise ValueError(
+                f"price source {self.source_type!r} declares no ref_kind; it is "
+                "derived at model build and never resolves through app.security_links"
+            )
+        return self.ref_kind
+
+
+def _load() -> tuple[PriceSource, ...]:
+    with REGISTRY_CSV.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    return tuple(
+        PriceSource(
+            source_type=row["source_type"],
+            source_rank=int(row["source_rank"]),
+            ref_kind=row["ref_kind"] or None,
+            ref_role=row["ref_role"] or None,
+            security_types=frozenset(
+                filter(None, row["security_types"].split(_SECURITY_TYPE_SEPARATOR))
+            ),
+        )
+        for row in sorted(rows, key=lambda r: int(r["source_rank"]))
+    )
+
+
+PRICE_SOURCES: Final[tuple[PriceSource, ...]] = _load()
+
+_BY_SOURCE_TYPE: Final = {source.source_type: source for source in PRICE_SOURCES}
+
+# The sources whose rows land in ``raw.security_prices`` and resolve through an
+# accepted binding. Mirrors the join ``prep.stg_security_prices`` performs.
+REF_KIND_BY_SOURCE_TYPE: Final[dict[str, str]] = {
+    source.source_type: source.ref_kind
+    for source in PRICE_SOURCES
+    if source.ref_kind is not None
+}
+
+
+def feed_key_ref_kinds(sources: Iterable[PriceSource]) -> frozenset[str]:
+    """Refs that name a market-data symbol rather than a second catalog row.
+
+    Accepting one BINDS the feed; accepting an identity ref MERGES two securities
+    and deletes one — opposite operations behind one reviewer intent.
+
+    Keyed on ref_role, never on security_types. Retiring a provider empties its
+    security_types, so deriving this set from that column would silently
+    reclassify the retired provider's ref_kind as an identity ref and route its
+    still-pending review decisions into the merge path.
+
+    Takes its sources as an argument so that rule can be tested by applying it to
+    a retired registry. Reading the module constant instead would only ever see
+    the unretired rows, which is how the first attempt at that guard came to pass
+    under the very derivation it was written to reject.
+    """
+    return frozenset(
+        source.feed_ref_kind for source in sources if source.ref_role == FEED_KEY_ROLE
+    )
+
+
+FEED_KEY_REF_KINDS: Final[frozenset[str]] = feed_key_ref_kinds(PRICE_SOURCES)
+
+_BY_SECURITY_TYPE: Final = {
+    security_type: source
+    for source in PRICE_SOURCES
+    for security_type in source.security_types
+}
+
+
+def price_source(source_type: str) -> PriceSource:
+    """The registry row for *source_type*, or ``KeyError``.
+
+    Deliberately unforgiving. The dispatch this replaced routed every
+    non-CoinGecko source to Tiingo, so an unregistered source_type silently
+    fetched another provider's series instead of reporting anything.
+    """
+    try:
+        return _BY_SOURCE_TYPE[source_type]
+    except KeyError:
+        raise KeyError(
+            f"{source_type!r} is not a registered price source; known sources are "
+            f"{sorted(_BY_SOURCE_TYPE)}. Add a row to {REGISTRY_CSV.name}."
+        ) from None
+
+
+def source_for_security_type(security_type: str) -> PriceSource | None:
+    """The source that prices *security_type*, or ``None`` if none does.
+
+    ``None`` is an ordinary answer, not a failure: cash and other carry no
+    market quote at all, because a sweep position's unit value is its face
+    value rather than a traded price.
+    """
+    return _BY_SECURITY_TYPE.get(security_type)

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -1540,14 +1540,16 @@ class DoctorService:
     def _run_investment_unmapped_price_source(self) -> InvariantResult:
         """Price rows whose ``source_type`` the staging view cannot resolve.
 
-        ``prep.stg_security_prices`` maps each ``source_type`` to a ``ref_kind``
-        through a CASE, then INNER JOINs on the result. An unmapped source makes
-        that CASE return NULL, the comparison UNKNOWN, and the join drop the row
-        — silently, and permanently: unlike an unresolved binding, no number of
-        later accepted bindings will ever surface it, because the failure is in
-        the mapping rather than the binding. C.2 shipped a writer one commit
-        ahead of its mapping and every row it wrote in between was discarded
-        this way, which is why this check exists.
+        ``prep.stg_security_prices`` takes each ``source_type``'s ``ref_kind``
+        from ``seeds.price_source_map``, then INNER JOINs on the result. A source
+        absent from that registry — or carrying no ``ref_kind`` — matches
+        nothing, and the join drops the row silently and permanently: unlike an
+        unresolved binding, no number of later accepted bindings will ever
+        surface it, because the failure is in the registry rather than the
+        binding. C.2 shipped a writer one commit ahead of its mapping and every
+        row it wrote in between was discarded this way, which is why this check
+        exists. Declaring a source now declares both halves at once, so this
+        covers the rows already written and a registry row someone deletes.
 
         The accepted-binding join is what separates the two conditions without
         parsing the model's SQL. A row reaching this query already has an
@@ -1558,14 +1560,14 @@ class DoctorService:
         ingestion, before the resolver has minted a canonical security.
 
         The staging test asks whether the SOURCE stages at all, not whether this
-        row did. An unmapped ``source_type`` is a property of the CASE, so it
+        row did. An unmapped ``source_type`` is a property of the registry, so it
         costs the source every row it will ever write. Correlating row-by-row
         instead read a second, unrelated exclusion as the same failure:
         ``prep.stg_security_prices`` also bounds each key to the interval its
         current link owns, so a close predating a key's handover to a new owner
         — or postdating an automatic retirement — is absent from staging by
         design, and the row-wise form reported its source as unmapped when the
-        CASE arm exists and is correct. What that costs: a mapped source whose
+        registry row exists and is correct. What that costs: a mapped source whose
         entire staging output is empty for some other reason still reports here.
         """
         name = "investment_unmapped_price_source"
@@ -1603,8 +1605,8 @@ class DoctorService:
                     "prep.stg_security_prices has no ref_kind mapping for the "
                     "source, so every observation is discarded and no holding "
                     "is valued from it — this cannot be fixed by accepting "
-                    "bindings and needs the source added to that model's "
-                    "ref_kind CASE"
+                    "bindings and needs the source given a ref_kind in the "
+                    "seeds.price_source_map registry"
                 ),
                 affected_ids=[str(r[0]) for r in rows],
             )

--- a/src/moneybin/services/price_service.py
+++ b/src/moneybin/services/price_service.py
@@ -79,6 +79,12 @@ def _no_derivation(source_type: str) -> NoReturn:
     correctly-registered third provider would silently bind or fetch a Tiingo
     ticker. Failing here keeps the registry honest about what it does and does
     not decide, and matches ``_adapter_for``'s refusal to guess an adapter.
+
+    ``_catalog_ref`` is the one that actually enforces it: every route into
+    ``_feed_key``'s dispatch passes through it first, so its guard fires before
+    the mirrored branch there can. That branch is defence in depth against the
+    upstream call moving, and is marked unreachable rather than left implying
+    independent coverage it does not have.
     """
     raise NotImplementedError(
         f"price source {source_type!r} is routed by the registry but has no feed-key "
@@ -895,7 +901,13 @@ class PriceService:
             derivation = self._coingecko_key(security)
         elif source_type == TIINGO.source_type:
             derivation = self._tiingo_key(security, adapter)
-        else:
+        else:  # pragma: no cover — _review_settled above raises via _catalog_ref
+            # Defence in depth, not the enforcing guard. Every path that reaches
+            # here has already passed through _catalog_ref — _review_settled calls
+            # it as its first statement, and _binding_is_stale calls it for an
+            # auto binding — so an unregistered source has already been refused.
+            # The one path that skips both (a user-decided binding) returns above.
+            # Kept so this dispatch stays exhaustive if that upstream call moves.
             _no_derivation(source_type)
 
         if derivation.ref_value is not None and self._was_reversed_by_user(

--- a/src/moneybin/services/price_service.py
+++ b/src/moneybin/services/price_service.py
@@ -26,7 +26,7 @@ import re
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, NoReturn, Protocol
 
 import duckdb
 import polars as pl
@@ -68,6 +68,24 @@ if TYPE_CHECKING:
     from moneybin.database import Database
 
 logger = logging.getLogger(__name__)
+
+
+def _no_derivation(source_type: str) -> NoReturn:
+    """Refuse to derive a feed key for a source that has no derivation here.
+
+    The registry decides which sources are ROUTED; it cannot supply the
+    provider-specific logic that turns a catalog row into that provider's own
+    identifier. Both call sites below used to fall through to Tiingo's, so a
+    correctly-registered third provider would silently bind or fetch a Tiingo
+    ticker. Failing here keeps the registry honest about what it does and does
+    not decide, and matches ``_adapter_for``'s refusal to guess an adapter.
+    """
+    raise NotImplementedError(
+        f"price source {source_type!r} is routed by the registry but has no feed-key "
+        "derivation implemented in PriceService; add one rather than letting it fall "
+        "through to another provider's, which would bind that provider's identifier"
+    )
+
 
 # Named handles onto seeds.price_source_map rows. Every source_type, ref_kind,
 # and security-type routing decision below reads through one of these, so a new
@@ -875,8 +893,10 @@ class PriceService:
 
         if source_type == COINGECKO.source_type:
             derivation = self._coingecko_key(security)
-        else:
+        elif source_type == TIINGO.source_type:
             derivation = self._tiingo_key(security, adapter)
+        else:
+            _no_derivation(source_type)
 
         if derivation.ref_value is not None and self._was_reversed_by_user(
             security.security_id, ref_kind, source_type, derivation.ref_value
@@ -1035,11 +1055,11 @@ class PriceService:
 
     def _catalog_ref(self, security: HeldSecurity, source_type: str) -> str | None:
         """The catalog value a feed key for this source is derived from."""
-        return (
-            security.coingecko_id
-            if source_type == COINGECKO.source_type
-            else security.ticker
-        )
+        if source_type == COINGECKO.source_type:
+            return security.coingecko_id
+        if source_type == TIINGO.source_type:
+            return security.ticker
+        _no_derivation(source_type)
 
     def _binding_is_stale(
         self, security: HeldSecurity, source_type: str, bound: _Binding

--- a/src/moneybin/services/price_service.py
+++ b/src/moneybin/services/price_service.py
@@ -44,6 +44,7 @@ from moneybin.metrics.registry import (
     PRICE_REFRESH_SECURITIES_TOTAL,
     PRICE_ROWS_WRITTEN_TOTAL,
 )
+from moneybin.price_sources import price_source, source_for_security_type
 from moneybin.repositories.security_link_decisions_repo import (
     SecurityLinkDecisionsRepo,
 )
@@ -68,14 +69,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-TIINGO_SOURCE_TYPE = "tiingo"
-COINGECKO_SOURCE_TYPE = "coingecko"
-TIINGO_REF_KIND = "tiingo_ticker"
-COINGECKO_REF_KIND = "coingecko_slug"
-
-# Security types Tiingo prices. Crypto routes to CoinGecko instead; cash and
-# other carry no market quote at all.
-_TIINGO_SECURITY_TYPES = frozenset({"equity", "etf", "mutual_fund", "bond"})
+# Named handles onto seeds.price_source_map rows. Every source_type, ref_kind,
+# and security-type routing decision below reads through one of these, so a new
+# adapter is a row in that CSV rather than an edit here and in two SQL models.
+TIINGO = price_source("tiingo")
+COINGECKO = price_source("coingecko")
 
 # Matches SecurityResolver's name cutoff — the same question ("do these two
 # strings name the same issuer?") must not have two different answers.
@@ -294,8 +292,12 @@ class PriceService:
         owns that date permanently.
         """
         self._db = db
-        self._tiingo = tiingo
-        self._coingecko = coingecko
+        # Keyed by the registry's own source_type so dispatch is a lookup rather
+        # than a chain of comparisons against two named attributes.
+        self._adapters: dict[str, _PriceAdapter | None] = {
+            TIINGO.source_type: tiingo,
+            COINGECKO.source_type: coingecko,
+        }
         self._actor = actor
         self._today = today or datetime.now(UTC).date()
         self._links = SecurityLinksRepo(db)
@@ -828,19 +830,27 @@ class PriceService:
     # --------------------------- key derivation ---------------------------
 
     def _route(self, security: HeldSecurity) -> tuple[str, _PriceAdapter | None]:
-        """Which provider prices this security type."""
-        if security.security_type == "crypto":
-            return COINGECKO_SOURCE_TYPE, self._coingecko
-        if security.security_type in _TIINGO_SECURITY_TYPES:
-            return TIINGO_SOURCE_TYPE, self._tiingo
-        # cash and other carry no market quote; a sweep position's unit value is
-        # its face value, not a traded price.
-        return TIINGO_SOURCE_TYPE, None
+        """Which provider prices this security type, per the registry.
+
+        The returned ``source_type`` labels the outcome even when no adapter
+        answers, so a skip is counted under a real source rather than a
+        synthetic bucket the metric's other rows never use.
+        """
+        source = source_for_security_type(security.security_type)
+        if source is None:
+            # cash and other carry no market quote; a sweep position's unit value
+            # is its face value, not a traded price.
+            return TIINGO.source_type, None
+        return source.source_type, self._adapters.get(source.source_type)
 
     def _adapter_for(self, source_type: str) -> _PriceAdapter | None:
-        if source_type == COINGECKO_SOURCE_TYPE:
-            return self._coingecko
-        return self._tiingo
+        """The adapter that fetches *source_type*; raises if it is unregistered.
+
+        Deliberately not a two-way branch. The previous form returned the Tiingo
+        adapter for every value that was not CoinGecko, so an unregistered
+        source_type silently fetched another provider's series.
+        """
+        return self._adapters.get(price_source(source_type).source_type)
 
     def _feed_key(
         self, security: HeldSecurity, source_type: str, adapter: _PriceAdapter
@@ -851,11 +861,7 @@ class PriceService:
         The user already confirmed it, or a previous pull derived it with
         certainty; re-deriving would re-ask a settled question.
         """
-        ref_kind = (
-            COINGECKO_REF_KIND
-            if source_type == COINGECKO_SOURCE_TYPE
-            else TIINGO_REF_KIND
-        )
+        ref_kind = price_source(source_type).feed_ref_kind
         bound = self._bound_ref(security.security_id, ref_kind, source_type)
         stale = bound is not None and self._binding_is_stale(
             security, source_type, bound
@@ -867,7 +873,7 @@ class PriceService:
         if settled is not None:
             return _Derivation(ref_value=None, unpriced_reason=settled)
 
-        if source_type == COINGECKO_SOURCE_TYPE:
+        if source_type == COINGECKO.source_type:
             derivation = self._coingecko_key(security)
         else:
             derivation = self._tiingo_key(security, adapter)
@@ -1031,7 +1037,7 @@ class PriceService:
         """The catalog value a feed key for this source is derived from."""
         return (
             security.coingecko_id
-            if source_type == COINGECKO_SOURCE_TYPE
+            if source_type == COINGECKO.source_type
             else security.ticker
         )
 
@@ -1153,16 +1159,8 @@ class PriceService:
         self, security: HeldSecurity, source_type: str, derivation: _Derivation
     ) -> bool:
         """File one pending decision for an ambiguous derivation. ``True`` if filed."""
-        ref_kind = (
-            COINGECKO_REF_KIND
-            if source_type == COINGECKO_SOURCE_TYPE
-            else TIINGO_REF_KIND
-        )
-        ref_value = (
-            security.coingecko_id
-            if source_type == COINGECKO_SOURCE_TYPE
-            else security.ticker
-        )
+        ref_kind = price_source(source_type).feed_ref_kind
+        ref_value = self._catalog_ref(security, source_type)
         if ref_value is None:  # pragma: no cover — a review always has a ref
             return False
         self._decisions.insert(

--- a/src/moneybin/services/security_links_service.py
+++ b/src/moneybin/services/security_links_service.py
@@ -47,6 +47,7 @@ from moneybin.database import Database
 from moneybin.errors import UserError
 from moneybin.investments.cost_basis import compute_lot_id
 from moneybin.metrics.registry import SECURITY_LINK_DECISION_OUTCOMES_TOTAL
+from moneybin.price_sources import FEED_KEY_REF_KINDS
 from moneybin.repositories.lot_selections_repo import LotSelectionsRepo
 from moneybin.repositories.manual_investment_transactions_repo import (
     ManualInvestmentTransactionsRepo,
@@ -70,14 +71,6 @@ logger = logging.getLogger(__name__)
 # (lot_id, quantity) pairs keyed by disposal — the shape LotSelectionsRepo takes.
 _SelectionSet = dict[str, list[tuple[str, Decimal]]]
 
-# Refs that name a market-data symbol rather than a second catalog row for one
-# instrument. Accepting one BINDS the feed; accepting an identity ref MERGES two
-# securities — opposite operations behind one reviewer intent, which is why
-# `accept` routes on this set. Kept in step with what PriceService actually
-# queues by test_price_service.py, which asserts every ref_kind the service files
-# appears here: a new adapter whose ref_kind is missing would silently route its
-# decisions into the merge path and destroy the security they were meant to price.
-_FEED_KEY_REF_KINDS = frozenset({"tiingo_ticker", "coingecko_slug"})
 
 # What an accepted decision actually did. A feed key BINDS (creates a link,
 # touches nothing else); an identity ref MERGES (re-points every reference and
@@ -321,13 +314,21 @@ class SecurityLinksService:
     def binds_a_feed_key(ref_kind: str) -> bool:
         """Whether accepting this ref binds a price feed rather than merging identities.
 
+        The set comes from ``seeds.price_source_map``: a source PriceService
+        routes to declares both the security types it prices and the ref_kind it
+        binds, so a new adapter reaches this router by existing rather than by a
+        second edit here. Accepting a feed key BINDS; accepting an identity ref
+        MERGES two securities and deletes one, so a ref_kind missing from the
+        registry would route its decisions into the merge path and destroy the
+        very security they were meant to price.
+
         Public because the coarse batch preflight has to route the same way
         ``accept`` does, one step earlier. Re-deriving the rule from
-        ``_FEED_KEY_REF_KINDS`` at that second call site is exactly how the coarse
+        ``FEED_KEY_REF_KINDS`` at that second call site is exactly how the coarse
         path came to run every accept through the merge preflight while the
         fine-grained one routed correctly.
         """
-        return ref_kind in _FEED_KEY_REF_KINDS
+        return ref_kind in FEED_KEY_REF_KINDS
 
     def _require_bindable(
         self,
@@ -398,7 +399,7 @@ class SecurityLinksService:
         Returns which mechanism ran. The caller cannot see the routing and the
         two outcomes are opposite, so a surface that assumed one would tell the
         user it merged two securities when it only created a link. Re-deriving
-        it from ``_FEED_KEY_REF_KINDS`` in each adapter would put the routing
+        it from ``FEED_KEY_REF_KINDS`` in each adapter would put the routing
         rule in two places instead.
 
         ``in_outer_txn`` lets the coarse batch enter through this same router

--- a/src/moneybin/sqlmesh/models/core/fct_security_prices.sql
+++ b/src/moneybin/sqlmesh/models/core/fct_security_prices.sql
@@ -74,9 +74,11 @@
    for. Withholding there would blank a routine grain and report the position unpriced.
    A rank threshold cannot express the distinction (override is rank 1 and trade_implied
    rank 5, so the two derived sources bracket the three provider ones) and a rank RANGE
-   would break silently the first time a new adapter takes rank 6. The provider set is
-   therefore enumerated; keep it in step with investment_price_disagreement, which
-   restricts its comparison to the same three sources for the same reason.
+   would break silently the first time a new adapter takes rank 6. The scope is therefore
+   the sources that carry a ref_kind in seeds.price_source_map — exactly the ones whose
+   rows arrive through app.security_links, which is what a churning provider key means
+   and what the two derived sources structurally are not. It follows the registry rather
+   than naming a set, so a new adapter is covered by declaring its ref_kind.
 
    This is a total order over the emitted columns. The model exposes security_id,
    price_date, and quote_currency (the partition), plus close, source_type, price_basis,
@@ -96,7 +98,10 @@
    this layer — the ordering is deterministic, not exhaustive over information staging
    already threw away. app.security_price_overrides has the same shape for the same
    reason (quote_currency is in its primary key), and resolves it the same way. A new
-   adapter takes the next free rank. See
+   adapter appends the next free rank to seeds.price_source_map, which is where every
+   rank here comes from; the LEFT JOIN is deliberate, since an INNER one would drop a
+   source missing from the registry rather than bucket it at 99, repeating in core the
+   silent discard prep exists to warn about. See
    docs/specs/investments-price-feeds.md. */
 MODEL (
   name core.fct_security_prices,
@@ -210,25 +215,15 @@ WITH provider AS (
     c.observation_key,
     c.price_basis,
     c.extracted_at,
-    CASE c.source_type
-      WHEN 'override'
-      THEN 1
-      WHEN 'plaid'
-      THEN 2
-      WHEN 'tiingo'
-      THEN 3
-      WHEN 'coingecko'
-      THEN 4
-      WHEN 'trade_implied'
-      THEN 5
-      ELSE 99
-    END AS source_rank,
+    COALESCE(src.source_rank, 99) AS source_rank,
     (
-      c.source_type IN ('plaid', 'tiingo', 'coingecko')
+      NOT src.ref_kind IS NULL
       AND MIN(c.observation_key) OVER same_pull <> MAX(c.observation_key) OVER same_pull
       AND MIN(c.close) OVER same_pull <> MAX(c.close) OVER same_pull
     ) AS same_pull_key_conflict
   FROM candidates AS c
+  LEFT JOIN seeds.price_source_map AS src
+    ON src.source_type = c.source_type
   WINDOW same_pull AS (
     PARTITION BY c.security_id, c.price_date, c.quote_currency, c.source_type, c.source_origin, c.extracted_at
   )
@@ -238,7 +233,7 @@ SELECT
   price_date, /* The date this close applies to (grain) */
   quote_currency, /* ISO 4217 the close is expressed in (grain); this model converts nothing — M1K.2 owns FX */
   close, /* The winning close for one unit, in quote_currency */
-  source_type, /* Which source supplied the winning close: plaid, override, or trade_implied today; tiingo and coingecko join when their adapters land — see docs/specs/investments-price-feeds.md */
+  source_type, /* Which source supplied the winning close; seeds.price_source_map is the closed set it can name — see docs/specs/investments-price-feeds.md */
   price_basis, /* Always 'raw' here; adjusted provider observations are excluded upstream and stay visible in prep.stg_security_prices, and the two derived sources are raw by construction */
   extracted_at AS updated_at /* When the winning observation was served: the provider's own timestamp, the mark's last edit, or the trade's ledger timestamp */
 FROM ranked

--- a/src/moneybin/sqlmesh/models/prep/stg_security_prices.sql
+++ b/src/moneybin/sqlmesh/models/prep/stg_security_prices.sql
@@ -13,8 +13,8 @@ MODEL (
    catches one carrying modeled transactions. A price-only observation for a security
    that is neither held nor transacted has no doctor coverage — it simply waits in raw.
 
-   ref_kind is mapped per source rather than hardcoded, so C.2's tiingo_ticker and
-   coingecko_slug extend the CASE instead of forking a second resolution path.
+   ref_kind comes from seeds.price_source_map rather than being hardcoded, so a new
+   provider extends one registry row instead of forking a second resolution path.
 
    RETIRED KEYS still resolve their own history. A reversed link is one of two very
    different things, and only reversed_by tells them apart. PriceService retires an
@@ -53,36 +53,37 @@ MODEL (
    arm reads as "this security has no history", and one in the handover CTE silently
    turns a user's rejection into a transfer of ownership.
 
-   COVERAGE — read this before adding a price adapter. The CASE below maps three
-   sources: 'plaid', 'tiingo', and 'coingecko'. That is the complete set that resolves
-   today. Any other value of raw.security_prices.source_type makes the CASE return NULL,
-   `links.ref_kind = NULL` evaluates to UNKNOWN, and this INNER JOIN discards the row
-   silently — no error and no counter. The doctor check
-   investment_unmapped_price_source is the safety net: it reports any source_type
-   present in raw.security_prices that this CASE does not map. It reports rows already
-   written, so it cannot prevent the drop — extending this CASE in the same change that
-   starts writing a source is still the requirement.
+   COVERAGE — read this before adding a price adapter. seeds.price_source_map supplies
+   the ref_kind, and only its rows carrying one resolve here: 'plaid', 'tiingo', and
+   'coingecko' today. A source_type absent from the registry, or present with a NULL
+   ref_kind, matches nothing in that join — or makes `links.ref_kind = NULL` UNKNOWN —
+   and this INNER JOIN discards the row silently, with no error and no counter. The
+   doctor check investment_unmapped_price_source is the safety net: it reports any
+   source_type present in raw.security_prices that never reaches this view. It reports
+   rows already written, so it cannot prevent the drop.
 
    That drop is PERMANENT, not deferred, and this is the one way it differs from the
    unresolved-binding case described above. An unresolved observation waits in raw and
    reappears here the moment its security binds. A row whose source_type has no ref_kind
-   mapping never reappears no matter how many bindings are accepted, because the
-   failure is in the mapping, not the binding. It is invisible and unrecoverable until
-   someone edits this file.
+   never reappears no matter how many bindings are accepted, because the failure is in
+   the registry, not the binding. It is invisible and unrecoverable until someone edits
+   the registry.
 
-   Nothing upstream prevents it: raw.security_prices.source_type carries no CHECK constraint
-   (unlike price_basis), and core.fct_security_prices already ranks override and
-   trade_implied, neither of which passes through this view at all. So a new adapter MUST
-   extend this CASE in the SAME change that starts writing its rows — the tiingo and
-   coingecko arms below were added one commit late, and every row those adapters wrote in
-   between was discarded here.
+   Nothing upstream prevents it: raw.security_prices.source_type carries no CHECK
+   constraint (unlike price_basis), and core.fct_security_prices ranks override and
+   trade_implied, neither of which passes through this view at all. What the registry
+   buys is that a writer can no longer ship ahead of its mapping the way the tiingo and
+   coingecko adapters did — a source_type PriceService dispatches on and the ref_kind
+   this join needs are now the same CSV row, so declaring one declares the other.
 
-   Two tests guard the two directions, because one alone cannot see both. This model's own
-   coverage test reads the CASE and grows itself when a mapping is added, so it catches a
-   mapping whose ref_kind or CHECK constraint is wrong. It cannot catch a writer shipping
-   ahead of its mapping — the CASE is unchanged, so the test is unchanged. That direction is
-   tests/moneybin/test_services/test_price_service.py, which asserts every source_type
-   PriceService writes appears here.
+   Two tests still guard what the registry alone cannot. This model's own coverage test
+   reads the registry and grows itself when a source is added, so it catches a mapping
+   whose ref_kind or CHECK constraint is wrong; it cannot see a registry row someone
+   DELETES, since removing one merely shrinks the set it iterates. That direction is
+   tests/moneybin/test_price_sources.py, which pins the shipped rows and their rank
+   order, and tests/moneybin/test_services/test_price_service.py, which asserts every
+   source PriceService routes to still carries a ref_kind and that this model still joins
+   the registry rather than restating it.
 
    No close-positivity filter follows: raw.security_prices enforces CHECK (close > 0) at
    write, so a zero or negative close can never reach this view — the guard lives at the
@@ -116,17 +117,12 @@ SELECT
   p.extracted_at,
   p.loaded_at
 FROM raw.security_prices AS p
+JOIN seeds.price_source_map AS src
+  ON src.source_type = p.source_type
 JOIN app.security_links AS links
   ON links.source_type = p.source_type
   AND links.ref_value = p.provider_security_key
-  AND links.ref_kind = CASE p.source_type
-    WHEN 'plaid'
-    THEN 'plaid_security_id'
-    WHEN 'tiingo'
-    THEN 'tiingo_ticker'
-    WHEN 'coingecko'
-    THEN 'coingecko_slug'
-  END
+  AND links.ref_kind = src.ref_kind
 LEFT JOIN handover AS h
   ON h.link_id = links.link_id
 WHERE

--- a/src/moneybin/sqlmesh/models/seeds/price_source_map.csv
+++ b/src/moneybin/sqlmesh/models/seeds/price_source_map.csv
@@ -1,0 +1,6 @@
+source_type,source_rank,ref_kind,ref_role,security_types
+override,1,,,
+plaid,2,plaid_security_id,identity,
+tiingo,3,tiingo_ticker,feed_key,bond|equity|etf|mutual_fund
+coingecko,4,coingecko_slug,feed_key,crypto
+trade_implied,5,,,

--- a/src/moneybin/sqlmesh/models/seeds/price_source_map.sql
+++ b/src/moneybin/sqlmesh/models/seeds/price_source_map.sql
@@ -1,0 +1,67 @@
+/* The price-source registry: every source a close can carry, declared once.
+
+   Five sites used to restate this vocabulary by hand — the ref_kind CASE in
+   prep.stg_security_prices, the rank CASE and the provider enumeration in
+   core.fct_security_prices, PriceService's adapter dispatch, and
+   SecurityLinksService's feed-key routing set. Adding a provider meant ~10
+   coordinated edits, and missing one dropped or mis-ranked rows in silence:
+   C.2 shipped the tiingo and coingecko writers one commit ahead of the ref_kind
+   CASE, and every row they wrote in between was discarded permanently. Both SQL
+   models now join this table and moneybin.price_sources loads this same CSV, so
+   a new provider is one row rather than a coordination problem.
+
+   ref_kind — the kind of app.security_links reference this source's rows resolve
+   through. NULL means the source never lands in raw.security_prices at all:
+   `override` and `trade_implied` are derived at model build, which is what lets a
+   security no feed covers carry a price. That NULL is load-bearing rather than
+   cosmetic — core.fct_security_prices scopes its same-pull withhold to the rows
+   that HAVE a ref_kind, so the withhold follows the provider set automatically
+   instead of naming it.
+
+   source_rank — declared precedence when two sources hold a close for one
+   security, date, and currency. APPEND RANKS; NEVER REORDER THEM. Inserting a
+   provider ahead of an incumbent changes which close wins on every historical
+   date where both hold a row, silently revaluing core.dim_holdings.market_value
+   and the C.3 daily series. Rank 99 is the fallback for a source this table does
+   not name, and it is reachable only from the two branches core.fct_security_prices
+   computes itself: a PROVIDER row absent from this table never reaches a rank at
+   all, because prep.stg_security_prices' INNER JOIN has already discarded it.
+
+   ref_role — what accepting a review decision for this ref_kind DOES, and the
+   reason this is a column rather than a derivation. 'feed_key' BINDS a price feed;
+   'identity' MERGES two catalog rows for one instrument and deletes one. They are
+   opposite operations behind one reviewer intent, which is why
+   SecurityLinksService.accept routes on it. It is deliberately NOT derived from
+   security_types below: that column is operational and empties when a provider is
+   retired, and reclassifying a retired provider's ref_kind from 'feed_key' to
+   'identity' would route its still-pending decisions into the merge path — the
+   precise destruction the routing exists to prevent. A ref_kind's role is a
+   permanent property of the ref_kind, so retirement must not be able to change it.
+
+   security_types — pipe-delimited; which app.securities.security_type values
+   PriceService routes to this source, and the ONLY column retirement touches.
+   Empty means the service fetches nothing for it: `plaid` resolves through links
+   but its closes arrive from the Plaid extractor, and the two derived sources have
+   no adapter at all. A non-empty value requires a ref_kind and a 'feed_key'
+   ref_role, since a routed source with neither writes rows staging discards.
+
+   A RETIRED SOURCE KEEPS ITS ROW FOREVER. raw.security_prices is append-only, so
+   a provider's closes outlive the decision to stop fetching from it. Retiring one
+   means clearing security_types alone, never deleting the row and never clearing
+   ref_kind or ref_role: deleting the row discards every historical close it wrote
+   from prep and core, silently, and clearing ref_role re-routes its open reviews.
+   Edit the CSV to change entries; SQLMesh detects changes automatically. */
+MODEL (
+  name seeds.price_source_map,
+  kind SEED (
+    path 'price_source_map.csv'
+  ),
+  columns (
+    source_type TEXT,
+    source_rank INT,
+    ref_kind TEXT,
+    ref_role TEXT,
+    security_types TEXT
+  ),
+  grain source_type
+)

--- a/src/moneybin/tables.py
+++ b/src/moneybin/tables.py
@@ -144,6 +144,7 @@ SEED_CATEGORY_SOURCE_MAP = TableRef("seeds", "category_source_map")
 SEED_EXCHANGE_MIC_MAP = TableRef("seeds", "exchange_mic_map")
 SEED_ACCOUNT_TYPE_MAP = TableRef("seeds", "account_type_map")
 SEED_INSTITUTIONS = TableRef("seeds", "institutions")
+SEED_PRICE_SOURCE_MAP = TableRef("seeds", "price_source_map")
 
 # -- Prep / staging views (built by SQLMesh transforms) --
 INT_TRANSACTIONS_UNIONED = TableRef("prep", "int_transactions__unioned")

--- a/tests/moneybin/price_model_helpers.py
+++ b/tests/moneybin/price_model_helpers.py
@@ -1,11 +1,12 @@
-"""Read the price-staging model's source -> ref_kind mapping out of the model file.
+"""Read the price models' declared vocabulary rather than restating it in tests.
 
 Shared by the staging model's own tests and by the price service's, because the
 guard that matters spans both: `PriceService` writes `raw.security_prices` rows,
-and `prep.stg_security_prices` resolves them through a per-`source_type` CASE
-with an INNER JOIN. A source the CASE does not map is discarded silently and
-permanently. Deriving the mapping from the model — rather than restating it —
-is what makes editing the CASE extend what the tests exercise.
+and `prep.stg_security_prices` resolves them through the ref_kind
+`seeds.price_source_map` declares, with an INNER JOIN. A source the registry
+does not map is discarded silently and permanently. Deriving from the registry
+and from the model files — rather than restating either — is what makes editing
+one extend what the tests exercise.
 """
 
 from __future__ import annotations
@@ -14,6 +15,7 @@ import re
 from pathlib import Path
 
 import moneybin
+from moneybin.price_sources import REF_KIND_BY_SOURCE_TYPE
 
 MODEL_PATH = (
     Path(moneybin.__file__).parent
@@ -117,14 +119,26 @@ def historical_reversal_actor() -> str:
 
 
 def ref_kind_mapping() -> dict[str, str]:
-    """The (source_type -> ref_kind) pairs the model's CASE actually maps."""
+    """The (source_type -> ref_kind) pairs the model actually resolves through.
+
+    Read from the registry rather than parsed out of the model, because the
+    model no longer restates the mapping: it joins ``seeds.price_source_map``,
+    which SQLMesh builds from the same CSV ``moneybin.price_sources`` loads.
+    The property the parsing version bought — that editing the mapping edits
+    what these tests exercise — is stronger this way, since the registry is now
+    the only place either side can be edited.
+    """
+    assert REF_KIND_BY_SOURCE_TYPE, "the price-source registry maps no ref_kinds"
     sql = MODEL_PATH.read_text()
-    case_blocks = re.findall(r"CASE\s+p\.source_type(.*?)\bEND\b", sql, re.DOTALL)
-    assert len(case_blocks) == 1, (
-        f"expected exactly one `CASE p.source_type` in {MODEL_PATH.name}; a second one "
-        f"means ref_kind resolution forked and these tests no longer cover it: "
-        f"{case_blocks}"
+    assert re.search(r"\bJOIN\s+seeds\.price_source_map\b", sql), (
+        f"{MODEL_PATH.name} no longer JOINs the registry, so a mapping read from "
+        "it is no longer evidence about what the model resolves. Matching the "
+        "bare table name would not catch this — it appears in this model's prose "
+        "independently of the join."
     )
-    mapping = dict(re.findall(r"WHEN\s+'([^']+)'\s+THEN\s+'([^']+)'", case_blocks[0]))
-    assert mapping, "no WHEN ... THEN pairs parsed out of the ref_kind CASE"
-    return mapping
+    assert not re.search(r"CASE\s+p\.source_type", sql), (
+        f"{MODEL_PATH.name} resolves ref_kind through a restated CASE again; the "
+        "registry and the model can now disagree, which is the split that "
+        "discarded every row C.2's adapters wrote"
+    )
+    return dict(REF_KIND_BY_SOURCE_TYPE)

--- a/tests/moneybin/test_cli/test_investments_prices.py
+++ b/tests/moneybin/test_cli/test_investments_prices.py
@@ -23,6 +23,7 @@ from typer.testing import CliRunner
 from moneybin import error_codes
 from moneybin.cli.commands.investments.prices import PriceSourceChoice, app
 from moneybin.errors import UserError
+from moneybin.price_sources import PRICE_SOURCES
 from moneybin.services.price_service import PullResult
 from moneybin.services.refresh import RefreshResult
 
@@ -508,13 +509,13 @@ class TestPriceSourceFilter:
         from the stored value filters to nothing while still exiting 0. The
         walk below derives its expectation from this enum, so it cannot see
         either — it proves the gate opens, not that it opens on the right five.
+
+        `seeds.price_source_map` supplies the expectation because it is what
+        the fact table ranks and what staging resolves, so a provider appended
+        there fails here until the flag admits it.
         """
         assert {choice.value for choice in PriceSourceChoice} == {
-            "plaid",
-            "tiingo",
-            "coingecko",
-            "override",
-            "trade_implied",
+            source.source_type for source in PRICE_SOURCES
         }
 
     @patch("moneybin.cli.commands.investments.prices.get_database")

--- a/tests/moneybin/test_fct_security_prices.py
+++ b/tests/moneybin/test_fct_security_prices.py
@@ -11,16 +11,15 @@ from unittest.mock import MagicMock
 import pytest
 
 from moneybin.database import Database, sqlmesh_context
+from moneybin.price_sources import REF_KIND_BY_SOURCE_TYPE
 
 pytestmark = pytest.mark.integration
 
-# source_rank is now mutation-tested across sources, but only via the two DERIVED ones:
-# 'override' (rank 1) and 'trade_implied' (rank 5) reach this model without a
-# provider binding, because neither is a row in raw.security_prices. The three
-# PROVIDER ranks still cannot be tested against each other — only 'plaid' resolves to
-# a canonical security_id through prep.stg_security_prices' 'plaid_security_id' link,
-# so tiingo and coingecko have no binding to reach this model. That provider-vs-provider
-# ordering test lands with C.2's adapters and their ref_kind bindings.
+# source_rank is mutation-tested across every source in seeds.price_source_map: the
+# two DERIVED ones ('override' rank 1, 'trade_implied' rank 5) reach this model
+# without a provider binding, and the three PROVIDER ones are ranked against each
+# other by test_the_provider_ranks_order_against_each_other below, which binds
+# tiingo and coingecko through the ref_kinds C.2's adapters made available.
 
 
 def _insert_price(
@@ -47,16 +46,33 @@ def _insert_price(
     )
 
 
-def _accept_link(db: Database, *, key: str, canonical_id: str) -> None:
+def _accept_link(
+    db: Database,
+    *,
+    key: str,
+    canonical_id: str,
+    source_type: str = "plaid",
+) -> None:
+    """Bind *key* to *canonical_id* with the ref_kind the registry declares.
+
+    Taking the ref_kind from ``REF_KIND_BY_SOURCE_TYPE`` rather than a literal is
+    what lets a tiingo or coingecko row reach this model at all: staging joins
+    the same registry, so a binding spelled any other way is discarded.
+    """
     db.execute(
         """
         INSERT INTO app.security_links
             (link_id, security_id, ref_kind, ref_value, source_type,
              status, decided_by, decided_at)
-        VALUES (?, ?, 'plaid_security_id', ?, 'plaid', 'accepted', 'auto',
-                CURRENT_TIMESTAMP)
+        VALUES (?, ?, ?, ?, ?, 'accepted', 'auto', CURRENT_TIMESTAMP)
         """,  # noqa: S608  # test fixture, not executing user SQL
-        [f"link_{key}", canonical_id, key],
+        [
+            f"link_{key}",
+            canonical_id,
+            REF_KIND_BY_SOURCE_TYPE[source_type],
+            key,
+            source_type,
+        ],
     )
 
 
@@ -428,6 +444,33 @@ def security_price_cases_template(
         origin="mb21_unbound",
     )
 
+    # One security priced by all three providers on one date, then the same
+    # without plaid. Adversarial orientation: the source that SHOULD win carries
+    # the STALEST extracted_at and the lowest close, so a rank that stops being
+    # applied falls through to source_type ASC (extracted_at DESC only breaks a
+    # tie after it) and lands on coingecko, never coincidentally on the right
+    # answer.
+    for security, sources in (
+        ("mb21_rank_all", ("plaid", "tiingo", "coingecko")),
+        ("mb21_rank_no_plaid", ("tiingo", "coingecko")),
+    ):
+        for hour, source in enumerate(sources):
+            key = f"{security}_{source}_key"
+            _insert_price(
+                db,
+                key=key,
+                close=f"{100 + hour}.00",
+                source=source,
+                origin=f"{security}_{source}",
+                extracted_at=f"2026-07-15 {9 + hour:02d}:00:00",
+            )
+            _accept_link(
+                db,
+                key=key,
+                canonical_id=f"{security}_security",
+                source_type=source,
+            )
+
     with sqlmesh_context(db) as ctx:
         ctx.plan(auto_apply=True, no_prompts=True)
     db.close()
@@ -779,6 +822,35 @@ def test_an_override_outranks_a_provider_close_on_the_same_date(
     ).fetchall()
     assert rows == [("override", Decimal("300.0000000000"))], (
         "the mark must win its own date despite the provider row being fresher"
+    )
+
+
+@pytest.mark.slow
+def test_the_provider_ranks_order_against_each_other(
+    security_price_cases: Database,
+) -> None:
+    """Plaid (2) beats tiingo (3) beats coingecko (4), per seeds.price_source_map.
+
+    Until C.2's adapters shipped their ref_kinds, only plaid could reach this
+    model, so the three provider ranks had never been ordered against one
+    another in either direction — the ranks were asserted only across the two
+    derived sources that bracket them. Both cases below are oriented so the
+    freshest row is the one that must LOSE, and coingecko carries it in both
+    cases: a rank that stops being applied falls through to source_type ASC and
+    resolves to coingecko either way, never to the expected answer.
+    """
+    db = security_price_cases
+
+    assert db.execute(
+        "SELECT source_type, close FROM core.fct_security_prices "
+        "WHERE security_id = 'mb21_rank_all_security'"
+    ).fetchall() == [("plaid", Decimal("100.0000000000"))]
+
+    assert db.execute(
+        "SELECT source_type, close FROM core.fct_security_prices "
+        "WHERE security_id = 'mb21_rank_no_plaid_security'"
+    ).fetchall() == [("tiingo", Decimal("100.0000000000"))], (
+        "with plaid absent the next rank must win, not the freshest row"
     )
 
 

--- a/tests/moneybin/test_price_sources.py
+++ b/tests/moneybin/test_price_sources.py
@@ -1,0 +1,219 @@
+"""The price-source registry — the one declaration every dispatch site reads.
+
+Assertions here are deliberately *literal*, which is the opposite of how the
+rest of the price tests are written. Everywhere else, restating the vocabulary
+would drift the moment someone edited the model; here the registry IS the
+declaration, so a test that re-derives from it asserts nothing. This file is
+where the shipped set is pinned — above all the rank order, which
+``docs/specs/investments-price-feeds.md`` forbids reordering because it
+silently revalues every historical holding.
+"""
+
+from __future__ import annotations
+
+import csv
+import re
+from dataclasses import replace
+
+import pytest
+
+from moneybin.price_sources import (
+    FEED_KEY_REF_KINDS,
+    FEED_KEY_ROLE,
+    PRICE_SOURCES,
+    REF_KIND_BY_SOURCE_TYPE,
+    REGISTRY_CSV,
+    SEED_MODEL_SQL,
+    feed_key_ref_kinds,
+    price_source,
+    source_for_security_type,
+)
+from tests.moneybin.price_model_helpers import FCT_PRICES_PATH
+
+
+def test_an_unknown_source_type_fails_loudly_instead_of_falling_through() -> None:
+    """The whole point of the registry: no silent default for an unknown source.
+
+    ``_adapter_for`` used to route every non-CoinGecko source to Tiingo, so a
+    typo'd or unregistered source_type fetched the wrong provider's series
+    rather than reporting anything.
+    """
+    with pytest.raises(KeyError, match="yahoo"):
+        price_source("yahoo")
+
+
+def test_the_shipped_rank_order_is_pinned() -> None:
+    """Append ranks; never reorder them.
+
+    Inserting a provider ahead of an incumbent changes which close wins on
+    every historical date where both hold a row, silently revaluing
+    ``core.dim_holdings.market_value``. A new source appends a row here; a
+    changed row means someone reordered, which is a deliberate announced
+    revaluation and not a refactor.
+    """
+    assert [(s.source_type, s.source_rank) for s in PRICE_SOURCES] == [
+        ("override", 1),
+        ("plaid", 2),
+        ("tiingo", 3),
+        ("coingecko", 4),
+        ("trade_implied", 5),
+    ]
+
+
+def test_a_ref_kind_marks_the_sources_that_resolve_through_security_links() -> None:
+    """Exactly the sources whose rows land in ``raw.security_prices``.
+
+    ``override`` and ``trade_implied`` are derived at model build and never
+    pass through ``app.security_links``, so they carry no ref_kind — which is
+    what lets ``core.fct_security_prices`` scope its same-pull withhold to the
+    provider sources without enumerating them.
+    """
+    assert REF_KIND_BY_SOURCE_TYPE == {
+        "plaid": "plaid_security_id",
+        "tiingo": "tiingo_ticker",
+        "coingecko": "coingecko_slug",
+    }
+
+
+def test_feed_key_ref_kinds_are_the_sources_price_service_derives_a_key_for() -> None:
+    """``plaid`` resolves through links but is written by the extractor.
+
+    ``SecurityLinksService.accept`` routes on this set: a ref_kind inside it
+    BINDS a feed, one outside MERGES two securities and deletes one. A
+    ``plaid_security_id`` decision is an identity ref and must stay outside.
+    """
+    assert FEED_KEY_REF_KINDS == frozenset({"tiingo_ticker", "coingecko_slug"})
+
+
+def test_a_security_type_routes_to_the_source_that_declares_it() -> None:
+    crypto = source_for_security_type("crypto")
+    equity = source_for_security_type("equity")
+    assert crypto is not None
+    assert equity is not None
+    assert crypto.source_type == "coingecko"
+    assert equity.source_type == "tiingo"
+
+
+def test_a_security_type_no_source_declares_routes_nowhere() -> None:
+    """Cash and other carry no market quote; a sweep position's unit value is face."""
+    assert source_for_security_type("cash") is None
+    assert source_for_security_type("other") is None
+
+
+def test_no_two_sources_claim_the_same_security_type() -> None:
+    """Routing must be a function, not a first-match-wins scan."""
+    claimed: dict[str, str] = {}
+    for source in PRICE_SOURCES:
+        for security_type in source.security_types:
+            assert security_type not in claimed, (
+                f"{security_type!r} is claimed by both {claimed[security_type]!r} "
+                f"and {source.source_type!r}; routing would depend on row order"
+            )
+            claimed[security_type] = source.source_type
+
+
+def test_a_source_price_service_fetches_declares_a_ref_kind() -> None:
+    """A routed source with no ref_kind writes rows staging discards forever."""
+    for source in PRICE_SOURCES:
+        if source.security_types:
+            assert source.ref_kind is not None, (
+                f"{source.source_type!r} is routed by security type but declares "
+                "no ref_kind, so every row it writes is dropped by "
+                "prep.stg_security_prices' INNER JOIN"
+            )
+
+
+def test_the_shipped_ref_roles_are_pinned() -> None:
+    """What accepting a ref DOES is permanent; retirement must not change it.
+
+    ``ref_role`` is a separate column precisely so it cannot be derived from
+    ``security_types``, which empties when a provider is retired. Deriving it
+    would reclassify a retired provider's ref_kind from a feed key to an
+    identity ref, sending its still-pending review decisions into the merge
+    path — which re-points every reference and deletes a security.
+    """
+    assert {s.source_type: s.ref_role for s in PRICE_SOURCES} == {
+        "override": None,
+        "plaid": "identity",
+        "tiingo": FEED_KEY_ROLE,
+        "coingecko": FEED_KEY_ROLE,
+        "trade_implied": None,
+    }
+
+
+def test_retiring_a_provider_cannot_reclassify_its_ref_kind() -> None:
+    """Clearing security_types must leave the feed-key set untouched.
+
+    The regression this pins is a derivation, not a value: FEED_KEY_REF_KINDS
+    once read ``if source.security_types``, which made the documented
+    retirement procedure — clear security_types, never delete the row — flip
+    the ref_kind's routing as a side effect.
+    """
+    retired = [
+        replace(source, security_types=frozenset())
+        if source.ref_role == FEED_KEY_ROLE
+        else source
+        for source in PRICE_SOURCES
+    ]
+    assert not any(source.security_types for source in retired), (
+        "the fixture must actually retire every feed source, or it pins nothing"
+    )
+
+    assert feed_key_ref_kinds(retired) == FEED_KEY_REF_KINDS, (
+        "retiring every provider changed the feed-key set, so the derivation is "
+        "reading security_types again; a retired provider's open review decisions "
+        "would route to the merge path, which deletes a security"
+    )
+
+
+def test_a_source_declaring_a_ref_role_declares_the_ref_kind_it_roles() -> None:
+    for source in PRICE_SOURCES:
+        assert (source.ref_role is None) == (source.ref_kind is None), (
+            f"{source.source_type!r} declares ref_role={source.ref_role!r} and "
+            f"ref_kind={source.ref_kind!r}; a role with no ref to apply it to "
+            "routes nothing, and a ref with no role routes to the merge path"
+        )
+
+
+def test_every_source_the_price_fact_can_emit_is_registered() -> None:
+    """The two derived branches name their source_type as a SQL literal.
+
+    ``override`` and ``trade_implied`` are computed in ``core.fct_security_prices``
+    rather than read from staging, so nothing forces them through the registry
+    the way a provider row is forced. Deleting either registry row would send
+    its close to the ELSE-99 bucket and let a provider outrank a user's own
+    mark, which is the one ordering the model exists to guarantee.
+    """
+    emitted = set(re.findall(r"'(\w+)' AS source_type", FCT_PRICES_PATH.read_text()))
+    assert emitted, f"no `'<source>' AS source_type` literals in {FCT_PRICES_PATH.name}"
+    registered = {source.source_type for source in PRICE_SOURCES}
+    assert emitted <= registered, (
+        f"{sorted(emitted - registered)} win dates in core.fct_security_prices "
+        f"but carry no rank in {REGISTRY_CSV.name}, so they resolve at rank 99 "
+        "and lose to every registered source"
+    )
+
+
+def test_the_seed_model_loads_the_file_the_registry_loads() -> None:
+    """One file, two readers — SQLMesh materializes it, Python imports it.
+
+    A seed pointed at a second CSV would restore exactly the split this
+    registry exists to remove, and nothing else would notice.
+    """
+    path = re.search(r"path\s+'([^']+)'", SEED_MODEL_SQL.read_text())
+    assert path is not None, f"no `path '<file>.csv'` in {SEED_MODEL_SQL.name}"
+    assert path.group(1) == REGISTRY_CSV.name
+
+
+def test_the_seed_declares_every_column_the_registry_csv_carries() -> None:
+    """A column absent from the MODEL header is dropped from the seeded table."""
+    columns_block = re.search(
+        r"columns\s*\((.*?)\)", SEED_MODEL_SQL.read_text(), re.DOTALL
+    )
+    assert columns_block is not None, f"no `columns (...)` in {SEED_MODEL_SQL.name}"
+    declared = re.findall(r"(\w+)\s+\w+", columns_block.group(1))
+
+    with REGISTRY_CSV.open(newline="", encoding="utf-8") as handle:
+        header = next(csv.reader(handle))
+
+    assert declared == header

--- a/tests/moneybin/test_services/test_doctor_service.py
+++ b/tests/moneybin/test_services/test_doctor_service.py
@@ -2453,7 +2453,7 @@ def _unmapped_source_fixture(db: Database, *, source: str, staged: bool) -> None
 def test_unmapped_price_source_warns_when_a_bound_row_never_stages(
     db: Database, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The binding is accepted and matches, so only the ref_kind CASE can be dropping it.
+    """The binding is accepted and matches, so only the registry can be dropping it.
 
     This is the exact defect that made C.2 inert: PriceService wrote tiingo rows
     for a commit while prep.stg_security_prices mapped only 'plaid', and the
@@ -2483,7 +2483,7 @@ def test_unmapped_price_source_passes_when_the_row_stages(
 def test_unmapped_price_source_ignores_a_row_the_ownership_interval_excluded(
     db: Database, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Absent from staging is not the same question as absent from the CASE.
+    """Absent from staging is not the same question as absent from the registry.
 
     `prep.stg_security_prices` bounds each key to the interval its current link
     owns, so a close predating a handover — the previous owner of a recycled

--- a/tests/moneybin/test_services/test_price_service.py
+++ b/tests/moneybin/test_services/test_price_service.py
@@ -8,6 +8,7 @@ rather than any provider's behaviour, which test_connectors/test_prices covers.
 
 from __future__ import annotations
 
+import re
 import time as _time
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
@@ -18,6 +19,7 @@ from unittest.mock import MagicMock
 import pytest
 from prometheus_client import REGISTRY
 
+import moneybin
 from moneybin import error_codes
 from moneybin.connectors.prices.errors import PriceFeedAuthError
 from moneybin.connectors.prices.protocol import (
@@ -29,6 +31,11 @@ from moneybin.connectors.prices.protocol import (
 from moneybin.connectors.prices.tiingo import TickerMetadata
 from moneybin.database import Database
 from moneybin.errors import UserError
+from moneybin.price_sources import (
+    FEED_KEY_ROLE,
+    PRICE_SOURCES,
+    REF_KIND_BY_SOURCE_TYPE,
+)
 from moneybin.repositories.security_link_decisions_repo import (
     SecurityLinkDecisionsRepo,
 )
@@ -36,17 +43,14 @@ from moneybin.repositories.security_links_repo import SecurityLinksRepo
 from moneybin.services._validators import NOTE_MAX_LEN
 from moneybin.services.price_service import (
     _AUTO_REVERSAL,  # pyright: ignore[reportPrivateUsage]  # pinned against the model
-    COINGECKO_REF_KIND,
-    COINGECKO_SOURCE_TYPE,
+    COINGECKO,
     MAX_STORED_PRICE,
     PRICE_QUANTUM,
-    TIINGO_REF_KIND,
-    TIINGO_SOURCE_TYPE,
+    TIINGO,
+    HeldSecurity,
     PriceService,
 )
-from moneybin.services.security_links_service import (
-    _FEED_KEY_REF_KINDS,  # pyright: ignore[reportPrivateUsage]  # the routing set under test
-)
+from moneybin.services.security_links_service import SecurityLinksService
 from moneybin.services.undo_service import UndoService
 from moneybin.tables import (
     AUDIT_LOG,
@@ -635,7 +639,7 @@ def test_a_name_that_reduces_to_no_tokens_is_not_treated_as_agreement(
     _service(db, tiingo).pull()
 
     assert _links(db) == []
-    assert _decisions(db) == [(TIINGO_REF_KIND, "TRST", "name_divergence")]
+    assert _decisions(db) == [(TIINGO.feed_ref_kind, "TRST", "name_divergence")]
 
 
 def test_a_rejected_feed_key_is_not_re_proposed_on_the_next_pull(
@@ -694,7 +698,7 @@ def test_an_undone_binding_is_not_silently_recreated(db: Database) -> None:
     service.pull()
 
     assert _links(db) == []
-    assert _decisions(db) == [(TIINGO_REF_KIND, "SOH", "binding_was_reversed")]
+    assert _decisions(db) == [(TIINGO.feed_ref_kind, "SOH", "binding_was_reversed")]
 
 
 def test_a_reversed_binding_is_not_silently_recreated(db: Database) -> None:
@@ -720,7 +724,7 @@ def test_a_reversed_binding_is_not_silently_recreated(db: Database) -> None:
     service.pull()
 
     assert _links(db) == []
-    assert _decisions(db) == [(TIINGO_REF_KIND, "SOH", "binding_was_reversed")]
+    assert _decisions(db) == [(TIINGO.feed_ref_kind, "SOH", "binding_was_reversed")]
 
 
 def test_correcting_a_typod_ticker_stops_the_old_symbols_prices(
@@ -778,7 +782,7 @@ def test_a_user_confirmed_binding_is_never_treated_as_stale(db: Database) -> Non
 
     _service(db, tiingo).pull()
 
-    assert _links(db) == [(TIINGO_REF_KIND, "BRK-B", "s_brk")]
+    assert _links(db) == [(TIINGO.feed_ref_kind, "BRK-B", "s_brk")]
     assert [ref.provider_security_key for ref in tiingo.fetched] == ["BRK-B"]
     assert tiingo.metadata_calls == []
 
@@ -1686,64 +1690,137 @@ def test_listing_prices_can_bound_the_start_date(db: Database) -> None:
 def test_every_source_the_service_writes_resolves_in_staging() -> None:
     """A source_type this service writes MUST be mapped in prep.stg_security_prices.
 
-    The two halves ship in different files, and nothing else connects them.
-    ``PriceService`` writes ``raw.security_prices`` rows tagged with its own
-    ``source_type`` constants; ``prep.stg_security_prices`` resolves each row
-    through a ``CASE p.source_type`` whose result is compared against
-    ``app.security_links.ref_kind`` in an INNER JOIN. An unmapped source makes
-    that CASE return NULL, the comparison UNKNOWN, and the join drops the row —
-    with no error, no counter, and no way to recover it by accepting bindings
-    later, because the failure is in the mapping rather than the binding.
+    The two halves used to ship in different files with nothing connecting them:
+    ``PriceService`` wrote ``raw.security_prices`` rows tagged with its own
+    ``source_type`` constants, and ``prep.stg_security_prices`` restated the
+    ``source_type`` -> ``ref_kind`` mapping in a CASE. An unmapped source made
+    that CASE return NULL, the comparison UNKNOWN, and the INNER JOIN drop the
+    row — with no error, no counter, and no way to recover it by accepting
+    bindings later, because the failure was in the mapping rather than the
+    binding. That is how C.2 discarded every row its writers produced.
 
-    The staging module's own tripwire could not catch this: it reads the CASE and
-    fires only when the CASE changes, so shipping a *writer* for an unmapped
-    source left it green while every row written went nowhere. This test watches
-    the other direction, and lives in the unit gate so it runs on every commit.
+    ``seeds.price_source_map`` now declares both halves in one row, so the
+    failure needs a source declaring the security types it prices while
+    declaring no ref_kind. ``ref_kind_mapping`` additionally fails if the model
+    stops joining the registry, which is the other way the two could part.
     """
     mapping = ref_kind_mapping()
-    written = {TIINGO_SOURCE_TYPE, COINGECKO_SOURCE_TYPE}
+    written = {s.source_type for s in PRICE_SOURCES if s.security_types}
 
+    assert written, (
+        "no price source declares the security types it prices, so the subset "
+        "check below would hold vacuously"
+    )
     assert written <= mapping.keys(), (
-        f"PriceService writes {sorted(written - mapping.keys())} but "
-        f"prep.stg_security_prices maps only {sorted(mapping)} — every row written "
-        f"for an unmapped source is discarded permanently by the INNER JOIN. Add "
-        f"`WHEN '<source>' THEN '<ref_kind>'` to the model's CASE."
+        f"PriceService fetches {sorted(written - mapping.keys())} but "
+        f"prep.stg_security_prices resolves only {sorted(mapping)} — every row "
+        f"written for an unmapped source is discarded permanently by the INNER "
+        f"JOIN. Give the source a ref_kind in the registry."
     )
 
 
-def test_the_ref_kind_the_service_binds_matches_what_staging_expects() -> None:
-    """Mapping the source is only half of it — the ref_kind must agree too.
+def test_every_ref_kind_the_registry_declares_is_admitted_by_the_schema() -> None:
+    """Declaring a ref_kind is only half of it — the CHECK must admit it too.
 
-    ``PriceService`` writes the binding into ``app.security_links.ref_kind``;
-    staging joins on ``ref_kind = CASE ... END``. If the two disagree on the
-    spelling, the source is mapped, the binding is accepted, and the row is
-    still dropped — the same silent loss as an unmapped source, reached a
-    different way.
+    ``PriceService`` writes the binding into ``app.security_links.ref_kind``,
+    whose CHECK constraint is a hand-maintained list in a migration-frozen
+    schema file that no registry edit can reach. A ref_kind the registry
+    declares but the constraint rejects fails every insert at run time, so
+    adding a provider needs a migration in the same change.
+
+    This replaces a comparison of the registry against itself. Before the
+    registry, staging restated the mapping in a CASE and the service held its
+    own constants, so asserting the two agreed was a real cross-check; now both
+    sides read one row and only the schema is genuinely independent.
     """
-    mapping = ref_kind_mapping()
+    schema = (
+        Path(moneybin.__file__).parent / "sql" / "schema" / "app_security_links.sql"
+    ).read_text()
+    check = re.search(r"CHECK\s*\(\s*ref_kind\s+IN\s*\(([^)]*)\)", schema)
+    assert check is not None, (
+        "no `CHECK (ref_kind IN (...))` found in app_security_links.sql; the "
+        "constraint this test crosses the registry against has moved"
+    )
+    admitted = set(re.findall(r"'([^']+)'", check.group(1)))
+    declared = set(REF_KIND_BY_SOURCE_TYPE.values())
 
-    assert mapping[TIINGO_SOURCE_TYPE] == TIINGO_REF_KIND
-    assert mapping[COINGECKO_SOURCE_TYPE] == COINGECKO_REF_KIND
+    assert declared <= admitted, (
+        f"the registry declares {sorted(declared - admitted)}, which "
+        f"app.security_links.ref_kind rejects — every binding the service writes "
+        f"for those sources fails its CHECK. Widen the constraint in a migration."
+    )
 
 
 def test_every_ref_kind_the_service_queues_is_routed_as_a_feed_key() -> None:
     """The opposite direction of the same contract, per the C.2 staging lesson.
 
-    `SecurityLinksService.accept` routes on `_FEED_KEY_REF_KINDS`: a ref_kind in
+    `SecurityLinksService.accept` routes on `FEED_KEY_REF_KINDS`: a ref_kind in
     that set BINDS the feed, one outside it MERGES two securities and DELETEs
     one. So a new adapter whose ref_kind never reaches that set would have its
     review decisions routed into the merge path — destroying the very security
     the user was trying to price.
 
-    The consumer's own tests read the set, so they cannot see a producer that
-    ships ahead of it. This reads the producer.
-    """
-    queued = {TIINGO_REF_KIND, COINGECKO_REF_KIND}
+    Asserted against the router itself, and across two INDEPENDENT registry
+    columns, so it can actually fail. ``security_types`` says what PriceService
+    fetches; ``ref_role`` says what accepting the ref does. Comparing the
+    router against the set it reads, or against the column that set derives
+    from, would restate one expression twice and could never fail.
 
-    assert queued <= _FEED_KEY_REF_KINDS, (
-        "PriceService queues these ref_kinds, but SecurityLinksService.accept "
-        f"routes them to the MERGE path: {sorted(queued - _FEED_KEY_REF_KINDS)}"
+    Only the routed direction is universal. A RETIRED provider keeps
+    ``ref_role = 'feed_key'`` with no ``security_types``, which is exactly the
+    state that must still bind, so the reverse implication is pinned on the
+    concrete identity row instead.
+    """
+    for source in PRICE_SOURCES:
+        if not source.security_types:
+            continue
+        assert SecurityLinksService.binds_a_feed_key(source.feed_ref_kind), (
+            f"PriceService fetches {source.source_type!r}, but accepting a "
+            f"{source.feed_ref_kind!r} decision routes to the MERGE path, which "
+            "re-points every reference and deletes the provisional security — "
+            f"destroying the one the review meant to price. Set ref_role to "
+            f"{FEED_KEY_ROLE!r} in the registry."
+        )
+
+    identity_ref = REF_KIND_BY_SOURCE_TYPE["plaid"]
+    assert not SecurityLinksService.binds_a_feed_key(identity_ref), (
+        f"{identity_ref!r} names a second catalog row for one instrument, not a "
+        "market-data symbol; routing it to the BIND path would create a link and "
+        "skip the merge that accepting it exists to perform"
     )
+
+
+def test_every_source_the_registry_routes_to_has_an_adapter_wired() -> None:
+    """A registry row with no adapter behind it reports every holding as cash.
+
+    ``_route`` returns ``self._adapters.get(...)``, and a ``None`` adapter makes
+    the pull record ``no_price_source`` — the same answer a sweep position gets,
+    which is the one reply that must not be counterfeitable. ``_adapter_for`` was
+    made loud for the UNREGISTERED case; this is the registered-but-unwired one,
+    and wiring an adapter is the step the registry deliberately cannot do for you.
+    """
+    service = PriceService(
+        MagicMock(), tiingo=_FakeTiingo(), coingecko=_FakeCoinGecko()
+    )
+
+    for source in PRICE_SOURCES:
+        for security_type in sorted(source.security_types):
+            held = HeldSecurity(
+                security_id="s1",
+                name="Test Security",
+                security_type=security_type,
+                quote_currency="USD",
+                ticker="TEST",
+                exchange=None,
+                coingecko_id="test-coin",
+            )
+            routed, adapter = service._route(held)  # pyright: ignore[reportPrivateUsage]  # the dispatch under test
+            assert routed == source.source_type
+            assert adapter is not None, (
+                f"{source.source_type!r} is routed for security_type "
+                f"{security_type!r} but no adapter is wired for it, so every such "
+                "holding reports no_price_source and reads as unpriceable"
+            )
 
 
 class TestMarkCurrencyResolution:
@@ -2048,9 +2125,9 @@ def _seed_stale_binding(db: Database, *, ticker: str, ref_value: str) -> None:
     _hold(db, "s1")
     SecurityLinksRepo(db).insert(
         security_id="s1",
-        ref_kind=TIINGO_REF_KIND,
+        ref_kind=TIINGO.feed_ref_kind,
         ref_value=ref_value,
-        source_type=TIINGO_SOURCE_TYPE,
+        source_type=TIINGO.source_type,
         decided_by="auto",
         actor="system",
     )
@@ -2073,7 +2150,7 @@ def test_a_stale_binding_is_kept_when_no_replacement_can_be_derived(
 
     service.pull()
 
-    assert _links(db) == [(TIINGO_REF_KIND, "FB", "s1")]
+    assert _links(db) == [(TIINGO.feed_ref_kind, "FB", "s1")]
 
 
 def test_a_stale_binding_is_retired_once_its_replacement_is_derived(
@@ -2091,7 +2168,7 @@ def test_a_stale_binding_is_retired_once_its_replacement_is_derived(
 
     service.pull()
 
-    assert _links(db) == [(TIINGO_REF_KIND, "META", "s1")]
+    assert _links(db) == [(TIINGO.feed_ref_kind, "META", "s1")]
 
 
 def test_a_feed_key_carried_across_a_merge_is_still_re_derived(db: Database) -> None:
@@ -2115,9 +2192,9 @@ def test_a_feed_key_carried_across_a_merge_is_still_re_derived(db: Database) -> 
     repo = SecurityLinksRepo(db)
     event = repo.insert(
         security_id="s0",
-        ref_kind=TIINGO_REF_KIND,
+        ref_kind=TIINGO.feed_ref_kind,
         ref_value="FB",
-        source_type=TIINGO_SOURCE_TYPE,
+        source_type=TIINGO.source_type,
         decided_by="auto",
         actor="system",
     )
@@ -2132,7 +2209,7 @@ def test_a_feed_key_carried_across_a_merge_is_still_re_derived(db: Database) -> 
 
     _service(db, tiingo).pull()
 
-    assert _links(db) == [(TIINGO_REF_KIND, "META", "s1")]
+    assert _links(db) == [(TIINGO.feed_ref_kind, "META", "s1")]
 
 
 def test_a_stale_binding_is_retired_even_when_its_replacement_collides(
@@ -2167,9 +2244,9 @@ def test_a_stale_binding_is_retired_even_when_its_replacement_collides(
     _hold(db, "s_holder")
     SecurityLinksRepo(db).insert(
         security_id="s_holder",
-        ref_kind=COINGECKO_REF_KIND,
+        ref_kind=COINGECKO.feed_ref_kind,
         ref_value="bitcoin",
-        source_type=COINGECKO_SOURCE_TYPE,
+        source_type=COINGECKO.source_type,
         decided_by="auto",
         actor="system",
     )
@@ -2183,16 +2260,16 @@ def test_a_stale_binding_is_retired_even_when_its_replacement_collides(
     _hold(db, "s_renamed")
     SecurityLinksRepo(db).insert(
         security_id="s_renamed",
-        ref_kind=COINGECKO_REF_KIND,
+        ref_kind=COINGECKO.feed_ref_kind,
         ref_value="btc-legacy-slug",
-        source_type=COINGECKO_SOURCE_TYPE,
+        source_type=COINGECKO.source_type,
         decided_by="auto",
         actor="system",
     )
 
     result = _service(db, _FakeTiingo(), _FakeCoinGecko()).pull()
 
-    assert _links(db) == [(COINGECKO_REF_KIND, "bitcoin", "s_holder")]
+    assert _links(db) == [(COINGECKO.feed_ref_kind, "bitcoin", "s_holder")]
     assert [u.reason for u in result.unpriced] == ["feed_key_bound_elsewhere"]
 
 

--- a/tests/moneybin/test_services/test_price_service.py
+++ b/tests/moneybin/test_services/test_price_service.py
@@ -1790,6 +1790,38 @@ def test_every_ref_kind_the_service_queues_is_routed_as_a_feed_key() -> None:
     )
 
 
+def test_a_routed_source_with_no_derivation_refuses_to_borrow_another_providers() -> (
+    None
+):
+    """Registering a provider must not silently give it Tiingo's key derivation.
+
+    ``_route`` selects any source the registry declares security types for, so
+    a third provider becomes reachable the moment its row lands. Both derivation
+    sites used to read "CoinGecko, else Tiingo", which meant that provider would
+    be handed ``security.ticker`` and Tiingo's metadata contract — binding or
+    fetching another provider's identifier while looking correctly registered.
+    That is the same silent default ``_adapter_for`` was made loud for, and all
+    three had to move together or the fix only relocates the failure.
+    """
+    service = PriceService(
+        MagicMock(), tiingo=_FakeTiingo(), coingecko=_FakeCoinGecko()
+    )
+    security = HeldSecurity(
+        security_id="s1",
+        name="Test Security",
+        security_type="equity",
+        quote_currency="USD",
+        ticker="TEST",
+        exchange=None,
+        coingecko_id="test-coin",
+    )
+
+    with pytest.raises(NotImplementedError, match="unregistered_provider"):
+        service._catalog_ref(  # pyright: ignore[reportPrivateUsage]  # the dispatch under test
+            security, "unregistered_provider"
+        )
+
+
 def test_every_source_the_registry_routes_to_has_an_adapter_wired() -> None:
     """A registry row with no adapter behind it reports every holding as cash.
 

--- a/tests/moneybin/test_services/test_security_links_service.py
+++ b/tests/moneybin/test_services/test_security_links_service.py
@@ -1327,7 +1327,7 @@ def test_accept_reports_binding_a_feed_key_as_a_bind(db: Database) -> None:
     ``accept`` routes on ref_kind, so a surface that reports one fixed outcome
     tells the user it merged two securities when it only created a link. The
     routing decision is the service's; the word for it has to come back with it
-    rather than be re-derived from ``_FEED_KEY_REF_KINDS`` in every adapter.
+    rather than be re-derived from ``FEED_KEY_REF_KINDS`` in every adapter.
     """
     security = _mint(db, name="BHP Group Ltd", created_by="user")
     decision_id = _feed_key_decision(db, security_id=security)

--- a/tests/moneybin/test_stg_security_prices.py
+++ b/tests/moneybin/test_stg_security_prices.py
@@ -11,6 +11,7 @@ import duckdb
 import pytest
 
 from moneybin.database import Database, sqlmesh_context
+from moneybin.tables import SEED_PRICE_SOURCE_MAP
 from tests.moneybin.price_model_helpers import ref_kind_mapping as _ref_kind_mapping
 
 pytestmark = pytest.mark.integration
@@ -440,20 +441,21 @@ def test_reversed_link_does_not_resolve(security_price_cases: Database) -> None:
 def test_every_mapped_source_resolves_end_to_end(
     security_price_cases: Database,
 ) -> None:
-    """Every source the ref_kind CASE maps must actually reach staging.
+    """Every source seeds.price_source_map maps must actually reach staging.
 
-    The mapped set is read from the model file, so this test grows itself: adding
-    `WHEN 'x' THEN 'x_key'` to the CASE makes this test start seeding an `x` row and an
-    `x_key` binding for it, and fail immediately unless app.security_links.ref_kind is
-    CHECK-constrained to admit `x_key` too. Extending the CASE alone does not make a
-    source resolve; the constraint must be widened in the same change. (That is what
-    V042 did for tiingo_ticker and coingecko_slug.) Pinning the mapping's *shipped* set
-    as a literal here instead would drift the moment someone edited the model, which is
-    exactly when the check needs to fire.
+    The mapped set is read from the registry, so this test grows itself: adding a row
+    with a ref_kind makes this test start seeding an `x` row and an `x_key` binding for
+    it, and fail immediately unless app.security_links.ref_kind is CHECK-constrained to
+    admit `x_key` too. Declaring the mapping alone does not make a source resolve; the
+    constraint must be widened in the same change. (That is what V042 did for
+    tiingo_ticker and coingecko_slug.) Pinning the mapping's *shipped* set as a literal
+    here instead would drift the moment someone edited the registry, which is exactly
+    when the check needs to fire — tests/moneybin/test_price_sources.py holds that pin,
+    where changing it is the point rather than the accident.
 
-    This direction only sees mappings that exist. A writer shipping ahead of its mapping
-    leaves the CASE untouched and this test unchanged — see
-    test_price_service.py::test_every_source_the_service_writes_resolves_in_staging.
+    This direction only sees mappings that exist. A registry row someone deletes merely
+    shrinks the set iterated here; that direction is the rank-order pin in
+    test_price_sources.py and the run-time investment_unmapped_price_source check.
     """
     db = security_price_cases
     mapping = _ref_kind_mapping()
@@ -466,32 +468,54 @@ def test_every_mapped_source_resolves_end_to_end(
         ).fetchall()
     }
     assert resolved == set(mapping), (
-        f"every source mapped in the ref_kind CASE must resolve; mapped={set(mapping)} "
-        f"resolved={resolved}. A source in the CASE but absent here is dropped by the "
-        f"INNER JOIN with no error and no doctor coverage."
+        f"every source the registry maps must resolve; mapped={set(mapping)} "
+        f"resolved={resolved}. A source in the registry but absent here is dropped by "
+        f"the INNER JOIN with no error and no doctor coverage."
     )
+
+
+def test_the_seeded_registry_nulls_the_ref_kind_of_a_derived_source(
+    security_price_cases: Database,
+) -> None:
+    """A blank CSV cell must seed as NULL, not as the empty string.
+
+    ``core.fct_security_prices`` scopes its same-pull withhold to the sources
+    that HAVE a ref_kind, so an empty string seeded in place of NULL would pull
+    ``override`` and ``trade_implied`` into a churn check meant only for
+    provider keys — and would blank a grain whose two rows are a routine pair of
+    partial fills. Nothing else in the suite reads that distinction directly.
+    """
+    db = security_price_cases
+
+    unmapped = {
+        row[0]
+        for row in db.execute(
+            f"SELECT source_type FROM {SEED_PRICE_SOURCE_MAP.full_name} "  # noqa: S608  # TableRef constant, not user input
+            "WHERE ref_kind IS NULL"
+        ).fetchall()
+    }
+    assert unmapped == {"override", "trade_implied"}
 
 
 def test_an_unmapped_source_is_dropped_permanently_not_deferred(
     security_price_cases: Database,
 ) -> None:
-    """A source the ref_kind CASE does not map is discarded silently and forever.
+    """A source the registry does not map is discarded silently and forever.
 
     This is the finding the COVERAGE block in the model documents, pinned as behavior.
     The binding here is *accepted* and its ref_value matches, so the row fails for one
-    reason only: the CASE returns NULL for an unmapped source, making
-    `links.ref_kind = NULL` UNKNOWN and the INNER JOIN drop the row. That is unlike the
+    reason only: seeds.price_source_map holds no row for the source, so the join to it
+    matches nothing and the INNER JOIN drops the row. That is unlike the
     unresolved-binding case, where the observation waits in raw and reappears once its
     security binds — no number of accepted bindings will ever surface this one.
 
     Originally written against 'tiingo' as a tripwire that would fire when the tiingo
-    adapter landed. It did not fire, because it watches the CASE and the adapter shipped
-    a *writer* one commit ahead of its mapping — every tiingo row written in between was
-    dropped here. Two guards replaced that role, in the directions this test cannot see:
-    `test_price_service.py` asserts every source PriceService writes is mapped (build
-    time), and `investment_unmapped_price_source` reports any unmapped source_type
-    already sitting in raw (run time). This test now pins only the drop semantics, using
-    a source with no adapter behind it.
+    adapter landed. It did not fire, because it watched the mapping while the adapter
+    shipped a *writer* one commit ahead of it — every tiingo row written in between was
+    dropped here. One registry row now declares both halves, so that split is
+    structural rather than guarded; `investment_unmapped_price_source` still reports any
+    unmapped source_type already sitting in raw (run time). This test now pins only the
+    drop semantics, using a source with no adapter behind it.
     """
     unmapped = "yahoo"
     assert unmapped not in _ref_kind_mapping(), (


### PR DESCRIPTION
## Summary

The price-source vocabulary was restated by hand in five places: a `source_type` → `ref_kind` CASE in `prep.stg_security_prices`, a `source_rank` CASE and a separate provider `IN`-list in `core.fct_security_prices`, `PriceService`'s adapter and `ref_kind` dispatch, and `SecurityLinksService`'s feed-key `ref_kind` set. Adding a provider meant editing all five, and missing one failed silently: C.2 shipped the Tiingo and CoinGecko writers one commit ahead of the staging CASE, and every row those adapters wrote in between was discarded permanently by an INNER JOIN with no error and no counter.

This adds `seeds.price_source_map`, a five-row CSV declaring each source's `source_rank`, `ref_kind`, `ref_role`, and the security types it prices. SQLMesh materializes it as a seed the two models join, and `moneybin.price_sources` loads the same CSV so the Python dispatch reads that one declaration. Declaring a source now declares both halves at once, so a writer can no longer ship ahead of its mapping.

No persisted value changes. Every `source_type`, `ref_kind`, and `source_rank` is carried across verbatim — the spec forbids reordering ranks because doing so silently revalues every historical holding.

## Background

Two facts that used to be enumerated now fall out of the registry. `core.fct_security_prices` scoped its same-pull withhold to `source_type IN ('plaid', 'tiingo', 'coingecko')`; that set is exactly the sources carrying a `ref_kind`, because a `ref_kind` is what makes a row arrive through `app.security_links`, so the predicate follows the registry instead of naming a set. `SecurityLinksService`'s feed-key set is now read off the registry's `ref_role` column instead of being restated — which keeps `plaid_security_id` correctly outside it, where accepting one merges two securities rather than binding a feed.

`ref_role` is a separate column rather than a derivation, and that is the one non-obvious call here. It says what accepting a review decision for a ref_kind *does* — `feed_key` binds a price feed, `identity` merges two catalog rows and deletes one. An earlier revision derived it from `security_types`, which is wrong in a way that only shows up later: retiring a provider is documented as clearing `security_types`, so a derived role would silently reclassify the retired provider's ref_kind from a feed key to an identity ref and route its still-pending review decisions into the merge path. A ref_kind's role is a permanent property of the ref_kind; `security_types` is operational and empties on retirement. They are different facts and now sit in different columns, with `test_retiring_a_provider_cannot_reclassify_its_ref_kind` pinning the distinction.

Two of the three "source rank" CASEs named in the issue are deliberately untouched. `core.dim_accounts` and `prep.int_transactions__matched` rank *ingest* sources (`ofx`, `plaid`, `manual`, tabular) — a different vocabulary that happens to share the word `plaid`. Folding them into a price-source registry would conflate two domains.

One comment was factually wrong and is corrected: `core.fct_security_prices` claimed the provider set had to be kept in step with `investment_price_disagreement`, whose own docstring says it is "deliberately not scoped to an enumerated provider list".

Operational note: `seeds.price_source_map` is a new registered model, so an already-built profile reports `transform_model_presence` as failing until its next `refresh run` builds it. That is the same one-refresh lag any added model produces, not a new failure mode; a freshly initialized profile is unaffected because `never_built` still short-circuits the check.

## Changes

- **One declaration.** `src/moneybin/sqlmesh/models/seeds/price_source_map.{csv,sql}` plus `src/moneybin/price_sources.py`, which loads that CSV into `PRICE_SOURCES`, `REF_KIND_BY_SOURCE_TYPE`, `FEED_KEY_REF_KINDS`, and the `price_source()` / `source_for_security_type()` lookups. `price_source()` raises on an unregistered source instead of falling through, and `SEED_PRICE_SOURCE_MAP` joins the other seed `TableRef`s in `tables.py`.
- **SQL derives from it.** `prep.stg_security_prices` joins the seed for its `ref_kind`; `core.fct_security_prices` LEFT JOINs it for `COALESCE(src.source_rank, 99)` and scopes the withhold on `ref_kind IS NOT NULL`. The LEFT JOIN is deliberate — an INNER one would drop an unregistered source in `core` rather than bucket it at 99, repeating the silent discard this change exists to end.
- **Python derives from it.** `PriceService` keys its adapters by the registry's own `source_type` and takes every `ref_kind` from it, so `_adapter_for` no longer returns the Tiingo adapter for every value that is not CoinGecko. `SecurityLinksService._FEED_KEY_REF_KINDS` is replaced by the registry's `FEED_KEY_REF_KINDS`, which also drops two `reportPrivateUsage` suppressions in the MCP tool.
- **Guards derive from it, or got stronger.** `ref_kind_mapping()` reads the registry and additionally fails if the model stops `JOIN`ing it or restates a `CASE p.source_type` beside it — matching the bare table name would not have caught that, since it also appears in the model's prose. The two hand-written literal sets in `test_price_service.py` now derive. The CLI `--source` enum is deliberately NOT auto-generated — `PriceSourceChoice` stays a hand-written `StrEnum` because Typer needs a static enum for its choices; what changed is that its guard test now compares it against the registry instead of a literal, so drift fails loudly rather than silently. The feed-key guard now asserts `SecurityLinksService.binds_a_feed_key` across two independent columns (`security_types` against `ref_role`) rather than comparing the router to the set it reads, which could never fail. `test_the_ref_kind_the_service_binds_matches_what_staging_expects` became `x == x` once both sides read one registry row, so it is replaced by a cross-check against the genuinely independent thing: the hand-maintained `CHECK (ref_kind IN (...))` on `app.security_links`, which no registry edit can reach and which a new provider needs a migration to widen.

## Test plan

- `tests/moneybin/test_price_sources.py` (new) pins the shipped rows and their rank order, so a changed row means someone reordered rather than appended; it also covers the loud failure on an unregistered source, that routing is a function rather than a first-match scan, and that the seed model and the Python loader read the same file with the same columns.
- `test_the_provider_ranks_order_against_each_other` (new) ranks `plaid` over `tiingo` over `coingecko` end to end. That ordering had no test in either direction before this. The fixture is oriented adversarially: the source that must win carries the stalest `extracted_at` and the lowest close, so a rank that stops applying resolves onto a different row instead of coincidentally landing on the right answer.
- `test_the_seeded_registry_nulls_the_ref_kind_of_a_derived_source` (new) pins that a blank CSV cell seeds as NULL rather than an empty string, which is the distinction the withhold predicate depends on and which nothing else in the suite reads directly.
- `test_retiring_a_provider_cannot_reclassify_its_ref_kind` (new) applies the documented retirement to every feed source and asserts the production derivation still returns the same feed-key set. Mutation-checked: reverting the derivation to key on `security_types` makes it fail with an empty set, which is the regression it exists to catch.
- `test_every_source_the_registry_routes_to_has_an_adapter_wired` (new) walks every declared security type through `_route` and requires a wired adapter, so a registry row whose adapter was never passed to the constructor cannot report its holdings as unpriceable cash.
- Gates run: `make lint` pass; `uv run pyright` 0 errors, 3 pre-existing warnings; `make test` 10377 passed / 1 failed; `make test-integration` 563 passed; `make test-scenarios` 92 passed; `make test-e2e` 380 passed; `tests/test_documentation_policy.py` 8 passed; and a targeted run across the price, doctor, links, CLI, and MCP suites, 1768 passed. The e2e gate is included because the registry loads its CSV at import, which puts packaging and CLI startup in the blast radius.
- The single `make test` failure is `test_google_oauth_authorizes_with_the_shipped_client_id_and_secret_pair`. It is pre-existing and environmental: it fails identically on the unmodified base tree, confirmed by re-running it against a stashed working tree. It touches nothing this diff changes and is tracked separately.

## Related

Refs MB-46, a sub-issue of MB-39 (the 2026-08-21 architecture consolidation review).
