### PR TITLE
Stop ambient MONEYBIN_* env vars leaking into the test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ the segfault.
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
@@ -110,16 +111,25 @@ MONEYBIN_ENV_AT_STARTUP = frozenset(
 )
 
 
-def pytest_report_header() -> list[str] | None:
+def pytest_configure(config: pytest.Config) -> None:
     """Name the ambient ``MONEYBIN_*`` vars this run ignored.
 
     Dropping them silently would make a deliberate
     ``MONEYBIN_LOGGING__LEVEL=DEBUG uv run pytest ...`` look broken rather than
     overridden. Names only, never values — these fields hold credentials.
+
+    Written to stderr rather than through ``pytest_report_header`` because
+    ``addopts`` bakes in ``-q``, which suppresses header hooks and would hide
+    this from ``make test`` and ``make test-integration`` — the two gates run
+    most often, and so the two that most need it. xdist workers inherit an
+    environment the controller already cleared, but they are excluded
+    explicitly so the line cannot multiply by worker count.
     """
-    if not _CLEARED_AMBIENT_ENV:
-        return None
-    return [f"moneybin: ignored ambient env {', '.join(_CLEARED_AMBIENT_ENV)}"]
+    if not _CLEARED_AMBIENT_ENV or hasattr(config, "workerinput"):
+        return
+    sys.stderr.write(
+        f"moneybin: ignored ambient env {', '.join(_CLEARED_AMBIENT_ENV)}\n"
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,10 @@ typer.Typer.__init__ = _typer_init_no_rich  # type: ignore[method-assign]
 # re-added immediately below. The match is case-insensitive because
 # MoneyBinSettings sets `case_sensitive=False`, so a lowercase export reaches
 # the same field. Guarded by tests/moneybin/test_env_isolation.py.
-for _ambient in [_k for _k in os.environ if _k.upper().startswith("MONEYBIN_")]:
+_CLEARED_AMBIENT_ENV = sorted(
+    _k for _k in os.environ if _k.upper().startswith("MONEYBIN_")
+)
+for _ambient in _CLEARED_AMBIENT_ENV:
     del os.environ[_ambient]
 
 # Per-xdist-worker MoneyBin home so parallel tests don't trample each other's
@@ -97,6 +100,32 @@ os.environ["MONEYBIN_HOME"] = str(_worker_home)
 _worker_inbox_root = _worker_home / "inbox-root"
 _worker_inbox_root.mkdir(parents=True, exist_ok=True)
 os.environ["MONEYBIN_IMPORT___INBOX_ROOT"] = str(_worker_inbox_root)
+
+# Snapshot the isolated environment now, at import, because import is when the
+# isolation actually happens. A test that instead read os.environ at call time
+# would also see whatever a test sharing its xdist worker had left behind, and
+# would report that as the developer's shell leaking in.
+MONEYBIN_ENV_AT_STARTUP = frozenset(
+    _k for _k in os.environ if _k.upper().startswith("MONEYBIN_")
+)
+
+
+def pytest_report_header() -> list[str] | None:
+    """Name the ambient ``MONEYBIN_*`` vars this run ignored.
+
+    Dropping them silently would make a deliberate
+    ``MONEYBIN_LOGGING__LEVEL=DEBUG uv run pytest ...`` look broken rather than
+    overridden. Names only, never values — these fields hold credentials.
+    """
+    if not _CLEARED_AMBIENT_ENV:
+        return None
+    return [f"moneybin: ignored ambient env {', '.join(_CLEARED_AMBIENT_ENV)}"]
+
+
+@pytest.fixture(scope="session")
+def moneybin_env_at_startup() -> frozenset[str]:
+    """``MONEYBIN_*`` names surviving conftest's environment isolation."""
+    return MONEYBIN_ENV_AT_STARTUP
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,19 @@ def _typer_init_no_rich(self: typer.Typer, *args: object, **kwargs: object) -> N
 
 typer.Typer.__init__ = _typer_init_no_rich  # type: ignore[method-assign]
 
+# Ambient MoneyBin configuration must not reach the suite. Every field on
+# MoneyBinSettings resolves from a MONEYBIN_-prefixed variable, so one the
+# developer exports — their own Google OAuth client id, a sync server URL —
+# silently replaces the shipped default inside any test that constructs
+# settings without an explicit override. Such a test asserts against the
+# machine it runs on: green in CI where no var is set, red locally, or the
+# reverse. Clear the whole prefix here; the two vars the harness owns are
+# re-added immediately below. The match is case-insensitive because
+# MoneyBinSettings sets `case_sensitive=False`, so a lowercase export reaches
+# the same field. Guarded by tests/moneybin/test_env_isolation.py.
+for _ambient in [_k for _k in os.environ if _k.upper().startswith("MONEYBIN_")]:
+    del os.environ[_ambient]
+
 # Per-xdist-worker MoneyBin home so parallel tests don't trample each other's
 # `.moneybin/profiles/` directory. Each worker (`gw0`, `gw1`, …) gets its own
 # tempdir; serial runs use a single shared dir under `gw-main`.

--- a/tests/moneybin/test_env_isolation.py
+++ b/tests/moneybin/test_env_isolation.py
@@ -8,27 +8,73 @@ against the shipped defaults, and they pass in CI — where no such var
 exists — while failing locally, or the reverse.
 
 ``tests/conftest.py`` clears the whole prefix at import time and re-adds only
-the vars the harness itself owns. This guard pins that set: a new harness-owned
-var must be added here deliberately, and a leaked ambient var fails loudly with
-the offending names.
+the vars the harness itself owns. Two tests guard that, and they are not
+redundant: the first pins *which* names survive, the second proves the
+clearing code actually runs.
 
-It asserts against the snapshot conftest took at import rather than against
-live ``os.environ``, because isolation is an import-time property. Reading the
-environment at call time would fold in every mutation made by the other tests
-sharing this xdist worker, turning an unrestored ``os.environ`` write elsewhere
-in the suite into an order-dependent failure here that blames the developer's
-shell for it.
+The split exists because the first test cannot fail on a clean CI runner.
+There, no ambient ``MONEYBIN_*`` var exists to begin with, so the snapshot
+equals the harness-owned set whether or not conftest deletes anything — the
+predicate never executes, and a passing run says nothing. Only the second test
+seeds a variable of its own, so only it holds the deletion path in place
+everywhere the suite runs.
 """
 
 from __future__ import annotations
+
+import os
+import subprocess  # noqa: S404 — a child pytest run is how this proves isolation
+import sys
+from pathlib import Path
 
 # Set by tests/conftest.py: a per-xdist-worker MoneyBin home, and the import
 # inbox root beneath it.
 HARNESS_OWNED = frozenset({"MONEYBIN_HOME", "MONEYBIN_IMPORT___INBOX_ROOT"})
 
+_REPO_ROOT = Path(__file__).parents[2]
+_SNAPSHOT_TEST = "test_only_harness_owned_moneybin_env_vars_are_visible"
+
+# Deliberately lowercase. MoneyBinSettings sets `case_sensitive=False`, so
+# pydantic reads this spelling into the same field an uppercase export would;
+# seeding it this way keeps conftest's `.upper()` match load-bearing.
+_SEEDED_VAR = "moneybin_seeded_ambient_probe"
+
 
 def test_only_harness_owned_moneybin_env_vars_are_visible(
     moneybin_env_at_startup: frozenset[str],
 ) -> None:
-    """No ambient ``MONEYBIN_*`` var survived conftest's cleanup."""
+    """No ambient ``MONEYBIN_*`` var survived conftest's cleanup.
+
+    Asserts against the snapshot conftest took at import rather than against
+    live ``os.environ``, because isolation is an import-time property. Reading
+    the environment at call time would fold in mutations made by other tests
+    sharing this xdist worker and report them as the developer's shell.
+    """
     assert moneybin_env_at_startup == HARNESS_OWNED
+
+
+def test_seeded_ambient_var_does_not_survive_into_a_child_run() -> None:
+    """Conftest strips a ``MONEYBIN_*`` var this test plants itself.
+
+    The guard above is only load-bearing on a machine that already exports
+    ambient config. This one supplies its own, so the deletion path runs on
+    every machine including a clean CI runner, and deleting conftest's
+    clearing loop fails it there too.
+    """
+    env = dict(os.environ) | {_SEEDED_VAR: "1"}
+    nodeid = f"{Path(__file__).relative_to(_REPO_ROOT)}::{_SNAPSHOT_TEST}"
+
+    result = subprocess.run(  # noqa: S603 — fixed interpreter, literal arguments
+        [sys.executable, "-m", "pytest", nodeid, "-n0", "-p", "no:cacheprovider"],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    # Two independent halves: the child reported clearing the seeded name, and
+    # the child's own snapshot assertion then passed. The first proves conftest
+    # matched and removed it; the second proves nothing put it back.
+    assert _SEEDED_VAR in result.stderr, result.stderr
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/moneybin/test_env_isolation.py
+++ b/tests/moneybin/test_env_isolation.py
@@ -26,6 +26,8 @@ import os
 import subprocess  # noqa: S404 — a child pytest run is how this proves isolation
 from pathlib import Path
 
+import pytest
+
 # Set by tests/conftest.py: a per-xdist-worker MoneyBin home, and the import
 # inbox root beneath it.
 HARNESS_OWNED = frozenset({"MONEYBIN_HOME", "MONEYBIN_IMPORT___INBOX_ROOT"})
@@ -52,6 +54,12 @@ def test_only_harness_owned_moneybin_env_vars_are_visible(
     assert moneybin_env_at_startup == HARNESS_OWNED
 
 
+# Marked slow because it spawns a whole pytest run — seconds, against a suite
+# whose other tests are microseconds. `make test` (`-m "unit and not slow"`)
+# therefore skips it locally, while CI's unit job (`-m unit`) still runs it.
+# That is the right split: this test only becomes load-bearing on a machine
+# with no ambient MONEYBIN_* vars of its own, which is CI, not a dev laptop.
+@pytest.mark.slow
 def test_seeded_ambient_var_does_not_survive_into_a_child_run() -> None:
     """Conftest strips a ``MONEYBIN_*`` var this test plants itself.
 

--- a/tests/moneybin/test_env_isolation.py
+++ b/tests/moneybin/test_env_isolation.py
@@ -11,18 +11,24 @@ exists — while failing locally, or the reverse.
 the vars the harness itself owns. This guard pins that set: a new harness-owned
 var must be added here deliberately, and a leaked ambient var fails loudly with
 the offending names.
+
+It asserts against the snapshot conftest took at import rather than against
+live ``os.environ``, because isolation is an import-time property. Reading the
+environment at call time would fold in every mutation made by the other tests
+sharing this xdist worker, turning an unrestored ``os.environ`` write elsewhere
+in the suite into an order-dependent failure here that blames the developer's
+shell for it.
 """
 
 from __future__ import annotations
 
-import os
-
 # Set by tests/conftest.py: a per-xdist-worker MoneyBin home, and the import
 # inbox root beneath it.
-HARNESS_OWNED = {"MONEYBIN_HOME", "MONEYBIN_IMPORT___INBOX_ROOT"}
+HARNESS_OWNED = frozenset({"MONEYBIN_HOME", "MONEYBIN_IMPORT___INBOX_ROOT"})
 
 
-def test_only_harness_owned_moneybin_env_vars_are_visible() -> None:
-    """No ambient ``MONEYBIN_*`` var survives into the test process."""
-    present = {name for name in os.environ if name.upper().startswith("MONEYBIN_")}
-    assert present == HARNESS_OWNED
+def test_only_harness_owned_moneybin_env_vars_are_visible(
+    moneybin_env_at_startup: frozenset[str],
+) -> None:
+    """No ambient ``MONEYBIN_*`` var survived conftest's cleanup."""
+    assert moneybin_env_at_startup == HARNESS_OWNED

--- a/tests/moneybin/test_env_isolation.py
+++ b/tests/moneybin/test_env_isolation.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import os
 import subprocess  # noqa: S404 — a child pytest run is how this proves isolation
-import sys
 from pathlib import Path
 
 # Set by tests/conftest.py: a per-xdist-worker MoneyBin home, and the import
@@ -64,8 +63,11 @@ def test_seeded_ambient_var_does_not_survive_into_a_child_run() -> None:
     env = dict(os.environ) | {_SEEDED_VAR: "1"}
     nodeid = f"{Path(__file__).relative_to(_REPO_ROOT)}::{_SNAPSHOT_TEST}"
 
-    result = subprocess.run(  # noqa: S603 — fixed interpreter, literal arguments
-        [sys.executable, "-m", "pytest", nodeid, "-n0", "-p", "no:cacheprovider"],
+    # `uv run pytest`, not `sys.executable -m pytest`: AGENTS.md makes uv the
+    # only supported entry point, and this test is about harness startup, so it
+    # has to start the harness the way the project actually does.
+    result = subprocess.run(  # noqa: S603  # explicit command list, no user input
+        ["uv", "run", "pytest", nodeid, "-n0", "-p", "no:cacheprovider"],  # noqa: S607  # uv resolved via PATH
         cwd=_REPO_ROOT,
         env=env,
         capture_output=True,

--- a/tests/moneybin/test_env_isolation.py
+++ b/tests/moneybin/test_env_isolation.py
@@ -1,0 +1,28 @@
+"""The suite must not read the developer's own ``MONEYBIN_*`` configuration.
+
+``MoneyBinSettings`` resolves every field from ``MONEYBIN_``-prefixed
+environment variables, so a var exported in the developer's shell (or their
+launch wrapper) reaches any test that constructs settings without an explicit
+override. Those tests then assert against the developer's machine rather than
+against the shipped defaults, and they pass in CI — where no such var
+exists — while failing locally, or the reverse.
+
+``tests/conftest.py`` clears the whole prefix at import time and re-adds only
+the vars the harness itself owns. This guard pins that set: a new harness-owned
+var must be added here deliberately, and a leaked ambient var fails loudly with
+the offending names.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Set by tests/conftest.py: a per-xdist-worker MoneyBin home, and the import
+# inbox root beneath it.
+HARNESS_OWNED = {"MONEYBIN_HOME", "MONEYBIN_IMPORT___INBOX_ROOT"}
+
+
+def test_only_harness_owned_moneybin_env_vars_are_visible() -> None:
+    """No ambient ``MONEYBIN_*`` var survives into the test process."""
+    present = {name for name in os.environ if name.upper().startswith("MONEYBIN_")}
+    assert present == HARNESS_OWNED


### PR DESCRIPTION
## Summary

`MoneyBinSettings` resolves every field from a `MONEYBIN_`-prefixed environment variable, so anything a developer exports reaches any test that builds settings without an explicit override. Those tests then assert against the machine they run on: green in CI where nothing is set, red locally, or the reverse. `test_google_oauth_authorizes_with_the_shipped_client_id_and_secret_pair` was already failing this way — an ambient `MONEYBIN_GSHEET__OAUTH_CLIENT_ID` paired a custom client id with the shipped secret and correctly tripped a production guard.

The fix is in the harness rather than in the test. `tests/conftest.py` already isolated `MONEYBIN_HOME` and `MONEYBIN_IMPORT___INBOX_ROOT` defensively; it now clears the whole prefix at import and re-adds only those two, extending the existing pattern rather than adding a second one beside it. Nine ambient variables were reaching the suite on the machine this surfaced on, so the failing test was one visible symptom of a broader class. No test file changed to accommodate the fix.

`tests/moneybin/test_env_isolation.py` carries two guards, and they are deliberately not redundant. `test_only_harness_owned_moneybin_env_vars_are_visible` pins the harness-owned set — mirroring the existing `test_keyring_isolation.py` guard — so a new harness-owned variable has to be added deliberately and a leaked one fails with the offending names. It asserts against a snapshot conftest takes at import rather than against live `os.environ`, because isolation is an import-time property: reading the environment at call time would fold in mutations from other tests sharing the same xdist worker and report them as the developer's shell.

That first guard cannot fail on a clean CI runner, though, and that is the point of the second. Where no ambient `MONEYBIN_*` variable exists, the snapshot equals the harness-owned set whether or not the clearing loop runs at all — the predicate never executes, which is exactly the trap `.claude/rules/testing.md` describes under "A Fixture That Never Reaches the Predicate Proves Nothing." So `test_seeded_ambient_var_does_not_survive_into_a_child_run` plants a lowercase `moneybin_seeded_ambient_probe` into a child `uv run pytest` and asserts two independent halves: that the harness *reported* clearing that name (proving the case-insensitive match fired) and that the child's own snapshot assertion then passed (proving nothing put it back). It is marked `@pytest.mark.slow` because it spawns a full pytest run, so `make test` (`-m "unit and not slow"`) skips it while CI's unit job (`-m unit`) still runs it — which is the right split, since it only becomes load-bearing where no ambient variables exist, and that is CI rather than a dev laptop.

The clearing is reported by an unconditional `sys.stderr.write` in `pytest_configure`, names only and never values, so a deliberate `MONEYBIN_LOGGING__LEVEL=DEBUG` run is visibly ignored rather than silently dropped. It is written to stderr rather than through `pytest_report_header` because `addopts` bakes in `-q`, which suppresses header hooks and would have hidden the line from `make test` and `make test-integration` — the two gates run most often, and so the two that most need it. xdist workers are excluded via `hasattr(config, "workerinput")`, so exactly one line is emitted per invocation rather than one per worker.

## Test plan

- [x] `make test` on the final head — 10,357 passed, 4 skipped; all four skips pre-existing and unrelated
- [x] `make test-integration` (564), `make test-scenarios` (92), `make test-e2e` (380) — all passed against the `conftest.py` change; later commits touched only the unit test file, which those marker selections do not collect
- [x] `make check` — ruff clean; pyright 0 errors, 3 pre-existing `reportlab` stub warnings
- [x] Root cause confirmed by counterfactual: unsetting the single variable turned the failing test green with no change to the test
- [x] Both guards mutation-verified across the full 2×2. With ambient vars present, disabling the clearing loop reds both. Simulating a clean runner (`env -u` on all nine), disabling the loop passes the snapshot guard and **fails** the seeded guard — which is the hole the second test exists to close
- [x] Marker split verified by collection, not assumption: `-m "unit and not slow"` collects 1 of 2, `-m unit` collects 2
- [x] Case-insensitive match confirmed load-bearing: pydantic-settings reads a fully lowercase export, and the guard catches it
- [x] Report line verified to appear exactly once per invocation under default flags with 12 xdist workers, in all four suites

Worth a reviewer's eye: whether `HARNESS_OWNED` is the right set to pin.
