### PR TITLE
Adopt moneybin.tables constants at executed-SQL call sites

### DIFF
--- a/src/moneybin/cli/commands/stats.py
+++ b/src/moneybin/cli/commands/stats.py
@@ -13,6 +13,7 @@ import typer
 from moneybin.cli.output import OutputFormat, output_option, quiet_option
 from moneybin.cli.utils import handle_cli_errors
 from moneybin.database import get_database
+from moneybin.tables import METRICS
 from moneybin.utils.parsing import parse_duration
 
 logger = logging.getLogger(__name__)
@@ -78,7 +79,7 @@ def stats_command(
                                    PARTITION BY metric_name, metric_type, labels
                                    ORDER BY recorded_at DESC
                                ) AS rn
-                        FROM app.metrics
+                        FROM {METRICS.full_name}
                         {where_sql}
                     )
                     WHERE rn = 1

--- a/src/moneybin/cli/commands/synthetic.py
+++ b/src/moneybin/cli/commands/synthetic.py
@@ -63,13 +63,17 @@ def _run_generate(
             from moneybin.database import (
                 get_database,  # noqa: PLC0415 — deferred import
             )
+            from moneybin.tables import (
+                OFX_TRANSACTIONS,  # noqa: PLC0415 — deferred import
+                TABULAR_TRANSACTIONS,
+            )
 
             with get_database(read_only=False) as db:
                 # Check if profile already has data
                 try:
                     row = db.execute(
-                        """SELECT (SELECT COUNT(*) FROM raw.ofx_transactions)
-                                + (SELECT COUNT(*) FROM raw.tabular_transactions)"""
+                        f"""SELECT (SELECT COUNT(*) FROM {OFX_TRANSACTIONS.full_name})
+                                + (SELECT COUNT(*) FROM {TABULAR_TRANSACTIONS.full_name})"""  # noqa: S608  # TableRef constants
                     ).fetchone()
                     existing_count = row[0] if row else 0
                 except Exception:  # noqa: BLE001,S110 — tables may not exist in a fresh DB

--- a/src/moneybin/connectors/gsheet/pull_service.py
+++ b/src/moneybin/connectors/gsheet/pull_service.py
@@ -35,6 +35,7 @@ from moneybin.connectors.gsheet.errors import (
 from moneybin.connectors.gsheet.sheets_api import SheetsAPI
 from moneybin.database import Database
 from moneybin.repositories.gsheet_connections_repo import GSheetConnectionsRepo
+from moneybin.tables import IMPORT_LOG
 
 logger = logging.getLogger(__name__)
 
@@ -300,12 +301,12 @@ class GSheetPullService:
         """Insert an ``importing`` row in raw.import_log scoped to this pull."""
         account_names = [] if conn.account_name is None else [conn.account_name]
         self._db.execute(
-            """
-            INSERT INTO raw.import_log (
+            f"""
+            INSERT INTO {IMPORT_LOG.full_name} (
                 import_id, source_file, source_type, source_origin,
                 format_name, format_source, account_names, status
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            """,
+            """,  # noqa: S608  # IMPORT_LOG is a TableRef constant, values parameterized
             [
                 import_id,
                 f"gsheet://{conn.spreadsheet_id}/{conn.sheet_gid}",
@@ -330,13 +331,13 @@ class GSheetPullService:
     ) -> None:
         """Finalize the import_log row with terminal status."""
         self._db.execute(
-            """
-            UPDATE raw.import_log
+            f"""
+            UPDATE {IMPORT_LOG.full_name}
                SET status = ?,
                    rows_imported = ?,
                    completed_at = CURRENT_TIMESTAMP
              WHERE import_id = ?
-            """,
+            """,  # noqa: S608  # IMPORT_LOG is a TableRef constant, values parameterized
             [status, rows_imported, import_id],
         )
 

--- a/src/moneybin/extractors/plaid/extractor.py
+++ b/src/moneybin/extractors/plaid/extractor.py
@@ -38,11 +38,14 @@ from moneybin.metrics.registry import (
     SYNC_INVESTMENTS_RECORDS_LOADED,
 )
 from moneybin.tables import (
+    PLAID_ACCOUNTS,
+    PLAID_BALANCES,
     PLAID_INVESTMENT_HOLDING_LOTS,
     PLAID_INVESTMENT_HOLDINGS,
     PLAID_INVESTMENT_HOLDINGS_SNAPSHOTS,
     PLAID_INVESTMENT_TRANSACTIONS,
     PLAID_SECURITIES,
+    PLAID_TRANSACTIONS,
     SECURITY_PRICES,
 )
 
@@ -529,7 +532,7 @@ class PlaidExtractor:
             ],
             schema=_ACCOUNTS_SCHEMA,
         )
-        self.db.ingest_dataframe("raw.plaid_accounts", df, on_conflict="upsert")
+        self.db.ingest_dataframe(PLAID_ACCOUNTS.full_name, df, on_conflict="upsert")
         # Info, not debug: the CLI's per-institution totals go out via
         # typer.echo, which never reaches the log file — so these row counts
         # are the only durable record of what a sync loaded. Denylisted from
@@ -563,7 +566,7 @@ class PlaidExtractor:
             ],
             schema=_TRANSACTIONS_SCHEMA,
         )
-        self.db.ingest_dataframe("raw.plaid_transactions", df, on_conflict="upsert")
+        self.db.ingest_dataframe(PLAID_TRANSACTIONS.full_name, df, on_conflict="upsert")
         logger.info(f"Loaded {len(df)} Plaid transactions")
         return len(df)
 
@@ -591,7 +594,7 @@ class PlaidExtractor:
             ],
             schema=_BALANCES_SCHEMA,
         )
-        self.db.ingest_dataframe("raw.plaid_balances", df, on_conflict="upsert")
+        self.db.ingest_dataframe(PLAID_BALANCES.full_name, df, on_conflict="upsert")
         logger.info(f"Loaded {len(df)} Plaid balance snapshots")
         return len(df)
 
@@ -933,12 +936,12 @@ class PlaidExtractor:
         # COUNT(*) is the simplest accurate signal; the two statements share the
         # write lock for the duration of the call.
         count_row = self.db.execute(
-            f"SELECT COUNT(*) FROM raw.plaid_transactions WHERE transaction_id IN ({placeholders})",  # noqa: S608  # placeholders are ?, values parameterized
+            f"SELECT COUNT(*) FROM {PLAID_TRANSACTIONS.full_name} WHERE transaction_id IN ({placeholders})",  # noqa: S608  # placeholders are ?, values parameterized
             removed_ids,
         ).fetchone()
         deleted = int(count_row[0]) if count_row else 0
         self.db.execute(
-            f"DELETE FROM raw.plaid_transactions WHERE transaction_id IN ({placeholders})",  # noqa: S608  # placeholders are ?, values parameterized
+            f"DELETE FROM {PLAID_TRANSACTIONS.full_name} WHERE transaction_id IN ({placeholders})",  # noqa: S608  # placeholders are ?, values parameterized
             removed_ids,
         )
         return deleted

--- a/src/moneybin/extractors/tabular/formats.py
+++ b/src/moneybin/extractors/tabular/formats.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING, Literal
 import yaml
 from pydantic import BaseModel
 
+from moneybin.tables import TABULAR_FORMATS
+
 if TYPE_CHECKING:
     from moneybin.database import Database
 
