### PR TITLE
Make PR descriptions and reviews understandable without session context

### DIFF
--- a/.github/ai-review-protocol.md
+++ b/.github/ai-review-protocol.md
@@ -1,3 +1,47 @@
+## Writing descriptions and review comments
+
+Adapted from [PAO's PR-writing guidance](https://github.com/bsaffel/personal-agent-os/blob/a732866111247cdcd335f0ffb79640e493736c8c/packages/pao/references/pr-writing.md).
+This section is embedded in both hosted review prompts; it requires no local PAO
+installation. Writing guidance grants no authority to post, edit a PR, accept a
+deferral, or merge. The approval contract below remains authoritative.
+
+Write for a contributor who understands software but is new to MoneyBin. The
+title and opening together explain the problem, changed behavior, and any action
+needed. Introduce project terms through their purpose. Describe the final change;
+put material limitations, recovery actions, and unresolved decisions beside the
+explanation. Mechanisms and verification follow. Use descriptive links with
+enough context to understand the concern without opening them.
+
+After the required verdict or tier marker, lead with the specific finding,
+answer, changed state, or decision needed. Explain the consequence, cite evidence,
+and state the remaining action. Name the concern even in replies and re-review
+requests. A proposed deferral names what remains unresolved, why, and its tracked
+follow-up; it still requires reviewer acceptance under the contract below.
+Later updates explain the delta and current uncertainty, not every review round.
+
+Use concrete verbs and a calm engineering voice. Keep effective prose; density
+alone is not a defect. Treat optional wording polish as non-blocking. Choose
+sections for the reader's needs and omit empty praise and repeated explanations,
+while retaining the exact verdict lines and severity markers required below.
+
+Preserve conditions, negation, quantities, causal claims, uncertainty, and
+requirement strength. Keep decision-relevant commands, results, tested revision,
+and evidence links. Explain what checks establish and what remains untested;
+distinguish local checks, pending CI, and live observations. Summarize long logs
+without hiding blockers. Before presenting text, check that its opening makes
+the problem and action understandable, then compare the full text to the source
+evidence for omissions and invented claims. Writing quality is not verification
+or approval.
+
+For posted bodies and comments, use one source line per paragraph with blank
+lines between paragraphs; inspect the rendered text after an authorized post.
+Apply [MoneyBin's public-text privacy rules](../.claude/rules/branching.md#branch-names-pr-and-issue-text-and-comments-are-a-public-surface)
+to the exact composed text before sending, including verification evidence.
+Describe data by shape and use synthetic examples. Real institutions linked to
+holdings, account names, last fours (even masked), balances, merchants, and
+transaction descriptions stay out of public text. The log permitted list does
+not authorize publication.
+
 ## Tiered findings — required prefix on every comment
 
 Every finding (inline comment AND summary bullet) MUST start with one of three tier markers:

--- a/.github/ai-review-protocol.md
+++ b/.github/ai-review-protocol.md
@@ -1,6 +1,6 @@
 ## Writing descriptions and review comments
 
-Adapted from [PAO's PR-writing guidance](https://github.com/bsaffel/personal-agent-os/blob/a732866111247cdcd335f0ffb79640e493736c8c/packages/pao/references/pr-writing.md).
+Adapted from Personal Agent OS (PAO) PR-writing guidance.
 This section is embedded in both hosted review prompts; it requires no local PAO
 installation. Writing guidance grants no authority to post, edit a PR, accept a
 deferral, or merge. The approval contract below remains authoritative.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+<!-- Follow the writing guidance in .github/ai-review-protocol.md and the public-text privacy rules in .claude/rules/branching.md. Remove these prompts before posting. -->
+## Summary
+
+<!-- Explain the problem, trigger, and resulting behavior for a contributor new to MoneyBin. Describe the final change; keep material limitations, recovery actions, and decisions needed nearby. Use descriptive issue links with enough context to understand the change without opening them. -->
+
+## Test plan
+
+<!-- State meaningful checks, results, tested revision, and remaining gaps. Distinguish local checks, pending CI, and live observations. Describe verification data by shape, never by real holdings or identifiers. Add sections only when they help review this change. -->


### PR DESCRIPTION
## Summary

PR descriptions and review comments need to explain the problem and next action without relying on the author's session. This adds a minimal PR template and guidance for hosted reviewers to lead with outcomes and consequences, then preserve evidence and material limitations.

The guidance adapts [PAO's PR-writing change](https://github.com/bsaffel/personal-agent-os/pull/230) with a pinned source reference. MoneyBin's existing severity tiers, deferral rules, and exact approval signals remain unchanged. Public-text privacy rules still apply to the complete composed text, including verification evidence. Both hosted review paths already embed the protocol.

## Test plan

- `UV_CACHE_DIR=/private/tmp/uv-cache uv run --no-sync pytest tests/test_documentation_policy.py` — 43 passed on the unchanged contents subsequently committed as `bcc8fe68`.
- `git diff --check` — passed.
- Independent pre-push review of base `23ce645e` through head `bcc8fe68` — clear, with no MUST FIX or CONSIDER findings.
- Verified that the original review protocol remains byte-for-byte intact beneath the added guidance.

These checks establish structural compatibility; hosted reviewer compliance and a full authoring/review cycle remain unverified.
