### PR TITLE
Route every classified envelope through one builder

### DIFF
--- a/docs/specs/mcp-architecture.md
+++ b/docs/specs/mcp-architecture.md
@@ -440,10 +440,14 @@ declared contract type, and every one of those builds its response through
 which derives the classes, takes the max tier across them, redacts, and reports
 the classes for the audit row — one home for those four steps, so a change to
 the classification contract is one edit rather than one per tool. The rest
-classify from SQL lineage, where the classes come from the columns a particular
-query actually projected: `sql_query`, `sql_schema`, and `reports` carry their
-own `tier` and `classes_returned` into `build_envelope`, because no declared
-type can describe a per-call row set.
+carry their own `tier` and `classes_returned` into `build_envelope`, because no
+declared type can describe a per-call row set — but they derive those values
+three different ways. `sql_query` classifies from SQL lineage, where the classes
+come from the columns a particular query actually projected. `sql_schema`
+returns catalog metadata rather than user rows, so each branch declares a fixed
+`low` / `["aggregate"]`. `reports` reads the `@report` contract's own
+declarations: `catalog_sensitivity` / `catalog_classes_returned` when listing the
+catalog, and `ReportResult.tier` / `.classes_returned` when executing a report.
 
 Both paths read the response. A tool that shows the caller classified data
 somewhere else — today, only the text of a confirmation elicitation — declares

--- a/docs/specs/mcp-architecture.md
+++ b/docs/specs/mcp-architecture.md
@@ -434,6 +434,16 @@ Every tool is classified through one of two live paths. Static tools derive a
 maximum sensitivity from the data classes on their typed response payload.
 Tools whose projection varies by request declare `dynamic_classification=True`,
 classify the returned payload, and advertise a `maximum_sensitivity` ceiling.
+Such a tool classifies from one of two sources. Most read the classes off a
+declared contract type, and every one of those builds its response through
+`build_classified_envelope` (`src/moneybin/privacy/classified_envelope.py`),
+which derives the classes, takes the max tier across them, redacts, and reports
+the classes for the audit row — one home for those four steps, so a change to
+the classification contract is one edit rather than one per tool. The rest
+classify from SQL lineage, where the classes come from the columns a particular
+query actually projected: `sql_query`, `sql_schema`, and `reports` carry their
+own `tier` and `classes_returned` into `build_envelope`, because no declared
+type can describe a per-call row set.
 
 Both paths read the response. A tool that shows the caller classified data
 somewhere else — today, only the text of a confirmation elicitation — declares

--- a/src/moneybin/cli/commands/import_cmd.py
+++ b/src/moneybin/cli/commands/import_cmd.py
@@ -15,7 +15,7 @@ from dataclasses import asdict, dataclass
 from datetime import date
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import typer
 