@@ -224,16 +226,16 @@ def load_formats_from_db(db: Database) -> dict[str, TabularFormat]:
     """
     try:
         rows = db.execute(
-            """
+            f"""
             SELECT
                 name, institution_name, file_type, delimiter, encoding,
                 skip_rows, sheet, header_signature, field_mapping,
                 sign_convention, date_format, number_format,
                 skip_trailing_patterns, multi_account, source,
                 times_used, last_used_at
-            FROM app.tabular_formats
+            FROM {TABULAR_FORMATS.full_name}
             ORDER BY name
-            """
+            """  # noqa: S608  # TABULAR_FORMATS is a TableRef constant
         ).fetchall()
     except Exception:  # noqa: BLE001  # table may not exist before first migration
         logger.debug("app.tabular_formats not available; returning empty format set")

--- a/src/moneybin/investments/sqlmesh_loader.py
+++ b/src/moneybin/investments/sqlmesh_loader.py
@@ -26,6 +26,7 @@ from decimal import Decimal
 import pandas as pd
 
 from moneybin.investments.cost_basis import LedgerEvent, resolve_cost_basis_method
+from moneybin.tables import ACCOUNT_SETTINGS, LOT_SELECTIONS, SECURITIES
 
 if t.TYPE_CHECKING:
     from sqlmesh import ExecutionContext  # type: ignore[import-untyped]
@@ -164,7 +165,8 @@ def _load_ledger(
 def _load_method_for(context: ExecutionContext) -> MethodFor:
     """Fetch the election tables and bind them to ``resolve_cost_basis_method``."""
     securities: pd.DataFrame = context.fetchdf(
-        "SELECT security_id, cost_basis_method, security_type FROM app.securities"
+        "SELECT security_id, cost_basis_method, security_type "  # noqa: S608  # SECURITIES is a TableRef constant
+        f"FROM {SECURITIES.full_name}"
     )
     security_method: dict[str, str] = {}
     security_type: dict[str, str] = {}
@@ -175,11 +177,11 @@ def _load_method_for(context: ExecutionContext) -> MethodFor:
         if method is not None:
             security_method[sid] = str(method)
     accounts: pd.DataFrame = context.fetchdf(
-        """
+        f"""
         SELECT account_id, default_cost_basis_method
-        FROM app.account_settings
+        FROM {ACCOUNT_SETTINGS.full_name}
         WHERE NOT default_cost_basis_method IS NULL
-        """
+        """  # noqa: S608  # ACCOUNT_SETTINGS is a TableRef constant
     )
     account_default = {
         str(record["account_id"]): str(record["default_cost_basis_method"])
@@ -203,11 +205,11 @@ def _load_selections_for(context: ExecutionContext) -> SelectionsFor:
     # to the LAST slice. A non-deterministic row order could shift a one-cent
     # residual between lots across rebuilds, breaking content-hash-stable output.
     selections_frame: pd.DataFrame = context.fetchdf(
-        """
+        f"""
         SELECT investment_transaction_id, lot_id, quantity::VARCHAR AS quantity
-        FROM app.lot_selections
+        FROM {LOT_SELECTIONS.full_name}
         ORDER BY investment_transaction_id, lot_id
-        """
+        """  # noqa: S608  # LOT_SELECTIONS is a TableRef constant
     )
     selections: dict[str, list[tuple[str, Decimal]]] = {}
     for record in _records(selections_frame):

--- a/src/moneybin/matching/priority.py
+++ b/src/moneybin/matching/priority.py
@@ -9,6 +9,7 @@ import logging
 
 from moneybin.config import MatchingSettings
 from moneybin.database import Database
+from moneybin.tables import SEED_SOURCE_PRIORITY
 
 logger = logging.getLogger(__name__)
 
@@ -19,14 +20,14 @@ def seed_source_priority(db: Database, settings: MatchingSettings) -> None:
     Deletes all existing rows and reinserts from the settings list.
     This is safe because the table is never user-edited — config owns it.
     """
