### PR TITLE
Make errors.py a leaf and answer setup state at raise time

### DIFF
--- a/.claude/rules/cli.md
+++ b/.claude/rules/cli.md
@@ -36,25 +36,43 @@ When designing a new command, ask: "Could an agent drive this end-to-end without
 
 ```python
 @app.command("command-name")
-def command_function(source_path: Path = typer.Option(..., help="Description")) -> None:
+def command_function(
+    output: OutputFormat = output_option,
+    source_path: Path = typer.Option(..., help="Description"),
+) -> None:
     """Clear command description."""
-    setup_logging(cli_mode=True)
-    try:
-        config = ConfigClass(source_path=source_path)
-        processor = BusinessClass(config)
-        results = processor.main_operation()
-        logger.info(f"Processed {len(results)} records")
-    except FileNotFoundError as e:
-        logger.error(f"{e}")
-        raise typer.Exit(1) from e
+    with handle_cli_errors(cli_actor="command_name", payload_type=CommandPayload):
+        with get_database(read_only=True) as db:
+            result = BusinessClass(db).main_operation(source_path)
+    render_or_json(build_envelope(data=result), output, cli_actor="command_name")
 ```
 
 ## Error Handling
 
-- Catch specific exceptions (FileNotFoundError, PermissionError, etc.)
-- Any command that calls `get_database()` must also catch `DatabaseKeyError` with a "run `moneybin db unlock`" message.
-- Use `raise typer.Exit(code) from e` for error chaining
-- Exit codes: 0 = success, 1 = general error, 2+ = command-specific
+`handle_cli_errors` is the single error boundary. It runs every exception
+through `classify_user_error` (`src/moneybin/errors.py`), exits 1 with the
+classified message — or a structured error envelope under `--output json` — and
+re-raises whatever the classifier does not recognize, so a programmer error
+still surfaces as a failure. `typer.Exit` passes through untouched.
+
+- **Do not re-implement it per command.** `DatabaseKeyError`,
+  `DatabaseNotInitializedError`, `DatabaseLockError`, `SchemaDriftError`, the
+  `moneybin.secrets` families, `FileNotFoundError`, `PermissionError`, and bare
+  `ValueError` / `LookupError` are already classified, with hints and recovery
+  actions attached centrally.
+- **Catch a specific exception only to do something the classifier cannot** —
+  recover, fall back, or add context only the failure site holds. Then raise
+  `UserError(...)` with the right `error_codes` constant rather than logging a
+  bare message: a write site that means "invalid" or "not found" names a
+  `MUTATION_*` code the classifier is not positioned to infer (see the note in
+  `error_codes.py`).
+- **A new exception family needs a `classify_user_error` branch**, or it reaches
+  the user as a traceback and an agent as `infra_unclassified_error`.
+  `tests/moneybin/test_errors/test_exception_family_coverage.py` enumerates the
+  families off their modules and fails when one drifts out of coverage.
+- Use `raise typer.Exit(code) from e` for early exits the classifier should not
+  see (mutually exclusive flags, a declined prompt).
+- Exit codes: 0 = success, 1 = general error, 2+ = command-specific.
 
 ## Secrets in Error Output
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the count rather than leaving it to be inferred.
 
 ### Fixed