@@ -792,26 +792,19 @@ def import_files_command(
 
     classes_returned: list[str] | None = None
     if any(_gates_an_account(f) for f in files_list):
-        from moneybin.cli.output import (  # noqa: PLC0415 — defer import to keep CLI cold-start light
-            derive_log_sensitivity,
-        )
-        from moneybin.privacy.introspection import (  # noqa: PLC0415 — defer import to keep CLI cold-start light
-            extract_data_classes,
+        from moneybin.privacy.classified_envelope import (  # noqa: PLC0415 — defer import to keep CLI cold-start light
+            classify,
         )
         from moneybin.privacy.payloads.imports import (  # noqa: PLC0415 — defer import to keep CLI cold-start light
             ImportConfirmationPayload,
         )
 
-        # `derive_log_sensitivity`, not a second inline `derive_tier` call: it
-        # is the existing helper for exactly this question and already serves
-        # the audit path, so one function answers it everywhere.
-        batch_sensitivity = cast(
-            'Literal["low", "medium", "high", "critical"]',
-            derive_log_sensitivity(ImportConfirmationPayload, batch_sensitivity),
-        )
-        classes_returned = sorted(
-            c.value for c in extract_data_classes(ImportConfirmationPayload)
-        )
+        # The shared classification primitive, not a second inline derivation:
+        # one function answers "what tier and classes does this payload carry"
+        # on every surface, so a change to the declarations moves them together.
+        classification = classify(ImportConfirmationPayload)
+        batch_sensitivity = classification.sensitivity
+        classes_returned = classification.classes_returned
     envelope = build_envelope(data=data, sensitivity=batch_sensitivity)
     if batch_result is not None:
         # Same gate the MCP import_files tool applies, from the same function:

--- a/src/moneybin/cli/commands/import_inbox.py
+++ b/src/moneybin/cli/commands/import_inbox.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, Literal, cast
+from typing import Any, cast
 
 import typer
 
@@ -226,19 +226,14 @@ def inbox_default(
         # declarations rather than restated, so they move together.
         classes_returned: list[str] | None = None
         if any(p.get("account_proposals") for p in result.pending):
-            from moneybin.cli.output import derive_log_sensitivity
-            from moneybin.privacy.introspection import extract_data_classes
+            from moneybin.privacy.classified_envelope import classify
             from moneybin.privacy.payloads.imports import ImportConfirmationPayload
 
-            # The same helper the audit path uses, rather than a second inline
-            # derive_tier call beside it.
-            sensitivity = cast(
-                'Literal["low", "medium", "high", "critical"]',
-                derive_log_sensitivity(ImportConfirmationPayload, sensitivity),
-            )
-            classes_returned = sorted(
-                c.value for c in extract_data_classes(ImportConfirmationPayload)
-            )
+            # The shared classification primitive the audit path uses, rather
+            # than a second inline derivation beside it.
+            classification = classify(ImportConfirmationPayload)
+            sensitivity = classification.sensitivity
+            classes_returned = classification.classes_returned
         payload = dataclasses.asdict(result)
         payload["pending"] = _masked_pending(result.pending)
         # Flattened out of the nested field `asdict` produced, so these read

--- a/src/moneybin/cli/output.py
+++ b/src/moneybin/cli/output.py
@@ -38,7 +38,7 @@ import typer
 
 from moneybin.cli.render import render_note
 from moneybin.errors import UserError
-from moneybin.privacy.introspection import derive_tier, extract_data_classes
+from moneybin.privacy.classified_envelope import classify
 from moneybin.privacy.log import build_tool_call_event, write_privacy_event
 from moneybin.privacy.redaction import has_active_transform, redact_typed
 from moneybin.privacy.taxonomy import DataClass
@@ -360,10 +360,7 @@ def render_or_json(
         event_classes = (
             classes_returned
             if classes_returned is not None
-            else [
-                c.value
-                for c in sorted(extract_data_classes(original_data_type))  # pyright: ignore[reportUnknownArgumentType]
-            ]
+            else classify(original_data_type).classes_returned  # pyright: ignore[reportUnknownArgumentType]
         )
         # envelope.summary.sensitivity is the derived value (stamped above) for
         # typed payloads, or the command's declared value for bare list/dict
@@ -455,7 +452,7 @@ def derive_log_sensitivity(payload_type: type, envelope_sensitivity: str) -> str
     """
     if payload_type in (list, dict, tuple, set, type(None)):
         return envelope_sensitivity
-    return derive_tier(payload_type).name.lower()
+    return classify(payload_type).sensitivity
 
 
 def _has_active_transform(payload_type: type) -> bool:

--- a/src/moneybin/cli/utils.py
+++ b/src/moneybin/cli/utils.py
@@ -48,18 +48,14 @@ def _error_audit_classification(payload_type: type | None) -> tuple[str, list[st
     """
     if payload_type is None:
         return "high", []
-    from moneybin.cli.output import derive_log_sensitivity  # noqa: PLC0415
-    from moneybin.privacy.introspection import (  # noqa: PLC0415
-        PrivacyContractError,
-        extract_data_classes,
-    )
+    from moneybin.privacy.classified_envelope import classify  # noqa: PLC0415
+    from moneybin.privacy.introspection import PrivacyContractError  # noqa: PLC0415
 
+    classification = classify(payload_type)
     try:
-        sensitivity = derive_log_sensitivity(payload_type, "high")
-        classes = [c.value for c in sorted(extract_data_classes(payload_type))]
+        return classification.sensitivity, classification.classes_returned
     except PrivacyContractError:
         return "high", []
-    return sensitivity, classes
 
 
 @contextmanager

--- a/src/moneybin/mcp/decorator.py
+++ b/src/moneybin/mcp/decorator.py
@@ -42,11 +42,8 @@ from moneybin.errors import (
     exception_origin,
 )
 from moneybin.mcp.privacy import Sensitivity, log_tool_call, tier_to_sensitivity
-from moneybin.privacy.introspection import (
-    PrivacyContractError,
-    derive_tier,
-    extract_data_classes,
-)
+from moneybin.privacy.classified_envelope import classify
+from moneybin.privacy.introspection import PrivacyContractError, derive_tier
 from moneybin.privacy.log import build_tool_call_event, write_privacy_event
 from moneybin.privacy.redaction import has_active_transform, redact_typed
 from moneybin.privacy.taxonomy import Tier
@@ -514,9 +511,7 @@ def mcp_tool(
             if discloses is not None:
                 tier = max(tier, discloses)
             sensitivity = tier_to_sensitivity(tier)
-            classes_for_log = [
-                c.value for c in sorted(extract_data_classes(payload_type_arg))
-            ]
+            classes_for_log = classify(payload_type_arg).classes_returned
             # Skip the redact_typed walk for payloads that would pass through
             # unchanged. Derived from _TRANSFORMS (not `tier == CRITICAL`) so
             # the gate stays correct automatically when PR3 wires real

--- a/src/moneybin/mcp/tools/accounts.py
+++ b/src/moneybin/mcp/tools/accounts.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections.abc import Callable
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from datetime import date as _date
 from decimal import Decimal
 from typing import Annotated, Any, Literal, cast
@@ -49,10 +49,10 @@ from moneybin.mcp.confirmation import (
     grant_confirmation_or_raise,
 )
 from moneybin.mcp.decorator import mcp_tool
-from moneybin.mcp.privacy import Sensitivity, tier_to_sensitivity
+from moneybin.mcp.privacy import Sensitivity
 from moneybin.mcp.rematch_report import rematch_actions
 from moneybin.mcp.write_contracts import FiniteDecimal
-from moneybin.privacy.introspection import extract_data_classes
+from moneybin.privacy.classified_envelope import build_classified_envelope
 from moneybin.privacy.payloads.accounts import (
     AccountDetail,
     AccountLinksHistoryPayload,
@@ -81,7 +81,6 @@ from moneybin.privacy.payloads.balances import (
     BalanceAssertionPayload,
     BalanceObservationListPayload,
 )
-from moneybin.privacy.redaction import redact_typed
 from moneybin.protocol.envelope import (
     UNSET,
     ResponseEnvelope,
@@ -990,29 +989,16 @@ def _coarse_envelope[T](
     has_more: bool | None = None,
 ) -> ResponseEnvelope[T]:
     """Build and redact a dynamically classified account-read envelope."""
-    classes = extract_data_classes(contract_type)
-    tier = max(data_class.tier for data_class in classes)
-    redacted = cast(T, redact_typed(data, None))
-    envelope = cast(
-        ResponseEnvelope[T],
-        build_envelope(
-            data=redacted,
-            sensitivity=cast(Any, tier_to_sensitivity(tier).value),
-            total_count=total_count,
-            returned_count=returned_count,
-            next_cursor=next_cursor,
-            period=period,
-            display_currency=display_currency,
-            actions=actions,
-            classes_returned=sorted(data_class.value for data_class in classes),
-        ),
-    )
-    return replace(
-        envelope,
-        summary=replace(
-            envelope.summary,
-            has_more=next_cursor is not None if has_more is None else has_more,
-        ),
+    return build_classified_envelope(
+        data,
+        contract_type=contract_type,
+        total_count=total_count,
+        returned_count=returned_count,
+        next_cursor=next_cursor,
+        period=period,
+        display_currency=display_currency,
+        actions=actions,
+        has_more=next_cursor is not None if has_more is None else has_more,
     )
 
 

--- a/src/moneybin/mcp/tools/gsheet.py
+++ b/src/moneybin/mcp/tools/gsheet.py
@@ -48,8 +48,8 @@ from moneybin.mcp.confirmation import (
     grant_confirmation_or_raise,
 )
 from moneybin.mcp.decorator import internal_envelope_adapter, mcp_tool
-from moneybin.mcp.privacy import Sensitivity, tier_to_sensitivity
-from moneybin.privacy.introspection import extract_data_classes
+from moneybin.mcp.privacy import Sensitivity
+from moneybin.privacy.classified_envelope import build_classified_envelope
 from moneybin.privacy.payloads.gsheet import (
     GsheetAuthPayload,
     GsheetCoarsePayload,
@@ -68,7 +68,6 @@ from moneybin.privacy.payloads.gsheet import (
     GsheetPullRow,
     GsheetStatusView,
 )
-from moneybin.privacy.redaction import redact_typed
 from moneybin.protocol.envelope import (
     ResponseEnvelope,
     build_envelope,
@@ -446,28 +445,22 @@ def _gsheet_coarse_envelope(
     data: GsheetConnectionsView | GsheetStatusView,
 ) -> ResponseEnvelope[GsheetCoarsePayload]:
     """Build and redact a dynamically classified Google Sheets view."""
-    contract_type = type(data)
-    classes = extract_data_classes(contract_type)
-    tier = max(data_class.tier for data_class in classes)
-    redacted = cast(
-        GsheetConnectionsView | GsheetStatusView,
-        redact_typed(data, None),
-    )
-    return cast(
-        ResponseEnvelope[GsheetCoarsePayload],
-        build_envelope(
-            data=redacted,
-            sensitivity=cast(Any, tier_to_sensitivity(tier).value),
-            total_count=len(redacted.connections),
-            returned_count=len(redacted.connections),
-            actions=[
-                f"Use gsheet_connect(connection_id='{row.connection_id}') to "
-                "re-detect and reconnect this binding."
-                for row in redacted.connections
-                if row.status == "drift_detected"
-            ],
-            classes_returned=sorted(data_class.value for data_class in classes),
-        ),
+    # Counts and the drift hint read `connection_id` and `status` before the
+    # builder redacts, which is identical to the redacted copy this used to read
+    # only while both classes pass through. That matters because `actions[]`
+    # sits outside the redaction walk and still reaches the wire, so
+    # `test_connection_drift_hint_reads_only_passthrough_classes` measures the
+    # invariant from `_TRANSFORMS` rather than leaving it to this comment.
+    return build_classified_envelope(
+        data,
+        total_count=len(data.connections),
+        returned_count=len(data.connections),
+        actions=[
+            f"Use gsheet_connect(connection_id='{row.connection_id}') to "
+            "re-detect and reconnect this binding."
+            for row in data.connections
+            if row.status == "drift_detected"
+        ],
     )
 
 
@@ -724,18 +717,7 @@ def _gsheet_connect_envelope(
     actions: list[str],
 ) -> ResponseEnvelope[GsheetConnectCoarsePayload]:
     """Build a typed, redacted, mode-specific consolidated connect result."""
-    classes = extract_data_classes(type(data))
-    tier = max(data_class.tier for data_class in classes)
-    redacted = redact_typed(data, None)
-    return cast(
-        ResponseEnvelope[GsheetConnectCoarsePayload],
-        build_envelope(
-            data=redacted,
-            sensitivity=cast(Any, tier_to_sensitivity(tier).value),
-            actions=actions,
-            classes_returned=sorted(data_class.value for data_class in classes),
-        ),
-    )
+    return build_classified_envelope(data, actions=actions)
 
 
 def _json_value(value: object) -> JsonValue:
@@ -811,7 +793,7 @@ async def gsheet_disconnect_coarse(
                 code=error_codes.GSHEET_CONFIRMATION_NOT_ALLOWED,
             )
         await asyncio.to_thread(_disconnect_gsheet, connection_id)
-        return _gsheet_disconnect_envelope(
+        return build_classified_envelope(
             GsheetDisconnectCoarsePayload(
                 kind="disconnected",
                 connection_id=connection_id,
@@ -835,7 +817,7 @@ async def gsheet_disconnect_coarse(
     )
     await asyncio.to_thread(_purge_gsheet_confirmed, connection_id, grant)
     before = plan.connection_before_state
-    return _gsheet_disconnect_envelope(
+    return build_classified_envelope(
         GsheetDisconnectCoarsePayload(
             kind="absent",
             connection_id=connection_id,
@@ -854,22 +836,6 @@ async def gsheet_disconnect_coarse(
             "This purge is permanent. Recreate the connection from its Google "
             "Sheets URL to resume future pulls.",
         ],
-    )
-
-
-def _gsheet_disconnect_envelope(
-    data: GsheetDisconnectCoarsePayload,
-    *,
-    actions: list[str],
-) -> ResponseEnvelope[GsheetDisconnectCoarsePayload]:
-    """Build one typed consolidated disconnect result."""
-    classes = extract_data_classes(type(data))
-    tier = max(data_class.tier for data_class in classes)
-    return build_envelope(
-        data=cast(GsheetDisconnectCoarsePayload, redact_typed(data, None)),
-        sensitivity=cast(Any, tier_to_sensitivity(tier).value),
-        actions=actions,
-        classes_returned=sorted(data_class.value for data_class in classes),
     )
 
 

--- a/src/moneybin/mcp/tools/import_tools.py
+++ b/src/moneybin/mcp/tools/import_tools.py
@@ -53,9 +53,9 @@ from moneybin.mcp.confirmation import (
     grant_confirmation_or_raise,
 )
 from moneybin.mcp.decorator import mcp_tool
-from moneybin.mcp.privacy import Sensitivity, tier_to_sensitivity
+from moneybin.mcp.privacy import Sensitivity
 from moneybin.mcp.rematch_report import retired_transfers_action
-from moneybin.privacy.introspection import extract_data_classes
+from moneybin.privacy.classified_envelope import build_classified_envelope, classify
 from moneybin.privacy.payloads.imports import (
     ImportConfirmationPayload,
     ImportConfirmCoarsePayload,
@@ -1032,23 +1032,6 @@ def _read_pdf_preview_bytes(path: Path) -> bytes:
     return source_bytes
 
 
-def _import_dynamic_envelope[T](
-    data: T,
-    *,
-    actions: list[str],
-) -> ResponseEnvelope[T]:
-    """Build one typed, redacted, dynamically classified import envelope."""
-    classes = extract_data_classes(type(data))
-    tier = max(data_class.tier for data_class in classes)
-    redacted = cast(T, redact_typed(data, None))
-    return build_envelope(
-        data=redacted,
-        sensitivity=cast(Any, tier_to_sensitivity(tier).value),
-        actions=actions,
-        classes_returned=sorted(data_class.value for data_class in classes),
-    )
-
-
 @mcp_tool(
     read_only=False,
     idempotent=False,
@@ -1222,9 +1205,7 @@ def import_preview_coarse(
     snapshot: dict[str, Any] = {
         "data": persisted_data,
         "actions": actions,
-        "sensitivity": tier_to_sensitivity(
-            max(data_class.tier for data_class in extract_data_classes(type(payload)))
-        ).value,
+        "sensitivity": classify(type(payload)).sensitivity,
         "plan": reviewed_plan,
     }
     channel: Literal["tabular", "pdf", "ofx"] = (
@@ -1268,7 +1249,7 @@ def import_preview_coarse(
         ]
     return cast(
         ResponseEnvelope[ImportPreviewCoarsePayload],
-        _import_dynamic_envelope(final_payload, actions=actions),
+        build_classified_envelope(final_payload, actions=actions),
     )
 
 
@@ -1597,28 +1578,14 @@ def _import_status_envelope(
     actions: list[str],
 ) -> ResponseEnvelope[ImportStatusCoarsePayload]:
     """Build and redact a dynamically classified import-status envelope."""
-    classes = {
-        data_class
-        for contract_type in contract_types
-        for data_class in extract_data_classes(contract_type)
-    }
-    tier = max(data_class.tier for data_class in classes)
-    redacted = cast(ImportStatusCoarsePayload, redact_typed(data, None))
-    envelope = cast(
-        ResponseEnvelope[ImportStatusCoarsePayload],
-        build_envelope(
-            data=redacted,
-            sensitivity=cast(Any, tier_to_sensitivity(tier).value),
-            total_count=total_count,
-            returned_count=returned_count,
-            next_cursor=next_cursor,
-            actions=actions,
-            classes_returned=sorted(data_class.value for data_class in classes),
-        ),
-    )
-    return replace(
-        envelope,
-        summary=replace(envelope.summary, has_more=next_cursor is not None),
+    return build_classified_envelope(
+        data,
+        contract_type=contract_types,
+        total_count=total_count,
+        returned_count=returned_count,
+        next_cursor=next_cursor,
+        actions=actions,
+        has_more=next_cursor is not None,
     )
 
 
@@ -2106,7 +2073,7 @@ def _run_import_confirm_attempt(
                 observations.flush("rollback")
                 return cast(
                     ResponseEnvelope[ImportConfirmCoarsePayload],
-                    _import_dynamic_envelope(
+                    build_classified_envelope(
                         ImportPdfBridgeInvalidPayload(
                             kind="pdf_bridge_invalid",
                             preview_id=preview_id,
@@ -2371,7 +2338,7 @@ async def import_confirm_coarse(
                     wire.pop(sign_key, None)
                 return cast(
                     ResponseEnvelope[ImportConfirmCoarsePayload],
-                    _import_dynamic_envelope(
+                    build_classified_envelope(
                         ImportConfirmRequiredPayload(
                             preview_id=preview_id,
                             **cast(Any, wire),
@@ -2484,7 +2451,7 @@ async def import_confirm_coarse(
         )
     return cast(
         ResponseEnvelope[ImportConfirmCoarsePayload],
-        _import_dynamic_envelope(
+        build_classified_envelope(
             payload,
             actions=actions,
         ),

--- a/src/moneybin/mcp/tools/investments.py
+++ b/src/moneybin/mcp/tools/investments.py
@@ -32,7 +32,7 @@ surface-budget tests.
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from datetime import date as _date
 from decimal import Decimal
 from typing import Annotated, Any, Literal, cast
@@ -51,9 +51,9 @@ from moneybin.mcp.confirmation import (
     grant_confirmation_or_raise,
 )
 from moneybin.mcp.decorator import mcp_tool
-from moneybin.mcp.privacy import Sensitivity, tier_to_sensitivity
+from moneybin.mcp.privacy import Sensitivity
 from moneybin.price_sources import FEED_KEY_REF_KINDS
-from moneybin.privacy.introspection import extract_data_classes
+from moneybin.privacy.classified_envelope import build_classified_envelope
 from moneybin.privacy.payloads.investments import (
     InvestmentEventsPayload,
     InvestmentGainsPayload,
@@ -74,7 +74,6 @@ from moneybin.privacy.payloads.investments import (
     SecurityLinksPendingPayload,
     SecurityLinksSetPayload,
 )
-from moneybin.privacy.redaction import redact_typed
 from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
 from moneybin.protocol.pagination import (
     KeysetPosition,
@@ -1297,26 +1296,14 @@ def _investment_coarse_envelope(
     actions: list[str],
 ) -> ResponseEnvelope[InvestmentsCoarsePayload]:
     """Build a runtime-classified investment envelope."""
-    contract_type = type(data)
-    classes = extract_data_classes(contract_type)
-    tier = max(data_class.tier for data_class in classes)
-    redacted = cast(InvestmentsCoarsePayload, redact_typed(data, None))
-    envelope = cast(
-        ResponseEnvelope[InvestmentsCoarsePayload],
-        build_envelope(
-            data=redacted,
-            sensitivity=cast(Any, tier_to_sensitivity(tier).value),
-            total_count=total_count,
-            returned_count=len(data.rows),
-            next_cursor=next_cursor,
-            period=period,
-            actions=actions,
-            classes_returned=sorted(data_class.value for data_class in classes),
-        ),
-    )
-    return replace(
-        envelope,
-        summary=replace(envelope.summary, has_more=next_cursor is not None),
+    return build_classified_envelope(
+        data,
+        total_count=total_count,
+        returned_count=len(data.rows),
+        next_cursor=next_cursor,
+        period=period,
+        actions=actions,
+        has_more=next_cursor is not None,
     )
 
 

--- a/src/moneybin/mcp/tools/privacy.py
+++ b/src/moneybin/mcp/tools/privacy.py
@@ -13,8 +13,7 @@ deferred — these tools record and report consent only.
 from __future__ import annotations
 
 import asyncio
-from dataclasses import replace
-from typing import Annotated, Any, Literal, cast
+from typing import Annotated, Literal, cast
 
 from fastmcp import FastMCP
 from pydantic import Field, JsonValue
@@ -30,9 +29,9 @@ from moneybin.mcp.confirmation import (
     grant_confirmation_or_raise,
 )
 from moneybin.mcp.decorator import mcp_tool
-from moneybin.mcp.privacy import Sensitivity, tier_to_sensitivity
+from moneybin.mcp.privacy import Sensitivity
+from moneybin.privacy.classified_envelope import build_classified_envelope
 from moneybin.privacy.consent import ConsentMode
-from moneybin.privacy.introspection import extract_data_classes
 from moneybin.privacy.log import (
     MAX_LOG_ROWS,
     read_privacy_events,
@@ -49,7 +48,6 @@ from moneybin.privacy.payloads.consent import (
     PrivacyStatusPayload,
     PrivacyStatusView,
 )
-from moneybin.privacy.redaction import redact_typed
 from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
 from moneybin.protocol.pagination import (
     KeysetPosition,
@@ -228,25 +226,13 @@ def _privacy_coarse_envelope(
     actions: list[str] | None = None,
 ) -> ResponseEnvelope[PrivacyCoarsePayload]:
     """Build and redact one dynamically classified privacy view."""
-    contract_type = type(data)
-    classes = extract_data_classes(contract_type)
-    tier = max(data_class.tier for data_class in classes)
-    redacted = cast(PrivacyStatusView | PrivacyLogView, redact_typed(data, None))
-    envelope = cast(
-        ResponseEnvelope[PrivacyCoarsePayload],
-        build_envelope(
-            data=redacted,
-            sensitivity=cast(Any, tier_to_sensitivity(tier).value),
-            total_count=total_count,
-            returned_count=returned_count,
-            next_cursor=next_cursor,
-            actions=actions,
-            classes_returned=sorted(data_class.value for data_class in classes),
-        ),
-    )
-    return replace(
-        envelope,
-        summary=replace(envelope.summary, has_more=next_cursor is not None),
+    return build_classified_envelope(
+        data,
+        total_count=total_count,
+        returned_count=returned_count,
+        next_cursor=next_cursor,
+        actions=actions,
+        has_more=next_cursor is not None,
     )
 
 

--- a/src/moneybin/mcp/tools/reviews.py
+++ b/src/moneybin/mcp/tools/reviews.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from decimal import Decimal
 from typing import Annotated, Any, Literal, cast
 
@@ -26,7 +26,7 @@ from moneybin.mcp.confirmation import (
     grant_confirmation_or_raise,
 )
 from moneybin.mcp.decorator import mcp_tool
-from moneybin.mcp.privacy import Sensitivity, tier_to_sensitivity
+from moneybin.mcp.privacy import Sensitivity
 from moneybin.mcp.rematch_report import rematch_actions
 from moneybin.mcp.write_contracts import (
     AutoRuleDecisionRequest,
@@ -34,7 +34,7 @@ from moneybin.mcp.write_contracts import (
     OrdinaryReviewDecisionRequest,
     ReviewDecisionRequest,
 )
-from moneybin.privacy.introspection import extract_data_classes
+from moneybin.privacy.classified_envelope import build_classified_envelope
 from moneybin.privacy.payloads.accounts import LinkHistoryRow, LinkPendingGroup
 from moneybin.privacy.payloads.categorize import (
     AutoAcceptPayload,
@@ -86,7 +86,6 @@ from moneybin.privacy.payloads.reviews import (
     SecurityLinkReviewRow,
 )
 from moneybin.privacy.payloads.transactions import MatchHistoryRow, MatchPendingRow
-from moneybin.privacy.redaction import redact_typed
 from moneybin.privacy.taxonomy import Tier
 from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
 from moneybin.protocol.pagination import (
@@ -204,29 +203,16 @@ def _review_envelope[T](
     degraded_reason: str | None = None,
 ) -> ResponseEnvelope[T]:
     """Build and redact a dynamically classified review envelope."""
-    classes = extract_data_classes(contract_type)
-    tier = max(data_class.tier for data_class in classes)
-    redacted = cast(T, redact_typed(data, None))
-    envelope = cast(
-        ResponseEnvelope[T],
-        build_envelope(
-            data=redacted,
-            sensitivity=cast(Any, tier_to_sensitivity(tier).value),
-            total_count=total_count,
-            returned_count=returned_count,
-            next_cursor=next_cursor,
-            actions=actions,
-            classes_returned=sorted(data_class.value for data_class in classes),
-        ),
-    )
-    return replace(
-        envelope,
-        summary=replace(
-            envelope.summary,
-            has_more=next_cursor is not None,
-            degraded=degraded,
-            degraded_reason=degraded_reason,
-        ),
+    return build_classified_envelope(
+        data,
+        contract_type=contract_type,
+        total_count=total_count,
+        returned_count=returned_count,
+        next_cursor=next_cursor,
+        actions=actions,
+        degraded=degraded,
+        degraded_reason=degraded_reason,
+        has_more=next_cursor is not None,
     )
 
 

--- a/src/moneybin/mcp/tools/sync.py
+++ b/src/moneybin/mcp/tools/sync.py
@@ -31,9 +31,9 @@ from moneybin.mcp.confirmation import (
     grant_confirmation_or_raise,
 )
 from moneybin.mcp.decorator import mcp_tool
-from moneybin.mcp.privacy import Sensitivity, tier_to_sensitivity
+from moneybin.mcp.privacy import Sensitivity
 from moneybin.mcp.rematch_report import retired_transfers_action
-from moneybin.privacy.introspection import extract_data_classes
+from moneybin.privacy.classified_envelope import build_classified_envelope
 from moneybin.privacy.payloads.sync import (
     SyncAuthView,
     SyncConnectionRow,
@@ -51,7 +51,6 @@ from moneybin.privacy.payloads.sync import (
     SyncStatusCoarsePayload,
     SyncStatusPayload,
 )
-from moneybin.privacy.redaction import redact_typed
 from moneybin.protocol.envelope import (
     ResponseEnvelope,
     build_envelope,
@@ -392,17 +391,7 @@ def sync_status_coarse(
             expiration=response.data.expiration,
         )
         actions = list(response.actions)
-    classes = extract_data_classes(type(data))
-    tier = max(data_class.tier for data_class in classes)
-    return cast(
-        ResponseEnvelope[SyncStatusCoarsePayload],
-        build_envelope(
-            data=redact_typed(data, None),
-            sensitivity=cast(Any, tier_to_sensitivity(tier).value),
-            actions=actions,
-            classes_returned=sorted(data_class.value for data_class in classes),
-        ),
-    )
+    return build_classified_envelope(data, actions=actions)
 
 
 @mcp_tool(read_only=False, idempotent=False, open_world=True)

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -27,8 +27,8 @@ from moneybin.errors import (
 )
 from moneybin.mcp._registration import register
 from moneybin.mcp.decorator import mcp_tool
-from moneybin.mcp.privacy import Sensitivity, tier_to_sensitivity
-from moneybin.privacy.introspection import extract_data_classes
+from moneybin.mcp.privacy import Sensitivity
+from moneybin.privacy.classified_envelope import build_classified_envelope
 from moneybin.privacy.payloads.system import (
     AuditDetail,
     AuditEvents,
@@ -67,7 +67,6 @@ from moneybin.privacy.payloads.system import (
     SystemStatusTransformsInfo,
     SystemStatusWriter,
 )
-from moneybin.privacy.redaction import redact_typed
 from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
 from moneybin.protocol.pagination import (
     KeysetPosition,
@@ -808,26 +807,15 @@ def _dynamic_coarse_envelope[T](
     degraded_reason: str | None = None,
 ) -> ResponseEnvelope[T]:
     """Build a runtime-classified coarse envelope from its selected variants."""
-    classes = {
-        data_class
-        for contract_type in contract_types
-        for data_class in extract_data_classes(contract_type)
-    }
-    tier = max(data_class.tier for data_class in classes)
-    redacted = cast(T, redact_typed(data, None))
-    return cast(
-        ResponseEnvelope[T],
-        build_envelope(
-            data=redacted,
-            sensitivity=cast(Any, tier_to_sensitivity(tier).value),
-            total_count=total_count,
-            returned_count=returned_count,
-            next_cursor=next_cursor,
-            actions=actions,
-            degraded=degraded,
-            degraded_reason=degraded_reason,
-            classes_returned=sorted(data_class.value for data_class in classes),
-        ),
+    return build_classified_envelope(
+        data,
+        contract_type=contract_types,
+        total_count=total_count,
+        returned_count=returned_count,
+        next_cursor=next_cursor,
+        actions=actions,
+        degraded=degraded,
+        degraded_reason=degraded_reason,
     )
 
 

--- a/src/moneybin/mcp/tools/taxonomy.py
+++ b/src/moneybin/mcp/tools/taxonomy.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from dataclasses import replace
 from typing import Annotated, Any, Literal, cast
 
 from fastmcp import FastMCP
@@ -21,12 +20,12 @@ from moneybin.mcp.confirmation import (
     grant_confirmation_or_raise,
 )
 from moneybin.mcp.decorator import mcp_tool
-from moneybin.mcp.privacy import Sensitivity, tier_to_sensitivity
+from moneybin.mcp.privacy import Sensitivity
 from moneybin.mcp.write_contracts import (
     CategoryStateRequest,
     TaxonomyStateRequest,
 )
-from moneybin.privacy.introspection import extract_data_classes
+from moneybin.privacy.classified_envelope import build_classified_envelope
 from moneybin.privacy.payloads.categories import CategoryRow, MerchantRow
 from moneybin.privacy.payloads.taxonomy import (
     TaxonomyCategoriesView,
@@ -35,7 +34,6 @@ from moneybin.privacy.payloads.taxonomy import (
     TaxonomySetPayload,
     TaxonomyStateResult,
 )
-from moneybin.privacy.redaction import redact_typed
 from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
 from moneybin.protocol.pagination import (
     KeysetPosition,
@@ -107,24 +105,14 @@ def _taxonomy_envelope[T](
     actions: list[str],
 ) -> ResponseEnvelope[T]:
     """Build one dynamically classified taxonomy envelope."""
-    classes = extract_data_classes(contract_type)
-    tier = max(data_class.tier for data_class in classes)
-    redacted = cast(T, redact_typed(data, None))
-    envelope = cast(
-        ResponseEnvelope[T],
-        build_envelope(
-            data=redacted,
-            sensitivity=cast(Any, tier_to_sensitivity(tier).value),
-            total_count=total_count,
-            returned_count=returned_count,
-            next_cursor=next_cursor,
-            actions=actions,
-            classes_returned=sorted(data_class.value for data_class in classes),
-        ),
-    )
-    return replace(
-        envelope,
-        summary=replace(envelope.summary, has_more=next_cursor is not None),
+    return build_classified_envelope(
+        data,
+        contract_type=contract_type,
+        total_count=total_count,
+        returned_count=returned_count,
+        next_cursor=next_cursor,
+        actions=actions,
+        has_more=next_cursor is not None,
     )
 
 

--- a/src/moneybin/privacy/classified_envelope.py
+++ b/src/moneybin/privacy/classified_envelope.py
@@ -1,0 +1,174 @@
+"""One builder for every runtime-classified response envelope.
+
+A tool that classifies its response per call (``dynamic_classification=True``)
+owes four steps before the payload crosses a surface: read the declared data
+classes off the contract type, take the max tier across them, redact the
+payload, and report the classes for the privacy audit row. Every one of those
+steps is security-relevant, and each hand-rolled copy is somewhere the four can
+drift apart — a tier taken from the wrong type under-declares the response, a
+forgotten ``redact_typed`` ships an unmasked account identifier, and a dropped
+class leaves the audit trail claiming less than was returned.
+
+``build_classified_envelope`` performs all four, so a classification-contract
+change is one edit instead of sixteen. ``mcp.md``'s "tools contain no privacy
+enforcement" is what this makes true.
+
+Redaction deliberately walks ``type(data)`` rather than ``contract_type``:
+``contract_type`` names what the *surface* may return (often a union spanning
+tiers), while the transform must walk the annotations of the object actually in
+hand. Classification uses the wider contract on purpose — an agent reads
+``summary.sensitivity`` before it sees the payload, so the declaration has to
+cover every arm the tool could have returned.
+
+Lives under ``moneybin.privacy`` rather than ``moneybin.mcp``: both surfaces
+use it, and ``moneybin.mcp.privacy`` already imports from here, so the reverse
+edge would be a cycle.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Any, Literal, cast
+
+from moneybin.privacy.introspection import PrivacyContractError, extract_data_classes
+from moneybin.privacy.redaction import redact_typed
+from moneybin.privacy.taxonomy import DataClass, Tier
+from moneybin.protocol.envelope import UNSET, ResponseEnvelope, Unset, build_envelope
+
+type SensitivityLiteral = Literal["low", "medium", "high", "critical"]
+
+
+def tier_sensitivity(tier: Tier) -> SensitivityLiteral:
+    """Return the envelope's ``sensitivity`` string for ``tier``.
+
+    Spelled here rather than through ``mcp.privacy.tier_to_sensitivity`` to
+    keep ``moneybin.privacy`` free of an import edge back into
+    ``moneybin.mcp``. A test pins the two spellings together.
+    """
+    return cast(SensitivityLiteral, tier.name.lower())
+
+
+@dataclass(frozen=True, slots=True)
+class Classification:
+    """The data classes one or more contract types declare, and their tier."""
+
+    classes: frozenset[DataClass]
+    contract_types: tuple[Any, ...] = ()
+
+    @property
+    def classes_returned(self) -> list[str]:
+        """Sorted class values for the envelope and the privacy audit row.
+
+        Never raises. Reporting "declares no classes" is honest for a payload
+        that declares none — an audit row saying ``[]`` is more useful than no
+        row. ``tier`` is where an unclassified payload fails, because that is
+        the value a caller would otherwise act on.
+        """
+        return sorted(data_class.value for data_class in self.classes)
+
+    @property
+    def tier(self) -> Tier:
+        """Return the max tier across the classes. Fails closed when empty."""
+        if not self.classes:
+            named = (
+                ", ".join(getattr(t, "__name__", repr(t)) for t in self.contract_types)
+                or "the given contract"
+            )
+            raise PrivacyContractError(
+                f"{named} has no Annotated[T, DataClass] metadata; every "
+                "surface-crossing return type must classify every field."
+            )
+        return max(data_class.tier for data_class in self.classes)
+
+    @property
+    def sensitivity(self) -> SensitivityLiteral:
+        """Return the envelope ``sensitivity`` string for the derived tier."""
+        return tier_sensitivity(self.tier)
+
+
+def classify(*contract_types: Any) -> Classification:
+    """Return the union of every data class ``contract_types`` declare.
+
+    Several types union rather than compete: a coarse tool that can return
+    any of three views declares the classes of all three, because the
+    declaration is what an agent trusts before the payload arrives.
+    """
+    classes = frozenset[DataClass]().union(
+        *(extract_data_classes(contract_type) for contract_type in contract_types)
+    )
+    return Classification(classes=classes, contract_types=tuple(contract_types))
+
+
+def _declared_types(
+    data: Any, contract_type: Any | Sequence[Any] | None
+) -> tuple[Any, ...]:
+    """Normalize the caller's declared contract into the tuple ``classify`` takes."""
+    if contract_type is None:
+        return (type(data),)
+    if isinstance(contract_type, Sequence) and not isinstance(contract_type, str):
+        return tuple(cast("Sequence[Any]", contract_type))
+    return (contract_type,)
+
+
+def build_classified_envelope[T](
+    data: T,
+    *,
+    contract_type: Any | Sequence[Any] | None = None,
+    total_count: int | None = None,
+    returned_count: int | None = None,
+    next_cursor: str | None = None,
+    period: str | None = None,
+    display_currency: str | None | Unset = UNSET,
+    actions: list[str] | None = None,
+    degraded: bool = False,
+    degraded_reason: str | None = None,
+    has_more: bool | None = None,
+) -> ResponseEnvelope[T]:
+    """Classify, redact, and wrap ``data`` in one envelope.
+
+    Args:
+        data: The payload. Redaction walks its runtime type.
+        contract_type: The type (or types) the surface declares it may return.
+            Defaults to ``type(data)``. Pass a sequence when one tool serves
+            several view payloads — the classes union across all of them.
+        total_count: Total matching records, when wider than this page.
+        returned_count: Rows in this page; defaults to the payload's own shape.
+        next_cursor: Opaque pagination token.
+        period: Human-readable period covered.
+        display_currency: Currency for the amounts, when the payload cannot say.
+        actions: Contextual next-step hints.
+        degraded: Whether the response is less than the caller asked for.
+        degraded_reason: Which degradation applies.
+        has_more: Overrides the count-derived ``summary.has_more``. Paginated
+            surfaces pass ``next_cursor is not None`` to say "this is the last
+            page" even where ``total_count`` exceeds what was returned.
+
+    Returns:
+        A redacted envelope whose ``summary.sensitivity`` and
+        ``classes_returned`` both come from ``contract_type``.
+
+    Raises:
+        PrivacyContractError: ``contract_type`` declares no data classes. No
+            envelope is better than one claiming ``low`` for an unknown payload.
+    """
+    classification = classify(*_declared_types(data, contract_type))
+    envelope = cast(
+        ResponseEnvelope[T],
+        build_envelope(
+            data=redact_typed(data, None),
+            sensitivity=classification.sensitivity,
+            total_count=total_count,
+            returned_count=returned_count,
+            next_cursor=next_cursor,
+            period=period,
+            display_currency=display_currency,
+            actions=actions,
+            degraded=degraded,
+            degraded_reason=degraded_reason,
+            classes_returned=classification.classes_returned,
+        ),
+    )
+    if has_more is None:
+        return envelope
+    return replace(envelope, summary=replace(envelope.summary, has_more=has_more))

--- a/src/moneybin/privacy/classified_envelope.py
+++ b/src/moneybin/privacy/classified_envelope.py
@@ -20,6 +20,14 @@ hand. Classification uses the wider contract on purpose — an agent reads
 ``summary.sensitivity`` before it sees the payload, so the declaration has to
 cover every arm the tool could have returned.
 
+``actions[]`` is the one field the builder does not redact: the caller composes
+it and the builder passes it through untouched. A caller that reads a field's
+*value* out of ``data`` to compose a hint is therefore reading it pre-redaction,
+which is safe only where that field's class is ``MaskStrength.PASSTHROUGH`` --
+anything else reaches the wire unmasked. Pin that assumption with a test derived
+from the transform table rather than a comment, the way the gsheet drift hint
+does; a comment does not fail when someone changes the class.
+
 Lives under ``moneybin.privacy`` rather than ``moneybin.mcp``: both surfaces
 use it, and ``moneybin.mcp.privacy`` already imports from here, so the reverse
 edge would be a cycle.

--- a/tests/moneybin/test_architecture/test_classified_envelope_is_the_only_pipeline.py
+++ b/tests/moneybin/test_architecture/test_classified_envelope_is_the_only_pipeline.py
@@ -1,0 +1,112 @@
+"""One builder owns the classify → redact → declare pipeline.
+
+`mcp.md` promises "tools contain no privacy enforcement", and
+`build_classified_envelope` is what makes that true. A second hand-rolled copy
+beside it is how the four steps drift apart on a security-relevant path, so
+this guard fails the moment one reappears — the behavioural partner to the
+parity tests in `tests/moneybin/test_privacy/test_classified_envelope.py`,
+which prove the builder does the same thing the copies did.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCANNED_ROOTS = (
+    REPO_ROOT / "src" / "moneybin" / "mcp",
+    REPO_ROOT / "src" / "moneybin" / "cli",
+)
+
+# The three primitives the builder composes. A surface module calling one
+# directly is re-rolling a step the builder already owns.
+GUARDED_CALLS = frozenset({
+    "extract_data_classes",
+    "derive_tier",
+    "redact_typed",
+})
+
+# Each exemption is a call the builder cannot absorb, with the reason it stays.
+EXEMPT: dict[tuple[str, str], str] = {
+    ("mcp/decorator.py", "derive_tier"): (
+        "The decorator folds a `discloses=` floor into the tier before mapping "
+        "it to a Sensitivity enum, so it needs the Tier itself, not the "
+        "envelope's sensitivity string."
+    ),
+    ("mcp/decorator.py", "redact_typed"): (
+        "Statically classified tools redact in the decorator, after the tool "
+        "body has already built its envelope — there is no builder call to "
+        "route through."
+    ),
+    ("cli/output.py", "redact_typed"): (
+        "`render_or_json` redacts an envelope a CLI command already built. "
+        "MB-45 routes CLI JSON output through this path; until then the "
+        "redaction has to happen on the finished envelope."
+    ),
+    ("cli/commands/import_inbox.py", "redact_typed"): (
+        "Masks one pending entry through its declared type before it becomes "
+        "part of a bare-dict payload; there is no typed envelope to build."
+    ),
+    ("cli/commands/import_cmd.py", "redact_typed"): (
+        "Masks a nested `confirmation_payload` inside a bare dict, and an "
+        "account proposal rendered to the terminal. Neither value rides a "
+        "typed envelope, so neither reaches the envelope's redaction walk."
+    ),
+    ("mcp/tools/import_tools.py", "redact_typed"): (
+        "Redacts the preview payload for the durable `import_previews` row, "
+        "which is persisted rather than returned; the tool's own envelope "
+        "goes through the builder."
+    ),
+}
+
+
+def _surface_modules() -> list[Path]:
+    return sorted(path for root in SCANNED_ROOTS for path in root.rglob("*.py"))
+
+
+def _guarded_calls(path: Path) -> set[str]:
+    """Return the guarded primitives ``path`` calls directly."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = (
+            func.id
+            if isinstance(func, ast.Name)
+            else func.attr
+            if isinstance(func, ast.Attribute)
+            else None
+        )
+        if name in GUARDED_CALLS:
+            found.add(name)
+    return found
+
+
+def test_surfaces_do_not_re_roll_the_classification_pipeline() -> None:
+    unexpected: list[str] = []
+    for path in _surface_modules():
+        relative = path.relative_to(REPO_ROOT / "src" / "moneybin").as_posix()
+        for call in sorted(_guarded_calls(path)):
+            if (relative, call) not in EXEMPT:
+                unexpected.append(f"{relative} calls {call}()")
+    assert not unexpected, (
+        "These surface modules call a privacy primitive directly instead of "
+        "build_classified_envelope() / classify(). Route them through the "
+        "builder, or add an EXEMPT entry stating why it cannot absorb the "
+        f"call: {unexpected}"
+    )
+
+
+@pytest.mark.parametrize(("module", "call"), sorted(EXEMPT))
+def test_every_exemption_still_describes_a_real_call(module: str, call: str) -> None:
+    """A stale exemption is a hole that reopens silently when code moves."""
+    path = REPO_ROOT / "src" / "moneybin" / module
+    assert path.exists(), f"EXEMPT names a module that no longer exists: {module}"
+    assert call in _guarded_calls(path), (
+        f"EXEMPT claims {module} calls {call}(), but it no longer does. Drop the entry."
+    )

--- a/tests/moneybin/test_cli/test_handle_cli_errors.py
+++ b/tests/moneybin/test_cli/test_handle_cli_errors.py
@@ -147,6 +147,20 @@ def test_error_audit_classification_defaults_high_without_payload_type() -> None
     assert classes == []
 
 
+def test_error_audit_classification_falls_back_high_for_an_unclassified_type() -> None:
+    """A payload declaring no classes must not audit as 'low'.
+
+    The classification primitive fails closed on an empty class set, and the
+    error path has to absorb that rather than raise out of the handler it is
+    reporting — a JSON-mode failure must still produce an audit row.
+    """
+    from moneybin.cli.utils import (
+        _error_audit_classification,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    assert _error_audit_classification(dict) == ("high", [])
+
+
 def test_error_audit_classification_derives_critical_from_payload() -> None:
     """A CRITICAL payload type derives 'critical' + its data classes."""
     from moneybin.cli.utils import (

--- a/tests/moneybin/test_mcp/test_gsheet.py
+++ b/tests/moneybin/test_mcp/test_gsheet.py
@@ -1171,3 +1171,31 @@ async def test_the_purge_confirmation_quotes_every_row_it_deletes() -> None:
 
     assert confirm.await_args is not None
     assert "all 4 raw rows" in confirm.await_args.kwargs["message"]
+
+
+def test_connection_drift_hint_reads_only_passthrough_classes() -> None:
+    """`_gsheet_coarse_envelope` reads its hint fields before redaction.
+
+    The builder redacts `data`, but `actions[]` sits outside that walk and
+    still reaches the wire, so the drift hint may only quote fields whose class
+    the redaction transform leaves alone. Measured from `_TRANSFORMS` rather
+    than restated, so giving `RECORD_ID` or `TXN_TYPE` a real transform fails
+    here instead of shipping a raw `connection_id` inside an action string.
+    """
+    from typing import get_args, get_type_hints
+
+    from moneybin.privacy.payloads.gsheet import GsheetConnectionRow
+    from moneybin.privacy.redaction import MaskStrength, mask_strength
+    from moneybin.privacy.taxonomy import DataClass
+
+    hints = get_type_hints(GsheetConnectionRow, include_extras=True)
+    quoted = {
+        data_class
+        for field_name in ("connection_id", "status")
+        for data_class in get_args(hints[field_name])[1:]
+        if isinstance(data_class, DataClass)
+    }
+
+    assert quoted == {DataClass.RECORD_ID, DataClass.TXN_TYPE}
+    for data_class in quoted:
+        assert mask_strength(data_class) is MaskStrength.PASSTHROUGH

--- a/tests/moneybin/test_privacy/test_classified_envelope.py
+++ b/tests/moneybin/test_privacy/test_classified_envelope.py
@@ -1,0 +1,300 @@
+"""The shared classified-envelope builder and its classification primitive.
+
+These tests pin the privacy properties the builder replaces at every call
+site: the tier it declares, the data classes it reports, and the redaction
+it applies. A builder that under-declares a tier, drops a class, or skips a
+transform relative to the inline pipeline it supersedes is a regression on a
+security-relevant path, so the parity tests below reproduce that pipeline
+verbatim and assert equality.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Annotated, Any
+
+import pytest
+
+from moneybin.mcp.privacy import tier_to_sensitivity
+from moneybin.privacy.classified_envelope import (
+    build_classified_envelope,
+    classify,
+    tier_sensitivity,
+)
+from moneybin.privacy.introspection import (
+    PrivacyContractError,
+    extract_data_classes,
+)
+from moneybin.privacy.redaction import redact_typed
+from moneybin.privacy.taxonomy import DataClass, Tier
+from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
+
+
+@dataclass(frozen=True)
+class _AccountRow:
+    """CRITICAL payload — carries an account identifier that must be masked."""
+
+    account_id: Annotated[str, DataClass.ACCOUNT_IDENTIFIER]
+    institution: Annotated[str, DataClass.INSTITUTION]
+
+
+@dataclass(frozen=True)
+class _AccountView:
+    rows: list[_AccountRow]
+    total: Annotated[int, DataClass.AGGREGATE]
+
+
+@dataclass(frozen=True)
+class _CategoryView:
+    """LOW payload — nothing here has an active redaction transform."""
+
+    category: Annotated[str, DataClass.CATEGORY]
+    total: Annotated[int, DataClass.AGGREGATE]
+
+
+@dataclass(frozen=True)
+class _MerchantView:
+    """MEDIUM payload."""
+
+    merchant: Annotated[str, DataClass.MERCHANT_NAME]
+
+
+class _Unclassified:
+    """Intentionally lacks Annotated metadata — a contract violation."""
+
+    x: str
+
+
+def _legacy_envelope(
+    data: Any,
+    contract_types: list[type[Any]],
+    **kwargs: Any,
+) -> ResponseEnvelope[Any]:
+    """The inline pipeline the builder replaces, reproduced verbatim.
+
+    Copied from the call sites this change deletes (``_review_envelope``,
+    ``_account_read_envelope``, ``_coarse_envelope``, …) so the parity tests
+    compare against what actually shipped, not against a paraphrase.
+    """
+    classes = {
+        data_class
+        for contract_type in contract_types
+        for data_class in extract_data_classes(contract_type)
+    }
+    tier = max(data_class.tier for data_class in classes)
+    return build_envelope(
+        data=redact_typed(data, None),
+        sensitivity=tier_to_sensitivity(tier).value,  # pyright: ignore[reportArgumentType]
+        classes_returned=sorted(data_class.value for data_class in classes),
+        **kwargs,
+    )
+
+
+# --- classify() -----------------------------------------------------------
+
+
+def test_classify_unions_classes_across_contract_types() -> None:
+    result = classify(_CategoryView, _MerchantView)
+
+    assert result.classes == frozenset({
+        DataClass.CATEGORY,
+        DataClass.AGGREGATE,
+        DataClass.MERCHANT_NAME,
+    })
+
+
+def test_classify_tier_is_the_max_across_the_union() -> None:
+    assert classify(_CategoryView, _AccountView).tier is Tier.CRITICAL
+
+
+def test_classify_defaults_to_the_single_contract_type() -> None:
+    assert classify(_CategoryView).tier is Tier.LOW
+
+
+def test_classes_returned_is_sorted_data_class_values() -> None:
+    assert classify(_AccountRow).classes_returned == [
+        "account_identifier",
+        "institution",
+    ]
+
+
+def test_sensitivity_agrees_with_the_mcp_tier_mapping() -> None:
+    """The builder derives the sensitivity string without importing mcp.
+
+    ``moneybin.privacy`` cannot import ``moneybin.mcp.privacy`` (that is the
+    dependency direction MB-49 removes), so the builder spells the mapping
+    itself. This pins the two spellings together.
+    """
+    for tier in Tier:
+        assert tier_sensitivity(tier) == tier_to_sensitivity(tier).value
+
+
+def test_classes_returned_is_empty_for_an_unclassified_type() -> None:
+    """Reporting no classes is honest; claiming a tier for them is not."""
+    assert classify(_Unclassified).classes_returned == []
+
+
+def test_tier_raises_for_an_unclassified_type() -> None:
+    with pytest.raises(PrivacyContractError):
+        _ = classify(_Unclassified).tier
+
+
+def test_sensitivity_raises_for_an_unclassified_type() -> None:
+    with pytest.raises(PrivacyContractError):
+        _ = classify(_Unclassified).sensitivity
+
+
+# --- build_classified_envelope(): privacy properties ----------------------
+
+
+def test_masks_a_critical_field_in_the_payload() -> None:
+    envelope = build_classified_envelope(
+        _AccountRow(account_id="123456789012", institution="Example Institution")
+    )
+
+    assert envelope.data.account_id == "****9012"
+
+
+def test_masks_critical_fields_nested_in_a_list() -> None:
+    view = _AccountView(
+        rows=[_AccountRow(account_id="987654321098", institution="X")], total=1
+    )
+
+    envelope = build_classified_envelope(view)
+
+    assert envelope.data.rows[0].account_id == "****1098"
+
+
+def test_declares_the_max_tier_as_summary_sensitivity() -> None:
+    envelope = build_classified_envelope(
+        _AccountRow(account_id="123456789012", institution="X")
+    )
+
+    assert envelope.summary.sensitivity == "critical"
+
+
+def test_reports_every_class_reachable_from_the_payload() -> None:
+    view = _AccountView(
+        rows=[_AccountRow(account_id="123456789012", institution="X")], total=1
+    )
+
+    envelope = build_classified_envelope(view)
+
+    assert envelope.classes_returned == [
+        "account_identifier",
+        "aggregate",
+        "institution",
+    ]
+
+
+def test_union_contract_declares_the_critical_arm_the_instance_omits() -> None:
+    """A coarse tool whose declared union spans tiers must report the max.
+
+    The runtime instance is the LOW arm; the contract still admits the
+    CRITICAL one, and the tool's declared sensitivity is what an agent
+    trusts before it sees the payload.
+    """
+    envelope = build_classified_envelope(
+        _CategoryView(category="groceries", total=3),
+        contract_type=[_CategoryView, _AccountView],
+    )
+
+    assert envelope.summary.sensitivity == "critical"
+    assert "account_identifier" in (envelope.classes_returned or [])
+
+
+def test_refuses_an_unclassified_payload_rather_than_shipping_it_untiered() -> None:
+    """Fail closed: no envelope at all beats an envelope claiming ``low``."""
+    with pytest.raises(PrivacyContractError):
+        build_classified_envelope(_Unclassified())
+
+
+# --- build_classified_envelope(): parity with the inline pipeline ---------
+
+
+def test_parity_with_the_inline_pipeline_for_a_single_contract_type() -> None:
+    data = _AccountView(
+        rows=[_AccountRow(account_id="123456789012", institution="X")], total=1
+    )
+
+    assert build_classified_envelope(data).to_dict() == (
+        _legacy_envelope(data, [type(data)]).to_dict()
+    )
+
+
+def test_parity_with_the_inline_pipeline_for_an_explicit_contract_type() -> None:
+    data = _CategoryView(category="groceries", total=3)
+
+    built = build_classified_envelope(data, contract_type=_CategoryView)
+
+    assert built.to_dict() == _legacy_envelope(data, [_CategoryView]).to_dict()
+    assert (
+        built.classes_returned
+        == _legacy_envelope(data, [_CategoryView]).classes_returned
+    )
+
+
+def test_parity_with_the_inline_pipeline_for_a_multi_type_union() -> None:
+    data = _CategoryView(category="groceries", total=3)
+    types = [_CategoryView, _MerchantView]
+
+    built = build_classified_envelope(data, contract_type=types)
+
+    assert built.to_dict() == _legacy_envelope(data, types).to_dict()
+    assert built.classes_returned == _legacy_envelope(data, types).classes_returned
+
+
+# --- build_classified_envelope(): metadata passthrough --------------------
+
+
+def test_forwards_count_and_pagination_metadata() -> None:
+    envelope = build_classified_envelope(
+        _CategoryView(category="groceries", total=3),
+        total_count=50,
+        returned_count=1,
+        next_cursor="opaque",
+        period="2026-01 to 2026-04",
+    )
+
+    assert envelope.summary.total_count == 50
+    assert envelope.summary.returned_count == 1
+    assert envelope.next_cursor == "opaque"
+    assert envelope.summary.period == "2026-01 to 2026-04"
+
+
+def test_forwards_degraded_actions_and_display_currency() -> None:
+    envelope = build_classified_envelope(
+        _CategoryView(category="groceries", total=3),
+        actions=["do the next thing"],
+        degraded=True,
+        degraded_reason="aggregates only",
+        display_currency="USD",
+    )
+
+    assert envelope.actions == ["do the next thing"]
+    assert envelope.summary.degraded is True
+    assert envelope.summary.degraded_reason == "aggregates only"
+    assert envelope.summary.display_currency == "USD"
+
+
+def test_has_more_override_forces_a_last_page_without_a_cursor() -> None:
+    """Paginated sites treat "no cursor" as "no more", not "total > returned"."""
+    envelope = build_classified_envelope(
+        _CategoryView(category="groceries", total=3),
+        total_count=50,
+        returned_count=1,
+        next_cursor=None,
+        has_more=False,
+    )
+
+    assert envelope.summary.has_more is False
+
+
+def test_omitting_has_more_keeps_the_count_derived_default() -> None:
+    envelope = build_classified_envelope(
+        _CategoryView(category="groceries", total=3),
+        total_count=50,
+        returned_count=1,
+    )
+
+    assert envelope.summary.has_more is True


### PR DESCRIPTION
## Summary

A tool that classifies its response per call (`dynamic_classification=True`) owes four steps before the payload crosses a surface: read the declared data classes off the contract type, take the max tier across them, redact the payload, and report the classes for the privacy audit row. All four were hand-rolled at sixteen call sites across nine MCP tool modules, and each copy is a place they can drift apart — a tier taken from the wrong type under-declares the response, a forgotten `redact_typed` ships an unmasked account identifier, and a dropped class leaves the audit row claiming less than was actually returned. Nothing failed when a copy diverged, because each copy is individually valid Python that returns a well-formed envelope.

This adds `moneybin.privacy.classified_envelope.build_classified_envelope`, which performs all four, and migrates every site onto it. A classification-contract change is now one edit instead of sixteen. `mcp.md`'s "tools contain no privacy enforcement" is what this makes true.

No behavior change. The parity tests below pin the builder against what each copy did.

## Background

Three calls here are worth stating explicitly, because each looks arbitrary from the diff alone.

**It lives under `moneybin.privacy`, not `moneybin.mcp`.** Both surfaces use it, and `moneybin.mcp.privacy` already imports from `moneybin.privacy`, so the reverse edge would be an import cycle. `tier_sensitivity` is therefore spelled out here rather than routed through `mcp.privacy.tier_to_sensitivity`; a test pins the two spellings together so they cannot diverge.

**Redaction walks `type(data)`, classification walks `contract_type`.** These are deliberately different. `contract_type` names what the *surface* may return — often a union spanning several tiers — while the transform has to walk the annotations of the object actually in hand. Classification uses the wider contract on purpose: an agent reads `summary.sensitivity` before it ever sees the payload, so the declaration must cover every arm the tool could have returned, not just the arm it did.

**An empty classification fails closed.** `Classification.tier` raises `PrivacyContractError` naming the offending type when a contract declares no `Annotated[T, DataClass]` metadata. No envelope is better than one claiming `low` for a payload nobody classified. `classes_returned` deliberately does *not* raise in that case — an audit row saying `[]` is more useful than no audit row, and `tier` is already where the failure belongs because it is the value a caller would act on.

The CLI sites take `classify()` rather than the full builder. They construct their envelope separately for reasons that predate this change, so what they needed was the classification half — the tier and the class list, derived once instead of from a `derive_log_sensitivity` call sitting beside a hand-rolled `extract_data_classes` comprehension. Routing those envelopes through the builder outright is MB-45's scope, not this one's.

**`mcp/tools/reports.py` is deliberately not migrated, and the issue asked for it.** MB-43 names three construction patterns including the hand-built envelope in `reports.py`, so this is a stated deviation rather than an oversight. That tool is `dynamic_classification=True`, but it does not classify from `Annotated[T, DataClass]` metadata — it classifies from the `@report` contract's own declared privacy classes, via `catalog_sensitivity` / `catalog_classes_returned` on the catalog branch and `result.tier` / `result.classes_returned` on the execute branch. It has to: a report's rows are arbitrary columns produced by SQL, so payload-type introspection cannot classify them, and `reports.md` already binds that surface to a declared-class mechanism with its own CI verification. Routing it through this builder would re-derive classification from a payload type that does not carry the answer, which is a downgrade, not a consolidation.

The honest consequence is that the guard's reach is narrower than "one builder owns every classified envelope". It catches a re-pasted *primitive*; it would not catch a new `dynamic_classification=True` tool that hand-builds an envelope and calls none of the three. Closing that would mean asserting over the decorator's registry rather than over source calls, which is a different guard and a larger change than this one. Flagged rather than smuggled in.

`has_more` is a wart, and an honest one. Paginated surfaces pass `next_cursor is not None` to say "this is the last page" even where `total_count` exceeds what was returned, which the count-derived default gets wrong. It is an override rather than a fix because correcting the derivation would change `has_more` on unpaginated surfaces too — out of scope here, and a public contract change.

## Changes

- **One primitive.** `src/moneybin/privacy/classified_envelope.py`: `build_classified_envelope()` for the full pipeline, plus `classify()` / `Classification` for callers that own their own envelope, and `tier_sensitivity()` for the tier→string mapping.
- **Sixteen sites migrated.** Nine MCP tool modules (`accounts`, `gsheet`, `import_tools`, `investments`, `privacy`, `reviews`, `sync`, `system`, `taxonomy`) now call the builder. `cli/output.py`, `cli/utils.py`, `cli/commands/import_cmd.py` and `cli/commands/import_inbox.py` take `classify()`. Net −191 lines of production source.
- **A guard that fails when a copy reappears.** `test_classified_envelope_is_the_only_pipeline.py` walks the AST of `src/moneybin/mcp` and `src/moneybin/cli` for direct calls to the three primitives the builder composes (`extract_data_classes`, `derive_tier`, `redact_typed`). Each surviving call is exempted by `(file, callee)` with the reason it cannot be absorbed — the decorator needs the `Tier` itself to fold in a `discloses=` floor, statically classified tools redact after the tool body has already built its envelope, and `render_or_json` redacts an envelope a CLI command already built.
- **`docs/specs/mcp-architecture.md`** records the builder as the pipeline's single home.

## Test plan

- `tests/moneybin/test_privacy/test_classified_envelope.py` (new, 300 lines) is the behavioural partner to the source-scan guard: a source scan proves no second copy exists, but only these prove the one copy does what the sixteen did. They cover the union-across-several-contract-types case, the fail-closed empty classification and its error text, `classes_returned` staying honest where `tier` raises, the `type(data)` vs `contract_type` split, and the `has_more` override.
- `tests/moneybin/test_architecture/test_classified_envelope_is_the_only_pipeline.py` (new) is the guard described above. It checks both directions: an unexempted call fails, and a parametrized case over the exemption map fails when an entry names a module that no longer exists or a call that module no longer makes. A stale exemption is how a guard quietly stops guarding, so it has to fail as loudly as a new unguarded call.
- `tests/moneybin/test_mcp/test_gsheet.py` and `tests/moneybin/test_cli/test_handle_cli_errors.py` gain cases for the two sites whose migration changed the most.
- One ordering question the diff raises and the tests settle: the old copies wrote `[c.value for c in sorted(extract_data_classes(...))]` (sort the members, then map) and the builder writes `sorted(c.value for c in ...)` (map, then sort). These agree because `DataClass` is a `StrEnum`, so member ordering *is* value ordering. If it were a plain `Enum` the sort would not even be defined.
- Gates run on this branch, rebased onto `7ad798db`: `make check` pass (ruff clean, pyright 0 errors / 3 pre-existing `reportlab` warnings); `make test` 10360 passed / 1 failed / 4 skipped; `make test-integration` 564 passed.
- The single `make test` failure is `test_google_oauth_authorizes_with_the_shipped_client_id_and_secret_pair`, which is environmental and unrelated to this diff: the machine running the gates has `MONEYBIN_GSHEET__OAUTH_CLIENT_ID` exported without the matching secret, so the connector correctly raises `GSheetAuthError` about a mismatched pair. It passes in CI.
- No MCP tool description, annotation, or title changed, so the surface snapshot needs no regeneration — confirmed by grepping the diff for those fields.

## Related

Refs MB-43, a sub-issue of MB-39 (the 2026-08-21 architecture consolidation review). MB-45 (route CLI JSON output through `render_or_json`) and MB-49 (relocate cross-surface privacy machinery out of `moneybin.mcp`) both build on this and are held until it lands.
