### PR TITLE
Render oneOf MCP parameters and drop the guard's dead row promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -404,7 +404,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   no description, the `gsheet auth` help named a retired MCP tool, and ten tool
   descriptions spelled the undo hint as a positional call — and the CLI
   reference guide now keeps its prose and links each group's generated page in
-  place of its command tables.
+  place of its command tables. (#525)
 - **`core.bridge_merchant_entities`** — a new queryable core view mapping each
   transaction to the merchant identifier its source system assigned, alongside
   the source that issued it and the merchant name that source stated. Available

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -212,7 +212,7 @@ Present or absent target state for one named local destination.
 | `kind` | `local` |  | required |
 | `state` | one of `present`, `absent` |  | required |
 | `name` | string |  | required; min length 1 |
-| `local_path` | string |  | min length 1 |
+| `local_path` | string |  | min length 1; required when `state` is `present`; forbidden otherwise |
 
 ##### `sheets`
 
@@ -223,8 +223,8 @@ Present or absent target state for one named Sheets destination.
 | `kind` | `sheets` |  | required |
 | `state` | one of `present`, `absent` |  | required |
 | `name` | string |  | required; min length 1 |
-| `spreadsheet_id` | string |  | min length 1 |
-| `managed_tab_prefix` | string |  | min length 1 |
+| `spreadsheet_id` | string |  | min length 1; required when `state` is `present`; forbidden otherwise |
+| `managed_tab_prefix` | string |  | min length 1; forbidden otherwise |
 
 ### gsheet
 
@@ -300,7 +300,7 @@ Accept or reject one account-link proposal.
 |---|---|---|---|
 | `decision_id` | string |  | required; min length 1; max length 64 |
 | `decision` | one of `accept`, `reject` |  | required |
-| `target_id` | string |  | min length 1; max length 64 |
+| `target_id` | string |  | min length 1; max length 64; required when `decision` is `accept`; forbidden when `decision` is `reject` |
 | `kind` | `account_link` |  | required |
 
 ##### `merchant_link`
@@ -311,7 +311,7 @@ Accept or reject one merchant-link proposal.
 |---|---|---|---|
 | `decision_id` | string |  | required; min length 1; max length 64 |
 | `decision` | one of `accept`, `reject` |  | required |
-| `target_id` | string |  | min length 1; max length 64 |
+| `target_id` | string |  | min length 1; max length 64; required when `decision` is `accept`; forbidden when `decision` is `reject` |
 | `kind` | `merchant_link` |  | required |
 
 ##### `security_link`
@@ -322,7 +322,7 @@ Accept or reject one security-link proposal.
 |---|---|---|---|
 | `decision_id` | string |  | required; min length 1; max length 64 |
 | `decision` | one of `accept`, `reject` |  | required |
-| `target_id` | string |  | min length 1; max length 64 |
+| `target_id` | string |  | min length 1; max length 64; required when `decision` is `accept`; forbidden when `decision` is `reject` |
 | `kind` | `security_link` |  | required |
 
 ### import_confirm
@@ -573,9 +573,9 @@ Accept or reject one categorization proposal.
 | `kind` | `categorization` |  | required |
 | `decision_id` | string |  | required; min length 1; max length 64 |
 | `decision` | one of `accept`, `reject` |  | required |
-| `category` | string |  | min length 1; max length 100 |
-| `subcategory` | string |  | min length 1; max length 100 |
-| `canonical_merchant_name` | string |  | min length 1; max length 200 |
+| `category` | string |  | min length 1; max length 100; required when `decision` is `accept`; forbidden when `decision` is `reject` |
+| `subcategory` | string |  | min length 1; max length 100; forbidden when `decision` is `reject` |
+| `canonical_merchant_name` | string |  | min length 1; max length 200; forbidden when `decision` is `reject` |
 
 ##### `match`
 
@@ -596,7 +596,7 @@ Accept or reject one auto-generated categorization-rule proposal.
 | `kind` | `auto_rule` |  | required |
 | `decision_id` | string |  | required; min length 1; max length 64 |
 | `decision` | one of `accept`, `reject` |  | required |
-| `allow_broad` | boolean | `false` |  |
+| `allow_broad` | boolean | `false` | must be `false` when `decision` is `reject` |
 
 ### sql_query
 
@@ -732,11 +732,11 @@ Declare one category's target state.
 |---|---|---|---|
 | `kind` | `category` |  | required |
 | `state` | one of `present`, `inactive`, `absent` |  | required |
-| `category_id` | string |  | min length 1; max length 64 |
-| `category` | string |  | min length 1; max length 100 |
-| `subcategory` | string |  | min length 1; max length 100 |
-| `description` | string |  | max length 2000 |
-| `force` | boolean | `false` |  |
+| `category_id` | string |  | min length 1; max length 64; required when `state` is `inactive` or `absent` |
+| `category` | string |  | min length 1; max length 100; required when `state` is `present`; forbidden when `state` is `inactive` or `absent` |
+| `subcategory` | string |  | min length 1; max length 100; forbidden when `state` is `inactive` or `absent` |
+| `description` | string |  | max length 2000; forbidden when `state` is `inactive` or `absent` |
+| `force` | boolean | `false` | must be `false` when `state` is `present` or `inactive` |
 
 ##### `merchant`
 
@@ -746,12 +746,12 @@ Declare one merchant mapping's target state.
 |---|---|---|---|
 | `kind` | `merchant` |  | required |
 | `state` | one of `present`, `absent` |  | required |
-| `merchant_id` | string |  | min length 1; max length 64 |
-| `raw_pattern` | string |  | min length 1; max length 500 |
-| `canonical_name` | string |  | min length 1; max length 200 |
-| `match_type` | one of `exact`, `contains`, `regex` |  |  |
-| `category` | string |  | min length 1; max length 100 |
-| `subcategory` | string |  | min length 1; max length 100 |
+| `merchant_id` | string |  | min length 1; max length 64; required when `state` is `absent` |
+| `raw_pattern` | string |  | min length 1; max length 500; required when `state` is `present`; forbidden when `state` is `absent` |
+| `canonical_name` | string |  | min length 1; max length 200; required when `state` is `present`; forbidden when `state` is `absent` |
+| `match_type` | one of `exact`, `contains`, `regex` |  | forbidden when `state` is `absent` |
+| `category` | string |  | min length 1; max length 100; forbidden when `state` is `absent` |
+| `subcategory` | string |  | min length 1; max length 100; forbidden when `state` is `absent` |
 
 ### transactions
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -144,9 +144,51 @@ Access: write, not idempotent, open world. Maximum sensitivity: `medium`.
 
 | Parameter | Type | Default | Notes |
 |---|---|---|---|
-| `subject` | any |  | required |
-| `destination` | any |  | required |
+| `subject` | one of `bundle`, `report` |  | required |
+| `destination` | one of `local`, `sheets` |  | required |
 | `redaction_mode` | one of `redacted`, `unredacted` |  |  |
+
+#### Variants of `subject`
+
+##### `bundle`
+
+The closed canonical portability bundle.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `kind` | `bundle` |  | required |
+
+##### `report`
+
+One registered report and typed parameter binding.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `kind` | `report` |  | required |
+| `report_id` | string |  | required; min length 1 |
+| `parameters` | object of any |  |  |
+
+#### Variants of `destination`
+
+##### `local`
+
+One named local delivery target and its local-only options.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `kind` | `local` |  | required |
+| `name` | string |  | required; min length 1 |
+| `format` | one of `csv`, `parquet`, `xlsx` | `csv` |  |
+| `compression` | `zip` |  |  |
+
+##### `sheets`
+
+One named Sheets delivery target with native format semantics.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `kind` | `sheets` |  | required |
+| `name` | string |  | required; min length 1 |
 
 ### exports_set
 
@@ -156,8 +198,33 @@ Access: write, destructive, idempotent, open world. Maximum sensitivity: `medium
 
 | Parameter | Type | Default | Notes |
 |---|---|---|---|
-| `target` | any |  | required |
+| `target` | one of `local`, `sheets` |  | required |
 | `confirmation_token` | string |  |  |
+
+#### Variants of `target`
+
+##### `local`
+
+Present or absent target state for one named local destination.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `kind` | `local` |  | required |
+| `state` | one of `present`, `absent` |  | required |
+| `name` | string |  | required; min length 1 |
+| `local_path` | string |  | min length 1 |
+
+##### `sheets`
+
+Present or absent target state for one named Sheets destination.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `kind` | `sheets` |  | required |
+| `state` | one of `present`, `absent` |  | required |
+| `name` | string |  | required; min length 1 |
+| `spreadsheet_id` | string |  | min length 1 |
+| `managed_tab_prefix` | string |  | min length 1 |
 
 ### gsheet
 
@@ -220,8 +287,43 @@ Access: write, destructive, idempotent. Maximum sensitivity: `medium`.
 
 | Parameter | Type | Default | Notes |
 |---|---|---|---|
-| `decisions` | array of any |  | required |
+| `decisions` | array of one of `account_link`, `merchant_link`, `security_link` |  | required |
 | `confirmation_token` | string |  |  |
+
+#### Variants of `decisions`
+
+##### `account_link`
+
+Accept or reject one account-link proposal.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `decision_id` | string |  | required; min length 1; max length 64 |
+| `decision` | one of `accept`, `reject` |  | required |
+| `target_id` | string |  | min length 1; max length 64 |
+| `kind` | `account_link` |  | required |
+
+##### `merchant_link`
+
+Accept or reject one merchant-link proposal.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `decision_id` | string |  | required; min length 1; max length 64 |
+| `decision` | one of `accept`, `reject` |  | required |
+| `target_id` | string |  | min length 1; max length 64 |
+| `kind` | `merchant_link` |  | required |
+
+##### `security_link`
+
+Accept or reject one security-link proposal.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `decision_id` | string |  | required; min length 1; max length 64 |
+| `decision` | one of `accept`, `reject` |  | required |
+| `target_id` | string |  | min length 1; max length 64 |
+| `kind` | `security_link` |  | required |
 
 ### import_confirm
 
@@ -458,7 +560,43 @@ Access: write, idempotent. Maximum sensitivity: `low`.
 
 | Parameter | Type | Default | Notes |
 |---|---|---|---|
-| `decisions` | array of any |  | required |
+| `decisions` | array of one of `categorization`, `match`, `auto_rule` |  | required |
+
+#### Variants of `decisions`
+
+##### `categorization`
+
+Accept or reject one categorization proposal.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `kind` | `categorization` |  | required |
+| `decision_id` | string |  | required; min length 1; max length 64 |
+| `decision` | one of `accept`, `reject` |  | required |
+| `category` | string |  | min length 1; max length 100 |
+| `subcategory` | string |  | min length 1; max length 100 |
+| `canonical_merchant_name` | string |  | min length 1; max length 200 |
+
+##### `match`
+
+Accept or reject one transaction-match proposal.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `kind` | `match` |  | required |
+| `decision_id` | string |  | required; min length 1; max length 64 |
+| `decision` | one of `accept`, `reject` |  | required |
+
+##### `auto_rule`
+
+Accept or reject one auto-generated categorization-rule proposal.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `kind` | `auto_rule` |  | required |
+| `decision_id` | string |  | required; min length 1; max length 64 |
+| `decision` | one of `accept`, `reject` |  | required |
+| `allow_broad` | boolean | `false` |  |
 
 ### sql_query
 
@@ -581,8 +719,39 @@ Access: write, destructive, idempotent. Maximum sensitivity: `low`.
 
 | Parameter | Type | Default | Notes |
 |---|---|---|---|
-| `items` | array of any |  | required |
+| `items` | array of one of `category`, `merchant` |  | required |
 | `confirmation_token` | string |  |  |
+
+#### Variants of `items`
+
+##### `category`
+
+Declare one category's target state.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `kind` | `category` |  | required |
+| `state` | one of `present`, `inactive`, `absent` |  | required |
+| `category_id` | string |  | min length 1; max length 64 |
+| `category` | string |  | min length 1; max length 100 |
+| `subcategory` | string |  | min length 1; max length 100 |
+| `description` | string |  | max length 2000 |
+| `force` | boolean | `false` |  |
+
+##### `merchant`
+
+Declare one merchant mapping's target state.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `kind` | `merchant` |  | required |
+| `state` | one of `present`, `absent` |  | required |
+| `merchant_id` | string |  | min length 1; max length 64 |
+| `raw_pattern` | string |  | min length 1; max length 500 |
+| `canonical_name` | string |  | min length 1; max length 200 |
+| `match_type` | one of `exact`, `contains`, `regex` |  |  |
+| `category` | string |  | min length 1; max length 100 |
+| `subcategory` | string |  | min length 1; max length 100 |
 
 ### transactions
 
@@ -611,8 +780,69 @@ Access: write, destructive, not idempotent. Maximum sensitivity: `low`.
 
 | Parameter | Type | Default | Notes |
 |---|---|---|---|
-| `requests` | array of any |  | required |
+| `requests` | array of one of `note_add`, `note_edit`, `note_delete`, `tags_set`, `splits_set`, `tag_rename` |  | required |
 | `confirmation_token` | string |  |  |
+
+#### Variants of `requests`
+
+##### `note_add`
+
+Append one independently addressable note to a transaction.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `kind` | `note_add` |  | required |
+| `transaction_id` | string |  | required; min length 1; max length 64 |
+| `text` | string |  | required; max length 2000 |
+
+##### `note_edit`
+
+Replace the text of one note without changing its identity.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `kind` | `note_edit` |  | required |
+| `note_id` | string |  | required; min length 1; max length 64 |
+| `text` | string |  | required; max length 2000 |
+
+##### `note_delete`
+
+Delete one note by its stable identity.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `kind` | `note_delete` |  | required |
+| `note_id` | string |  | required; min length 1; max length 64 |
+
+##### `tags_set`
+
+Replace the complete tag collection on one transaction.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `kind` | `tags_set` |  | required |
+| `transaction_id` | string |  | required; min length 1; max length 64 |
+| `tags` | array of string |  | required |
+
+##### `splits_set`
+
+Replace the complete split collection on one transaction.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `kind` | `splits_set` |  | required |
+| `transaction_id` | string |  | required; min length 1; max length 64 |
+| `splits` | array of object |  | required |
+
+##### `tag_rename`
+
+Rename one tag everywhere.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `kind` | `tag_rename` |  | required |
+| `old_name` | string |  | required; min length 1; max length 100 |
+| `new_name` | string |  | required; min length 1; max length 100 |
 
 ### transactions_categorize_assist
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -212,7 +212,7 @@ Present or absent target state for one named local destination.
 | `kind` | `local` |  | required |
 | `state` | one of `present`, `absent` |  | required |
 | `name` | string |  | required; min length 1 |
-| `local_path` | string |  | min length 1; required when `state` is `present`; forbidden otherwise |
+| `local_path` | string |  | min length 1; required when `state` is `present`; forbidden unless `state` is `present` |
 
 ##### `sheets`
 
@@ -223,8 +223,8 @@ Present or absent target state for one named Sheets destination.
 | `kind` | `sheets` |  | required |
 | `state` | one of `present`, `absent` |  | required |
 | `name` | string |  | required; min length 1 |
-| `spreadsheet_id` | string |  | min length 1; required when `state` is `present`; forbidden otherwise |
-| `managed_tab_prefix` | string |  | min length 1; forbidden otherwise |
+| `spreadsheet_id` | string |  | min length 1; required when `state` is `present`; forbidden unless `state` is `present` |
+| `managed_tab_prefix` | string |  | min length 1; forbidden unless `state` is `present` |
 
 ### gsheet
 

--- a/scripts/generate_reference_docs.py
+++ b/scripts/generate_reference_docs.py
@@ -463,7 +463,12 @@ _CONSTRAINT_KEYS = (
 )
 
 
-def _schema_notes(name: str, schema: Mapping[str, object], required: set[str]) -> str:
+def _schema_notes(
+    name: str,
+    schema: Mapping[str, object],
+    required: set[str],
+    conditionals: Mapping[str, list[str]] | None = None,
+) -> str:
     notes = ["required"] if name in required else []
     for key, template in _CONSTRAINT_KEYS:
         if key in schema:
@@ -476,6 +481,8 @@ def _schema_notes(name: str, schema: Mapping[str, object], required: set[str]) -
             for key, template in _CONSTRAINT_KEYS:
                 if key in option:
                     notes.append(template.format(option[key]))
+    if conditionals:
+        notes.extend(conditionals.get(name, []))
     if "description" in schema:
         notes.append(str(schema["description"]))
     return "; ".join(notes)
@@ -488,17 +495,202 @@ def _schema_default(schema: Mapping[str, object]) -> str:
 
 
 def _property_rows(
-    properties: Mapping[str, Mapping[str, object]], required: set[str]
+    properties: Mapping[str, Mapping[str, object]],
+    required: set[str],
+    conditionals: Mapping[str, list[str]] | None = None,
 ) -> list[list[str]]:
     return [
         [
             _code(name),
             _schema_type(schema),
             _schema_default(schema),
-            _schema_notes(name, schema, required),
+            _schema_notes(name, schema, required, conditionals),
         ]
         for name, schema in properties.items()
     ]
+
+
+# One conditional clause: (verdict, discriminator field, discriminator values it
+# fires on, the fixed value for a "must be" verdict). The discriminator field is
+# ``None`` for an ``else`` "forbidden otherwise" clause, which fires unconditionally.
+_Clause = tuple[str, str | None, list[object], object]
+
+
+def _condition_field_value(
+    param_name: str, variant_name: str, branch: Mapping[str, object]
+) -> tuple[str, object]:
+    """The ``(field, value)`` an ``allOf`` branch's ``if`` tests, or raise on a wider shape."""
+    if_ = branch.get("if")
+    if not isinstance(if_, Mapping) or set(if_) != {"properties", "required"}:
+        raise ValueError(
+            f"{param_name!r} variant {variant_name!r}: unrecognized if clause {if_!r}"
+        )
+    properties = typing.cast(Mapping[str, Mapping[str, object]], if_["properties"])
+    if len(properties) != 1:
+        raise ValueError(
+            f"{param_name!r} variant {variant_name!r}: if must test exactly one property"
+        )
+    ((field, field_schema),) = properties.items()
+    if set(field_schema) != {"const"} or if_["required"] != [field]:
+        raise ValueError(
+            f"{param_name!r} variant {variant_name!r}: if.{field} is not a bare const test"
+        )
+    return field, field_schema["const"]
+
+
+def _forbidden_fields(
+    param_name: str, variant_name: str, not_clause: object
+) -> list[str]:
+    """Field names a ``{"not": {"anyOf": [{"required": [name]}, ...]}}`` clause forbids."""
+    if not isinstance(not_clause, Mapping) or set(not_clause) != {"anyOf"}:
+        raise ValueError(
+            f"{param_name!r} variant {variant_name!r}: unrecognized not clause {not_clause!r}"
+        )
+    names = []
+    for item in typing.cast(list[Mapping[str, object]], not_clause["anyOf"]):
+        required = typing.cast(list[str], item.get("required"))
+        if (
+            set(item) != {"required"}
+            or not isinstance(required, list)
+            or len(required) != 1
+        ):
+            raise ValueError(
+                f"{param_name!r} variant {variant_name!r}: unrecognized forbidden "
+                f"clause {item!r}"
+            )
+        names.append(required[0])
+    return names
+
+
+def _then_clauses(
+    param_name: str,
+    variant_name: str,
+    then: Mapping[str, object],
+    condition_field: str,
+    condition_value: object,
+) -> dict[str, list[_Clause]]:
+    """The per-field clauses one branch's ``then`` contributes."""
+    remaining = dict(then)
+    required = typing.cast(list[str], remaining.pop("required", []))
+    clauses: dict[str, list[_Clause]] = {
+        name: [("required", condition_field, [condition_value], None)]
+        for name in required
+    }
+    not_clause = remaining.pop("not", None)
+    if not_clause is not None:
+        for name in _forbidden_fields(param_name, variant_name, not_clause):
+            clauses.setdefault(name, []).append((
+                "forbidden",
+                condition_field,
+                [condition_value],
+                None,
+            ))
+    properties = typing.cast(
+        Mapping[str, Mapping[str, object]], remaining.pop("properties", {})
+    )
+    for name, schema in properties.items():
+        if schema == {"not": {"type": "null"}}:
+            if name not in required:
+                raise ValueError(
+                    f"{param_name!r} variant {variant_name!r}: {name} is not-null "
+                    "without a matching required"
+                )
+            continue
+        if set(schema) == {"const"}:
+            clauses.setdefault(name, []).append((
+                "must_be",
+                condition_field,
+                [condition_value],
+                schema["const"],
+            ))
+            continue
+        raise ValueError(
+            f"{param_name!r} variant {variant_name!r}: unrecognized then.{name} {schema!r}"
+        )
+    if remaining:
+        raise ValueError(
+            f"{param_name!r} variant {variant_name!r}: unrecognized then keys "
+            f"{sorted(remaining)}"
+        )
+    return clauses
+
+
+def _else_clauses(
+    param_name: str, variant_name: str, else_: object
+) -> dict[str, list[_Clause]]:
+    """The per-field ``forbidden otherwise`` clauses one branch's ``else`` contributes."""
+    if not isinstance(else_, Mapping) or set(else_) != {"not"}:
+        raise ValueError(
+            f"{param_name!r} variant {variant_name!r}: unrecognized else clause {else_!r}"
+        )
+    names = _forbidden_fields(param_name, variant_name, else_["not"])
+    return {name: [("forbidden_otherwise", None, [], None)] for name in names}
+
+
+def _merge_clauses(clauses: list[_Clause]) -> list[_Clause]:
+    """Combine clauses sharing a verdict, condition field, and (for `must be`) value."""
+    merged: list[_Clause] = []
+    index: dict[tuple[str, str | None, object], int] = {}
+    for verdict, condition_field, values, must_be in clauses:
+        key = (verdict, condition_field, must_be)
+        if key in index:
+            merged[index[key]][2].extend(values)
+        else:
+            index[key] = len(merged)
+            merged.append((verdict, condition_field, list(values), must_be))
+    return merged
+
+
+def _render_clause(clause: _Clause) -> str:
+    verdict, condition_field, values, must_be = clause
+    if verdict == "forbidden_otherwise":
+        return "forbidden otherwise"
+    condition = " or ".join(_code(value) for value in values)
+    if verdict == "required":
+        return f"required when {_code(condition_field)} is {condition}"
+    if verdict == "must_be":
+        return f"must be {_json_code(must_be)} when {_code(condition_field)} is {condition}"
+    return f"forbidden when {_code(condition_field)} is {condition}"
+
+
+def _variant_conditionals(
+    param_name: str, variant_name: str, variant: Mapping[str, object]
+) -> dict[str, list[str]]:
+    """Field name -> ordered Notes clauses from a variant's ``allOf`` conditionals.
+
+    Covers exactly the shapes ``_state_schema`` (``exports.py``) and
+    ``_conditional_schema_branch`` (``write_contracts.py``) emit; any other
+    ``if``/``then``/``else`` shape raises so a future schema change fails
+    regeneration loudly instead of silently dropping a constraint.
+    """
+    all_of = variant.get("allOf")
+    if not all_of:
+        return {}
+    by_field: dict[str, list[_Clause]] = {}
+    for branch in typing.cast(list[Mapping[str, object]], all_of):
+        condition_field, condition_value = _condition_field_value(
+            param_name, variant_name, branch
+        )
+        then = typing.cast(Mapping[str, object], branch.get("then", {}))
+        for name, clauses in _then_clauses(
+            param_name, variant_name, then, condition_field, condition_value
+        ).items():
+            by_field.setdefault(name, []).extend(clauses)
+        if "else" in branch:
+            for name, clauses in _else_clauses(
+                param_name, variant_name, branch["else"]
+            ).items():
+                by_field.setdefault(name, []).extend(clauses)
+        extra = set(branch) - {"if", "then", "else"}
+        if extra:
+            raise ValueError(
+                f"{param_name!r} variant {variant_name!r}: unrecognized allOf keys "
+                f"{sorted(extra)}"
+            )
+    return {
+        name: [_render_clause(clause) for clause in _merge_clauses(clauses)]
+        for name, clauses in by_field.items()
+    }
 
 
 def _variant_sections(
@@ -507,7 +699,8 @@ def _variant_sections(
     """A ``Variants of `param_name`` block: one field table per discriminated variant."""
     lines = [f"#### Variants of {_code(param_name)}", ""]
     for index, variant in enumerate(variants):
-        lines += [f"##### {_code(_oneof_variant_name(variant, index))}", ""]
+        variant_name = _oneof_variant_name(variant, index)
+        lines += [f"##### {_code(variant_name)}", ""]
         description = variant.get("description")
         if description:
             lines += [_escape_angles(str(description).strip()), ""]
@@ -516,9 +709,10 @@ def _variant_sections(
         )
         required = set(typing.cast(list[str], variant.get("required", [])))
         if properties:
+            conditionals = _variant_conditionals(param_name, variant_name, variant)
             lines += _table(
                 ["Field", "Type", "Default", "Notes"],
-                _property_rows(properties, required),
+                _property_rows(properties, required, conditionals),
             )
         lines.append("")
     return lines[:-1]

--- a/scripts/generate_reference_docs.py
+++ b/scripts/generate_reference_docs.py
@@ -382,10 +382,40 @@ def _json_code(value: object) -> str:
     return _code(value if isinstance(value, str) else json.dumps(value))
 
 
+def _oneof_variant_name(variant: Mapping[str, object], index: int) -> str:
+    """Name a discriminated-union variant: its discriminator's const, else its title."""
+    for prop_schema in typing.cast(
+        Mapping[str, Mapping[str, object]], variant.get("properties", {})
+    ).values():
+        if "const" in prop_schema:
+            return str(prop_schema["const"])
+    title = variant.get("title")
+    return str(title) if title else f"variant {index + 1}"
+
+
+def _oneof_variants(schema: Mapping[str, object]) -> list[Mapping[str, object]] | None:
+    """The ``oneOf`` variants on this schema, or on an array schema's items."""
+    if "oneOf" in schema:
+        return typing.cast(list[Mapping[str, object]], schema["oneOf"])
+    if schema.get("type") == "array":
+        items = typing.cast(Mapping[str, object], schema.get("items", {}))
+        if "oneOf" in items:
+            return typing.cast(list[Mapping[str, object]], items["oneOf"])
+    return None
+
+
 def _schema_type(schema: Mapping[str, object]) -> str:
+    if "const" in schema:
+        return _json_code(schema["const"])
     if "enum" in schema:
         values = typing.cast(list[object], schema["enum"])
         return "one of " + ", ".join(_json_code(value) for value in values)
+    if "oneOf" in schema:
+        options = typing.cast(list[Mapping[str, object]], schema["oneOf"])
+        names = [
+            _oneof_variant_name(option, index) for index, option in enumerate(options)
+        ]
+        return "one of " + ", ".join(_code(name) for name in names)
     if "anyOf" in schema:
         options = typing.cast(list[Mapping[str, object]], schema["anyOf"])
         parts = [
@@ -456,6 +486,29 @@ def _property_rows(
         ]
         for name, schema in properties.items()
     ]
+
+
+def _variant_sections(
+    param_name: str, variants: list[Mapping[str, object]]
+) -> list[str]:
+    """A ``Variants of `param_name`` block: one field table per discriminated variant."""
+    lines = [f"#### Variants of {_code(param_name)}", ""]
+    for index, variant in enumerate(variants):
+        lines += [f"##### {_code(_oneof_variant_name(variant, index))}", ""]
+        description = variant.get("description")
+        if description:
+            lines += [_escape_angles(str(description).strip()), ""]
+        properties = typing.cast(
+            Mapping[str, Mapping[str, object]], variant.get("properties", {})
+        )
+        required = set(typing.cast(list[str], variant.get("required", [])))
+        if properties:
+            lines += _table(
+                ["Field", "Type", "Default", "Notes"],
+                _property_rows(properties, required),
+            )
+        lines.append("")
+    return lines[:-1]
 
 
 def _access(annotations: Mapping[str, object]) -> str:
@@ -541,6 +594,11 @@ def render_mcp_tools(
                 ["Parameter", "Type", "Default", "Notes"],
                 _property_rows(properties, required),
             )
+            for prop_name, prop_schema in properties.items():
+                variants = _oneof_variants(prop_schema)
+                if variants:
+                    lines.append("")
+                    lines += _variant_sections(prop_name, variants)
         else:
             lines.append("No parameters.")
         lines.append("")

--- a/scripts/generate_reference_docs.py
+++ b/scripts/generate_reference_docs.py
@@ -394,13 +394,26 @@ def _oneof_variant_name(variant: Mapping[str, object], index: int) -> str:
 
 
 def _oneof_variants(schema: Mapping[str, object]) -> list[Mapping[str, object]] | None:
-    """The ``oneOf`` variants on this schema, or on an array schema's items."""
+    """The ``oneOf`` variants on this schema, under its nullable wrapper, or on its items.
+
+    Mirrors the unwrapping in ``_schema_type`` so an optional discriminated
+    union gets the same variants block as a required one. An ``anyOf`` with
+    more than one non-null option is a real alternation, not a wrapper, and
+    yields no block.
+    """
     if "oneOf" in schema:
         return typing.cast(list[Mapping[str, object]], schema["oneOf"])
+    if "anyOf" in schema:
+        options = [
+            option
+            for option in typing.cast(list[Mapping[str, object]], schema["anyOf"])
+            if option.get("type") != "null"
+        ]
+        return _oneof_variants(options[0]) if len(options) == 1 else None
     if schema.get("type") == "array":
-        items = typing.cast(Mapping[str, object], schema.get("items", {}))
-        if "oneOf" in items:
-            return typing.cast(list[Mapping[str, object]], items["oneOf"])
+        return _oneof_variants(
+            typing.cast(Mapping[str, object], schema.get("items", {}))
+        )
     return None
 
 

--- a/scripts/generate_reference_docs.py
+++ b/scripts/generate_reference_docs.py
@@ -511,9 +511,8 @@ def _property_rows(
 
 
 # One conditional clause: (verdict, discriminator field, discriminator values it
-# fires on, the fixed value for a "must be" verdict). The discriminator field is
-# ``None`` for an ``else`` "forbidden otherwise" clause, which fires unconditionally.
-_Clause = tuple[str, str | None, list[object], object]
+# fires on, the fixed value for a "must be" verdict).
+_Clause = tuple[str, str, list[object], object]
 
 
 def _condition_field_value(
@@ -616,21 +615,28 @@ def _then_clauses(
 
 
 def _else_clauses(
-    param_name: str, variant_name: str, else_: object
+    param_name: str,
+    variant_name: str,
+    else_: object,
+    condition_field: str,
+    condition_value: object,
 ) -> dict[str, list[_Clause]]:
-    """The per-field ``forbidden otherwise`` clauses one branch's ``else`` contributes."""
+    """The per-field ``forbidden unless`` clauses one branch's ``else`` contributes."""
     if not isinstance(else_, Mapping) or set(else_) != {"not"}:
         raise ValueError(
             f"{param_name!r} variant {variant_name!r}: unrecognized else clause {else_!r}"
         )
     names = _forbidden_fields(param_name, variant_name, else_["not"])
-    return {name: [("forbidden_otherwise", None, [], None)] for name in names}
+    return {
+        name: [("forbidden_unless", condition_field, [condition_value], None)]
+        for name in names
+    }
 
 
 def _merge_clauses(clauses: list[_Clause]) -> list[_Clause]:
     """Combine clauses sharing a verdict, condition field, and (for `must be`) value."""
     merged: list[_Clause] = []
-    index: dict[tuple[str, str | None, object], int] = {}
+    index: dict[tuple[str, str, object], int] = {}
     for verdict, condition_field, values, must_be in clauses:
         key = (verdict, condition_field, must_be)
         if key in index:
@@ -643,14 +649,16 @@ def _merge_clauses(clauses: list[_Clause]) -> list[_Clause]:
 
 def _render_clause(clause: _Clause) -> str:
     verdict, condition_field, values, must_be = clause
-    if verdict == "forbidden_otherwise":
-        return "forbidden otherwise"
-    condition = " or ".join(_code(value) for value in values)
+    condition = f"{_code(condition_field)} is " + " or ".join(
+        _code(value) for value in values
+    )
     if verdict == "required":
-        return f"required when {_code(condition_field)} is {condition}"
+        return f"required when {condition}"
     if verdict == "must_be":
-        return f"must be {_json_code(must_be)} when {_code(condition_field)} is {condition}"
-    return f"forbidden when {_code(condition_field)} is {condition}"
+        return f"must be {_json_code(must_be)} when {condition}"
+    if verdict == "forbidden_unless":
+        return f"forbidden unless {condition}"
+    return f"forbidden when {condition}"
 
 
 def _variant_conditionals(
@@ -678,7 +686,11 @@ def _variant_conditionals(
             by_field.setdefault(name, []).extend(clauses)
         if "else" in branch:
             for name, clauses in _else_clauses(
-                param_name, variant_name, branch["else"]
+                param_name,
+                variant_name,
+                branch["else"],
+                condition_field,
+                condition_value,
             ).items():
                 by_field.setdefault(name, []).extend(clauses)
         extra = set(branch) - {"if", "then", "else"}

--- a/tests/moneybin/test_scripts/test_generate_reference_docs.py
+++ b/tests/moneybin/test_scripts/test_generate_reference_docs.py
@@ -215,6 +215,39 @@ SURFACE: dict[str, Any] = {
                             "anyOf": [{"type": "string"}, {"type": "null"}],
                             "default": None,
                         },
+                        "scope": {
+                            "anyOf": [
+                                {
+                                    "oneOf": [
+                                        {
+                                            "description": "Every thing.",
+                                            "properties": {
+                                                "kind": {
+                                                    "const": "everything",
+                                                    "type": "string",
+                                                }
+                                            },
+                                            "required": ["kind"],
+                                            "type": "object",
+                                        },
+                                        {
+                                            "description": "One thing.",
+                                            "properties": {
+                                                "kind": {
+                                                    "const": "one",
+                                                    "type": "string",
+                                                },
+                                                "thing_id": {"type": "string"},
+                                            },
+                                            "required": ["kind", "thing_id"],
+                                            "type": "object",
+                                        },
+                                    ]
+                                },
+                                {"type": "null"},
+                            ],
+                            "default": None,
+                        },
                         "target": {
                             "oneOf": [
                                 {
@@ -316,6 +349,19 @@ def test_mcp_page_renders_oneof_variants_by_discriminator() -> None:
         < page.index("#### Variants of `requests`")
         < page.index("### zeta")
     )
+
+
+def test_mcp_page_renders_variants_of_a_nullable_oneof() -> None:
+    """An optional discriminated union gets the same variants block as a required one."""
+    page = render_mcp_tools(SURFACE, {"accounts": "critical", "zeta": "low"})
+    assert "| `scope` | one of `everything`, `one` |" in page
+    assert "#### Variants of `scope`" in page
+    assert "##### `everything`" in page
+    assert "Every thing." in page
+    assert "##### `one`" in page
+    assert "One thing." in page
+    assert "| `thing_id` | string |  | required |" in page
+    assert page.index("#### Variants of `scope`") < page.index("### zeta")
 
 
 def test_mcp_page_refuses_a_tool_without_a_registered_sensitivity() -> None:

--- a/tests/moneybin/test_scripts/test_generate_reference_docs.py
+++ b/tests/moneybin/test_scripts/test_generate_reference_docs.py
@@ -448,6 +448,273 @@ def test_mcp_page_names_oneof_variant_by_position_without_a_title() -> None:
     assert "##### `variant 2`" in page
 
 
+def test_mcp_page_renders_conditional_required_and_else_forbidden() -> None:
+    """A ``state``-conditioned field states when it is required, and ``else`` forbidden."""
+    surface: dict[str, Any] = {
+        "tool_count": 1,
+        "tools": [
+            {
+                "name": "widget_target_set",
+                "definition": {
+                    "description": "Set one widget target.",
+                    "annotations": {"readOnlyHint": False},
+                    "inputSchema": {
+                        "properties": {
+                            "target": {
+                                "oneOf": [
+                                    {
+                                        "description": "A local target.",
+                                        "properties": {
+                                            "kind": {
+                                                "const": "local",
+                                                "type": "string",
+                                            },
+                                            "state": {"type": "string"},
+                                            "local_path": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                            },
+                                        },
+                                        "required": ["kind", "state"],
+                                        "type": "object",
+                                        "allOf": [
+                                            {
+                                                "if": {
+                                                    "properties": {
+                                                        "state": {"const": "present"}
+                                                    },
+                                                    "required": ["state"],
+                                                },
+                                                "then": {
+                                                    "required": ["local_path"],
+                                                    "properties": {
+                                                        "local_path": {
+                                                            "not": {"type": "null"}
+                                                        }
+                                                    },
+                                                },
+                                                "else": {
+                                                    "not": {
+                                                        "anyOf": [
+                                                            {"required": ["local_path"]}
+                                                        ]
+                                                    }
+                                                },
+                                            }
+                                        ],
+                                    },
+                                ]
+                            },
+                        },
+                        "type": "object",
+                    },
+                },
+            },
+        ],
+    }
+    page = render_mcp_tools(surface, {"widget_target_set": "low"})
+    assert (
+        "| `local_path` | string |  | min length 1; required when `state` is "
+        "`present`; forbidden otherwise |" in page
+    )
+
+
+def test_mcp_page_merges_conditional_forbidden_clauses_across_branches() -> None:
+    """Two branches forbidding the same field on the same discriminator merge with ``or``."""
+    surface: dict[str, Any] = {
+        "tool_count": 1,
+        "tools": [
+            {
+                "name": "taxonomy_set",
+                "definition": {
+                    "description": "Set one taxonomy target.",
+                    "annotations": {"readOnlyHint": False},
+                    "inputSchema": {
+                        "properties": {
+                            "items": {
+                                "oneOf": [
+                                    {
+                                        "description": "A category target.",
+                                        "properties": {
+                                            "kind": {
+                                                "const": "category",
+                                                "type": "string",
+                                            },
+                                            "state": {"type": "string"},
+                                            "category": {"type": "string"},
+                                        },
+                                        "required": ["kind", "state"],
+                                        "type": "object",
+                                        "allOf": [
+                                            {
+                                                "if": {
+                                                    "properties": {
+                                                        "state": {"const": "present"}
+                                                    },
+                                                    "required": ["state"],
+                                                },
+                                                "then": {"required": ["category"]},
+                                            },
+                                            {
+                                                "if": {
+                                                    "properties": {
+                                                        "state": {"const": "inactive"}
+                                                    },
+                                                    "required": ["state"],
+                                                },
+                                                "then": {
+                                                    "not": {
+                                                        "anyOf": [
+                                                            {"required": ["category"]}
+                                                        ]
+                                                    }
+                                                },
+                                            },
+                                            {
+                                                "if": {
+                                                    "properties": {
+                                                        "state": {"const": "absent"}
+                                                    },
+                                                    "required": ["state"],
+                                                },
+                                                "then": {
+                                                    "not": {
+                                                        "anyOf": [
+                                                            {"required": ["category"]}
+                                                        ]
+                                                    }
+                                                },
+                                            },
+                                        ],
+                                    },
+                                ]
+                            },
+                        },
+                        "type": "object",
+                    },
+                },
+            },
+        ],
+    }
+    page = render_mcp_tools(surface, {"taxonomy_set": "low"})
+    assert (
+        "| `category` | string |  | required when `state` is `present`; "
+        "forbidden when `state` is `inactive` or `absent` |" in page
+    )
+
+
+def test_mcp_page_renders_conditional_must_be_const() -> None:
+    """A discriminator branch that fixes a field's value states it as ``must be``."""
+    surface: dict[str, Any] = {
+        "tool_count": 1,
+        "tools": [
+            {
+                "name": "reviews_decide",
+                "definition": {
+                    "description": "Decide one review proposal.",
+                    "annotations": {"readOnlyHint": False},
+                    "inputSchema": {
+                        "properties": {
+                            "decisions": {
+                                "oneOf": [
+                                    {
+                                        "description": "An auto-rule decision.",
+                                        "properties": {
+                                            "kind": {
+                                                "const": "auto_rule",
+                                                "type": "string",
+                                            },
+                                            "decision": {"type": "string"},
+                                            "allow_broad": {"type": "boolean"},
+                                        },
+                                        "required": ["kind", "decision"],
+                                        "type": "object",
+                                        "allOf": [
+                                            {
+                                                "if": {
+                                                    "properties": {
+                                                        "decision": {"const": "reject"}
+                                                    },
+                                                    "required": ["decision"],
+                                                },
+                                                "then": {
+                                                    "properties": {
+                                                        "allow_broad": {"const": False}
+                                                    }
+                                                },
+                                            },
+                                        ],
+                                    },
+                                ]
+                            },
+                        },
+                        "type": "object",
+                    },
+                },
+            },
+        ],
+    }
+    page = render_mcp_tools(surface, {"reviews_decide": "low"})
+    assert (
+        "| `allow_broad` | boolean |  | must be `false` when `decision` is "
+        "`reject` |" in page
+    )
+
+
+def test_mcp_page_conditional_tripwire_raises_on_unrecognized_if() -> None:
+    """An ``if`` outside the closed vocabulary fails loudly, naming param and variant."""
+    surface: dict[str, Any] = {
+        "tool_count": 1,
+        "tools": [
+            {
+                "name": "widget_set",
+                "definition": {
+                    "description": "Set one widget.",
+                    "annotations": {"readOnlyHint": False},
+                    "inputSchema": {
+                        "properties": {
+                            "target": {
+                                "oneOf": [
+                                    {
+                                        "description": "A weird target.",
+                                        "properties": {
+                                            "kind": {
+                                                "const": "weird",
+                                                "type": "string",
+                                            },
+                                            "a": {"type": "string"},
+                                            "b": {"type": "string"},
+                                        },
+                                        "required": ["kind"],
+                                        "type": "object",
+                                        "allOf": [
+                                            {
+                                                "if": {
+                                                    "properties": {
+                                                        "a": {"const": "x"},
+                                                        "b": {"const": "y"},
+                                                    },
+                                                    "required": ["a", "b"],
+                                                },
+                                                "then": {"required": ["a"]},
+                                            },
+                                        ],
+                                    },
+                                ]
+                            },
+                        },
+                        "type": "object",
+                    },
+                },
+            },
+        ],
+    }
+    with pytest.raises(ValueError) as exc_info:
+        render_mcp_tools(surface, {"widget_set": "low"})
+    assert "target" in str(exc_info.value)
+    assert "weird" in str(exc_info.value)
+
+
 def test_mcp_page_refuses_a_tool_without_a_registered_sensitivity() -> None:
     with pytest.raises(ValueError, match="zeta"):
         render_mcp_tools(SURFACE, {"accounts": "critical"})

--- a/tests/moneybin/test_scripts/test_generate_reference_docs.py
+++ b/tests/moneybin/test_scripts/test_generate_reference_docs.py
@@ -364,6 +364,90 @@ def test_mcp_page_renders_variants_of_a_nullable_oneof() -> None:
     assert page.index("#### Variants of `scope`") < page.index("### zeta")
 
 
+def test_mcp_page_names_oneof_variant_by_title_without_a_const() -> None:
+    """A variant with no ``const``-bearing property falls back to its ``title``."""
+    surface: dict[str, Any] = {
+        "tool_count": 1,
+        "tools": [
+            {
+                "name": "titled",
+                "definition": {
+                    "description": "Has titled variants.",
+                    "annotations": {"readOnlyHint": True},
+                    "inputSchema": {
+                        "properties": {
+                            "target": {
+                                "oneOf": [
+                                    {
+                                        "title": "Widget Variant",
+                                        "description": "A widget target.",
+                                        "properties": {"widget_id": {"type": "string"}},
+                                        "required": ["widget_id"],
+                                        "type": "object",
+                                    },
+                                    {
+                                        "title": "Gadget Variant",
+                                        "description": "A gadget target.",
+                                        "properties": {"gadget_id": {"type": "string"}},
+                                        "required": ["gadget_id"],
+                                        "type": "object",
+                                    },
+                                ]
+                            },
+                        },
+                        "type": "object",
+                    },
+                },
+            },
+        ],
+    }
+    page = render_mcp_tools(surface, {"titled": "low"})
+    assert "| `target` | one of `Widget Variant`, `Gadget Variant` |  |  |" in page
+    assert "##### `Widget Variant`" in page
+    assert "##### `Gadget Variant`" in page
+
+
+def test_mcp_page_names_oneof_variant_by_position_without_a_title() -> None:
+    """A variant with neither ``const`` nor ``title`` falls back to its position."""
+    surface: dict[str, Any] = {
+        "tool_count": 1,
+        "tools": [
+            {
+                "name": "untitled",
+                "definition": {
+                    "description": "Has untitled variants.",
+                    "annotations": {"readOnlyHint": True},
+                    "inputSchema": {
+                        "properties": {
+                            "target": {
+                                "oneOf": [
+                                    {
+                                        "description": "First option.",
+                                        "properties": {"value": {"type": "string"}},
+                                        "required": ["value"],
+                                        "type": "object",
+                                    },
+                                    {
+                                        "description": "Second option.",
+                                        "properties": {"value": {"type": "string"}},
+                                        "required": ["value"],
+                                        "type": "object",
+                                    },
+                                ]
+                            },
+                        },
+                        "type": "object",
+                    },
+                },
+            },
+        ],
+    }
+    page = render_mcp_tools(surface, {"untitled": "low"})
+    assert "| `target` | one of `variant 1`, `variant 2` |  |  |" in page
+    assert "##### `variant 1`" in page
+    assert "##### `variant 2`" in page
+
+
 def test_mcp_page_refuses_a_tool_without_a_registered_sensitivity() -> None:
     with pytest.raises(ValueError, match="zeta"):
         render_mcp_tools(SURFACE, {"accounts": "critical"})

--- a/tests/moneybin/test_scripts/test_generate_reference_docs.py
+++ b/tests/moneybin/test_scripts/test_generate_reference_docs.py
@@ -515,7 +515,7 @@ def test_mcp_page_renders_conditional_required_and_else_forbidden() -> None:
     page = render_mcp_tools(surface, {"widget_target_set": "low"})
     assert (
         "| `local_path` | string |  | min length 1; required when `state` is "
-        "`present`; forbidden otherwise |" in page
+        "`present`; forbidden unless `state` is `present` |" in page
     )
 
 

--- a/tests/moneybin/test_scripts/test_generate_reference_docs.py
+++ b/tests/moneybin/test_scripts/test_generate_reference_docs.py
@@ -215,6 +215,59 @@ SURFACE: dict[str, Any] = {
                             "anyOf": [{"type": "string"}, {"type": "null"}],
                             "default": None,
                         },
+                        "target": {
+                            "oneOf": [
+                                {
+                                    "description": "A widget target.",
+                                    "properties": {
+                                        "kind": {"const": "widget", "type": "string"},
+                                        "widget_id": {"type": "string"},
+                                    },
+                                    "required": ["kind", "widget_id"],
+                                    "type": "object",
+                                },
+                                {
+                                    "description": "A gadget target.",
+                                    "properties": {
+                                        "kind": {"const": "gadget", "type": "string"},
+                                        "gadget_id": {"type": "string"},
+                                    },
+                                    "required": ["kind", "gadget_id"],
+                                    "type": "object",
+                                },
+                            ]
+                        },
+                        "requests": {
+                            "items": {
+                                "oneOf": [
+                                    {
+                                        "description": "Add a thing.",
+                                        "properties": {
+                                            "kind": {
+                                                "const": "thing_add",
+                                                "type": "string",
+                                            },
+                                            "name": {"type": "string"},
+                                        },
+                                        "required": ["kind", "name"],
+                                        "type": "object",
+                                    },
+                                    {
+                                        "description": "Remove a thing.",
+                                        "properties": {
+                                            "kind": {
+                                                "const": "thing_remove",
+                                                "type": "string",
+                                            },
+                                            "name": {"type": "string"},
+                                        },
+                                        "required": ["kind", "name"],
+                                        "type": "object",
+                                    },
+                                ]
+                            },
+                            "type": "array",
+                        },
                     },
                     "required": ["view"],
                     "type": "object",
@@ -237,6 +290,32 @@ def test_mcp_page_sorts_tools_and_renders_schema_rows() -> None:
     assert "| `view` | one of `list`, `detail` | `list` | required |" in page
     assert "| `query` | string |  |  |" in page
     assert "No parameters." in page
+
+
+def test_mcp_page_renders_oneof_variants_by_discriminator() -> None:
+    """A ``oneOf`` parameter names each variant and lists its fields below."""
+    page = render_mcp_tools(SURFACE, {"accounts": "critical", "zeta": "low"})
+    assert "| `target` | one of `widget`, `gadget` |  |  |" in page
+    assert "| `requests` | array of one of `thing_add`, `thing_remove` |  |  |" in page
+    assert "#### Variants of `target`" in page
+    assert "##### `widget`" in page
+    assert "A widget target." in page
+    assert "| `widget_id` | string |  | required |" in page
+    assert "##### `gadget`" in page
+    assert "A gadget target." in page
+    assert "| `gadget_id` | string |  | required |" in page
+    assert "#### Variants of `requests`" in page
+    assert "##### `thing_add`" in page
+    assert "Add a thing." in page
+    assert "##### `thing_remove`" in page
+    assert "Remove a thing." in page
+    assert (
+        page.index("### accounts")
+        < page.index("| `target` |")
+        < page.index("#### Variants of `target`")
+        < page.index("#### Variants of `requests`")
+        < page.index("### zeta")
+    )
 
 
 def test_mcp_page_refuses_a_tool_without_a_registered_sensitivity() -> None:

--- a/tests/test_documentation_policy.py
+++ b/tests/test_documentation_policy.py
@@ -25,7 +25,6 @@ import re
 import shlex
 import shutil
 import subprocess  # noqa: S404 -- the policy test queries local Git metadata
-from collections.abc import Collection
 from pathlib import Path
 from typing import NamedTuple
 
@@ -326,7 +325,6 @@ _TERMINATORS = {"|", "||", "&&", ";", ">", ">>", "2>", "<"}
 # `2>&1`, `>/dev/null`, a trailing `&`. Not `<`: that opens a placeholder.
 _REDIRECTION = re.compile(r"^(\d*>|&>|&$)")
 _ELISIONS = {"...", "…"}
-_FLAG_SPAN = re.compile(r"-{1,2}[A-Za-z]")  # `-y, --yes`, not a lone `-` cell
 _COMMAND_SUBSTITUTION = re.compile(r"\$\((?P<inner>[^()]*)\)")
 _SUBSTITUTED_INVOCATION = re.compile(r"^\s*moneybin(?:\s|$)")
 _ANGLE_PLACEHOLDER = re.compile(r"<[^<>]*>")
@@ -361,15 +359,8 @@ def _user_facing_documents() -> list[Path]:
     return [document for document in documents if document.exists()]
 
 
-def _inline_spans(
-    prose: list[tuple[int, str]], top_level: Collection[str]
-) -> list[tuple[int, str]]:
-    """Inline code spans in one run of prose, each on the line it opens.
-
-    With ``top_level`` (the CLI reference), a table row whose first span starts
-    with a top-level command is read as `moneybin …`, and the row's flag spans
-    (`-y, --yes`) are appended so the flags column is checked as well.
-    """
+def _inline_spans(prose: list[tuple[int, str]]) -> list[tuple[int, str]]:
+    """Inline code spans in one run of prose, each on the line it opens."""
     if not prose:
         return []
     first, joined = prose[0][0], "\n".join(line for _, line in prose)
@@ -377,20 +368,11 @@ def _inline_spans(
     for match in _INLINE_CODE.finditer(joined):
         number = first + joined.count("\n", 0, match.start())
         span = " ".join(match.group(1).split())
-        line = prose[number - first][1]
-        line_start = joined.rfind("\n", 0, match.start()) + 1
-        first_in_row = "`" not in joined[line_start : match.start()]
-        words = span.split(maxsplit=1)
-        if top_level and line.lstrip().startswith("|") and first_in_row:
-            if words and words[0] in top_level:
-                row_spans = [" ".join(s.split()) for s in _INLINE_CODE.findall(line)]
-                flags = [s for s in row_spans[1:] if _FLAG_SPAN.match(s)]
-                span = " ".join(["moneybin", span, *flags])
         spans.append((number, span))
     return spans
 
 
-def _code_lines(text: str, top_level: Collection[str] = ()) -> list[_CodeLine]:
+def _code_lines(text: str) -> list[_CodeLine]:
     """Return one `_CodeLine` per fenced-block line and inline code span."""
     lines: list[_CodeLine] = []
     prose: list[tuple[int, str]] = []
@@ -399,10 +381,7 @@ def _code_lines(text: str, top_level: Collection[str] = ()) -> list[_CodeLine]:
     for number, line in enumerate(text.splitlines(), start=1):
         match = _FENCE.match(line.strip())
         if match and (fence is None or line.strip().startswith(fence)):
-            lines += (
-                _CodeLine(n, c, runnable=False)
-                for n, c in _inline_spans(prose, top_level)
-            )
+            lines += (_CodeLine(n, c, runnable=False) for n, c in _inline_spans(prose))
             prose = []
             if fence:
                 fence = None
@@ -415,9 +394,7 @@ def _code_lines(text: str, top_level: Collection[str] = ()) -> list[_CodeLine]:
                 lines.append(_CodeLine(number, line, runnable=True))
         else:
             prose.append((number, line))
-    lines += (
-        _CodeLine(n, c, runnable=False) for n, c in _inline_spans(prose, top_level)
-    )
+    lines += (_CodeLine(n, c, runnable=False) for n, c in _inline_spans(prose))
     return lines
 
 
@@ -591,7 +568,7 @@ def _resolve_invocation(
             ):
                 return f"`{' '.join(path)}` option `{name}` requires a value"
             following = tokens[index] if index < len(tokens) else ""
-            # A bare value-taking option in a flags column (`--pattern`,
+            # A bare value-taking option in an inline mention (`--pattern`,
             # `--match-type {exact,contains,regex}`) must not swallow the next
             # flag; a negative number (`--amount -12.50`) is still a value. A
             # *runnable* transcript gets no such benefit of the doubt: Click
@@ -686,11 +663,9 @@ def test_public_docs_cli_invocations_resolve() -> None:
     subcommand, a required option, and a required positional (including a
     required variadic) actually being present, and a value-taking option
     greedily consuming the next token exactly as Click does; an inline span
-    or table row names a command and is exempt from those four. A row of the CLI
-    reference tables whose first code span starts with a top-level command is
-    read as `moneybin …` with the row's flag spans appended, so the flags
-    column is checked too. A line that must show a wrong invocation on
-    purpose (an error example) carries ``<!-- cli-invocation-ok: <reason> -->``.
+    or table row names a command and is exempt from those four. A line that
+    must show a wrong invocation on purpose (an error example) carries
+    ``<!-- cli-invocation-ok: <reason> -->``.
     """
     from typer.main import get_command
 
@@ -706,8 +681,7 @@ def test_public_docs_cli_invocations_resolve() -> None:
             for number, line in enumerate(text.splitlines(), start=1)
             if _CLI_INVOCATION_MARKER in line
         }
-        top_level = root.commands if document.name == "cli-reference.md" else ()
-        for entry in _join_continuations(_code_lines(text, top_level)):
+        for entry in _join_continuations(_code_lines(text)):
             if entry.number in allowed_lines:
                 continue
             for tokens in _invocations(entry.code):
@@ -948,23 +922,6 @@ def test_code_lines_reads_soft_wrapped_span(_fixture_cli: click.Group) -> None:
     assert (
         _resolve_invocation(command, _fixture_cli, runnable=entry.runnable) is not None
     )
-
-
-def test_code_lines_reference_row_checks_flags_column(
-    _fixture_cli: click.Group,
-) -> None:
-    """A CLI-reference-table row reads its flags column as part of the invocation.
-
-    The row's second span (`--bogus`, not first-in-row) surfaces as its own
-    non-invocation entry alongside the enriched one — harmless, since it
-    contains no `moneybin` for `_invocations` to find.
-    """
-    text = "| `create <name>` | Create a thing. | `--bogus` |"
-    entries = _code_lines(text, top_level=_fixture_cli.commands)
-    commands = [tokens for entry in entries for tokens in _invocations(entry.code)]
-    assert commands == [["create", "<name>", "--bogus"]]
-    (command,) = commands
-    assert _resolve_invocation(command, _fixture_cli, runnable=False) is not None
 
 
 def test_full_pipeline_scopes_fenced_block_vs_inline_mention(


### PR DESCRIPTION
## Summary

Two follow-ups from the review of #525, plus a CHANGELOG cite.

- **`oneOf` parameters render their variants** (Codex's P2 on #525). `_schema_type` fell through to `any` for a schema with no top-level `type`, so seven MCP parameters across six tools rendered as `any` or `array of any`: `export_run.subject` and `.destination`, `exports_set.target`, and the `decisions` (`identity_links_decide`, `reviews_decide`), `items` (`taxonomy_set`), and `requests` (`transactions_annotate`) arrays. Every one arrives inline with a `kind` discriminator carrying a `const` (no `$ref` anywhere in the surface), so the Type cell now reads ``one of `local`, `sheets` `` (or ``array of one of …``), and a ``Variants of `<parameter>` `` block under the tool's parameter table lists each variant's description and fields with type, default, and required-ness. A `const` field renders as its literal. A nullable discriminated union (`anyOf` wrapping the `oneOf` with `null`) is unwrapped the same way `_schema_type` already unwraps it, so an optional parameter of that shape gets the same block; an `anyOf` with more than one non-null option is a real alternation and gets none. Renderer tests cover a `oneOf` parameter, an array of them, and a nullable one on synthetic variants. A variant field's Notes cell now also states the conditional requirements the model enforces under a discriminator value — required, forbidden, or fixed to a value — with ``forbidden unless `<field>` is `<value>` `` for an else branch, closing a gap both claude[bot]'s review and Codex's P2 flagged on this PR (`docs/reference/mcp-tools.md:215`). The parser recognizes exactly the shapes the two schema helpers that emit these conditionals produce (`_state_schema` and `_conditional_schema_branch`); any other shape fails regeneration with a `ValueError` naming the parameter and variant.
- **The guard's table-row promotion is removed.** `_inline_spans` read a CLI-reference table row whose first span opened with a top-level command as `moneybin …` plus its flag spans. Since #525 no row in `docs/guides/cli-reference.md` opens with a command (a probe over the live page counted zero promotions), so the branch, `_FLAG_SPAN`, the `Collection` import, and `test_code_lines_reference_row_checks_flags_column` go.
- **CHANGELOG**: the generated-references entry now cites #525.

## Test plan

- `make check`: clean.
- `uv run pytest tests/test_documentation_policy.py tests/moneybin/test_scripts/test_generate_reference_docs.py tests/moneybin/test_mcp`: 1,529 passed.
- `uv run python scripts/generate_reference_docs.py --check`: exit 0 after `make generate-docs`; no `any` or `array of any` cell remains in `docs/reference/mcp-tools.md`.
- `make test`: 10,620 passed, 4 skipped (pre-existing environment skips). `uv run pyright`: clean.
- Second commit (the nullable unwrap) changed only the generator and its tests: `make check` and `uv run pyright` clean, `--check` exit 0 with no page changed, `tests/test_documentation_policy.py` plus the generator tests 59 passed.
- No user data involved; the page renders from an in-process registry boot with no database opened.
- Third commit adds coverage for `_oneof_variant_name`'s two fallback branches (a variant named by its schema `title` when no `const`-bearing property exists, and one named by position when neither does), addressing the review's CONSIDER. Each new test was confirmed red by temporarily breaking its branch, then green after reverting. `make check` and `uv run pyright`: clean. `uv run pytest tests/moneybin/test_scripts/test_generate_reference_docs.py tests/test_documentation_policy.py`: 61 passed. `uv run python scripts/generate_reference_docs.py --check`: exit 0, no page changed.
- Fourth commit renders the conditional-requirements finding: four new tests (an else-forbidden clause, a two-branch forbidden merge with "or", a fixed-value "must be" clause, and the tripwire raising on an unrecognized `if`) were confirmed red before the parser existed, then green after. `make check` and `uv run pyright` (bare, repo-wide): clean, 0 errors (3 pre-existing warnings in an unrelated fixture). `uv run pytest tests/moneybin/test_scripts/test_generate_reference_docs.py tests/test_documentation_policy.py`: 65 passed. `uv run python scripts/generate_reference_docs.py --check`: exit 0 after regenerating `docs/reference/mcp-tools.md` (42 lines changed, all in variant Notes cells).
- Fifth commit renders an else branch as ``forbidden unless `state` is `present` `` instead of `forbidden otherwise`, which had no antecedent on a field with no `then` clause (`managed_tab_prefix`). `make check` and `uv run pyright`: clean. Generator plus docs-policy tests: 65 passed. `--check`: exit 0 after regeneration (three rows changed).

## Left for a follow-up

- A plain `array of object` parameter whose items declare fields (`splits_set.splits`, `transactions_categorize_rules_set.rules`) still shows no field list; the same block that now serves `oneOf` variants could serve object items.
- The variant name is the first property carrying a `const`; every current variant discriminates on `kind` and nothing else carries a `const`, so this is a convention without a tripwire.
- Table rows of the promoted shape exist in twelve other public documents (forty rows) that the removed branch never checked because it was gated to the CLI reference guide; all forty resolve against the command tree today. Widening the gate would misread the MCP page's summary rows as CLI invocations, so this is a separate design question.