+- **A missing or locked keychain entry no longer prints a stack trace.**
+  `moneybin db info`, `db unlock` and the DuckDB init-script builder read the
+  encryption key directly, and the secret-store exceptions had no branch in the
+  error classifier — so the CLI showed a raw traceback and MCP returned
+  `infra_unclassified_error`. They now classify: a keychain that denies the
+  read reports `infra_permission_denied` with an unlock hint, and a missing
+  secret or absent keyring backend reports `infra_setup_required` naming the
+  command that stores it. (#522)
+
 - **A Plaid transaction's `category` no longer holds Plaid's own category
   code.** `prep.int_transactions__unioned` had aliased the raw
   personal-finance-category code into `category`, so one column mixed

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -301,7 +301,22 @@ class DatabaseLockError(Exception):
 
 
 class DatabaseNotInitializedError(Exception):
-    """Database file missing or incomplete; run 'moneybin db init'."""
+    """Database file missing or incomplete; run 'moneybin db init'.
+
+    ``profile_registered`` answers the one question the user-facing message
+    turns on: had the active profile finished setup (its ``config.yaml``
+    exists), or is its directory still incomplete? ``get_database`` fills it in
+    because it already holds resolved settings; ``classify_user_error`` reads
+    the answer rather than reaching up into the service layer to compute it
+    while the failure is in flight. ``None`` means unanswered — a directly
+    constructed instance, or a registration probe the filesystem refused — and
+    every reader falls back to the ``db init`` message.
+    """
+
+    def __init__(self, message: str, *, profile_registered: bool | None = None) -> None:
+        """Store the message and, when known, the profile's setup state."""
+        super().__init__(message)
+        self.profile_registered = profile_registered
 
 
 class SchemaDriftError(Exception):
@@ -1231,6 +1246,27 @@ def database_was_written() -> bool:
     return _database_written
 
 
+def _active_profile_is_registered() -> bool | None:
+    """Whether the active profile finished setup, or ``None`` if unreadable.
+
+    Answers the question ``DatabaseNotInitializedError`` carries — a registered
+    profile is only missing its database (``db init``), an unregistered one has
+    never been set up (``profile create``). Called only while that error is in
+    flight, and only from ``get_database``, which has already resolved settings
+    on the same frame — so this reads a cached value and can never trigger
+    first-run profile resolution.
+
+    ``Path.is_file`` swallows only ENOENT-class errors, so a denied read
+    (macOS TCC, a locked-down profile root) raises rather than answering False.
+    Left uncaught it would replace "database not found" with an unrelated
+    permission error, so an unanswerable probe degrades to ``None``.
+    """
+    try:
+        return (get_settings().profile_dir / "config.yaml").is_file()
+    except OSError:
+        return None
+
+
 def get_database(
     *,
     read_only: bool,
@@ -1277,7 +1313,8 @@ def get_database(
     if require_existing and not db_path.exists():
         raise DatabaseNotInitializedError(
             f"Database not found at {db_path}.\n"
-            f"Run 'moneybin db init' to initialize it first."
+            f"Run 'moneybin db init' to initialize it first.",
+            profile_registered=_active_profile_is_registered(),
         )
     deadline = time.monotonic() + max_wait
     skip_upgrade = (
@@ -1331,7 +1368,8 @@ def get_database(
         if require_existing and not db_path.exists():
             raise DatabaseNotInitializedError(
                 f"Database not found at {db_path}.\n"
-                f"Run 'moneybin db init' to initialize it first."
+                f"Run 'moneybin db init' to initialize it first.",
+                profile_registered=_active_profile_is_registered(),
             )
         db = _open_with_attach_retry(
             db_path=db_path,
@@ -1396,6 +1434,16 @@ def _open_with_attach_retry(
                 no_auto_upgrade=skip_upgrade,
             )
             return db
+        except DatabaseNotInitializedError as exc:
+            # Answered here rather than in `classify_user_error`: this frame
+            # runs under `get_database`, which already resolved settings, so
+            # the lookup cannot trigger first-run profile resolution — and the
+            # classifier stays free of the config and service layers it would
+            # otherwise have to reach into mid-failure. A `Database` built
+            # directly (tests, the template-copy fixture) has no such frame and
+            # leaves the state unanswered.
+            exc.profile_registered = _active_profile_is_registered()
+            raise
         except DatabaseLockError:
             if time.monotonic() >= deadline:
                 raise DatabaseLockError(

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -1256,13 +1256,19 @@ def _active_profile_is_registered() -> bool | None:
     on the same frame — so this reads a cached value and can never trigger
     first-run profile resolution.
 
-    ``Path.is_file`` swallows only ENOENT-class errors, so a denied read
-    (macOS TCC, a locked-down profile root) raises rather than answering False.
-    Left uncaught it would replace "database not found" with an unrelated
-    permission error, so an unanswerable probe degrades to ``None``.
+    ``ProfileService.is_registered`` owns this question and answers it the same
+    way. Calling it here would put ``database`` above ``services``, which import
+    it — so the predicate is duplicated deliberately, and duplicated *exactly*:
+    both spell the probe ``(<profile dir>/"config.yaml").exists()``, so the two
+    can never disagree about a profile.
+
+    ``Path.exists`` swallows only ENOENT-class errors, so a denied read (macOS
+    TCC, a locked-down profile root) raises rather than answering False. Left
+    uncaught it would replace "database not found" with an unrelated permission
+    error, so an unanswerable probe degrades to ``None``.
     """
     try:
-        return (get_settings().profile_dir / "config.yaml").is_file()
+        return (get_settings().profile_dir / "config.yaml").exists()
     except OSError:
         return None
 

--- a/src/moneybin/errors.py
+++ b/src/moneybin/errors.py
@@ -9,6 +9,13 @@ and MCP surfaces deliver via their own conventions:
 Unrecognized exceptions return ``None`` from ``classify_user_error`` so they
 propagate as 500-equivalent failures — programmer errors must not be silently
 translated into user-facing messages.
+
+This module is a leaf: importing it pulls in nothing from ``moneybin`` but
+``error_codes``, so any layer may raise a ``UserError`` without minting an
+import cycle — which is what lets ``connectors.feed_errors`` and the price and
+rate error modules subclass it outright. The domain families
+``classify_user_error`` recognizes are imported inside the function, on the
+failure path.
 """
 
 from __future__ import annotations
@@ -22,15 +29,6 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 from moneybin import error_codes
-from moneybin.connectors.sync_errors import SyncError
-from moneybin.database import (
-    DatabaseCryptoError,
-    DatabaseKeyError,
-    DatabaseLockError,
-    DatabaseNotInitializedError,
-    SchemaDriftError,
-    database_key_error_hint,
-)
 
 
 class RecoveryAction(BaseModel):
@@ -262,23 +260,42 @@ def classify_user_error(exc: BaseException) -> UserError | None:
     """
     if isinstance(exc, UserError):
         return exc
-    if isinstance(exc, DatabaseNotInitializedError):
-        suggest_create = False
-        try:  # deferred imports avoid an errors<->services import cycle
-            from moneybin.config import get_current_profile
-            from moneybin.services.profile_service import ProfileService
 
-            profiles = ProfileService()
-            profile = get_current_profile(auto_resolve=False)
-            # Registration, not the directory, decides the verb. `profile create`
-            # completes an unregistered directory in place (config, database, and
-            # inbox), so it is the right advice whether or not one is already there.
-            # A *registered* profile has finished setup and is only missing its
-            # database — that is `db init`'s job, and `profile create` would refuse.
-            suggest_create = not profiles.is_registered(profile)
-        except Exception:  # noqa: BLE001 — fall back to the db-init message
-            suggest_create = False
-        if suggest_create:
+    # Deferred so this module stays a leaf of the import graph. A module-level
+    # import would put `moneybin.database` (and everything it loads) behind
+    # every `from moneybin.errors import UserError`, so nothing `database.py`
+    # imports could raise a UserError without minting a cycle — which is what
+    # forced the service layer into deferred imports back the other way.
+    # Classification runs on the failure path, where a one-time module load
+    # costs nothing and the module that raised is already loaded.
+    # Guarded by tests/moneybin/test_architecture/test_errors_is_import_light.py.
+    from moneybin.connectors.sync_errors import (  # noqa: PLC0415 — keeps errors.py import-light
+        SyncError,
+    )
+    from moneybin.database import (  # noqa: PLC0415 — keeps errors.py import-light
+        DatabaseCryptoError,
+        DatabaseKeyError,
+        DatabaseLockError,
+        DatabaseNotInitializedError,
+        SchemaDriftError,
+        database_key_error_hint,
+    )
+    from moneybin.secrets import (  # noqa: PLC0415 — keeps errors.py import-light
+        SecretNotFoundError,
+        SecretStorageUnavailableError,
+        SecretUnavailableError,
+    )
+
+    if isinstance(exc, DatabaseNotInitializedError):
+        # Registration, not the directory, decides the verb. `profile create`
+        # completes an unregistered directory in place (config, database, and
+        # inbox), so it is the right advice whether or not one is already there.
+        # A *registered* profile has finished setup and is only missing its
+        # database — that is `db init`'s job, and `profile create` would refuse.
+        # `get_database` answers this while it still holds resolved settings; an
+        # unanswered `None` takes the `db init` message, the verb that never
+        # refuses.
+        if exc.profile_registered is False:
             message = (
                 "Profile not set up. Run 'moneybin profile create <name> "
                 "--init-inbox' to create the profile (config, database, and inbox)."
@@ -339,6 +356,37 @@ def classify_user_error(exc: BaseException) -> UserError | None:
             str(exc),
             code=error_codes.INFRA_SCHEMA_DRIFT,
             hint="💡 Run 'moneybin transform apply' to rebuild stale models",
+        )
+    if isinstance(exc, SecretUnavailableError):
+        # Above its SecretNotFoundError base on purpose: the keychain reported
+        # the read as denied rather than missing, and "unlock it" is a different
+        # remedy from "store the secret".
+        return UserError(
+            str(exc),
+            code=error_codes.INFRA_PERMISSION_DENIED,
+            hint=(
+                "💡 Unlock the OS keychain, or grant the process running MoneyBin "
+                "access to it, then retry."
+            ),
+        )
+    if isinstance(exc, SecretNotFoundError):
+        return UserError(
+            str(exc),
+            code=error_codes.INFRA_SETUP_REQUIRED,
+            hint=(
+                "💡 The message names the missing secret — store it with the "
+                "command that owns it (e.g. 'moneybin db unlock' for the "
+                "database encryption key)."
+            ),
+        )
+    if isinstance(exc, SecretStorageUnavailableError):
+        return UserError(
+            str(exc),
+            code=error_codes.INFRA_SETUP_REQUIRED,
+            hint=(
+                "💡 No OS keyring backend is available to store secrets. "
+                "Configure one (macOS Keychain, GNOME Keyring, KWallet) and retry."
+            ),
         )
     if isinstance(exc, FileNotFoundError):
         # Drop the "[Errno 2]" prefix that str(FileNotFoundError) includes —
@@ -410,12 +458,17 @@ def classify_user_error(exc: BaseException) -> UserError | None:
 def _is_match_run_error(exc: BaseException) -> bool:
     """True if ``exc`` is the matcher's partial-run carrier.
 
-    Imported inside the call because `moneybin.matching.engine` reaches back
-    into repositories that import this module — the same cycle the deferred
-    imports above avoid. Kept out of the hot path: only an exception that
-    matched no branch above gets this far.
+    Imported inside the call for the same reason as the block in
+    ``classify_user_error``: ``moneybin.matching.engine`` pulls in the config,
+    database and metrics layers, and this module stays a leaf. There is no
+    cycle to break here — this marker used to claim one, but
+    ``matching.engine`` imports no repository and reaches this module by no
+    module-level path, so hoisting it would cost import weight, not correctness.
+
+    Kept in its own function rather than joining that block so only an exception
+    that matched no branch above pays the import.
     """
-    from moneybin.matching.engine import (  # noqa: PLC0415 — errors<->matching cycle
+    from moneybin.matching.engine import (  # noqa: PLC0415 — keeps errors.py import-light
         MatchRunError,
     )
 

--- a/tests/moneybin/test_architecture/test_errors_is_import_light.py
+++ b/tests/moneybin/test_architecture/test_errors_is_import_light.py
@@ -1,0 +1,75 @@
+"""Structural guardrail: `moneybin.errors` is a leaf of the import graph.
+
+`errors.py` carries the cross-cutting error taxonomy — `UserError`,
+`ErrorDetail`, `RecoveryAction` — that every layer raises and every surface
+catches. If importing it drags in `moneybin.database`, then `database.py` can
+no longer import `UserError` without minting an import cycle, and neither can
+anything `database.py` itself imports. That is how the pre-MB-51 tangle formed:
+`errors -> database` at module level forced `db_lock` and the service layer
+into deferred imports to get back.
+
+The classifier still recognizes those families; it imports them inside
+`classify_user_error`, on the failure path, where a one-time module load costs
+nothing. This test pins the module-load footprint so the module-level import
+cannot creep back.
+
+Measured in a fresh interpreter: `sys.modules` in this process is already
+polluted by everything the test suite imported.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess  # noqa: S404 — clean-interpreter import check
+import sys
+
+# Everything `import moneybin.errors` may pull in: the package root, the
+# constant table, and itself. Nothing else — `error_codes` is a flat list of
+# string constants, so this set cannot grow without a new module-level import.
+ALLOWED_MODULE_LOADS = frozenset({
+    "moneybin",
+    "moneybin.error_codes",
+    "moneybin.errors",
+})
+
+_PROBE = """
+import json
+import sys
+
+import moneybin.errors  # noqa: F401
+
+print(json.dumps(sorted(m for m in sys.modules if m.startswith("moneybin"))))
+"""
+
+
+def _modules_loaded_by_importing_errors() -> frozenset[str]:
+    result = subprocess.run(  # noqa: S603  # fixed argv, no shell, no user input
+        [sys.executable, "-c", _PROBE],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return frozenset(json.loads(result.stdout))
+
+
+def test_importing_errors_loads_only_leaf_modules() -> None:
+    loaded = _modules_loaded_by_importing_errors()
+    unexpected = loaded - ALLOWED_MODULE_LOADS
+    assert not unexpected, (
+        "importing moneybin.errors now loads "
+        f"{sorted(unexpected)}. Keep the taxonomy a leaf: move the import "
+        "inside the function that needs it, or add the module here only if "
+        "it is genuinely a leaf with no MoneyBin imports of its own."
+    )
+
+
+def test_importing_errors_does_not_load_the_database_or_service_layers() -> None:
+    """The two directions that reintroduce the cycle, named explicitly.
+
+    `test_importing_errors_loads_only_leaf_modules` already covers these; this
+    states the failure mode so the diff that breaks it reads as a cycle, not as
+    an allowlist that needs one more entry.
+    """
+    loaded = _modules_loaded_by_importing_errors()
+    assert "moneybin.database" not in loaded
+    assert not any(m.startswith("moneybin.services") for m in loaded)

--- a/tests/moneybin/test_docs/test_mcp_surface_docs.py
+++ b/tests/moneybin/test_docs/test_mcp_surface_docs.py
@@ -3156,7 +3156,7 @@ def test_final_review_refresh_surface_semantics_match_runtime() -> None:
     # Derived, not spelled, like the sibling test above: a literal here pins
     # whatever the docs happen to say.
     from moneybin.cli.commands.refresh import RefreshStepChoice
-    from moneybin.services.refresh import CANONICAL_STEPS
+    from moneybin.orchestration.refresh import CANONICAL_STEPS
 
     mcp_default = " → ".join(CANONICAL_STEPS)
     selectable = {choice.value for choice in RefreshStepChoice}

--- a/tests/moneybin/test_errors/test_error_classification.py
+++ b/tests/moneybin/test_errors/test_error_classification.py
@@ -7,14 +7,20 @@ from unittest.mock import patch
 import pytest
 
 from moneybin import error_codes
-from moneybin.database import DatabaseCryptoError, DatabaseKeyError
+from moneybin.database import (
+    DatabaseCryptoError,
+    DatabaseKeyError,
+    DatabaseNotInitializedError,
+)
 from moneybin.errors import UserError, classify_user_error
 
 
 def test_classify_database_key_error_returns_user_error() -> None:
     """DatabaseKeyError maps to a UserError carrying the recovery hint."""
+    # Patched at its definition, not on `moneybin.errors`: the classifier
+    # imports it inside the function to keep `errors.py` import-light.
     with patch(
-        "moneybin.errors.database_key_error_hint",
+        "moneybin.database.database_key_error_hint",
         return_value="Run: moneybin db unlock",
     ):
         result = classify_user_error(DatabaseKeyError("locked"))
@@ -268,76 +274,195 @@ def _clean_active_profile() -> Generator[None, None, None]:  # pyright: ignore[r
         config._current_profile = original  # pyright: ignore[reportPrivateUsage]
 
 
-def test_db_not_initialized_unregistered_points_at_profile_create(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    from moneybin.config import set_current_profile
-    from moneybin.database import DatabaseNotInitializedError
+class TestDatabaseNotInitializedAdvice:
+    """The `profile create` vs `db init` verb is decided at raise time.
 
-    monkeypatch.setenv("MONEYBIN_HOME", str(tmp_path))
-    set_current_profile("ghost")  # active profile, but no config.yaml under tmp_path
+    `get_database` answers "did this profile finish setup?" while it still
+    holds resolved settings; the classifier only reads the answer. These
+    tests cover both halves — the reading, and the answering.
+    """
 
-    result = classify_user_error(DatabaseNotInitializedError("missing"))
-    assert result is not None
-    assert "profile create" in result.message
-    assert result.code == error_codes.INFRA_DATABASE_NOT_INITIALIZED
+    def test_unregistered_profile_points_at_profile_create(self) -> None:
+        result = classify_user_error(
+            DatabaseNotInitializedError("missing", profile_registered=False)
+        )
+        assert result is not None
+        assert "profile create" in result.message
+        assert result.code == error_codes.INFRA_DATABASE_NOT_INITIALIZED
+
+    def test_registered_profile_points_at_db_init(self) -> None:
+        result = classify_user_error(
+            DatabaseNotInitializedError("missing", profile_registered=True)
+        )
+        assert result is not None
+        assert "profile create" not in result.message
+        assert "db init" in result.message.lower()
+
+    def test_unanswered_setup_state_points_at_db_init(self) -> None:
+        """An instance nobody annotated falls back to the safe verb."""
+        result = classify_user_error(DatabaseNotInitializedError("missing"))
+        assert result is not None
+        assert "profile create" not in result.message
+        assert "db init" in result.message.lower()
+
+    def test_classification_reads_no_config_and_builds_no_service(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Classification runs on the failure path — it must touch neither.
+
+        The pre-MB-51 classifier instantiated `ProfileService` and read the
+        active profile from config here, behind a bare `except Exception` that
+        turned any config or filesystem failure into silently wrong advice.
+        Both reaches are now poisoned: the test fails loudly if either returns.
+        """
+        from moneybin import config
+        from moneybin.services import profile_service
+
+        def _forbidden(*args: object, **kwargs: object) -> object:
+            raise AssertionError("classification must not reach into config/services")
+
+        monkeypatch.setattr(config, "get_current_profile", _forbidden)
+        monkeypatch.setattr(profile_service.ProfileService, "__init__", _forbidden)
+
+        for state, expected in (
+            (False, "profile create"),
+            (True, "db init"),
+            (None, "db init"),
+        ):
+            result = classify_user_error(
+                DatabaseNotInitializedError("missing", profile_registered=state)
+            )
+            assert result is not None
+            assert expected in result.message.lower()
 
 
-def test_db_not_initialized_bare_directory_points_at_profile_create(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    # A directory that exists but was never registered. This used to be steered at
-    # `db init` because `profile create` refused on the bare directory — a dead end
-    # dressed up as advice: `db init` would build a database into a profile that
-    # `profile list` still hides and that has no inbox. `create()` now completes the
-    # directory in place, so the guidance names the verb that actually finishes setup.
-    from moneybin.config import set_current_profile
-    from moneybin.database import DatabaseNotInitializedError
+class TestDatabaseNotInitializedAnnotation:
+    """`get_database` records the profile's setup state on the exception."""
 
-    monkeypatch.setenv("MONEYBIN_HOME", str(tmp_path))
-    (tmp_path / "profiles" / "bare").mkdir(parents=True)  # no config.yaml, no db
-    set_current_profile("bare")
+    def test_unregistered_profile_is_marked_and_advised(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from moneybin.config import set_current_profile
+        from moneybin.database import get_database
 
-    result = classify_user_error(DatabaseNotInitializedError("missing"))
-    assert result is not None
-    assert "profile create" in result.message
+        monkeypatch.setenv("MONEYBIN_HOME", str(tmp_path))
+        # An active profile with no config.yaml anywhere under tmp_path.
+        set_current_profile("ghost")
+
+        with pytest.raises(DatabaseNotInitializedError) as excinfo:
+            get_database(read_only=True)
+
+        assert excinfo.value.profile_registered is False
+        classified = classify_user_error(excinfo.value)
+        assert classified is not None
+        assert "profile create" in classified.message
+
+    def test_bare_directory_is_unregistered(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A directory that exists but was never registered. This used to be steered
+        # at `db init` because `profile create` refused on the bare directory — a
+        # dead end dressed up as advice: `db init` would build a database into a
+        # profile that `profile list` still hides and that has no inbox. `create()`
+        # completes the directory in place, so the guidance names the verb that
+        # actually finishes setup.
+        from moneybin.config import set_current_profile
+        from moneybin.database import get_database
+
+        monkeypatch.setenv("MONEYBIN_HOME", str(tmp_path))
+        (tmp_path / "profiles" / "bare").mkdir(parents=True)  # no config.yaml, no db
+        set_current_profile("bare")
+
+        with pytest.raises(DatabaseNotInitializedError) as excinfo:
+            get_database(read_only=True)
+
+        assert excinfo.value.profile_registered is False
+        classified = classify_user_error(excinfo.value)
+        assert classified is not None
+        assert "profile create" in classified.message
+
+    def test_registered_profile_is_marked_and_advised(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A fully registered profile whose database is missing (deleted, or never
+        # init'd). Setup is done; only the database is absent — so `db init` is the
+        # right verb, and `profile create` would (correctly) refuse.
+        from moneybin.config import set_current_profile
+        from moneybin.database import get_database
+        from moneybin.services.profile_service import ProfileService
+
+        monkeypatch.setenv("MONEYBIN_HOME", str(tmp_path))
+        with patch.object(ProfileService, "_init_database"):  # no keychain here
+            ProfileService().create("registered")
+        set_current_profile("registered")
+
+        with pytest.raises(DatabaseNotInitializedError) as excinfo:
+            get_database(read_only=True)
+
+        assert excinfo.value.profile_registered is True
+        classified = classify_user_error(excinfo.value)
+        assert classified is not None
+        assert "profile create" not in classified.message
+        assert "db init" in classified.message.lower()
+
+    def test_denied_registration_read_leaves_the_state_unanswered(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An EPERM on the registration probe must not replace the error.
+
+        `Path.is_file` swallows only ENOENT-class errors, so a denied read
+        (macOS TCC, a locked-down profile root) propagates. If that escaped it
+        would turn "database not found" into an unrelated PermissionError —
+        the error path is exactly where a second failure must stay quiet.
+        """
+        from moneybin.config import get_settings, set_current_profile
+        from moneybin.database import get_database
+
+        monkeypatch.setenv("MONEYBIN_HOME", str(tmp_path))
+        set_current_profile("denied")
+        get_settings()  # warm the cache before Path.is_file starts raising
+
+        def _denied(self: Path) -> bool:
+            raise PermissionError(1, "Operation not permitted", str(self))
+
+        monkeypatch.setattr(Path, "is_file", _denied)
+
+        with pytest.raises(DatabaseNotInitializedError) as excinfo:
+            get_database(read_only=True)
+
+        assert excinfo.value.profile_registered is None
+        classified = classify_user_error(excinfo.value)
+        assert classified is not None
+        assert "db init" in classified.message.lower()
 
 
-def test_db_not_initialized_registered_profile_points_at_db_init(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    # A fully registered profile whose database is missing (deleted, or never
-    # init'd). Setup is done; only the database is absent — so `db init` is the
-    # right verb, and `profile create` would (correctly) refuse.
-    from moneybin.config import set_current_profile
-    from moneybin.database import DatabaseNotInitializedError
-    from moneybin.services.profile_service import ProfileService
+class TestSecretFamilyClassification:
+    """`moneybin.secrets` raises past several boundaries; none of it may crash.
 
-    monkeypatch.setenv("MONEYBIN_HOME", str(tmp_path))
-    with patch.object(ProfileService, "_init_database"):  # no keychain in unit tests
-        ProfileService().create("registered")
-    set_current_profile("registered")
+    `moneybin db info` and `db unlock` call `SecretStore.get_key` directly, so
+    before MB-51 a missing or keychain-denied key reached `handle_cli_errors`
+    unclassified and printed a raw traceback.
+    """
 
-    result = classify_user_error(DatabaseNotInitializedError("missing"))
-    assert result is not None
-    assert "profile create" not in result.message
-    assert "db init" in result.message.lower()
+    def test_missing_secret_is_setup_guidance(self) -> None:
+        from moneybin.secrets import SecretNotFoundError
 
+        result = classify_user_error(SecretNotFoundError("Secret 'X' not found."))
+        assert result is not None
+        assert result.code == error_codes.INFRA_SETUP_REQUIRED
+        assert "not found" in result.message
 
-def test_db_not_initialized_registered_points_at_db_init(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    from unittest.mock import patch as _patch
+    def test_denied_keychain_read_is_a_permission_failure(self) -> None:
+        """Checked before its `SecretNotFoundError` base, or it would be masked."""
+        from moneybin.secrets import SecretUnavailableError
 
-    from moneybin.config import set_current_profile
-    from moneybin.database import DatabaseNotInitializedError
-    from moneybin.services.profile_service import ProfileService
+        result = classify_user_error(SecretUnavailableError("keychain locked"))
+        assert result is not None
+        assert result.code == error_codes.INFRA_PERMISSION_DENIED
 
-    monkeypatch.setenv("MONEYBIN_HOME", str(tmp_path))
-    with _patch.object(ProfileService, "_init_database"):
-        ProfileService().create("real")  # registered: config.yaml written
-    set_current_profile("real")
+    def test_absent_keyring_backend_is_setup_guidance(self) -> None:
+        from moneybin.secrets import SecretStorageUnavailableError
 
-    result = classify_user_error(DatabaseNotInitializedError("missing"))
-    assert result is not None
-    assert "db init" in result.message.lower()
+        result = classify_user_error(SecretStorageUnavailableError("no backend"))
+        assert result is not None
+        assert result.code == error_codes.INFRA_SETUP_REQUIRED

--- a/tests/moneybin/test_errors/test_error_classification.py
+++ b/tests/moneybin/test_errors/test_error_classification.py
@@ -410,7 +410,7 @@ class TestDatabaseNotInitializedAnnotation:
     ) -> None:
         """An EPERM on the registration probe must not replace the error.
 
-        `Path.is_file` swallows only ENOENT-class errors, so a denied read
+        `Path.exists` swallows only ENOENT-class errors, so a denied read
         (macOS TCC, a locked-down profile root) propagates. If that escaped it
         would turn "database not found" into an unrelated PermissionError —
         the error path is exactly where a second failure must stay quiet.
@@ -420,12 +420,19 @@ class TestDatabaseNotInitializedAnnotation:
 
         monkeypatch.setenv("MONEYBIN_HOME", str(tmp_path))
         set_current_profile("denied")
-        get_settings()  # warm the cache before Path.is_file starts raising
+        get_settings()  # warm the cache before the probe starts raising
+
+        # Only the registration probe is denied. `Database.__init__` reaches
+        # `db_path.exists()` first, and denying that too would raise before the
+        # annotation ever runs — proving nothing about the guard under test.
+        real_exists = Path.exists
 
         def _denied(self: Path) -> bool:
-            raise PermissionError(1, "Operation not permitted", str(self))
+            if self.name == "config.yaml":
+                raise PermissionError(1, "Operation not permitted", str(self))
+            return real_exists(self)
 
-        monkeypatch.setattr(Path, "is_file", _denied)
+        monkeypatch.setattr(Path, "exists", _denied)
 
         with pytest.raises(DatabaseNotInitializedError) as excinfo:
             get_database(read_only=True)

--- a/tests/moneybin/test_errors/test_exception_family_coverage.py
+++ b/tests/moneybin/test_errors/test_exception_family_coverage.py
@@ -1,0 +1,86 @@
+"""Every domain exception family reaches a user as a message, not a traceback.
+
+`UserError` is the taxonomy the CLI and MCP surfaces know how to present.
+Domain modules deliberately raise their *own* families instead — a caller that
+wants to react to a locked database catches `DatabaseLockError`, not a string
+code. That second pattern only works while `classify_user_error` has a branch
+for each family: a family it does not recognize propagates unclassified, which
+on the CLI is a raw traceback and on MCP is `infra_unclassified_error`.
+
+Nothing forced that correspondence before, and `moneybin.secrets` had drifted
+out of it. This test enumerates the families off the modules themselves, so a
+class added later fails here rather than in front of a user.
+
+The constructor map is checked by set equality against what the modules
+actually define — a new exception class cannot be classified-by-omission.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from types import ModuleType
+
+import pytest
+
+from moneybin import database, secrets
+from moneybin.errors import classify_user_error
+from moneybin.matching import application as matching_application
+
+# One constructor per family member. Values are the arguments each class needs;
+# the message text is irrelevant here, only that classification recognizes it.
+FAMILY_CONSTRUCTORS: dict[str, Callable[[], BaseException]] = {
+    "DatabaseCryptoError": lambda: database.DatabaseCryptoError("no crypto module"),
+    "DatabaseKeyError": lambda: database.DatabaseKeyError("key unreadable"),
+    "DatabaseLockError": lambda: database.DatabaseLockError("lock held"),
+    "DatabaseNotInitializedError": lambda: database.DatabaseNotInitializedError(
+        "no database"
+    ),
+    "SchemaDriftError": lambda: database.SchemaDriftError("stale snapshot"),
+    "SecretNotFoundError": lambda: secrets.SecretNotFoundError("no such secret"),
+    "SecretStorageUnavailableError": lambda: secrets.SecretStorageUnavailableError(
+        "no keyring backend"
+    ),
+    "SecretUnavailableError": lambda: secrets.SecretUnavailableError("keychain locked"),
+    "MatchDecisionNotFoundError": lambda: (
+        matching_application.MatchDecisionNotFoundError("match-1")
+    ),
+    "MatchDecisionStateError": lambda: matching_application.MatchDecisionStateError(
+        "match-1", "accepted", "rejected"
+    ),
+}
+
+GUARDED_MODULES = (database, secrets, matching_application)
+
+
+def _families_defined_in(module: ModuleType) -> set[str]:
+    """Exception classes the module itself defines, not ones it imports."""
+    return {
+        name
+        for name, obj in inspect.getmembers(module, inspect.isclass)
+        if issubclass(obj, BaseException) and obj.__module__ == module.__name__
+    }
+
+
+def test_constructor_map_covers_exactly_the_declared_families() -> None:
+    """The map is an enumeration, not an allowlist — drift fails here first."""
+    declared: set[str] = set()
+    for module in GUARDED_MODULES:
+        declared |= _families_defined_in(module)
+    assert declared == set(FAMILY_CONSTRUCTORS), (
+        "the exception families in "
+        f"{[m.__name__ for m in GUARDED_MODULES]} changed. Add the new class to "
+        "FAMILY_CONSTRUCTORS (and give it a classify_user_error branch), or drop "
+        "the entry for a class that no longer exists."
+    )
+
+
+@pytest.mark.parametrize("family", sorted(FAMILY_CONSTRUCTORS))
+def test_family_is_classified(family: str) -> None:
+    classified = classify_user_error(FAMILY_CONSTRUCTORS[family]())
+    assert classified is not None, (
+        f"{family} reaches the CLI as a raw traceback and MCP as "
+        "infra_unclassified_error. Give it a classify_user_error branch."
+    )
+    assert classified.message, f"{family} classifies to an empty message"
+    assert classified.code, f"{family} classifies without a code"

--- a/tests/test_documentation_policy.py
+++ b/tests/test_documentation_policy.py
@@ -989,7 +989,7 @@ def test_public_docs_refresh_cascades_match_runtime() -> None:
     every other spelling, so a step appended to the cascade cannot leave a guide
     stale and green.
     """
-    from moneybin.services.refresh import CANONICAL_STEPS
+    from moneybin.orchestration.refresh import CANONICAL_STEPS
 
     step = "|".join(CANONICAL_STEPS)
     chain = re.compile(rf"\b(?:{step})(?: → (?:{step}))+\b")


### PR DESCRIPTION
Closes MB-51.

`src/moneybin/errors.py` is the cross-cutting error taxonomy, but importing it
loaded 25 `moneybin` modules, and `classify_user_error` reached *upward* into
the service layer at call time: it constructed a `ProfileService`, read the
active profile from config, and touched the filesystem — all behind a bare
`except Exception  # noqa: BLE001` that turned any failure on that path into
silently wrong onboarding advice.

## The cycle was real

PR #518's commit message records that the `errors<->services cycle` annotation
"was simply wrong". It was right about `refresh.py` and wrong about this one.
`src/moneybin/services/profile_service.py:22` imports `UserError` from
`moneybin.errors` at module level, and `errors.py`'s module-level import block
sits above `class UserError`, so hoisting the deferred `ProfileService` import
raises. Measured by hoisting it and importing from each end:

```
import moneybin.errors
  ImportError: cannot import name 'UserError' from partially initialized
  module 'moneybin.errors' (most likely due to a circular import)

import moneybin.services.profile_service
  ImportError: cannot import name 'ProfileService' from partially initialized
  module 'moneybin.services.profile_service' (most likely due to a circular import)
```

A module-level SCC pass cannot see this. It reports whether a cycle exists
*now*, not whether a deferral is holding one open — to test a deferral you have
to hoist it and re-run the graph.

## Shape chosen: invert, don't relocate

Module structure is a two-way door (`design-principles.md`), so this takes the
simpler of the two shapes the issue offers rather than splitting the classifier
into a new module and churning ~10 import sites.

`DatabaseNotInitializedError` now carries `profile_registered: bool | None`,
answered by `get_database` — which already holds resolved settings, so the
probe is one `Path.is_file` against a cached value and can never trigger
first-run profile resolution (the reason the old code passed
`auto_resolve=False`). The classifier reads the answer. The service
construction, the config read, and the bare except are gone; both user-facing
messages are byte-identical.

`None` — an instance nobody annotated, or a probe the filesystem refused —
takes the `db init` message, the verb that never refuses. The one narrow
`except OSError` that remains is deliberate and covered: `Path.is_file` swallows
only ENOENT-class errors, so a denied read (macOS TCC, a locked-down profile
root) would otherwise replace "database not found" with an unrelated
`PermissionError`.

## errors.py is now a leaf

`import moneybin.errors` loads exactly `moneybin`, `moneybin.error_codes` and
`moneybin.errors` — down from 25. `classify_user_error` imports the domain
families it recognizes inside the function, on the failure path, where the
module that raised is already loaded. That is what lets `database.py`,
`secrets.py` and `connectors/sync_errors.py` raise a `UserError` without minting
a cycle — the pattern `connectors/feed_errors.py` and the price and rate error
modules already use by subclassing it.

`tests/moneybin/test_architecture/test_errors_is_import_light.py` measures the
footprint in a fresh interpreter (this process's `sys.modules` is already
polluted by the suite) and pins it by set equality.

## The second exception-family pattern

The issue names three sites. Each was checked against the live classifier:

| Site | Verdict |
|---|---|
| `database.py` — five `Database*Error` / `SchemaDriftError` classes | Already classified. Nothing enforced it. |
| `secrets.py` — `SecretNotFoundError`, `SecretUnavailableError`, `SecretStorageUnavailableError` | **Not classified.** `db info`, `db unlock` and the init-script builder call `SecretStore.get_key` directly, so a missing or keychain-denied key reached `handle_cli_errors` as a raw traceback and MCP as `infra_unclassified_error`. Now classified: denied reads map to `infra_permission_denied`, missing secrets and an absent keyring backend to `infra_setup_required`, each with its own remedy. `SecretUnavailableError` is checked above its `SecretNotFoundError` base. |
| `matching/application.py` — `MatchDecisionNotFoundError`, `MatchDecisionStateError` | Already classified — both subclass `ValueError` — and `MatchingService` wraps them into explicit `MUTATION_*` `UserError`s at the write site, which is exactly what the note in `error_codes.py` prescribes for write context. No change. |

`tests/moneybin/test_errors/test_exception_family_coverage.py` enumerates the
families off the three modules themselves and checks its constructor map by set
equality, so a class added to any of them fails there rather than in front of a
user.

## Also in this PR

- **`.claude/rules/cli.md`** still taught the pre-`handle_cli_errors` pattern:
  a per-command `try/except FileNotFoundError`, a `setup_logging(cli_mode=True)`
  call no command module makes any more, and "any command that calls
  `get_database()` must also catch `DatabaseKeyError`". Rewritten around the
  boundary that actually exists.
- **An unrelated pre-existing break, fixed because it reds the repo-wide
  gates.** PR #518 moved `moneybin.services.refresh` to
  `moneybin.orchestration.refresh` but left two function-level imports of the
  old path behind, in `tests/test_documentation_policy.py:992` and
  `tests/moneybin/test_docs/test_mcp_surface_docs.py:3158`. Deferred imports do
  not fail at collection, so on `main` those two tests fail at runtime with
  `ModuleNotFoundError`, `uv run pyright` reports 9 errors and `ruff check`
  reports one `I001`. Both call sites re-pointed; nothing else in the tree
  referenced the old path.

## Notes for review

- The `# noqa: PLC0415` markers are documentation, not suppressions — `PL` is
  not in ruff's `select`, so every such marker in this repo is inert. Kept for
  consistency with the 24 existing ones; retiring them is separate cleanup.
- `classify_user_error` still calls `database_key_error_hint()` with no
  `db_path`, which that function's own docstring warns can recommend `db init`
  against a database that already exists at a caller's `--database` path. Left
  alone deliberately: same defect class, different branch, and fixing it means
  moving the hint to raise time. Worth a follow-up, not this PR.
- One more false cycle claim sits in this file and is corrected here rather than
  left for the sweep: `_is_match_run_error`'s marker read
  `errors<->matching cycle`. `moneybin.matching.engine` imports no repository
  and reaches `moneybin.errors` by no module-level path (measured in a fresh
  interpreter), so there is no cycle. The deferral stays — `matching.engine`
  pulls in config, database and metrics, and the leaf property is the real
  reason — but the annotation now says so.
- `docs/specs/demo-preset.md` still describes an older version of this
  guidance rule ("unregistered **and** has no directory yet"). That drift
  predates this PR — the code has keyed on registration alone since
  `ProfileService.create` learned to adopt a bare directory — and this diff
  preserves current behaviour exactly, so the spec is left alone.

## Test plan

- `make format && make lint` — clean.
- `uv run pyright` (bare, repo-wide) — **0 errors**, 3 pre-existing warnings
  (`reportlab` stubs).
- `make test` — **10602 passed, 4 skipped**, exit 0.
- `make test-integration` — **578 passed**, exit 0 (run because the diff touches
  `database.py`, a shared primitive).
- New coverage, all failing before the change: the classifier's three
  `profile_registered` states; a poisoned-config/service test asserting
  classification constructs no `ProfileService` and reads no profile; three
  `get_database` annotation tests (unregistered, bare directory, registered);
  a denied-registration-read test that pins the exception type and the `None`
  fallback; the secrets-family codes; the import-footprint guard; and the
  family-coverage enumeration.
- No user data touched at any point — every fixture is a `tmp_path` profile
  with no database file.
