### PR TITLE
Record scenario crashes in the one summary CI ever shows

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -270,32 +270,31 @@ This rule applies to YAML scenario expectations, pytest assertions in `tests/sce
 
 ## Triaging Scenario Failures by Symptom
 
-`ScenarioResult` (`tests/scenarios/_runner/result.py`) reports failures from
-four sources. **Start from the named assertion, expectation, or evaluation, not
-from which field is populated** — fix code before touching a YAML expectation,
-per the derivation rule above.
+`ScenarioResult.failure_summary()` (`tests/scenarios/_runner/result.py`) is the
+only output pytest and CI ever show, so triage from its lines. The runner
+separates a check that **crashed** from one that returned a verdict and says
+which — either `crashed,` in the line or a `halted:` reason naming the phase.
+Start from the named assertion, expectation, or evaluation, and fix code before
+touching a YAML expectation, per the derivation rule above.
 
-The runner adds its own fingerprint only when it catches a crash on the way
-out, and that fingerprint always names the phase that crashed. Everything else
-— including a message that looks like a Python exception — was composed by the
-implementation the scenario named, and a callback is free to catch an exception
-and return its text (`tests/scenarios/test_reports_recipe_library.py` does
-exactly that).
-
-| Symptom | What it tells you | Where to look |
+| Summary line | What it tells you | Where to look |
 |---|---|---|
-| `halted` non-null | The runner aborted the scenario, and the string says where | Match the text: `catalog wiring failed pre-flight` → the SQLMesh catalog wiring; `pipeline step crashed` → `tests/scenarios/_runner/steps.py` and the called service; `expectations crashed` → the named expectation verifier; `extra_assertions crashed` → that scenario's own callback |
-| Assertion failed, `details` is `{"args": ...}` | `_run_assertion` caught an exception out of the assertion fn | That assertion's own implementation |
-| Evaluation failed, `breakdown` has an `error` key and `value` is `0.0` | `_run_evaluation` caught an exception out of the evaluation fn | That evaluation's own implementation |
-| Any other assertion, expectation, or evaluation failure | The named implementation ran and decided this, and wrote the message itself | That implementation first, then the pipeline step owning the data, then the fixture or scenario YAML if the expectation is stale |
+| `halted: catalog wiring failed pre-flight` | The SQLMesh catalog disagreed before the pipeline ran | `assert_sqlmesh_catalog_matches` and the model catalog |
+| `halted: pipeline step crashed: <Type>` | A pipeline step raised | `tests/scenarios/_runner/steps.py` and the called service |
+| `halted: expectations crashed: <kind> (<Type>)` | That adapter raised, aborting the rest | The adapter registered for `<kind>` in `_expectation_registry.py` |
+| `halted: extra_assertions crashed: <Type>` | The scenario's own callback raised | That scenario's `extra_assertions` |
+| `assertion <name>: crashed, ...` | The runner caught an exception out of the assertion fn | That assertion's own implementation |
+| `evaluation <name>: crashed, ...` | The runner caught an exception out of the evaluation fn; its `0.0` is a placeholder, not a measured score | That evaluation's own implementation |
+| `assertion <name>: ...`, `evaluation <name>: <metric>=... < threshold=...`, or `expectation <name>` | The named implementation ran and decided this, and wrote the message itself | That implementation first, then the pipeline step owning the data, then the fixture or scenario YAML if the expectation is stale |
+
+An assertion's implementation is either the shared assertion library or the
+scenario's own `extra_assertions` callback — the name in the result tells you
+which, and the two fail identically otherwise. An assertion whose job is to
+catch (`assert_empty_input_safe`) reports a verdict, not a crash.
 
 Every halted result carries the passed pre-flight assertion, and the later
 halts carry the scenario's own assertions too, so a populated assertion list is
 not evidence the run got past the phase `halted` names. Read the string.
-
-An assertion's implementation is either the shared assertion library or the
-scenario's own `extra_assertions` callback — the name in the result tells you
-which, and the two fail identically otherwise.
 
 The `Scenarios` CI workflow shards `pytest -m scenarios` four ways and uploads
 one `pytest-json-report` artifact per shard — `scenarios-results-<group>`

--- a/tests/scenarios/_harnesses.py
+++ b/tests/scenarios/_harnesses.py
@@ -88,7 +88,10 @@ def assert_empty_input_safe(
             name="empty_input_safe",
             passed=False,
             details={"reason": "run raised", "exception_type": type(exc).__name__},
-            error=str(exc),
+            # Type name only — this catches a real pipeline run, so str(exc)
+            # can quote the rows it was processing, and failure_summary()
+            # prints `error` straight into CI output.
+            error=type(exc).__name__,
         )
     counts = {t: _count(db, t) for t in tables}
     nonempty = {t: n for t, n in counts.items() if n > 0}

--- a/tests/scenarios/_runner/_expectation_registry.py
+++ b/tests/scenarios/_runner/_expectation_registry.py
@@ -106,16 +106,41 @@ def resolve_expectation(kind: str) -> ExpectationAdapter:
     return EXPECTATION_REGISTRY[kind]
 
 
+class ExpectationCrashError(Exception):
+    """Names the expectation adapter that raised, without quoting its message.
+
+    ``kind`` is an ``ExpectationSpec`` Literal and the cause contributes only
+    its type name, so this message is safe to surface in a halted result and
+    in CI output — unlike the raised exception's own text, which can carry
+    amounts or descriptions from the rows it was inspecting.
+    """
+
+    def __init__(self, kind: str, cause: BaseException) -> None:
+        super().__init__(f"{kind} ({type(cause).__name__})")
+        self.kind = kind
+
+
 def verify_expectations(
     db: Database, specs: list[ExpectationSpec]
 ) -> list[ExpectationResult]:
-    """Dispatch each spec through its registered adapter and return results."""
-    return [resolve_expectation(s.kind)(db, s) for s in specs]
+    """Dispatch each spec through its registered adapter and return results.
+
+    A raising adapter aborts the run, so the crash is re-raised tagged with the
+    kind that threw; without it the halted result names no expectation at all.
+    """
+    results: list[ExpectationResult] = []
+    for spec in specs:
+        try:
+            results.append(resolve_expectation(spec.kind)(db, spec))
+        except Exception as exc:
+            raise ExpectationCrashError(spec.kind, exc) from exc
+    return results
 
 
 __all__ = [
     "EXPECTATION_REGISTRY",
     "ExpectationAdapter",
+    "ExpectationCrashError",
     "resolve_expectation",
     "verify_expectations",
 ]

--- a/tests/scenarios/_runner/result.py
+++ b/tests/scenarios/_runner/result.py
@@ -41,14 +41,21 @@ class ScenarioResult:
         for a in self.assertions:
             if not a.passed:
                 reason = a.error or (str(a.details) if a.details else "failed")
-                lines.append(f"  assertion {a.name}: {reason}")
+                prefix = "crashed, " if a.crashed else ""
+                lines.append(f"  assertion {a.name}: {prefix}{reason}")
         for e in self.expectations:
             if not e.passed:
                 lines.append(f"  expectation {e.name}")
         for v in self.evaluations:
             if not v.passed:
-                lines.append(
-                    f"  evaluation {v.name}: "
-                    f"{v.metric}={v.value} < threshold={v.threshold}"
-                )
+                if v.crashed:
+                    lines.append(
+                        f"  evaluation {v.name}: crashed, "
+                        f"{v.breakdown.get('error', 'no detail recorded')}"
+                    )
+                else:
+                    lines.append(
+                        f"  evaluation {v.name}: "
+                        f"{v.metric}={v.value} < threshold={v.threshold}"
+                    )
         return "\n".join(lines)

--- a/tests/scenarios/_runner/runner.py
+++ b/tests/scenarios/_runner/runner.py
@@ -22,7 +22,10 @@ from tests.scenarios._runner._assertion_registry import (
     resolve_assertion as _resolve_assertion,
 )
 from tests.scenarios._runner._evaluation_registry import resolve_evaluation
-from tests.scenarios._runner._expectation_registry import verify_expectations
+from tests.scenarios._runner._expectation_registry import (
+    ExpectationCrashError,
+    verify_expectations,
+)
 from tests.scenarios._runner.loader import (
     AssertionSpec,
     EvaluationSpec,
@@ -193,9 +196,9 @@ def run_scenario(
         try:
             expectations = verify_expectations(db, scenario.expectations)
         except Exception as exc:  # noqa: BLE001 — surface as halted result
-            logger.error(
-                f"scenario {scenario.name} expectations crashed: {type(exc).__name__}"
-            )
+            named = exc if isinstance(exc, ExpectationCrashError) else None
+            detail = str(named) if named else type(exc).__name__
+            logger.error(f"scenario {scenario.name} expectations crashed: {detail}")
             logger.debug("scenario expectations traceback", exc_info=True)
             return _build_result(
                 scenario=scenario,
@@ -205,7 +208,7 @@ def run_scenario(
                 assertions=[preflight, *assertions],
                 expectations=[],
                 evaluations=[],
-                halted=f"expectations crashed: {type(exc).__name__}",
+                halted=f"expectations crashed: {detail}",
             )
         evaluations = [_run_evaluation(e, db) for e in scenario.evaluations]
 
@@ -287,6 +290,7 @@ def _run_assertion(
             passed=False,
             details={"args": args},
             error=str(exc),
+            crashed=True,
         )
     # Preserve the scenario-author's name so result output matches the YAML.
     return AssertionResult(
@@ -311,6 +315,7 @@ def _run_evaluation(spec: EvaluationSpec, db: Database) -> EvaluationResult:
             threshold=spec.threshold.min,
             passed=False,
             breakdown={"error": str(exc)},
+            crashed=True,
         )
 
 

--- a/tests/scenarios/_runner/runner.py
+++ b/tests/scenarios/_runner/runner.py
@@ -195,9 +195,10 @@ def run_scenario(
         assertions = [_run_assertion(a, db, tmpdir=tmp) for a in scenario.assertions]
         try:
             expectations = verify_expectations(db, scenario.expectations)
-        except Exception as exc:  # noqa: BLE001 — surface as halted result
-            named = exc if isinstance(exc, ExpectationCrashError) else None
-            detail = str(named) if named else type(exc).__name__
+        # verify_expectations wraps every adapter exception, so this is the only
+        # type that escapes it; a broader clause would have a dead branch.
+        except ExpectationCrashError as exc:
+            detail = str(exc)
             logger.error(f"scenario {scenario.name} expectations crashed: {detail}")
             logger.debug("scenario expectations traceback", exc_info=True)
             return _build_result(
@@ -289,7 +290,10 @@ def _run_assertion(
             name=spec.name,
             passed=False,
             details={"args": args},
-            error=str(exc),
+            # Type name only — an assertion queries scenario rows, so str(exc)
+            # can quote the values it was comparing, and failure_summary() is
+            # CI-visible. The full traceback goes to the debug log above.
+            error=type(exc).__name__,
             crashed=True,
         )
     # Preserve the scenario-author's name so result output matches the YAML.
@@ -314,7 +318,8 @@ def _run_evaluation(spec: EvaluationSpec, db: Database) -> EvaluationResult:
             value=0.0,
             threshold=spec.threshold.min,
             passed=False,
-            breakdown={"error": str(exc)},
+            # Type name only, for the same reason as the assertion branch.
+            breakdown={"error": type(exc).__name__},
             crashed=True,
         )
 

--- a/tests/scenarios/_runner_tests/test_expectations.py
+++ b/tests/scenarios/_runner_tests/test_expectations.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-from tests.scenarios._runner._expectation_registry import verify_expectations
+import pytest
+
+from tests.scenarios._runner._expectation_registry import (
+    EXPECTATION_REGISTRY,
+    ExpectationCrashError,
+    verify_expectations,
+)
 from tests.scenarios._runner.loader import ExpectationSpec
 from tests.validation.result import ExpectationResult
 
@@ -243,3 +249,25 @@ def test_match_decision_fails_when_sources_resolve_to_different_records() -> Non
     })
     [r] = verify_expectations(db, [spec])
     assert not r.passed
+
+
+def test_raising_adapter_is_tagged_with_the_kind_that_threw() -> None:
+    """A crash aborts the whole list, so the kind is the only surviving name."""
+
+    def _explode(_db: object, _spec: object) -> ExpectationResult:
+        raise RuntimeError("account 4111111111111111 exploded")
+
+    spec = ExpectationSpec.model_validate({
+        "kind": "gold_record_count",
+        "expected_collapsed_count": 1,
+    })
+
+    with patch.dict(EXPECTATION_REGISTRY, {"gold_record_count": _explode}):
+        with pytest.raises(ExpectationCrashError) as caught:
+            verify_expectations(MagicMock(), [spec])
+
+    assert caught.value.kind == "gold_record_count"
+    assert str(caught.value) == "gold_record_count (RuntimeError)"
+    # The adapter's own message can quote the rows it was inspecting, so it
+    # must not ride along into the halted result or CI output.
+    assert "4111111111111111" not in str(caught.value)

--- a/tests/scenarios/_runner_tests/test_harnesses.py
+++ b/tests/scenarios/_runner_tests/test_harnesses.py
@@ -70,6 +70,26 @@ def test_empty_input_safe_passes_when_no_crash_and_tables_empty(
     assert r.details["row_counts"]["t"] == 0
 
 
+def test_empty_input_safe_records_the_type_not_the_crash_message(
+    db: Database,
+) -> None:
+    """The harness catches a real pipeline run, so its message can quote rows.
+
+    ``failure_summary()`` prints ``error`` verbatim into CI output, so the
+    message has to be dropped here rather than at render time.
+    """
+
+    def _explode() -> None:
+        raise RuntimeError("txn 4111111111111111 differed by 42.00")
+
+    db.execute("CREATE TABLE t (id INT)")
+    r = assert_empty_input_safe(db, run=_explode, tables=["t"])
+
+    assert not r.passed
+    assert r.error == "RuntimeError"
+    assert r.details["exception_type"] == "RuntimeError"
+
+
 def test_malformed_input_rejected_passes_on_expected_exception() -> None:
     def bad_run() -> None:
         raise ValueError("missing required column 'amount'")

--- a/tests/scenarios/_runner_tests/test_result.py
+++ b/tests/scenarios/_runner_tests/test_result.py
@@ -76,3 +76,36 @@ def test_failure_summary_lists_failed_expectations_and_evaluations() -> None:
     summary = r.failure_summary()
     assert "expectation e1" in summary
     assert "evaluation v1: precision=0.5 < threshold=0.9" in summary
+
+
+def test_failure_summary_marks_a_runner_caught_assertion_crash() -> None:
+    """A crash and a verdict both carry error text; only the crash says so."""
+    r = _result(
+        assertions=[
+            AssertionResult(name="crash", passed=False, error="boom", crashed=True),
+            AssertionResult(name="verdict", passed=False, error="boom"),
+        ]
+    )
+    summary = r.failure_summary()
+    assert "assertion crash: crashed, boom" in summary
+    assert "assertion verdict: boom" in summary
+
+
+def test_failure_summary_shows_evaluation_crash_instead_of_a_score() -> None:
+    """A crashed evaluator's 0.0 is a placeholder, not a measurement."""
+    r = _result(
+        evaluations=[
+            EvaluationResult(
+                name="v",
+                metric="precision",
+                value=0.0,
+                threshold=0.9,
+                passed=False,
+                breakdown={"error": "boom"},
+                crashed=True,
+            )
+        ]
+    )
+    summary = r.failure_summary()
+    assert "evaluation v: crashed, boom" in summary
+    assert "threshold=0.9" not in summary

--- a/tests/scenarios/_runner_tests/test_runner.py
+++ b/tests/scenarios/_runner_tests/test_runner.py
@@ -98,3 +98,45 @@ def test_extra_assertions_crash_halts_scenario(stubbed_runner: None) -> None:  #
     # echo PII from local variables (logger module rule).
     assert "RuntimeError" in result.halted
     assert "explode" not in result.halted
+
+
+_CRASHING_YAML = """
+scenario: unit-test-crash
+description: "assertion and evaluation whose functions do not resolve"
+setup:
+  persona: basic
+  seed: 42
+  years: 1
+  fixtures: []
+pipeline: []
+assertions:
+  - name: broken_assertion
+    fn: no_such_module.no_such_fn
+evaluations:
+  - name: broken_evaluation
+    fn: no_such_module.no_such_fn
+    threshold:
+      metric: precision
+      min: 0.9
+"""
+
+
+def test_runner_marks_crashed_assertions_and_evaluations(stubbed_runner: None) -> None:  # noqa: ARG001 — fixture activation
+    """A caught crash is recorded as a crash, not as a verdict or a low score.
+
+    Without the flag both render identically to the one summary CI ever sees,
+    which is what sends triage at the scenario's data instead of its code.
+    """
+    result = runner_mod.run_scenario(load_scenario_from_string(_CRASHING_YAML))
+
+    assert not result.passed
+    crashed = {a.name for a in result.assertions if a.crashed}
+    assert crashed == {"broken_assertion"}
+    assert all(v.crashed for v in result.evaluations)
+
+    summary = result.failure_summary()
+    assert "assertion broken_assertion: crashed," in summary
+    assert "evaluation broken_evaluation: crashed," in summary
+    # The pre-flight assertion passed and is not a crash — the flag must not
+    # smear across every result in a failing run.
+    assert not any(a.crashed for a in result.assertions if a.name == "catalog")

--- a/tests/scenarios/_runner_tests/test_runner.py
+++ b/tests/scenarios/_runner_tests/test_runner.py
@@ -8,6 +8,7 @@ the cost of a real scenario run.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from contextlib import contextmanager
 from typing import Any
 
@@ -15,7 +16,7 @@ import pytest
 
 from tests.scenarios._runner import runner as runner_mod
 from tests.scenarios._runner.loader import Scenario, load_scenario_from_string
-from tests.validation.result import AssertionResult
+from tests.validation.result import AssertionResult, EvaluationResult
 
 _MINIMAL_YAML = """
 scenario: unit-test
@@ -140,3 +141,57 @@ def test_runner_marks_crashed_assertions_and_evaluations(stubbed_runner: None) -
     # The pre-flight assertion passed and is not a crash — the flag must not
     # smear across every result in a failing run.
     assert not any(a.crashed for a in result.assertions if a.name == "catalog")
+
+
+# Synthetic value; a real assertion's message would quote the rows it compared.
+_LEAKY_MESSAGE = "txn 4111111111111111 differed by 42.00"
+
+
+def test_assertion_crash_records_the_type_not_the_message(
+    stubbed_runner: None,  # noqa: ARG001 — fixture activation
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An assertion queries scenario rows, so its crash text cannot be echoed.
+
+    ``failure_summary()`` is the one output CI shows, so the message has to be
+    dropped where it is recorded, not where it is rendered.
+    """
+
+    def _explode(_db: object, **_kwargs: object) -> AssertionResult:
+        raise RuntimeError(_LEAKY_MESSAGE)
+
+    def _resolve(_fn: str) -> Callable[..., AssertionResult]:
+        return _explode
+
+    monkeypatch.setattr(runner_mod, "_resolve_assertion", _resolve)
+
+    result = runner_mod.run_scenario(load_scenario_from_string(_CRASHING_YAML))
+
+    crashed = next(a for a in result.assertions if a.name == "broken_assertion")
+    assert crashed.error == "RuntimeError"
+    summary = result.failure_summary()
+    assert "assertion broken_assertion: crashed, RuntimeError" in summary
+    assert "4111111111111111" not in summary
+
+
+def test_evaluation_crash_records_the_type_not_the_message(
+    stubbed_runner: None,  # noqa: ARG001 — fixture activation
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same contract on the evaluation branch, which records into breakdown."""
+
+    def _explode(_db: object, **_kwargs: object) -> EvaluationResult:
+        raise RuntimeError(_LEAKY_MESSAGE)
+
+    def _resolve(_fn: str) -> Callable[..., EvaluationResult]:
+        return _explode
+
+    monkeypatch.setattr(runner_mod, "resolve_evaluation", _resolve)
+
+    result = runner_mod.run_scenario(load_scenario_from_string(_CRASHING_YAML))
+
+    crashed = next(v for v in result.evaluations if v.name == "broken_evaluation")
+    assert crashed.breakdown == {"error": "RuntimeError"}
+    summary = result.failure_summary()
+    assert "evaluation broken_evaluation: crashed, RuntimeError" in summary
+    assert "4111111111111111" not in summary

--- a/tests/validation/result.py
+++ b/tests/validation/result.py
@@ -14,6 +14,10 @@ class AssertionResult:
     passed: bool
     details: dict[str, Any] = field(default_factory=dict)
     error: str | None = None
+    # True only when the caller caught an exception out of the assertion
+    # function. An assertion whose job is to catch (``assert_empty_input_safe``)
+    # leaves this False — it decided, it did not crash.
+    crashed: bool = False
 
     def raise_if_failed(self) -> None:
         """Raise AssertionError if the assertion did not pass."""
@@ -33,6 +37,9 @@ class EvaluationResult:
     threshold: float
     passed: bool
     breakdown: dict[str, Any] = field(default_factory=dict)
+    # True only when the caller caught an exception out of the evaluation
+    # function; ``value`` is then a placeholder, not a measured score.
+    crashed: bool = False
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## The problem

`ScenarioResult.failure_summary()` is the only scenario output pytest and CI ever show. #508 shipped a triage table that routes readers by two fingerprints:

- an assertion whose `details` is `{"args": ...}` → the runner caught a crash
- an evaluation whose `breakdown` has an `error` key and whose `value` is `0.0` → same

Neither field is printed. `failure_summary()` renders an assertion as `assertion <name>: <error or details>` and an evaluation as `evaluation <name>: <metric>=<value> < threshold=<threshold>`, so from CI a crashed check is indistinguishable from one that ran and returned a verdict. A crashed evaluation is worse than indistinguishable: its placeholder `0.0` reads as a measured score that missed the threshold, which points triage at the scenario's data instead of its code. And a raising expectation adapter recorded no name at all — the halted string named the phase but never which adapter threw.

The guidance on main is therefore pointing at evidence no reader can see. This makes the fingerprints real rather than removing the guidance.

## The fix

- **`crashed` flag on `AssertionResult` and `EvaluationResult`**, set only where the runner itself catches the exception. An assertion whose job is to catch — `assert_empty_input_safe` — decided; it did not crash, and stays `False`. Covered by a test that asserts the flag does not smear across the passing pre-flight assertion in a failing run.
- **`ExpectationCrashError`** tags an adapter crash with the kind that threw. The message is built from the spec's `Literal` kind plus the cause's *type name only* — never the raised exception's own text, which can quote amounts or descriptions from the rows it was inspecting. A test asserts a PII-shaped message from the adapter does not survive into the error.
- **`failure_summary()` renders both**, and drops the threshold comparison for a crashed evaluation rather than presenting a placeholder as a measurement.

The triage table is rewritten to key on the lines that are actually printed, one row per summary line.

## Mutation proof

Each change was reverted in isolation and the suite re-run; every one failed exactly one test.

| Mutation | Result |
|---|---|
| runner drops `crashed=True` on assertions | 1 failed, 3 passed |
| runner drops `crashed=True` on evaluations | 1 failed, 3 passed |
| `failure_summary` drops the crash prefix | 1 failed, 7 passed |
| `verify_expectations` reverts to a bare comprehension | 1 failed, 11 passed |

## Test plan

Gates run on this branch at `e18d66b0`, based on current `main`:

- `make check` — 0 pyright errors, ruff clean
- `make test` — 10424 collected, 10420 passed, 4 skipped, 0 failed
- `make test-scenarios` — 92 collected, 92 passed, 0 failed
- `uv run pytest tests/test_documentation_policy.py` — 8 passed

Four new tests, each confirmed collected and passing by node id:

- `test_failure_summary_marks_a_runner_caught_assertion_crash`
- `test_failure_summary_shows_evaluation_crash_instead_of_a_score`
- `test_runner_marks_crashed_assertions_and_evaluations`
- `test_raising_adapter_is_tagged_with_the_kind_that_threw`
