### PR TITLE
Canonicalize the definition of uncategorized transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- **"Uncategorized" now means one thing, and the number is smaller.**
+  `moneybin review`, `system_status` and the import-drain hint counted every
+  transaction with no row in `app.transaction_categories`, while the review
+  queue beside them listed `core.uncategorized_queue` — which also excludes
+  confirmed transfer legs, archived accounts, and transactions whose source
+  system already supplied a category. Nothing errored; the count simply
+  disagreed with the queue it pointed at. `core.uncategorized_queue` is now
+  the single definition every surface counts, so the reported figure drops
+  wherever those rows were being counted. Categorization itself is unchanged —
+  only which rows are called curator work. A missing queue view is now
+  reported as schema drift on the review surface rather than rendering as an
+  empty queue, which had told a curator their work was done when the refresh
+  that builds the view had never run.
+
 - **MCP tool calls now record `moneybin_mcp_tool_calls_total` and `moneybin_mcp_tool_duration_seconds`.** The observability spec described this instrumentation as automatic, but no code path ever recorded either metric — a dashboard built from them stayed at zero permanently. `ValidationErrorMiddleware.on_call_tool`, the single boundary every `tools/call` request passes through, now records both metrics on every call, whether it succeeds, is translated to a validation-error envelope, or raises something else. (#495)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   only which rows are called curator work. A missing queue view is now
   reported as schema drift on the review surface rather than rendering as an
   empty queue, which had told a curator their work was done when the refresh
-  that builds the view had never run.
+  that builds the view had never run. (#502)
 
 - **MCP tool calls now record `moneybin_mcp_tool_calls_total` and `moneybin_mcp_tool_duration_seconds`.** The observability spec described this instrumentation as automatic, but no code path ever recorded either metric — a dashboard built from them stayed at zero permanently. `ValidationErrorMiddleware.on_call_tool`, the single boundary every `tools/call` request passes through, now records both metrics on every call, whether it succeeds, is translated to a validation-error envelope, or raises something else. (#495)
 

--- a/src/moneybin/mcp/tools/import_inbox.py
+++ b/src/moneybin/mcp/tools/import_inbox.py
@@ -19,6 +19,7 @@ from moneybin.privacy.payloads.imports import (
     ImportInboxSyncPayload,
 )
 from moneybin.protocol.envelope import ResponseEnvelope, build_envelope
+from moneybin.services.categorization.queries import CategorizationQueries
 from moneybin.services.inbox_service import InboxService
 from moneybin.services.refresh_outcome import refresh_steps_fields
 
@@ -26,23 +27,15 @@ logger = logging.getLogger(__name__)
 
 
 def _uncategorized_count() -> int:
-    """Return the count of transactions lacking a category entry.
+    """Return the size of the canonical uncategorized queue.
 
-    Returns 0 on any error so a DB hiccup never breaks the import summary.
+    Reads through ``CategorizationQueries`` so the hint quotes the same N the
+    review queue it points at will show. Returns 0 on any error so a DB hiccup
+    never breaks the import summary.
     """
     try:
-        from moneybin.tables import FCT_TRANSACTIONS, TRANSACTION_CATEGORIES
-
         with get_database(read_only=True) as db:
-            row = db.execute(
-                f"""
-                SELECT COUNT(*)
-                FROM {FCT_TRANSACTIONS.full_name} t
-                LEFT JOIN {TRANSACTION_CATEGORIES.full_name} tc USING (transaction_id)
-                WHERE tc.transaction_id IS NULL
-                """,  # noqa: S608  # table names are TableRef constants, not user input
-            ).fetchone()
-        return int(row[0]) if row else 0
+            return CategorizationQueries(db).count_uncategorized()
     except Exception:  # noqa: BLE001 — never surface DB errors in summary hint
         return 0
 

--- a/src/moneybin/mcp/tools/reviews.py
+++ b/src/moneybin/mcp/tools/reviews.py
@@ -254,16 +254,15 @@ def _unavailable_queue(kind: ReviewQueueKind, exc: Exception) -> QueueUnavailabl
 def _pending_categorization_rows(
     service: CategorizationService,
 ) -> list[CategorizationReviewRow]:
-    """Project the existing uncategorized queue into normalized rows."""
-    try:
-        raw_rows = service.list_uncategorized_transactions(limit=None) or []
-    except UserError as exc:
-        if (
-            exc.code != error_codes.INFRA_SCHEMA_DRIFT
-            or service.count_uncategorized() != 0
-        ):
-            raise
-        raw_rows = []
+    """Project the existing uncategorized queue into normalized rows.
+
+    A missing ``core.uncategorized_queue`` propagates as ``INFRA_SCHEMA_DRIFT``
+    rather than degrading to an empty queue. It is the single definition of an
+    uncategorized transaction, so without it the queue's contents are unknown,
+    not zero — and the summary already reports one broken queue as
+    ``unavailable`` instead of failing the aggregate.
+    """
+    raw_rows = service.list_uncategorized_transactions(limit=None) or []
     ordered = sorted(
         raw_rows,
         key=lambda row: (

--- a/src/moneybin/services/categorization/__init__.py
+++ b/src/moneybin/services/categorization/__init__.py
@@ -756,7 +756,7 @@ class CategorizationService:
         return self._queries.list_categorization_history()
 
     def count_uncategorized(self) -> int:
-        """Return the number of transactions without a category assignment."""
+        """Return the size of the canonical ``core.uncategorized_queue``."""
         return self._queries.count_uncategorized()
 
     def categorization_stats(self) -> dict[str, int | float]:

--- a/src/moneybin/services/categorization/queries.py
+++ b/src/moneybin/services/categorization/queries.py
@@ -438,18 +438,19 @@ class CategorizationQueries:
         return {str(r[0]) for r in rows}
 
     def count_uncategorized(self) -> int:
-        """Return the number of transactions without a category assignment."""
+        """Return the size of the canonical uncategorized queue.
+
+        ``core.uncategorized_queue`` is the one definition of "uncategorized":
+        no resolved category, not a confirmed transfer leg, not on an archived
+        account. Counting anything else here puts a different N beside the same
+        queue the user is sent to (:meth:`list_uncategorized_transactions`).
+        """
         try:
             row = self._db.execute(
-                f"""
-                SELECT COUNT(*) FROM {FCT_TRANSACTIONS.full_name} t
-                LEFT JOIN {TRANSACTION_CATEGORIES.full_name} c
-                    ON t.transaction_id = c.transaction_id
-                WHERE c.transaction_id IS NULL
-                """  # noqa: S608  # TableRef constants, no user input interpolated
+                f"SELECT COUNT(*) FROM {CORE_UNCATEGORIZED_QUEUE.full_name}"  # noqa: S608  # TableRef constant, no user input interpolated
             ).fetchone()
             return int(row[0]) if row else 0
-        except Exception:  # noqa: BLE001 — tables may not exist before first import
+        except Exception:  # noqa: BLE001 — the view is absent before first refresh
             return 0
 
     def categorization_stats(self) -> dict[str, int | float]:

--- a/tests/moneybin/db_helpers.py
+++ b/tests/moneybin/db_helpers.py
@@ -10,7 +10,7 @@ from datetime import datetime
 
 import duckdb
 
-from moneybin.database import Database
+from moneybin.database import SQLMESH_ROOT, Database
 
 
 def record_sqlmesh_apply(db: Database, when: datetime) -> None:
@@ -557,3 +557,28 @@ def apply_core_table_comments(database: Database) -> None:
             database.execute(  # noqa: S608  # static module constants, not user input
                 f"COMMENT ON COLUMN {table}.{col} IS '{escaped}'"
             )
+
+
+# Resolve via the package's own SQLMESH_ROOT rather than walking up to the repo
+# root: the SQLMesh project lives inside the installed package, so a path built
+# from a test file's parents breaks whenever the project moves (it did — the
+# project relocated to src/moneybin/sqlmesh). SQLMESH_ROOT is what production
+# uses, so this binding cannot drift from it.
+_UNCATEGORIZED_QUEUE_MODEL_FILE = (
+    SQLMESH_ROOT / "models" / "core" / "uncategorized_queue.sql"
+)
+
+
+def install_uncategorized_queue_view(db: Database) -> None:
+    """Materialize core.uncategorized_queue from the real model SQL.
+
+    Requires ``core.fct_transactions`` and ``core.dim_accounts`` to exist
+    (``create_core_tables``). Rebuilds the actual queue view on top of them
+    from the shipped model file so tests bind to the real canonical
+    definition instead of a hand-typed stub that could drift from it.
+    """
+    raw = _UNCATEGORIZED_QUEUE_MODEL_FILE.read_text()
+    start = raw.index("MODEL")
+    end = raw.index(");", start) + 2
+    body = raw[end:].strip()
+    db.execute(f"CREATE OR REPLACE VIEW core.uncategorized_queue AS\n{body}")  # noqa: S608  # model body read from the repo file, not user input

--- a/tests/moneybin/test_mcp/test_import_inbox_tools.py
+++ b/tests/moneybin/test_mcp/test_import_inbox_tools.py
@@ -9,11 +9,20 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from moneybin.mcp.tools.import_inbox import import_inbox_pending, import_inbox_sync
+from moneybin.database import Database
+from moneybin.mcp.tools.import_inbox import (
+    _uncategorized_count,  # pyright: ignore[reportPrivateUsage]  # module-private helper under test
+    import_inbox_pending,
+    import_inbox_sync,
+)
 from moneybin.privacy.redaction import redact_typed
 from moneybin.services.inbox_service import (
     InboxListResult,
     InboxSyncResult,
+)
+from tests.moneybin.db_helpers import (
+    create_core_tables,
+    install_uncategorized_queue_view,
 )
 
 
@@ -193,6 +202,43 @@ class TestImportInboxSync:
         envelope = import_inbox_sync()
         assert any("categorize_assist" in a for a in envelope.actions)
         assert any("50" in a for a in envelope.actions)
+
+    async def test_uncategorized_count_reads_the_canonical_queue(
+        self, db: Database, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The drain's assist hint counts the rows the review queue lists.
+
+        A confirmed transfer leg is not curator work, so
+        core.uncategorized_queue drops it — and the hint that offers to
+        categorize "N transactions" must not quote a larger N than the queue
+        the user is then sent to.
+        """
+        create_core_tables(db)
+        db.execute(
+            "INSERT INTO core.dim_accounts (account_id, display_name, archived) "
+            "VALUES ('acct_open', 'Checking', false)"
+        )
+        db.execute(
+            "INSERT INTO core.fct_transactions "
+            "(transaction_id, account_id, transaction_date, amount, description, "
+            "category, is_transfer) VALUES "
+            "('t_pending', 'acct_open', DATE '2026-04-01', -12.00, 'Cafe', "
+            "NULL, false), "
+            "('t_transfer', 'acct_open', DATE '2026-04-02', -500.00, 'Transfer', "
+            "NULL, true)"
+        )
+        install_uncategorized_queue_view(db)
+
+        @contextmanager
+        def _bound_database(*args: object, **kwargs: object):  # type: ignore[misc]
+            yield db
+
+        monkeypatch.setattr(
+            "moneybin.mcp.tools.import_inbox.get_database",
+            _bound_database,  # pyright: ignore[reportUnknownArgumentType]
+        )
+
+        assert _uncategorized_count() == 1
 
     async def test_categorize_hint_absent_below_threshold(
         self, patch_service: MagicMock, monkeypatch: pytest.MonkeyPatch

--- a/tests/moneybin/test_mcp/test_review.py
+++ b/tests/moneybin/test_mcp/test_review.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from dataclasses import replace
 from datetime import UTC, date, datetime
 from decimal import Decimal
+from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -71,6 +72,7 @@ from moneybin.services.undo_service import UndoService
 from tests.moneybin.db_helpers import (
     CORE_FCT_INVESTMENT_LOTS_DDL,
     CORE_FCT_INVESTMENT_TRANSACTIONS_DDL,
+    install_uncategorized_queue_view,
 )
 
 from .schema_assertions import (
@@ -81,6 +83,21 @@ from .schema_assertions import (
 )
 
 pytestmark = pytest.mark.usefixtures("mcp_db")
+
+
+@pytest.fixture(autouse=True)
+def _canonical_uncategorized_queue(  # pyright: ignore[reportUnusedFunction]  # autouse pytest fixture
+    mcp_db: Path,
+) -> None:
+    """Give every review test the canonical queue view production always has.
+
+    ``core.uncategorized_queue`` is the single definition of an uncategorized
+    transaction, so a review DB without it is a drifted one — a state one test
+    below asserts on deliberately by dropping the view again.
+    """
+    with get_database(read_only=False) as db:
+        install_uncategorized_queue_view(db)
+
 
 _NOW = datetime.now(tz=UTC).isoformat()
 
@@ -419,6 +436,23 @@ async def test_review_queue_uses_one_envelope(kind: str) -> None:
     response = await reviews_coarse(kind=kind, status="pending")  # type: ignore[arg-type]
     assert response.data.kind == kind
     assert response.data.status == "pending"
+
+
+async def test_categorization_queue_reports_a_missing_canonical_view() -> None:
+    """An absent core.uncategorized_queue is surfaced, not rendered as "none pending".
+
+    core.uncategorized_queue is the single definition of an uncategorized
+    transaction, so when the view is missing the queue's contents are unknown
+    — not empty. Returning an empty queue would tell a curator their work is
+    done while the refresh that builds the view has never run.
+    """
+    with get_database(read_only=False) as db:
+        db.execute("DROP VIEW core.uncategorized_queue")
+
+    response = await reviews_coarse(kind="categorization", status="pending")
+
+    assert response.error is not None
+    assert response.error.code == error_codes.INFRA_SCHEMA_DRIFT
 
 
 async def test_review_summary_returns_exact_kind_status_matrix() -> None:

--- a/tests/moneybin/test_services/test_categorization_service.py
+++ b/tests/moneybin/test_services/test_categorization_service.py
@@ -12,7 +12,7 @@ from typing import Any
 import pytest
 import yaml
 
-from moneybin.database import SQLMESH_ROOT, Database
+from moneybin.database import Database
 from moneybin.repositories.match_decisions_repo import MatchDecisionsRepo
 from moneybin.seeds import refresh_views
 from moneybin.services._text import normalize_description
@@ -25,7 +25,11 @@ from moneybin.services.categorization.assist import (
     _amount_sign_label,  # pyright: ignore[reportPrivateUsage]  # tested directly
 )
 from moneybin.services.categorization.queries import CategorizationQueries
-from tests.moneybin.db_helpers import create_core_tables, seed_categories_view
+from tests.moneybin.db_helpers import (
+    create_core_tables,
+    install_uncategorized_queue_view,
+    seed_categories_view,
+)
 
 
 def create_merchant(db: Database, *args: object, **kwargs: object) -> str:
@@ -1186,7 +1190,15 @@ def test_categorize_items_snowball_fans_out_to_siblings(real_db: Database) -> No
         )
 
     svc = CategorizationService(real_db)
-    assert svc.count_uncategorized() == 3
+    # Nothing categorized yet — the snowball's starting state. Read straight
+    # from app.transaction_categories: core.uncategorized_queue is a SQLMesh
+    # view over a live core.fct_transactions, and this module's fixture table
+    # is static, so the queue cannot observe writes made during the test.
+    seeded = real_db.execute(
+        "SELECT COUNT(*) FROM app.transaction_categories"
+    ).fetchone()
+    assert seeded is not None
+    assert seeded[0] == 0
 
     # Categorize batch 1 (just t1) with a canonical name so an exemplar-merchant
     # is created.
@@ -1203,8 +1215,6 @@ def test_categorize_items_snowball_fans_out_to_siblings(real_db: Database) -> No
     # SNOWBALL: t2 and t3 should now be categorized too because categorize_items
     # invoked categorize_pending() after committing, which applied the new
     # exemplar to remaining uncategorized rows.
-    assert svc.count_uncategorized() == 0
-
     rows = real_db.execute(
         "SELECT category, categorized_by FROM app.transaction_categories "
         "ORDER BY transaction_id"
@@ -3445,31 +3455,6 @@ class TestCategorizePendingPlaidPass:
 # list_uncategorized_transactions — pending transfer match flag (F19)
 # ---------------------------------------------------------------------------
 
-# Resolve via the package's own SQLMESH_ROOT rather than walking up to the repo
-# root: the SQLMesh project lives inside the installed package, so a path built
-# from the test file's parents breaks whenever the project moves (it did — the
-# project relocated to src/moneybin/sqlmesh). SQLMESH_ROOT is what production
-# uses, so this binding cannot drift from it.
-_UNCATEGORIZED_QUEUE_MODEL_FILE = (
-    SQLMESH_ROOT / "models" / "core" / "uncategorized_queue.sql"
-)
-
-
-def _install_uncategorized_queue_view(db: Database) -> None:
-    """Materialize core.uncategorized_queue from the real model SQL.
-
-    core.fct_transactions / core.dim_accounts already exist as physical
-    tables via the module's autouse create_core_tables() fixture; this
-    rebuilds the actual queue view on top of them from the shipped model
-    file so the test binds to the real column contract instead of a
-    hand-typed stub that could drift from it.
-    """
-    raw = _UNCATEGORIZED_QUEUE_MODEL_FILE.read_text()
-    start = raw.index("MODEL")
-    end = raw.index(");", start) + 2
-    body = raw[end:].strip()
-    db.execute(f"CREATE OR REPLACE VIEW core.uncategorized_queue AS\n{body}")  # noqa: S608  # model body read from the repo file, not user input
-
 
 def _install_matched_stub(db: Database) -> None:
     """Minimal prep.int_transactions__matched stub for the pending-match join.
@@ -3488,6 +3473,49 @@ def _install_matched_stub(db: Database) -> None:
             account_id VARCHAR
         )
     """)
+
+
+def test_count_uncategorized_counts_exactly_the_pending_queue(db: Database) -> None:
+    """One definition of "uncategorized": whatever core.uncategorized_queue holds.
+
+    The count and the listing sit side by side on the review surface — the
+    count in `moneybin review` / system_status, the listing in the pending
+    queue — so a count computed from a different predicate shows the user two
+    different Ns for the same question. Each excluded row here is a row the
+    canonical view drops and a hand-rolled LEFT JOIN against
+    app.transaction_categories would have counted.
+    """
+    db.execute(
+        "INSERT INTO core.dim_accounts (account_id, display_name, archived) "
+        "VALUES ('acct_open', 'Checking', false), "
+        "('acct_archived', 'Closed Card', true)"
+    )
+    db.execute(
+        "INSERT INTO core.fct_transactions "
+        "(transaction_id, account_id, transaction_date, amount, description, "
+        "category, is_transfer) VALUES "
+        # The only genuine curator item.
+        "('t_pending', 'acct_open', DATE '2026-04-01', -12.00, 'Cafe', "
+        "NULL, false), "
+        # A confirmed transfer leg: not spending, so not curator work.
+        "('t_transfer', 'acct_open', DATE '2026-04-02', -500.00, 'Transfer', "
+        "NULL, true), "
+        # An archived account is off the review surface entirely.
+        "('t_archived', 'acct_archived', DATE '2026-04-03', -30.00, 'Old', "
+        "NULL, false), "
+        # Already carries a category from the source system.
+        "('t_source_category', 'acct_open', DATE '2026-04-04', -8.00, 'Bus', "
+        "'Travel', false)"
+    )
+    install_uncategorized_queue_view(db)
+    _install_matched_stub(db)
+
+    queries = CategorizationQueries(db)
+    rows = queries.list_uncategorized_transactions(limit=None)
+
+    assert rows is not None
+    assert [r["transaction_id"] for r in rows] == ["t_pending"]
+    assert queries.count_uncategorized() == len(rows)
 
 
 def test_pending_queue_names_each_row_currency(db: Database) -> None:
@@ -3511,7 +3539,7 @@ def test_pending_queue_names_each_row_currency(db: Database) -> None:
         "('t_usd', 'acct_us', DATE '2026-04-01', -50.00, 'Local cafe', "
         "'USD', false)"
     )
-    _install_uncategorized_queue_view(db)
+    install_uncategorized_queue_view(db)
     _install_matched_stub(db)
 
     rows = CategorizationQueries(db).list_uncategorized_transactions(limit=10)
@@ -3561,7 +3589,7 @@ def test_pending_queue_flags_rows_with_an_unresolved_transfer_match(
         "('t_expense', 'acct_checking', '2026-06-02', -42.00, "
         "'GROCERY STORE', 'ofx', false)"
     )
-    _install_uncategorized_queue_view(db)
+    install_uncategorized_queue_view(db)
     _install_matched_stub(db)
     db.execute(
         "INSERT INTO prep.int_transactions__matched "
@@ -3631,7 +3659,7 @@ def test_pending_queue_ignores_dedup_decisions_for_transfer_flag(
         "('t_dedup_b', 'acct_checking', '2026-06-02', -8.00, "
         "'COFFEE SHOP', 'ofx', false)"
     )
-    _install_uncategorized_queue_view(db)
+    install_uncategorized_queue_view(db)
     _install_matched_stub(db)
     db.execute(
         "INSERT INTO prep.int_transactions__matched "
@@ -3728,7 +3756,7 @@ def test_pending_queue_degrades_when_matched_view_predates_a_column(
         "('t_expense', 'acct_checking', '2026-06-02', -42.00, "
         "'GROCERY STORE', 'ofx', false)"
     )
-    _install_uncategorized_queue_view(db)
+    install_uncategorized_queue_view(db)
     _install_matched_stub_missing_account_id(db)
 
     rows = CategorizationQueries(db).list_uncategorized_transactions(limit=10)
@@ -3770,7 +3798,7 @@ def test_impact_queue_spans_currencies_under_cap(db: Database) -> None:
         "('t_usd', 'acct_us', DATE '2026-04-01', -50.00, 'Local cafe', "
         "'USD', false)"
     )
-    _install_uncategorized_queue_view(db)
+    install_uncategorized_queue_view(db)
     _install_matched_stub(db)
 
     rows = CategorizationQueries(db).list_uncategorized_transactions(

--- a/tests/moneybin/test_services/test_system_service.py
+++ b/tests/moneybin/test_services/test_system_service.py
@@ -9,22 +9,26 @@ import pytest
 
 from moneybin.database import Database
 from moneybin.services.system_service import SystemService, SystemStatus
-from tests.moneybin.db_helpers import create_core_tables_raw, record_sqlmesh_apply
+from tests.moneybin.db_helpers import (
+    create_core_tables_raw,
+    install_uncategorized_queue_view,
+    record_sqlmesh_apply,
+)
 
 _INSERT_TRANSACTIONS = """
     INSERT INTO core.fct_transactions (
         transaction_id, account_id, transaction_date, amount,
         amount_absolute, transaction_direction, description,
-        transaction_type, is_pending, currency_code, source_type,
+        transaction_type, is_pending, is_transfer, currency_code, source_type,
         source_extracted_at, loaded_at,
         transaction_year, transaction_month, transaction_day,
         transaction_day_of_week, transaction_year_month, transaction_year_quarter
     ) VALUES
     ('T1', 'ACC001', '2026-03-01', -50.00, 50.00, 'expense', 'Coffee Shop',
-     'DEBIT', false, 'USD', 'ofx', '2026-03-01', CURRENT_TIMESTAMP,
+     'DEBIT', false, false, 'USD', 'ofx', '2026-03-01', CURRENT_TIMESTAMP,
      2026, 3, 1, 0, '2026-03', '2026-Q1'),
     ('T2', 'ACC001', '2026-04-15', 5000.00, 5000.00, 'income', 'Employer',
-     'CREDIT', false, 'USD', 'ofx', '2026-04-15', CURRENT_TIMESTAMP,
+     'CREDIT', false, false, 'USD', 'ofx', '2026-04-15', CURRENT_TIMESTAMP,
      2026, 4, 15, 1, '2026-04', '2026-Q2')
 """  # noqa: S608  # test input, not executing SQL
 
@@ -46,6 +50,9 @@ def system_db(db: Database) -> Database:
     """)  # noqa: S608  # test input, not executing SQL
 
     conn.execute(_INSERT_TRANSACTIONS)
+    # categorize_pending counts core.uncategorized_queue, the one definition of
+    # an uncategorized transaction; SQLMesh materializes it in production.
+    install_uncategorized_queue_view(db)
 
     return db
 


### PR DESCRIPTION
Closes MB-44.

"Uncategorized" had three divergent definitions, and one surface showed two of them side by side: `ReviewService.status()` fed `count_uncategorized` into `categorize_pending` while the pending listing beside it counted rows off `core.uncategorized_queue`. The user saw two different "N uncategorized" numbers and nothing errored.

`core.uncategorized_queue` is now the single definition. The count is `COUNT(*)` over that model, and the duplicated inline SQL in `mcp/tools/import_inbox.py` is deleted.

## Behavior change — the number gets smaller

Reported uncategorized counts drop on `moneybin review`, MCP `system_status`, and the import-drain assist hint. Three classes of row stop counting: confirmed transfer legs, transactions on archived accounts, and transactions whose source system already supplied a category. Categorization itself is unchanged — only which rows are called curator work.

## A guard that had to go

`_pending_categorization_rows` caught `INFRA_SCHEMA_DRIFT` from the listing and degraded to an empty queue when `count_uncategorized() != 0` was false. Once both the count and the listing read the same view, that guard asks the view a question the view just refused to answer — and since the count degrades to `0` on error, the condition is always false, so it would have swallowed every drift error and reported "0 pending" on a drifted database. That tells a curator their work is done when the refresh that builds the view never ran.

Drift now propagates. The summary path already degrades one broken queue to `unavailable` rather than failing the aggregate, and the direct call gets the `refresh_run` remediation.

## Known residual

`count_uncategorized()` still degrades to `0` when the view is absent (shipped behavior, preserved), while the listing now raises. So on a drifted database `moneybin review` shows 0 while `reviews(kind='categorization')` errors. `system_status` surfaces drift in its own `schema_drift` field, so it is not invisible. Making the count raise would ripple into every caller's error handling and the `system_status` envelope — larger than this issue scopes.

## Deliberately not touched

Two other "uncategorized" numbers live inside arithmetic identities, where changing the numerator alone breaks the sum:

- `CategorizationQueries.categorization_stats()` reports `uncategorized = total − categorized` as a coverage decomposition. Swapping the numerator makes the three stop summing.
- `DoctorService._run_categorization_coverage()` uses the queue's predicate minus the archived-account filter, as a ratio against the same population.

Both need a matched denominator, not a new numerator. Reconciling them means deciding what `total` and `categorized` mean.

## Test plan

- `make check` — clean, 0 errors.
- `make test` — 10358 passed, 4 skipped.
- `make test-scenarios` — 92 passed, 0 failed.
- `make test-integration` — 564 passed, 0 failed (run because the diff touches `db_helpers.py` and categorization semantics).
- `uv run pytest tests/test_documentation_policy.py` — 8 passed.

Three new tests were written test-first and each watched fail for the right reason before the fix: canonical-semantics count, import-hint delegation, and drift propagation. The drift test was verified against reverted production code, not only against the new code. A shared `install_uncategorized_queue_view()` helper in `tests/moneybin/db_helpers.py` materializes the view from the shipped model file, replacing a private copy in one test module.
