### PR TITLE
Spell the per-currency top-N so DuckDB does not rewrite it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the count rather than leaving it to be inferred.
 
 ### Fixed
+- **`reports merchants` and `reports large-transactions` run again.** Both
+  failed on every profile with "The report's query could not run against the
+  current schema", and the `reports` MCP tool failed the same way for
+  `core:merchants` and `core:large_transactions`: DuckDB rewrites their
+  `ROW_NUMBER() … <= n` filter into a top-N and pushes it through the recursive
+  match-group CTE behind `core.bridge_transfers`, where the plan fails. The
+  filter is now spelled `BETWEEN 1 AND n`, and the scenario suite executes
+  every built-in report over the real views so a runner shape that only fails
+  there cannot reach `main` green. (#539)
+
 - **A missing or locked keychain entry no longer prints a stack trace.**
   `moneybin db info`, `db unlock` and the DuckDB init-script builder read the
   encryption key directly, and the secret-store exceptions had no branch in the

--- a/src/moneybin/reports/definitions/large_transactions.py
+++ b/src/moneybin/reports/definitions/large_transactions.py
@@ -265,6 +265,11 @@ def large_transactions(
         predicate = "amount_zscore_account > 2.5"
     elif anomaly == "category":
         predicate = "amount_zscore_category > 2.5"
+    # `BETWEEN 1 AND ?`, not `<= ?`: DuckDB 1.5.4 and 1.5.5 rewrite a
+    # `ROW_NUMBER() ... <= n` filter into a top-N and push it through the
+    # recursive match-group CTE behind core.bridge_transfers, where it fails
+    # with "Type mismatch for SET OPERATION". The BETWEEN spelling is the same
+    # predicate and escapes the rewrite; tests/scenarios pins it on real views.
     sql = f"""
         SELECT transaction_id, account_id, merchant_id, account_name,
                merchant_normalized, description, category, currency_code,
@@ -282,7 +287,7 @@ def large_transactions(
             FROM {REPORTS_LARGE_TRANSACTIONS.full_name}
             WHERE {predicate}
         )
-        WHERE rank_in_currency <= ?
+        WHERE rank_in_currency BETWEEN 1 AND ?
         ORDER BY rank_in_currency, currency_code
     """  # noqa: S608  # TableRef + LARGE_TXN_ANOMALIES allowlists
     # The binding declares the class of the value it carries (R9).

--- a/src/moneybin/reports/definitions/merchant_activity.py
+++ b/src/moneybin/reports/definitions/merchant_activity.py
@@ -164,6 +164,11 @@ def merchant_activity(
         raise ValueError(f"Unknown sort: {sort}")
     if top < 1:
         raise ValueError(f"top must be >= 1, got {top!r}")
+    # `BETWEEN 1 AND ?`, not `<= ?`: DuckDB 1.5.4 and 1.5.5 rewrite a
+    # `ROW_NUMBER() ... <= n` filter into a top-N and push it through the
+    # recursive match-group CTE behind core.bridge_transfers, where it fails
+    # with "Type mismatch for SET OPERATION". The BETWEEN spelling is the same
+    # predicate and escapes the rewrite; tests/scenarios pins it on real views.
     sql = f"""
         SELECT merchant_id, merchant_normalized, currency_code, top_category,
                first_seen, last_seen, txn_count, active_months, account_count,
@@ -179,7 +184,7 @@ def merchant_activity(
                    ) AS rank_in_currency
             FROM {REPORTS_MERCHANT_ACTIVITY.full_name}
         )
-        WHERE rank_in_currency <= ?
+        WHERE rank_in_currency BETWEEN 1 AND ?
         ORDER BY rank_in_currency, currency_code
     """  # noqa: S608  # TableRef + MERCHANTS_SORTS allowlists
     return ReportQuery(sql, [Binding(top, DataClass.AGGREGATE)])

--- a/tests/scenarios/test_reports_recipe_library.py
+++ b/tests/scenarios/test_reports_recipe_library.py
@@ -249,6 +249,57 @@ def _reports_assertions(db: Database) -> list[AssertionResult]:
                 )
             )
 
+    results.extend(_runner_assertions(db))
+    return results
+
+
+# The two service-backed net-worth routes take a required window; every other
+# built-in runs on its declared defaults.
+_RUNNER_PARAMETERS: dict[str, dict[str, str]] = {
+    "core:networth_history": {"from_date": "2024-01-01", "to_date": "2024-12-31"},
+}
+
+
+def _runner_assertions(db: Database) -> list[AssertionResult]:
+    """Every built-in report executes through the catalog against the built views.
+
+    The row-count floors above SELECT each view directly, and the e2e suite
+    drives each command against one-row stub views. Neither runs a runner's
+    own SQL over the real views, so a runner shape the planner rewrites into
+    something DuckDB cannot execute over the recursive match-group CTE — the
+    `ROW_NUMBER() ... <= ?` top-N that broke `core:merchants` and
+    `core:large_transactions` — reached main with every gate green.
+    """
+    from moneybin.reports._framework.catalog import get_report_catalog, report_tier
+
+    catalog = get_report_catalog(db)
+    results: list[AssertionResult] = []
+    for report in catalog.list():
+        if report_tier(report) != "builtin":
+            continue
+        parameters = _RUNNER_PARAMETERS.get(report.report_id, {})
+        name = f"runner_{report.report_id}_executes"
+        try:
+            catalog.execute(
+                db, report_id=report.report_id, parameters=parameters, limit=5
+            )
+        except Exception as exc:  # noqa: BLE001 — surface as structured failure
+            results.append(
+                AssertionResult(
+                    name=name,
+                    passed=False,
+                    details={"report_id": report.report_id, "parameters": parameters},
+                    error=f"{type(exc).__name__}: {exc}",
+                )
+            )
+            continue
+        results.append(
+            AssertionResult(
+                name=name,
+                passed=True,
+                details={"report_id": report.report_id, "parameters": parameters},
+            )
+        )
     return results
 
 


### PR DESCRIPTION
## Summary

`moneybin reports merchants` and `moneybin reports large-transactions` failed on every profile — a fresh 20-row import and the `demo` persona alike — with "The report's query could not run against the current schema", and the `reports` MCP tool failed the same way for `core:merchants` and `core:large_transactions`. Found while capturing transcripts for the reports guide (docs pass, phase 2).

- **Root cause.** The runner SQL is valid. DuckDB 1.5.4 (the pinned Python build) and the 1.5.5 CLI rewrite a `ROW_NUMBER() OVER (...) <= n` filter into a top-N and push it through the recursive match-group CTE in `prep.int_transactions__matched`, which `core.bridge_transfers` and therefore `core.fct_transactions` read; the rewritten plan fails with `Invalid Input Error: Type mismatch for SET OPERATION` (an `InternalException` on the smaller profile). Bisection: the same window with no `ORDER BY` runs; the same filter over `prep.int_transactions__merged` runs; joining `core.bridge_transfers` alone reproduces it; `RANK()`, `BETWEEN 1 AND n`, a scalar-subquery bound, and a materialized base all run, while `r + 0 <= n`, `CAST(r AS BIGINT) <= n`, `QUALIFY`, and a materialized ranked CTE all still fail. Only these two runners filter on the rank, which is why the six other built-ins were unaffected. Upstream shape: duckdb/duckdb#21604 (CTEs + UNION ALL + ROW_NUMBER, regression in 1.5.1, open).
- **Fix.** Both runners filter with `WHERE rank_in_currency BETWEEN 1 AND ?` — the same predicate in a spelling the optimizer leaves alone — with a comment naming the rewrite so the shape is not simplified back.
- **Guard.** The `reports-recipe-library` scenario now executes every built-in report through `ReportCatalog.execute` against the real views. The existing floors `SELECT COUNT(*)` from each view and the e2e suite drives each command over one-row stub views, so no gate ran a runner's own SQL over the recursive CTE, and this reached `main` green.

## Test plan

- `uv run pytest tests/scenarios/test_reports_recipe_library.py -m scenarios`: red before the runner change with exactly `runner_core:large_transactions_executes` and `runner_core:merchants_executes` failing (`UserError: The report's query could not run against the current schema`), green after.
- `uv run pytest tests/moneybin/test_reports tests/e2e/test_e2e_reports.py`: 564 passed.
- `make check`: ruff clean; `uv run pyright` (bare, repo-wide): 0 errors, 3 pre-existing warnings in an unrelated fixture.
- Against the `family` demo persona (4 accounts, 2,886 transactions, seed 42) after the fix: `reports merchants --top 10`, `reports large-transactions --top 10`, and `reports large-transactions --anomaly category` all exit 0 with rows; the DuckDB CLI binary reproduces the same failure on the unfixed shape, so a DuckDB upgrade alone would not have closed it.
- No user data involved: the synthetic persona and a 20-row synthetic QFX.

## Left for a follow-up

- The DuckDB regression itself: a minimal standalone repro (recursive CTE + LEFT JOIN + `ROW_NUMBER() <= n`) is worth filing upstream against 1.5.5; not done here.