-    db.execute("DELETE FROM app.seed_source_priority")
+    db.execute(f"DELETE FROM {SEED_SOURCE_PRIORITY.full_name}")  # noqa: S608  # TableRef constant
     rows = [
         [source_type, rank]
         for rank, source_type in enumerate(settings.source_priority, start=1)
     ]
     if rows:
         db.executemany(
-            "INSERT INTO app.seed_source_priority (source_type, priority) VALUES (?, ?)",
+            f"INSERT INTO {SEED_SOURCE_PRIORITY.full_name} (source_type, priority) VALUES (?, ?)",  # noqa: S608  # TableRef constant
             rows,
         )
     logger.debug(

--- a/src/moneybin/metrics/persistence.py
+++ b/src/moneybin/metrics/persistence.py
@@ -19,6 +19,8 @@ from typing import Any, Protocol, cast
 from prometheus_client import CollectorRegistry
 from prometheus_client.metrics import MetricWrapperBase
 
+from moneybin.tables import METRICS
+
 
 class _DBExecutor(Protocol):
     """Minimal interface for database access in metrics persistence."""
@@ -121,12 +123,12 @@ def flush_to_duckdb(
     try:
         db.begin()
         db.executemany(
-            """
-            INSERT INTO app.metrics
+            f"""
+            INSERT INTO {METRICS.full_name}
                 (metric_name, metric_type, labels, value,
                  bucket_bounds, bucket_counts, recorded_at)
             VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
+            """,  # noqa: S608  # METRICS is a TableRef constant, values parameterized
             rows,
         )
         db.commit()
@@ -164,15 +166,15 @@ def load_from_duckdb(
         raw_rows = cast(
             list[tuple[Any, ...]],
             db.execute(
-                """
+                f"""
                 SELECT metric_name, metric_type, labels, value
-                FROM app.metrics
+                FROM {METRICS.full_name}
                 WHERE (metric_name, labels, recorded_at) IN (
                     SELECT metric_name, labels, MAX(recorded_at)
-                    FROM app.metrics
+                    FROM {METRICS.full_name}
                     GROUP BY metric_name, labels
                 )
-                """
+                """  # noqa: S608  # METRICS is a TableRef constant, no user input
             ).fetchall(),
         )
     except Exception:  # noqa: BLE001  # table may not exist yet; silently skip

--- a/src/moneybin/migrations.py
+++ b/src/moneybin/migrations.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from moneybin.tables import SCHEMA_MIGRATIONS, VERSIONS
+
 if TYPE_CHECKING:
     from datetime import datetime
 
@@ -253,7 +255,7 @@ class MigrationRunner:
         ).fetchone()
         if row is None:
             self._db.execute(
-                "ALTER TABLE app.schema_migrations ADD COLUMN content_hash VARCHAR"
+                f"ALTER TABLE {SCHEMA_MIGRATIONS.full_name} ADD COLUMN content_hash VARCHAR"
             )
         self._tracking_schema_bootstrapped = True
 
@@ -264,7 +266,7 @@ class MigrationRunner:
             List of DriftWarning for files that have changed or gone missing.
         """
         applied_rows = self._db.execute(
-            "SELECT version, filename, checksum FROM app.schema_migrations "
+            f"SELECT version, filename, checksum FROM {SCHEMA_MIGRATIONS.full_name} "  # noqa: S608  # TableRef constant
             "WHERE success = TRUE"
         ).fetchall()
         if not applied_rows:
@@ -343,7 +345,7 @@ class MigrationRunner:
         """
         self._ensure_tracking_schema()
         rows = self._db.execute(
-            "SELECT version, filename, content_hash FROM app.schema_migrations "
+            f"SELECT version, filename, content_hash FROM {SCHEMA_MIGRATIONS.full_name} "  # noqa: S608  # TableRef constant
             "WHERE success = FALSE ORDER BY version"
         ).fetchall()
         if not rows:
@@ -367,7 +369,7 @@ class MigrationRunner:
             Dict mapping version number to checksum string.
         """
         rows = self._db.execute(
-            "SELECT version, checksum FROM app.schema_migrations"
+            f"SELECT version, checksum FROM {SCHEMA_MIGRATIONS.full_name}"  # noqa: S608  # TableRef constant
         ).fetchall()
         return {row[0]: row[1] for row in rows}
 
@@ -378,8 +380,8 @@ class MigrationRunner:
             List of AppliedMigration records.
         """
         rows = self._db.execute(
-            "SELECT version, filename, success, execution_ms, applied_at "
-            "FROM app.schema_migrations ORDER BY version"
+            "SELECT version, filename, success, execution_ms, applied_at "  # noqa: S608  # TableRef constant
+            f"FROM {SCHEMA_MIGRATIONS.full_name} ORDER BY version"
         ).fetchall()
         return [
             AppliedMigration(
@@ -403,7 +405,7 @@ class MigrationRunner:
         """
         self._ensure_tracking_schema()
         rows = self._db.execute(
-            "SELECT version, success, content_hash FROM app.schema_migrations"
+            f"SELECT version, success, content_hash FROM {SCHEMA_MIGRATIONS.full_name}"  # noqa: S608  # TableRef constant
         ).fetchall()
         state_by_version: dict[int, tuple[bool, str | None]] = {
             row[0]: (row[1], row[2]) for row in rows
@@ -439,7 +441,7 @@ class MigrationRunner:
             elapsed_ms: Execution time in milliseconds.
         """
         self._db.execute(
-            "INSERT INTO app.schema_migrations "
+            f"INSERT INTO {SCHEMA_MIGRATIONS.full_name} "  # noqa: S608  # TableRef constant, values parameterized
             "(version, filename, checksum, success, execution_ms, content_hash) "
             "VALUES (?, ?, ?, ?, ?, ?)",
             [
@@ -471,7 +473,7 @@ class MigrationRunner:
         """
         self._ensure_tracking_schema()
         existing = self._db.execute(
-            "SELECT success, content_hash FROM app.schema_migrations WHERE version = ?",
+            f"SELECT success, content_hash FROM {SCHEMA_MIGRATIONS.full_name} WHERE version = ?",  # noqa: S608  # TableRef constant
             [migration.version],
         ).fetchone()
         if existing is not None:
@@ -501,7 +503,7 @@ class MigrationRunner:
                 f"and retrying."
             )
             self._db.execute(
-                "DELETE FROM app.schema_migrations WHERE version = ?",
+                f"DELETE FROM {SCHEMA_MIGRATIONS.full_name} WHERE version = ?",  # noqa: S608  # TableRef constant
                 [migration.version],
             )
 
@@ -602,7 +604,9 @@ def get_current_versions(db: Database) -> dict[str, str]:
     Returns:
         Dict mapping component name to version string.
     """
-    rows = db.execute("SELECT component, version FROM app.versions").fetchall()
+    rows = db.execute(
+        f"SELECT component, version FROM {VERSIONS.full_name}"  # noqa: S608  # TableRef constant
+    ).fetchall()
     return {row[0]: row[1] for row in rows}
 
 
@@ -618,18 +622,19 @@ def record_version(db: Database, component: str, version: str) -> None:
         version: Current version string.
     """
     existing = db.execute(
-        "SELECT version FROM app.versions WHERE component = ?", [component]
+        f"SELECT version FROM {VERSIONS.full_name} WHERE component = ?",  # noqa: S608  # TableRef constant
+        [component],
     ).fetchone()
 
     if existing is None:
         db.execute(
-            "INSERT INTO app.versions (component, version) VALUES (?, ?)",
+            f"INSERT INTO {VERSIONS.full_name} (component, version) VALUES (?, ?)",  # noqa: S608  # TableRef constant
             [component, version],
         )
         logger.debug(f"Recorded {component} version {version} (first install)")
     elif existing[0] != version:
         db.execute(
-            "UPDATE app.versions SET previous_version = version, "
+            f"UPDATE {VERSIONS.full_name} SET previous_version = version, "  # noqa: S608  # TableRef constant
             "version = ?, updated_at = CURRENT_TIMESTAMP WHERE component = ?",
             [version, component],
         )

--- a/src/moneybin/privacy/sql_lineage.py
+++ b/src/moneybin/privacy/sql_lineage.py
@@ -69,6 +69,7 @@ from moneybin.privacy.taxonomy import (
     DataClass,
     Tier,
 )
+from moneybin.tables import SCHEMA_MIGRATIONS
 
 logger = logging.getLogger(__name__)
 
@@ -172,7 +173,7 @@ class SchemaSnapshot:
 def _schema_version(db: Database) -> int:
     try:
         row = db.execute(
-            "SELECT COALESCE(MAX(version), 0) FROM app.schema_migrations"
+            f"SELECT COALESCE(MAX(version), 0) FROM {SCHEMA_MIGRATIONS.full_name}"  # noqa: S608  # TableRef constant
         ).fetchone()
         return int(row[0]) if row else 0
     except duckdb.CatalogException:

--- a/src/moneybin/repositories/securities_repo.py
+++ b/src/moneybin/repositories/securities_repo.py
@@ -26,7 +26,7 @@ from typing import Any, cast
 
 from moneybin.repositories.base import BaseRepo
 from moneybin.services.audit_service import AuditEvent
-from moneybin.tables import SECURITIES
+from moneybin.tables import AUDIT_LOG, SECURITIES
 
 _SECURITIES_COLUMNS = (
     "security_id",
@@ -268,8 +268,8 @@ class SecuritiesRepo(BaseRepo):
         legitimately owns.
         """
         row = self._db.execute(
-            """
-            SELECT after_value FROM app.audit_log
+            f"""
+            SELECT after_value FROM {AUDIT_LOG.full_name}
              WHERE target_schema = ? AND target_table = ? AND target_id = ?
                AND is_undo = FALSE
                AND after_value IS NOT NULL
@@ -277,7 +277,7 @@ class SecuritiesRepo(BaseRepo):
                     OR (action = 'securities.upsert' AND before_value IS NULL))
              ORDER BY rowid DESC
              LIMIT 1
-            """,
+            """,  # noqa: S608  # AUDIT_LOG is a TableRef constant, values parameterized
             [*self._audit_target, security_id],
         ).fetchone()
         if row is None:

--- a/src/moneybin/services/audit_service.py
+++ b/src/moneybin/services/audit_service.py
@@ -24,6 +24,7 @@ from typing import Any
 from moneybin.database import Database
 from moneybin.metrics.registry import audit_events_emitted_total
 from moneybin.services.mutation_context import current_operation_id
+from moneybin.tables import AUDIT_LOG
 
 logger = logging.getLogger(__name__)
 
@@ -133,14 +134,14 @@ class AuditService:
         # operation — operation_id is NOT NULL by design.
         operation_id = current_operation_id()
         self._db.conn.execute(
-            """
-            INSERT INTO app.audit_log (
+            f"""
+            INSERT INTO {AUDIT_LOG.full_name} (
                 audit_id, actor, action,
                 target_schema, target_table, target_id,
                 before_value, after_value, parent_audit_id, operation_id,
                 context_json, is_undo, undoes_operation_id
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
+            """,  # noqa: S608  # AUDIT_LOG is a TableRef constant, values parameterized
             [
                 audit_id,
                 actor,
@@ -239,7 +240,7 @@ class AuditService:
         )
         self._db.conn.execute(
             f"""
-            INSERT INTO app.audit_log (
+            INSERT INTO {AUDIT_LOG.full_name} (
                 audit_id, actor, action,
                 target_schema, target_table, target_id,
                 before_value, after_value, parent_audit_id, operation_id,
@@ -303,7 +304,7 @@ class AuditService:
                    target_schema, target_table, target_id,
                    before_value, after_value, parent_audit_id,
                    operation_id, context_json, {self._undo_columns_sql()}
-              FROM app.audit_log
+              FROM {AUDIT_LOG.full_name}
               {where}
               ORDER BY occurred_at DESC, audit_id DESC
               {limit_sql}
@@ -324,7 +325,7 @@ class AuditService:
             where = "WHERE occurred_at < ? OR (occurred_at = ? AND audit_id <= ?)"
             params.extend([snapshot[0], snapshot[0], snapshot[1]])
         row = self._db.conn.execute(
-            f"SELECT COUNT(*) FROM app.audit_log {where}",  # noqa: S608  # fixed predicate fragment
+            f"SELECT COUNT(*) FROM {AUDIT_LOG.full_name} {where}",  # noqa: S608  # fixed predicate fragment
             params,
         ).fetchone()
         return int(row[0]) if row is not None else 0
@@ -346,7 +347,7 @@ class AuditService:
                    target_schema, target_table, target_id,
                    before_value, after_value, parent_audit_id,
                    operation_id, context_json, {self._undo_columns_sql()}
-              FROM app.audit_log
+              FROM {AUDIT_LOG.full_name}
              WHERE target_id = ?
                 OR json_extract_string(before_value, '$.transaction_id') = ?
                 OR json_extract_string(after_value, '$.transaction_id') = ?
@@ -376,7 +377,7 @@ class AuditService:
                    target_schema, target_table, target_id,
                    before_value, after_value, parent_audit_id,
                    operation_id, context_json, {self._undo_columns_sql()}
-              FROM app.audit_log
+              FROM {AUDIT_LOG.full_name}
              WHERE operation_id = ?
              ORDER BY occurred_at ASC, rowid ASC
             """,  # noqa: S608  # undo-columns fragment is a controlled literal
@@ -392,7 +393,7 @@ class AuditService:
                    target_schema, target_table, target_id,
                    before_value, after_value, parent_audit_id,
                    operation_id, context_json, {self._undo_columns_sql()}
-              FROM app.audit_log
+              FROM {AUDIT_LOG.full_name}
              WHERE audit_id = ? OR parent_audit_id = ?
              ORDER BY occurred_at ASC, audit_id ASC
             """,  # noqa: S608  # undo-columns fragment is a controlled literal

--- a/src/moneybin/services/demo_service.py
+++ b/src/moneybin/services/demo_service.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 
 from moneybin import error_codes
 from moneybin.errors import UserError
+from moneybin.tables import OFX_TRANSACTIONS, TABULAR_TRANSACTIONS
 
 if TYPE_CHECKING:
     from moneybin.database import Database
@@ -133,8 +134,8 @@ def _check_refresh(result: RefreshResult) -> None:
 def _count_transactions(db: Database) -> int:
     try:
         row = db.execute(
-            "SELECT (SELECT COUNT(*) FROM raw.ofx_transactions) "
-            "+ (SELECT COUNT(*) FROM raw.tabular_transactions)"
+            f"SELECT (SELECT COUNT(*) FROM {OFX_TRANSACTIONS.full_name}) "
+            f"+ (SELECT COUNT(*) FROM {TABULAR_TRANSACTIONS.full_name})"  # noqa: S608  # TableRef constants
         ).fetchone()
         return int(row[0]) if row else 0
     except Exception:  # noqa: BLE001,S110 — tables may not exist in a fresh DB

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -61,6 +61,7 @@ from moneybin.tables import (
     SECURITY_LINKS,
     SECURITY_PRICE_OVERRIDES,
     SECURITY_PRICES,
+    STG_SECURITY_PRICES,
     TABULAR_FORMATS,
     TRANSACTION_CATEGORIES,
     TRANSACTION_ID_ALIASES,
@@ -1368,10 +1369,10 @@ class DoctorService:
         tolerance = get_settings().investments.price_disagreement_tolerance_pct / 100
         try:
             rows = self._db.execute(
-                """
+                f"""
                 SELECT DISTINCT a.security_id
-                FROM prep.stg_security_prices AS a
-                JOIN prep.stg_security_prices AS b
+                FROM {STG_SECURITY_PRICES.full_name} AS a
+                JOIN {STG_SECURITY_PRICES.full_name} AS b
                   ON b.security_id = a.security_id
                   AND b.price_date = a.price_date
                   AND b.quote_currency = a.quote_currency
@@ -1379,13 +1380,13 @@ class DoctorService:
                 WHERE ABS(a.close - b.close) / ((a.close + b.close) / 2) > ?
                   AND NOT EXISTS (
                     SELECT 1
-                    FROM app.security_price_overrides AS o
+                    FROM {SECURITY_PRICE_OVERRIDES.full_name} AS o
                     WHERE o.security_id = a.security_id
                       AND o.price_date = a.price_date
                       AND o.quote_currency = a.quote_currency
                   )
                 ORDER BY a.security_id
-                """,  # noqa: S608  # fixed view name + bound parameter, no user input
+                """,  # noqa: S608  # TableRef constants + bound parameter, no user input
                 [tolerance],
             ).fetchall()
         except Exception as e:  # noqa: BLE001 — staging view absent before first transform
@@ -1593,7 +1594,7 @@ class DoctorService:
                   AND l.ref_value = p.provider_security_key
                 WHERE NOT EXISTS (
                     SELECT 1
-                    FROM prep.stg_security_prices AS s
+                    FROM {STG_SECURITY_PRICES.full_name} AS s
                     WHERE s.source_type = p.source_type
                 )
                 ORDER BY p.source_type

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -81,6 +81,14 @@ from moneybin.services.ledger_overlap import (
 from moneybin.services.refresh import refresh as _refresh
 from moneybin.services.refresh import step_outcome as _step_outcome
 from moneybin.services.refresh_outcome import RefreshStepOutcome
+from moneybin.tables import (
+    IMPORTS,
+    OFX_ACCOUNTS,
+    OFX_BALANCES,
+    OFX_INSTITUTIONS,
+    OFX_TRANSACTIONS,
+    TABULAR_TRANSACTIONS,
+)
 from moneybin.utils.file import source_sha256
 
 logger = logging.getLogger(__name__)
@@ -2318,10 +2326,10 @@ class ImportService:
         rows_loaded: dict[str, int] = {}
         try:
             for table_key, qualified in (
-                ("institutions", "raw.ofx_institutions"),
-                ("accounts", "raw.ofx_accounts"),
-                ("transactions", "raw.ofx_transactions"),
-                ("balances", "raw.ofx_balances"),
+                ("institutions", OFX_INSTITUTIONS.full_name),
+                ("accounts", OFX_ACCOUNTS.full_name),
+                ("transactions", OFX_TRANSACTIONS.full_name),
+                ("balances", OFX_BALANCES.full_name),
             ):
                 df = data[table_key]
                 if len(df) > 0:
@@ -2402,7 +2410,7 @@ class ImportService:
 
         if transactions_imported > 0:
             result.date_range = self._query_date_range(
-                "raw.ofx_transactions", "CAST(date_posted AS DATE)", canonical_path
+                OFX_TRANSACTIONS.full_name, "CAST(date_posted AS DATE)", canonical_path
             )
 
         return result
@@ -3988,7 +3996,7 @@ class ImportService:
 
         if rows_imported > 0:
             result.date_range = self._query_date_range(
-                "raw.tabular_transactions", "transaction_date", file_path
+                TABULAR_TRANSACTIONS.full_name, "transaction_date", file_path
             )
 
         # Auto-save detected format for future imports.
@@ -6572,7 +6580,7 @@ class ImportService:
     def list_labels(self, import_id: str) -> list[str]:
         """Return the labels currently attached to ``import_id`` (or empty)."""
         row = self._db.conn.execute(
-            "SELECT labels FROM app.imports WHERE import_id = ?",
+            f"SELECT labels FROM {IMPORTS.full_name} WHERE import_id = ?",  # noqa: S608  # TableRef constant
             [import_id],
         ).fetchone()
         if row is None or row[0] is None:
@@ -6582,13 +6590,13 @@ class ImportService:
     def list_distinct_labels(self) -> list[tuple[str, int]]:
         """Return ``(label, usage_count)`` across all import rows, sorted desc."""
         rows = self._db.conn.execute(
-            """
+            f"""
             SELECT label, COUNT(*) AS n
-              FROM (SELECT UNNEST(labels) AS label FROM app.imports)
+              FROM (SELECT UNNEST(labels) AS label FROM {IMPORTS.full_name})
              WHERE label IS NOT NULL
              GROUP BY label
              ORDER BY n DESC, label ASC
-            """
+            """  # noqa: S608  # IMPORTS is a TableRef constant
         ).fetchall()
         return [(str(r[0]), int(r[1])) for r in rows]
 

--- a/src/moneybin/services/schema_catalog.py
+++ b/src/moneybin/services/schema_catalog.py
@@ -20,7 +20,7 @@ from moneybin import error_codes
 from moneybin.database import Database, get_database
 from moneybin.errors import UserError
 from moneybin.privacy.sql_query import ALLOWED_QUERY_SCHEMAS
-from moneybin.tables import IMPORT_LOG, INTERFACE_TABLES
+from moneybin.tables import GSHEET_CONNECTIONS, IMPORT_LOG, INTERFACE_TABLES
 
 logger = logging.getLogger(__name__)
 
@@ -911,14 +911,14 @@ def _gsheet_seed_views(db: Database) -> list[dict[str, Any]]:
     """
     try:
         connections = db.execute(
-            """
+            f"""
             SELECT connection_id, alias
-            FROM app.gsheet_connections
+            FROM {GSHEET_CONNECTIONS.full_name}
             WHERE adapter = 'seed'
               AND status != 'disconnected'
               AND alias IS NOT NULL
             ORDER BY created_at ASC, connection_id ASC
-            """
+            """  # noqa: S608  # GSHEET_CONNECTIONS is a TableRef constant
         ).fetchall()
     except duckdb.CatalogException:
         # Table absent on bare DBs before init_schemas — no seed views to add.

--- a/src/moneybin/services/system_service.py
+++ b/src/moneybin/services/system_service.py
@@ -149,7 +149,7 @@ class SystemService:
         try:
             row = self._db.execute(
                 "SELECT last_changed_at, last_applied_at, last_executed_at, model_kind "
-                f"FROM {MODEL_FRESHNESS.full_name} "
+                f"FROM {MODEL_FRESHNESS.full_name} "  # noqa: S608  # MODEL_FRESHNESS is a TableRef constant
                 "WHERE model_name = ?",
                 [model_name],
             ).fetchone()

--- a/src/moneybin/services/system_service.py
+++ b/src/moneybin/services/system_service.py
@@ -11,7 +11,7 @@ from moneybin.services.categorization import CategorizationService
 from moneybin.services.matching_service import MatchingService
 from moneybin.services.review_service import ReviewService
 from moneybin.services.transform_service import TransformService
-from moneybin.tables import DIM_ACCOUNTS, FCT_TRANSACTIONS, IMPORT_LOG
+from moneybin.tables import DIM_ACCOUNTS, FCT_TRANSACTIONS, IMPORT_LOG, MODEL_FRESHNESS
 
 logger = logging.getLogger(__name__)
 
@@ -149,7 +149,7 @@ class SystemService:
         try:
             row = self._db.execute(
                 "SELECT last_changed_at, last_applied_at, last_executed_at, model_kind "
-                "FROM meta.model_freshness "
+                f"FROM {MODEL_FRESHNESS.full_name} "
                 "WHERE model_name = ?",
                 [model_name],
             ).fetchone()

--- a/src/moneybin/services/transaction_service.py
+++ b/src/moneybin/services/transaction_service.py
@@ -57,6 +57,8 @@ from moneybin.tables import (
     FCT_TRANSACTIONS,
     MANUAL_TRANSACTIONS,
     TRANSACTION_NOTES,
+    TRANSACTION_SPLITS,
+    TRANSACTION_TAGS,
 )
 
 logger = logging.getLogger(__name__)
@@ -1329,11 +1331,11 @@ class TransactionService:
             transaction_id=transaction_id, note_id=note_id, text=text, actor=actor
         )
         row = self._db.conn.execute(
-            """
+            f"""
             SELECT note_id, transaction_id, text, author, created_at
-              FROM app.transaction_notes
+              FROM {TRANSACTION_NOTES.full_name}
              WHERE note_id = ?
-            """,
+            """,  # noqa: S608  # TRANSACTION_NOTES is a TableRef constant
             [note_id],
         ).fetchone()
         if row is None:  # defensive — insert just succeeded
@@ -1349,11 +1351,11 @@ class TransactionService:
         validate_note_text(text)
         self._notes_repo.edit(note_id=note_id, text=text, actor=actor)
         row = self._db.conn.execute(
-            """
+            f"""
             SELECT note_id, transaction_id, text, author, created_at
-              FROM app.transaction_notes
+              FROM {TRANSACTION_NOTES.full_name}
              WHERE note_id = ?
-            """,
+            """,  # noqa: S608  # TRANSACTION_NOTES is a TableRef constant
             [note_id],
         ).fetchone()
         if row is None:
@@ -1390,7 +1392,7 @@ class TransactionService:
         try:
             for tag in tags:
                 existed = self._db.conn.execute(
-                    "SELECT 1 FROM app.transaction_tags "
+                    f"SELECT 1 FROM {TRANSACTION_TAGS.full_name} "  # noqa: S608  # TableRef constant
                     "WHERE transaction_id = ? AND tag = ?",
                     [transaction_id, tag],
                 ).fetchone()
@@ -1427,7 +1429,7 @@ class TransactionService:
         try:
             for tag in tags:
                 existed = self._db.conn.execute(
-                    "SELECT 1 FROM app.transaction_tags "
+                    f"SELECT 1 FROM {TRANSACTION_TAGS.full_name} "  # noqa: S608  # TableRef constant
                     "WHERE transaction_id = ? AND tag = ?",
                     [transaction_id, tag],
                 ).fetchone()
@@ -1554,26 +1556,26 @@ class TransactionService:
         validate_slug(old_tag)
         validate_slug(new_tag)
         rows = self._db.conn.execute(
-            """
+            f"""
             SELECT transaction_id
-              FROM app.transaction_tags
+              FROM {TRANSACTION_TAGS.full_name}
              WHERE tag = ?
              ORDER BY transaction_id
-            """,
+            """,  # noqa: S608  # TRANSACTION_TAGS is a TableRef constant
             [old_tag],
         ).fetchall()
         target_ids = tuple(str(row[0]) for row in rows)
         if target_ids:
             conflicts = self._db.conn.execute(
-                """
+                f"""
                 SELECT transaction_id
-                  FROM app.transaction_tags
+                  FROM {TRANSACTION_TAGS.full_name}
                  WHERE tag = ? AND transaction_id IN (
                     SELECT transaction_id
-                      FROM app.transaction_tags
+                      FROM {TRANSACTION_TAGS.full_name}
                      WHERE tag = ?
                  )
-                """,
+                """,  # noqa: S608  # TRANSACTION_TAGS is a TableRef constant
                 [new_tag, old_tag],
             ).fetchall()
             if conflicts:
@@ -1622,11 +1624,11 @@ class TransactionService:
     def list_tags(self, transaction_id: str) -> list[str]:
         """Return the tags applied to a transaction in lexicographic order."""
         rows = self._db.conn.execute(
-            """
-            SELECT tag FROM app.transaction_tags
+            f"""
+            SELECT tag FROM {TRANSACTION_TAGS.full_name}
              WHERE transaction_id = ?
              ORDER BY tag
-            """,
+            """,  # noqa: S608  # TRANSACTION_TAGS is a TableRef constant
             [transaction_id],
         ).fetchall()
         return [str(r[0]) for r in rows]
@@ -1638,24 +1640,24 @@ class TransactionService:
         i.e. the number of (transaction, tag) applications.
         """
         rows = self._db.conn.execute(
-            """
+            f"""
             SELECT tag, COUNT(*) AS usage_count
-              FROM app.transaction_tags
+              FROM {TRANSACTION_TAGS.full_name}
              GROUP BY tag
              ORDER BY tag
-            """
+            """  # noqa: S608  # TRANSACTION_TAGS is a TableRef constant
         ).fetchall()
         return [(str(r[0]), int(r[1])) for r in rows]
 
     def list_notes(self, transaction_id: str) -> list[Note]:
         """Return all notes for a transaction in chronological order."""
         rows = self._db.conn.execute(
-            """
+            f"""
             SELECT note_id, transaction_id, text, author, created_at
-              FROM app.transaction_notes
+              FROM {TRANSACTION_NOTES.full_name}
              WHERE transaction_id = ?
              ORDER BY created_at, note_id
-            """,
+            """,  # noqa: S608  # TRANSACTION_NOTES is a TableRef constant
             [transaction_id],
         ).fetchall()
         return [_row_to_note(r) for r in rows]
@@ -1685,11 +1687,11 @@ class TransactionService:
         self._db.begin()
         try:
             ord_row = self._db.conn.execute(
-                """
+                f"""
                 SELECT COALESCE(MAX(ord) + 1, 0)
-                  FROM app.transaction_splits
+                  FROM {TRANSACTION_SPLITS.full_name}
                  WHERE transaction_id = ?
-                """,
+                """,  # noqa: S608  # TRANSACTION_SPLITS is a TableRef constant
                 [transaction_id],
             ).fetchone()
             next_ord = int(ord_row[0]) if ord_row is not None else 0
@@ -1711,12 +1713,12 @@ class TransactionService:
             self._db.rollback()
             raise
         row = self._db.conn.execute(
-            """
+            f"""
             SELECT split_id, transaction_id, amount, category, subcategory,
                    note, ord, created_at, created_by
-              FROM app.transaction_splits
+              FROM {TRANSACTION_SPLITS.full_name}
              WHERE split_id = ?
-            """,
+            """,  # noqa: S608  # TRANSACTION_SPLITS is a TableRef constant
             [split_id],
         ).fetchone()
         if row is None:  # defensive — insert just succeeded
@@ -1841,12 +1843,12 @@ class TransactionService:
                 code=error_codes.TRANSACTION_SPLIT_TOTAL_INVALID,
             )
         rows = self._db.conn.execute(
-            """
+            f"""
             SELECT amount, category, subcategory, category_id, note
-              FROM app.transaction_splits
+              FROM {TRANSACTION_SPLITS.full_name}
              WHERE transaction_id = ?
              ORDER BY ord, split_id
-            """,
+            """,  # noqa: S608  # TRANSACTION_SPLITS is a TableRef constant
             [transaction_id],
         ).fetchall()
         current = tuple(
@@ -1902,13 +1904,13 @@ class TransactionService:
     def list_splits(self, transaction_id: str) -> list[Split]:
         """Return all splits for a transaction ordered by ``ord, split_id``."""
         rows = self._db.conn.execute(
-            """
+            f"""
             SELECT split_id, transaction_id, amount, category, subcategory,
                    note, ord, created_at, created_by
-              FROM app.transaction_splits
+              FROM {TRANSACTION_SPLITS.full_name}
              WHERE transaction_id = ?
              ORDER BY ord, split_id
-            """,
+            """,  # noqa: S608  # TRANSACTION_SPLITS is a TableRef constant
             [transaction_id],
         ).fetchall()
         return [_row_to_split(r) for r in rows]
@@ -1942,7 +1944,7 @@ class TransactionService:
             f"""
             SELECT t.amount - COALESCE((
                 SELECT SUM(amount)
-                  FROM app.transaction_splits s
+                  FROM {TRANSACTION_SPLITS.full_name} s
                  WHERE s.transaction_id = t.transaction_id
             ), 0) AS residual
               FROM {FCT_TRANSACTIONS.full_name} t

--- a/src/moneybin/services/transform_service.py
+++ b/src/moneybin/services/transform_service.py
@@ -21,7 +21,7 @@ from moneybin.database import Database, sqlmesh_context
 from moneybin.metrics.registry import SQLMESH_RUN_DURATION_SECONDS
 from moneybin.seeds import refresh_views
 from moneybin.services.matching_service import MatchingService
-from moneybin.tables import DIM_ACCOUNTS, IMPORT_LOG
+from moneybin.tables import DIM_ACCOUNTS, IMPORT_LOG, MODEL_FRESHNESS
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +134,7 @@ def _build_raw_landing_scan(
         """  # noqa: S608  # identifiers come from the module constants above
     return f"""
         WITH bad_imports AS (
-            SELECT import_id FROM raw.import_log
+            SELECT import_id FROM {IMPORT_LOG.full_name}
             WHERE status IN ('reverted', 'failed')
         ), candidates AS (
             {union}
@@ -195,7 +195,7 @@ def _oldest_execution_scan(model_count: int) -> str:
         SELECT
             (MIN(last_executed_at) AT TIME ZONE 'UTC'),
             COUNT(*) FILTER (WHERE last_executed_at IS NULL)
-        FROM meta.model_freshness
+        FROM {MODEL_FRESHNESS.full_name}
         WHERE COALESCE(model_kind, '') NOT IN ({kinds})
           AND LOWER(model_name) IN ({names})
     """  # noqa: S608  # kinds are a module constant; names are `?` placeholders

--- a/src/moneybin/services/undo_service.py
+++ b/src/moneybin/services/undo_service.py
@@ -30,6 +30,7 @@ from moneybin.repositories.base import BaseRepo
 from moneybin.services.audit_service import AuditEvent, AuditService
 from moneybin.services.mutation_context import operation
 from moneybin.services.undo_dispatch import is_registered, repo_for
+from moneybin.tables import AUDIT_LOG
 
 logger = logging.getLogger(__name__)
 
@@ -303,7 +304,7 @@ class UndoService:
             clauses.append("is_undo = FALSE")
         if domain is not None:
             clauses.append(
-                "operation_id IN (SELECT operation_id FROM app.audit_log "
+                f"operation_id IN (SELECT operation_id FROM {AUDIT_LOG.full_name} "
                 "WHERE action LIKE ?)"
             )
             params.append(f"{domain}.%")
@@ -334,7 +335,7 @@ class UndoService:
                    MAX(undoes_operation_id) AS undoes_operation_id,
                    list(DISTINCT action) AS actions,
                    list(DISTINCT target_table) AS tables
-              FROM app.audit_log
+              FROM {AUDIT_LOG.full_name}
               {where}
              GROUP BY operation_id
              {having}
@@ -368,7 +369,7 @@ class UndoService:
             clauses.append("is_undo = FALSE")
         if domain is not None:
             clauses.append(
-                "operation_id IN (SELECT operation_id FROM app.audit_log "
+                f"operation_id IN (SELECT operation_id FROM {AUDIT_LOG.full_name} "
                 "WHERE action LIKE ?)"
             )
             params.append(f"{domain}.%")
@@ -385,7 +386,7 @@ class UndoService:
             SELECT COUNT(*)
             FROM (
                 SELECT operation_id
-                FROM app.audit_log
+                FROM {AUDIT_LOG.full_name}
                 {where}
                 GROUP BY operation_id
                 {having}
@@ -516,7 +517,7 @@ class UndoService:
         refuses with ``recovery_no_path``.
         """
         row = self._db.conn.execute(
-            "SELECT 1 FROM app.audit_log "
+            f"SELECT 1 FROM {AUDIT_LOG.full_name} "
             "WHERE operation_id = ? AND target_id IS NOT NULL "
             "AND before_value IS DISTINCT FROM after_value LIMIT 1",
             [operation_id],
@@ -531,7 +532,7 @@ class UndoService:
         still live?" — see :class:`_UndoLiveness`.
         """
         rows = self._db.conn.execute(
-            "SELECT DISTINCT operation_id, undoes_operation_id FROM app.audit_log "
+            f"SELECT DISTINCT operation_id, undoes_operation_id FROM {AUDIT_LOG.full_name} "
             "WHERE undoes_operation_id IS NOT NULL"
         ).fetchall()
         children: dict[str, list[str]] = {}
@@ -548,7 +549,7 @@ class UndoService:
         every row's full before/after payload.
         """
         rows = self._db.conn.execute(
-            "SELECT DISTINCT target_schema, target_table FROM app.audit_log "
+            f"SELECT DISTINCT target_schema, target_table FROM {AUDIT_LOG.full_name} "
             "WHERE operation_id = ? AND target_id IS NOT NULL",
             [operation_id],
         ).fetchall()
@@ -575,15 +576,15 @@ class UndoService:
         ``occurred_at`` so sub-second sequential operations order deterministically.
         """
         rows = self._db.conn.execute(
-            """
+            f"""
             WITH op_rows AS (
                 SELECT target_schema, target_table, target_id, rowid
-                  FROM app.audit_log
+                  FROM {AUDIT_LOG.full_name}
                  WHERE operation_id = ?
             ),
             boundary AS (SELECT MAX(rowid) AS r FROM op_rows)
             SELECT a.operation_id, MAX(a.rowid) AS latest
-              FROM app.audit_log a
+              FROM {AUDIT_LOG.full_name} a
               JOIN (
                   SELECT DISTINCT target_schema, target_table, target_id
                     FROM op_rows WHERE target_id IS NOT NULL
@@ -596,7 +597,7 @@ class UndoService:
                AND a.is_undo = FALSE
              GROUP BY a.operation_id
              ORDER BY latest DESC
-            """,
+            """,  # noqa: S608  # AUDIT_LOG is a TableRef constant, values parameterized
             [operation_id, operation_id],
         ).fetchall()
         return [str(r[0]) for r in rows if not liveness.is_undone(str(r[0]))]

--- a/src/moneybin/services/undo_service.py
+++ b/src/moneybin/services/undo_service.py
@@ -304,7 +304,7 @@ class UndoService:
             clauses.append("is_undo = FALSE")
         if domain is not None:
             clauses.append(
-                f"operation_id IN (SELECT operation_id FROM {AUDIT_LOG.full_name} "
+                f"operation_id IN (SELECT operation_id FROM {AUDIT_LOG.full_name} "  # noqa: S608  # AUDIT_LOG is a TableRef constant
                 "WHERE action LIKE ?)"
             )
             params.append(f"{domain}.%")
@@ -369,7 +369,7 @@ class UndoService:
             clauses.append("is_undo = FALSE")
         if domain is not None:
             clauses.append(
-                f"operation_id IN (SELECT operation_id FROM {AUDIT_LOG.full_name} "
+                f"operation_id IN (SELECT operation_id FROM {AUDIT_LOG.full_name} "  # noqa: S608  # AUDIT_LOG is a TableRef constant
                 "WHERE action LIKE ?)"
             )
             params.append(f"{domain}.%")
@@ -517,7 +517,7 @@ class UndoService:
         refuses with ``recovery_no_path``.
         """
         row = self._db.conn.execute(
-            f"SELECT 1 FROM {AUDIT_LOG.full_name} "
+            f"SELECT 1 FROM {AUDIT_LOG.full_name} "  # noqa: S608  # AUDIT_LOG is a TableRef constant
             "WHERE operation_id = ? AND target_id IS NOT NULL "
             "AND before_value IS DISTINCT FROM after_value LIMIT 1",
             [operation_id],
@@ -532,7 +532,7 @@ class UndoService:
         still live?" — see :class:`_UndoLiveness`.
         """
         rows = self._db.conn.execute(
-            f"SELECT DISTINCT operation_id, undoes_operation_id FROM {AUDIT_LOG.full_name} "
+            f"SELECT DISTINCT operation_id, undoes_operation_id FROM {AUDIT_LOG.full_name} "  # noqa: S608  # AUDIT_LOG is a TableRef constant
             "WHERE undoes_operation_id IS NOT NULL"
         ).fetchall()
         children: dict[str, list[str]] = {}
@@ -549,7 +549,7 @@ class UndoService:
         every row's full before/after payload.
         """
         rows = self._db.conn.execute(
-            f"SELECT DISTINCT target_schema, target_table FROM {AUDIT_LOG.full_name} "
+            f"SELECT DISTINCT target_schema, target_table FROM {AUDIT_LOG.full_name} "  # noqa: S608  # AUDIT_LOG is a TableRef constant
             "WHERE operation_id = ? AND target_id IS NOT NULL",
             [operation_id],
         ).fetchall()

--- a/src/moneybin/synthetic/reset.py
+++ b/src/moneybin/synthetic/reset.py
@@ -11,13 +11,20 @@ from sqlglot import exp
 
 from moneybin.database import Database
 from moneybin.tables import (
+    AUDIT_LOG,
     GROUND_TRUTH,
+    MATCH_DECISIONS,
+    METRICS,
     OFX_ACCOUNTS,
     OFX_BALANCES,
     OFX_TRANSACTIONS,
+    SCHEMA_MIGRATIONS,
+    SEED_SOURCE_PRIORITY,
     TABULAR_ACCOUNTS,
     TABULAR_TRANSACTIONS,
+    TRANSACTION_CATEGORIES,
     USER_MERCHANTS,
+    VERSIONS,
 )
 
 logger = logging.getLogger(__name__)
@@ -93,21 +100,21 @@ def has_synthetic_ground_truth(db: Database) -> bool:
 # guard is `test_demo_rerun_after_a_real_cli_run`, which runs `moneybin demo` twice
 # as a real subprocess.
 _NON_USER_TABLES = frozenset({
-    "app.schema_migrations",
-    "app.versions",
-    "app.seed_source_priority",
-    "app.metrics",
+    SCHEMA_MIGRATIONS.full_name,
+    VERSIONS.full_name,
+    SEED_SOURCE_PRIORITY.full_name,
+    METRICS.full_name,
     # Evidence, not financial state — and redundant here: every mutation it records
     # also landed in a table this guard already checks.
-    "app.audit_log",
+    AUDIT_LOG.full_name,
     # Strictly derived from transactions, and written by demo's own match/categorize
     # steps. Safe to exclude because they cannot exist without a transaction behind
     # them: if that transaction is real, the raw table it came from already flags the
     # profile; if it is synthetic, the rebuild regenerates these rows anyway. Contrast
     # `_OURS_IN_APP` below — a user can author a merchant with no transactions at all,
     # so that table needs a provenance filter rather than a blanket exclusion.
-    "app.transaction_categories",
-    "app.match_decisions",
+    TRANSACTION_CATEGORIES.full_name,
+    MATCH_DECISIONS.full_name,
 })
 
 # App tables BOTH we and the user write. Blanket-excluding one would blind the guard

--- a/src/moneybin/synthetic/writer.py
+++ b/src/moneybin/synthetic/writer.py
@@ -22,7 +22,14 @@ from moneybin.synthetic.models import (
     GeneratedTransaction,
     GenerationResult,
 )
-from moneybin.tables import GROUND_TRUTH
+from moneybin.tables import (
+    GROUND_TRUTH,
+    OFX_ACCOUNTS,
+    OFX_BALANCES,
+    OFX_TRANSACTIONS,
+    TABULAR_ACCOUNTS,
+    TABULAR_TRANSACTIONS,
+)
 from moneybin.utils.slugify import slugify
 
 logger = logging.getLogger(__name__)
@@ -144,7 +151,7 @@ class SyntheticWriter:
                 "extracted_at": now,
             })
         df = pl.DataFrame(rows)
-        self._db.ingest_dataframe("raw.ofx_accounts", df, on_conflict="upsert")
+        self._db.ingest_dataframe(OFX_ACCOUNTS.full_name, df, on_conflict="upsert")
         return len(rows)
 
     def _write_ofx_balances(
@@ -176,7 +183,7 @@ class SyntheticWriter:
                 "extracted_at": now,
             })
         df = pl.DataFrame(rows)
-        self._db.ingest_dataframe("raw.ofx_balances", df, on_conflict="upsert")
+        self._db.ingest_dataframe(OFX_BALANCES.full_name, df, on_conflict="upsert")
         return len(rows)
 
     def _write_ofx_transactions(
@@ -203,7 +210,7 @@ class SyntheticWriter:
                 "extracted_at": now,
             })
         df = pl.DataFrame(rows)
-        self._db.ingest_dataframe("raw.ofx_transactions", df, on_conflict="upsert")
+        self._db.ingest_dataframe(OFX_TRANSACTIONS.full_name, df, on_conflict="upsert")
         return len(rows)
 
     def _write_tabular_accounts(
@@ -227,7 +234,7 @@ class SyntheticWriter:
                 "extracted_at": now,
             })
         df = pl.DataFrame(rows)
-        self._db.ingest_dataframe("raw.tabular_accounts", df, on_conflict="upsert")
+        self._db.ingest_dataframe(TABULAR_ACCOUNTS.full_name, df, on_conflict="upsert")
         return len(rows)
 
     def _write_tabular_transactions(
@@ -265,7 +272,9 @@ class SyntheticWriter:
                 })
 
         df = pl.DataFrame(rows)
-        self._db.ingest_dataframe("raw.tabular_transactions", df, on_conflict="upsert")
+        self._db.ingest_dataframe(
+            TABULAR_TRANSACTIONS.full_name, df, on_conflict="upsert"
+        )
         return len(rows)
 
     def _write_ground_truth(

--- a/src/moneybin/tables.py
+++ b/src/moneybin/tables.py
@@ -94,6 +94,7 @@ GSHEET_CONNECTIONS = TableRef("app", "gsheet_connections")
 EXPORT_DESTINATIONS = TableRef("app", "export_destinations")
 AI_CONSENT_GRANTS = TableRef("app", "ai_consent_grants")
 USER_REPORTS = TableRef("app", "user_reports", audience="interface")
+METRICS = TableRef("app", "metrics")
 
 # -- App tabular tables --
 TABULAR_FORMATS = TableRef("app", "tabular_formats")
@@ -157,9 +158,11 @@ INT_TRANSACTIONS_UNIONED = TableRef("prep", "int_transactions__unioned")
 INT_TRANSACTIONS_MATCHED = TableRef("prep", "int_transactions__matched")
 INT_TRANSACTIONS_MERGED = TableRef("prep", "int_transactions__merged")
 STG_PLAID_TRANSACTIONS = TableRef("prep", "stg_plaid__transactions")
+STG_SECURITY_PRICES = TableRef("prep", "stg_security_prices")
 
 # -- Meta schema (cross-source provenance + lineage) --
 FCT_TRANSACTION_PROVENANCE = TableRef("meta", "fct_transaction_provenance")
+MODEL_FRESHNESS = TableRef("meta", "model_freshness")
 
 # -- Synthetic tables (created on demand by the generator) --
 GROUND_TRUTH = TableRef("synthetic", "ground_truth")


### PR DESCRIPTION
## Summary

The `moneybin.tables` `TableRef` registry existed as the canonical source of schema-qualified table names, but was bypassed by hardcoded string literals (e.g. `"app.audit_log"`) at roughly 90 executed-SQL call sites across the codebase — meaning a future table rename could silently miss a call site. `services/undo_service.py`, the one service whose job is restoring corrupted `app.*` state, had no `moneybin.tables` import at all and referenced `app.audit_log` nine times as a bare literal.

This closes three registry gaps (`meta.model_freshness`, `app.metrics`, `prep.stg_security_prices` had no constant) and sweeps the hardcoded literals to the matching `TableRef` constant. Pure mechanical adoption — every constant's `.full_name` renders to the exact string it replaced, so no query text changes and no behavior changes.

## Changes

- Added `MODEL_FRESHNESS`, `METRICS`, and `STG_SECURITY_PRICES` to `src/moneybin/tables.py`, following the existing shape.
- Swept ~90 literal sites to constants across 22 modules: services (`undo_service`, `audit_service`, `transaction_service`, `doctor_service`, `transform_service`, `system_service`, `demo_service`, `schema_catalog`, `import_service`), extractors (`plaid`, `tabular/formats`), `investments/sqlmesh_loader`, `matching/priority`, `metrics/persistence`, `migrations.py` (the runner, not the frozen historical scripts), `privacy/sql_lineage`, `repositories/securities_repo`, `connectors/gsheet/pull_service`, `synthetic/reset` and `synthetic/writer`, and two CLI commands.
- In the four files a parallel PR is restructuring import machinery in (`import_service.py`, `account_links_service.py`, `refresh.py`, `inbox_service.py`), touched only SQL string literals plus one added `moneybin.tables` import per file where needed — no import reordering, no `# noqa: PLC0415` lines touched. `account_links_service.py`, `refresh.py`, and `inbox_service.py` turned out to already be fully on constants; `import_service.py` had 8 real sites plus one deferred-import block extended in place.
- Deliberately left untouched: `src/moneybin/sql/migrations/*.py` (frozen, point-in-time DDL — must track the schema as it existed when it ran, not a live registry that can rename underneath it), user-facing hint text in error/detail messages that names a table for a suggested `moneybin db query` command, and `schema_catalog.py`'s `EXAMPLES` dict values (illustrative SQL text served to agents via the schema doc, never executed by MoneyBin itself).

## Test plan

- [x] `make check` (ruff format, ruff lint, pyright) — clean, 0 errors
- [x] `make test` — 10,544 passed, 0 failed, 4 skipped (pre-existing, unrelated)
- [x] `make test-integration` — 578 passed, 0 failed
- [x] `make test-scenarios` — 92 passed, 0 failed
- [x] Isolated adversarial pre-push review of the full base-to-head diff, independent of this session — verified every substitution renders byte-identical SQL, then flagged one real gap (`synthetic/writer.py` had five ingest-target literals in the same shape the Plaid-extractor sweep already converted) and a cosmetic noqa-comment inconsistency; both fixed in a follow-up commit, then the full three-suite gate re-run clean.
