### PR TITLE
Move adapter-layer inline SQL into owning repos and services

### DIFF
--- a/src/moneybin/cli/commands/import_cmd.py
+++ b/src/moneybin/cli/commands/import_cmd.py
@@ -11,8 +11,7 @@ from __future__ import annotations
 import json
 import logging
 import sys
-from dataclasses import asdict, dataclass
-from datetime import date
+from dataclasses import asdict
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -3029,6 +3028,7 @@ def import_status(
     from moneybin.cli.utils import handle_cli_errors
     from moneybin.config import get_settings
     from moneybin.database import get_database  # noqa: PLC0415 — deferred import
+    from moneybin.services.import_service import ImportService  # noqa: PLC0415
 
     db_path = get_settings().database.path
 
@@ -3057,7 +3057,7 @@ def import_status(
     try:
         with handle_cli_errors():
             with get_database(read_only=True) as db:
-                rows = _collect_import_status(db)
+                rows = ImportService(db).raw_data_summary()
     except Exception as e:  # noqa: BLE001 — surface connection errors generically
         logger.error(f"❌ Could not open database: {e}")
         raise typer.Exit(1) from e
@@ -3094,58 +3094,3 @@ def import_status(
 
     if not quiet:
         typer.echo()
-
-
-@dataclass(frozen=True, slots=True)
-class _ImportStatusRow:
-    schema: str
-    table: str
-    rows: int
-    date_min: date | None
-    date_max: date | None
-
-
-def _collect_import_status(db: Database) -> list[_ImportStatusRow]:
-    """Query raw tables and return per-table row counts and date ranges."""
-    tables = db.execute("""
-        SELECT table_schema, table_name
-        FROM information_schema.tables
-        WHERE table_schema = 'raw'
-        ORDER BY table_name
-    """).fetchall()
-
-    from sqlglot import exp
-
-    results: list[_ImportStatusRow] = []
-    for schema, table in tables:
-        safe_schema = exp.to_identifier(schema, quoted=True).sql("duckdb")  # type: ignore[reportUnknownMemberType]  # sqlglot has no stubs
-        safe_table = exp.to_identifier(table, quoted=True).sql("duckdb")  # type: ignore[reportUnknownMemberType]  # sqlglot has no stubs
-        row_count = db.execute(
-            f"SELECT COUNT(*) FROM {safe_schema}.{safe_table}"  # noqa: S608 — sqlglot-quoted catalog identifiers
-        ).fetchone()
-        count = row_count[0] if row_count else 0
-
-        date_min: date | None = None
-        date_max: date | None = None
-        if "transaction" in table:
-            date_col = "date_posted" if "ofx" in table else "transaction_date"
-            safe_date_col = exp.to_identifier(date_col, quoted=True).sql("duckdb")  # type: ignore[reportUnknownMemberType]  # sqlglot has no stubs
-            try:
-                dates = db.execute(
-                    f"SELECT MIN(CAST({safe_date_col} AS DATE)), MAX(CAST({safe_date_col} AS DATE)) FROM {safe_schema}.{safe_table}"  # noqa: S608 — sqlglot-quoted catalog identifiers; date_col from hardcoded map
-                ).fetchone()
-                if dates and dates[0]:
-                    date_min, date_max = dates[0], dates[1]
-            except Exception:  # noqa: BLE001 — column may not exist in all tables
-                logger.debug(f"Could not get date range for {schema}.{table}")
-
-        results.append(
-            _ImportStatusRow(
-                schema=schema,
-                table=table,
-                rows=count,
-                date_min=date_min,
-                date_max=date_max,
-            )
-        )
-    return results

--- a/src/moneybin/cli/commands/transactions/splits.py
+++ b/src/moneybin/cli/commands/transactions/splits.py
@@ -153,14 +153,11 @@ def transactions_splits_remove(
             with get_database(read_only=False) as db:
                 svc = TransactionService(db)
                 # Look up parent before delete so we can report residual after.
-                parent = db.conn.execute(
-                    "SELECT transaction_id FROM app.transaction_splits WHERE split_id = ?",
-                    [split_id],
-                ).fetchone()
-                if parent is None:
+                existing = svc.get_split(split_id)
+                if existing is None:
                     typer.echo(f"❌ split_id={split_id} not found", err=True)
                     raise typer.Exit(1)
-                transaction_id = parent[0]
+                transaction_id = existing.transaction_id
                 svc.remove_split(split_id, actor="cli")
                 residual = svc.splits_balance(transaction_id)
     except LookupError as e:

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -78,6 +78,7 @@ from moneybin.protocol.pagination import (
     reject_inverted_keyset,
     validate_keyset_shape,
 )
+from moneybin.repositories.gsheet_connections_repo import GSheetConnectionsRepo
 from moneybin.utils.db_processes import describe_process, find_blocking_processes
 
 logger = logging.getLogger(__name__)
@@ -99,13 +100,7 @@ def _gsheet_block(db: Any) -> dict[str, Any]:
     healthy and disconnected connections are excluded from ``needs_attention``.
     """
     try:
-        rows = db.execute(
-            """
-            SELECT connection_id, workbook_name, sheet_name, status, last_status_reason
-            FROM app.gsheet_connections
-            ORDER BY created_at ASC, connection_id ASC
-            """
-        ).fetchall()
+        connections = GSheetConnectionsRepo(db).list_all()
     except duckdb.CatalogException:
         # Table absent on bare DBs before init_schemas — report empty rather
         # than error. Narrowed from a blanket except so real DB/query problems
@@ -115,20 +110,21 @@ def _gsheet_block(db: Any) -> dict[str, Any]:
 
     by_status: dict[str, int] = {}
     needs_attention: list[dict[str, Any]] = []
-    for connection_id, workbook, sheet, status, drift_reason in rows:
+    for connection in connections:
+        status = connection["status"]
         by_status[status] = by_status.get(status, 0) + 1
         if status in _HEALTHY_STATUSES or status in _DISCONNECTED_STATUSES:
             continue
         needs_attention.append({
-            "connection_id": connection_id,
-            "workbook_name": workbook,
-            "sheet_name": sheet,
+            "connection_id": connection["connection_id"],
+            "workbook_name": connection["workbook_name"],
+            "sheet_name": connection["sheet_name"],
             "status": status,
-            "reason": drift_reason,
+            "reason": connection["last_status_reason"],
         })
 
     return {
-        "total_connections": len(rows),
+        "total_connections": len(connections),
         "by_status": by_status,
         "needs_attention": needs_attention,
     }

--- a/src/moneybin/repositories/transaction_splits_repo.py
+++ b/src/moneybin/repositories/transaction_splits_repo.py
@@ -45,6 +45,10 @@ class TransactionSplitsRepo(BaseRepo):
             TRANSACTION_SPLITS, _SPLITS_COLUMNS, "split_id", split_id
         )
 
+    def get(self, split_id: str) -> dict[str, Any] | None:
+        """Return one split row by id, or None if not found."""
+        return self._fetch_row(split_id)
+
     def insert(
         self,
         *,

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -1951,6 +1951,17 @@ def _ofx_source_accounts(parsed_ofx: Any, source_origin: str) -> list[SourceAcco
     return accounts
 
 
+@dataclass(frozen=True, slots=True)
+class RawTableStat:
+    """One row of :meth:`ImportService.raw_data_summary` — per-table row count and date span."""
+
+    schema: str
+    table: str
+    rows: int
+    date_min: date | None
+    date_max: date | None
+
+
 class ImportService:
     """Orchestrates the full file import pipeline.
 
@@ -2008,6 +2019,56 @@ class ImportService:
             format_name=format_name,
             format_source="manual",
         )
+
+    def raw_data_summary(self) -> list[RawTableStat]:
+        """Return row counts and date ranges for every ``raw.*`` table.
+
+        Backs ``moneybin import status``. Transaction tables (name containing
+        ``"transaction"``) additionally report a date range, read from
+        ``date_posted`` for OFX tables and ``transaction_date`` otherwise.
+        """
+        from sqlglot import exp  # noqa: PLC0415
+
+        tables = self._db.execute("""
+            SELECT table_schema, table_name
+            FROM information_schema.tables
+            WHERE table_schema = 'raw'
+            ORDER BY table_name
+        """).fetchall()
+
+        results: list[RawTableStat] = []
+        for schema, table in tables:
+            safe_schema = exp.to_identifier(schema, quoted=True).sql("duckdb")  # type: ignore[reportUnknownMemberType]  # sqlglot has no stubs
+            safe_table = exp.to_identifier(table, quoted=True).sql("duckdb")  # type: ignore[reportUnknownMemberType]  # sqlglot has no stubs
+            row_count = self._db.execute(
+                f"SELECT COUNT(*) FROM {safe_schema}.{safe_table}"  # noqa: S608 — sqlglot-quoted catalog identifiers
+            ).fetchone()
+            count = row_count[0] if row_count else 0
+
+            date_min: date | None = None
+            date_max: date | None = None
+            if "transaction" in table:
+                date_col = "date_posted" if "ofx" in table else "transaction_date"
+                safe_date_col = exp.to_identifier(date_col, quoted=True).sql("duckdb")  # type: ignore[reportUnknownMemberType]  # sqlglot has no stubs
+                try:
+                    dates = self._db.execute(
+                        f"SELECT MIN(CAST({safe_date_col} AS DATE)), MAX(CAST({safe_date_col} AS DATE)) FROM {safe_schema}.{safe_table}"  # noqa: S608 — sqlglot-quoted catalog identifiers; date_col from hardcoded map
+                    ).fetchone()
+                    if dates and dates[0]:
+                        date_min, date_max = dates[0], dates[1]
+                except Exception:  # noqa: BLE001 — date range is best-effort; any DB failure returns empty range
+                    logger.debug(f"Could not get date range for {schema}.{table}")
+
+            results.append(
+                RawTableStat(
+                    schema=schema,
+                    table=table,
+                    rows=count,
+                    date_min=date_min,
+                    date_max=date_max,
+                )
+            )
+        return results
 
     def _query_date_range(
         self,

--- a/src/moneybin/services/transaction_service.py
+++ b/src/moneybin/services/transaction_service.py
@@ -1913,6 +1913,24 @@ class TransactionService:
         ).fetchall()
         return [_row_to_split(r) for r in rows]
 
+    def get_split(self, split_id: str) -> Split | None:
+        """Return one split by id, or None if not found."""
+        row = self._splits_repo.get(split_id)
+        if row is None:
+            return None
+        amount = row["amount"]
+        return Split(
+            split_id=row["split_id"],
+            transaction_id=row["transaction_id"],
+            amount=amount if isinstance(amount, Decimal) else Decimal(str(amount)),
+            category=row["category"],
+            subcategory=row["subcategory"],
+            note=row["note"],
+            ord=row["ord"],
+            created_at=str(row["created_at"]),
+            created_by=str(row["created_by"]),
+        )
+
     def splits_balance(self, transaction_id: str) -> Decimal:
         """Return signed residual ``parent.amount - SUM(children.amount)``.
 

--- a/tests/moneybin/test_cli/test_cli_transactions_splits.py
+++ b/tests/moneybin/test_cli/test_cli_transactions_splits.py
@@ -84,6 +84,14 @@ def test_splits_remove_with_yes(runner: CliRunner, db: Database) -> None:
     assert rows is not None and rows[0] == 0
 
 
+def test_splits_remove_missing_exits_1(runner: CliRunner, db: Database) -> None:
+    result = runner.invoke(
+        app, ["transactions", "splits", "remove", "doesnotexist", "--yes"]
+    )
+    assert result.exit_code == 1
+    assert "not found" in result.output
+
+
 def test_splits_clear_with_yes(runner: CliRunner, db: Database) -> None:
     TransactionService(db).add_split("T1", Decimal("-50"), actor="cli")
     TransactionService(db).add_split("T1", Decimal("-25"), actor="cli")

--- a/tests/moneybin/test_mcp/test_system_status_gsheet.py
+++ b/tests/moneybin/test_mcp/test_system_status_gsheet.py
@@ -66,6 +66,20 @@ async def test_system_status_gsheet_block_present_when_no_connections(
 
 
 @pytest.mark.unit
+async def test_system_status_gsheet_block_zero_shape_when_table_absent(
+    mcp_db: object,
+) -> None:
+    """On a bare DB before init_schemas, an absent table reports zero-shape."""
+    with get_database(read_only=False) as db:
+        db.execute("DROP TABLE app.gsheet_connections")
+    env = system_status()
+    block = env.to_dict()["data"]["gsheet"]
+    assert block["total_connections"] == 0
+    assert block["by_status"] == {}
+    assert block["needs_attention"] == []
+
+
+@pytest.mark.unit
 async def test_system_status_groups_connections_by_status(mcp_db: object) -> None:
     """Mixed-status connections produce correct by_status counts."""
     _insert_connection(connection_id="c_h", status="healthy")

--- a/tests/moneybin/test_services/test_import_service.py
+++ b/tests/moneybin/test_services/test_import_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import date
 
 import pytest
 
@@ -158,3 +159,51 @@ def test_list_distinct_labels_returns_counts(db: Database) -> None:
     assert counts == {"budget-2026": 3, "tax:2026": 1, "loan": 1}
     # Ordering: highest count first.
     assert distinct[0][0] == "budget-2026"
+
+
+@pytest.mark.unit
+def test_raw_data_summary_counts_rows_with_no_date_range(db: Database) -> None:
+    """A non-transaction raw table reports its row count with no date range."""
+    db.conn.execute("CREATE TABLE raw.zzz_test_table (id INTEGER)")
+    db.conn.execute("INSERT INTO raw.zzz_test_table VALUES (1), (2), (3)")
+    stats = ImportService(db).raw_data_summary()
+    matching = [s for s in stats if s.table == "zzz_test_table"]
+    assert len(matching) == 1
+    stat = matching[0]
+    assert stat.schema == "raw"
+    assert stat.rows == 3
+    assert stat.date_min is None
+    assert stat.date_max is None
+
+
+@pytest.mark.unit
+def test_raw_data_summary_derives_date_range_from_transaction_date(
+    db: Database,
+) -> None:
+    """A non-OFX transaction table derives its date range from transaction_date."""
+    db.conn.execute("CREATE TABLE raw.aaa_test_transactions (transaction_date VARCHAR)")
+    db.conn.execute(
+        "INSERT INTO raw.aaa_test_transactions VALUES ('2026-01-05'), ('2026-02-10')"
+    )
+    stats = ImportService(db).raw_data_summary()
+    matching = [s for s in stats if s.table == "aaa_test_transactions"]
+    assert len(matching) == 1
+    stat = matching[0]
+    assert stat.rows == 2
+    assert stat.date_min == date(2026, 1, 5)
+    assert stat.date_max == date(2026, 2, 10)
+
+
+@pytest.mark.unit
+def test_raw_data_summary_uses_date_posted_for_ofx_tables(db: Database) -> None:
+    """An OFX-named transaction table derives its date range from date_posted."""
+    db.conn.execute("CREATE TABLE raw.ofx_test_transactions (date_posted VARCHAR)")
+    db.conn.execute(
+        "INSERT INTO raw.ofx_test_transactions VALUES ('2026-03-01'), ('2026-03-15')"
+    )
+    stats = ImportService(db).raw_data_summary()
+    matching = [s for s in stats if s.table == "ofx_test_transactions"]
+    assert len(matching) == 1
+    stat = matching[0]
+    assert stat.date_min == date(2026, 3, 1)
+    assert stat.date_max == date(2026, 3, 15)

--- a/tests/moneybin/test_services/test_transaction_service.py
+++ b/tests/moneybin/test_services/test_transaction_service.py
@@ -1024,6 +1024,29 @@ class TestSplits:
             txn_service.remove_split("doesnotexist", actor="cli")
 
     @pytest.mark.unit
+    def test_get_split_returns_matching_split(
+        self, txn_service: TransactionService, sample_transaction_id: str
+    ) -> None:
+        added = txn_service.add_split(
+            sample_transaction_id,
+            Decimal("-15.00"),
+            category="Coffee",
+            actor="cli",
+        )
+        found = txn_service.get_split(added.split_id)
+        assert found is not None
+        assert found.split_id == added.split_id
+        assert found.transaction_id == sample_transaction_id
+        assert found.amount == Decimal("-15.00")
+        assert found.category == "Coffee"
+
+    @pytest.mark.unit
+    def test_get_split_returns_none_when_missing(
+        self, txn_service: TransactionService
+    ) -> None:
+        assert txn_service.get_split("doesnotexist") is None
+
+    @pytest.mark.unit
     def test_clear_splits_removes_all_and_emits_per_row_remove(
         self,
         txn_service: TransactionService,


### PR DESCRIPTION
Closes MB-48.

The adapter layer held inline SQL and business logic duplicating existing repo/service methods, against `mcp.md`'s contract that MCP tools "contain no business logic, no SQL" — the layer the privacy-middleware trust model depends on. The CI layering guard only checks imports, so this drift compounds unchecked, and each instance is logic invisible to the sibling surface, breaking CLI↔MCP capability symmetry.

## What moved

| From | To | Kind |
|---|---|---|
| `_gsheet_block` in `mcp/tools/system.py` | `GSheetConnectionsRepo.list_all()` | dedup — the inline query was verbatim identical |
| `information_schema` walk in `cli/commands/import_cmd.py` | new `ImportService.raw_data_summary()` returning a `RawTableStat` | relocation — no existing method covered it |
| parent-lookup SQL in `cli/commands/transactions/splits.py` | new `TransactionService.get_split()` on `TransactionSplitsRepo.get()` | relocation |

All three are behavior-preserving: same queries, same ordering, same error handling. The `system.py` case is a true duplicate — `list_all()` already selected the same columns in the same order.

## Scope note

A fourth instance of the same defect class was found in `mcp/tools/import_inbox.py` and deliberately left alone. MB-44 is canonicalizing the definition of "uncategorized transactions" on `core.uncategorized_queue` and deletes the twin that call site would otherwise have been routed to; fixing it here would have pinned the non-canonical definition in tests just as MB-44 removes it. That instance belongs to MB-44.

## Found but not fixed

Reported for the record, none actioned: `cli/commands/db.py` (explicit operator-bypass territory per `mcp.md`), `cli/commands/synthetic.py` (dev-tooling guard query), `cli/commands/transactions/matches.py` (a `COUNT(*)` populating a progress line, not business logic), and `cli/commands/stats.py` (window-function SQL with no owning service — moving it means designing a new abstraction, not a mechanical move).

The import-only CI layering guard still cannot see inline SQL. Not addressed here; it is a second-pass candidate on MB-39.

## Test plan

- `make check` — clean, 0 errors.
- `make test` — 10363 passed, 4 skipped, 0 failed.
- `make test-e2e` — 380 passed, 0 failed (run against the same CLI changes; required because CLI module structure changed).

New tests cover each moved method plus zero-row and not-found shapes, and were confirmed to pass against the pre-refactor code before each move.
