### PR TITLE
Count bare list fields and check a declared row set names one

### DIFF
--- a/tests/moneybin/test_protocol/test_row_set_declaration_coverage.py
+++ b/tests/moneybin/test_protocol/test_row_set_declaration_coverage.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import importlib
 import pkgutil
+import types
 import typing
 from dataclasses import fields, is_dataclass
 
@@ -50,9 +51,16 @@ def _is_list_hint(hint: object) -> bool:
     origin = typing.get_origin(hint)
     if origin is list:
         return True
-    if origin is None:
-        return False
-    return any(_is_list_hint(arg) for arg in typing.get_args(hint))
+    # Unwrap only what wraps a field's type without changing what the field
+    # holds. Recursing into any generic instead would find the ``list[str]``
+    # inside ``dict[str, list[str]]`` and call that field a collection, while
+    # ``row_set_field`` sees a dict and refuses it — the disagreement this
+    # helper exists to prevent, one container level down.
+    if origin is typing.Annotated:
+        return _is_list_hint(typing.get_args(hint)[0])
+    if origin is typing.Union or origin is types.UnionType:
+        return any(_is_list_hint(arg) for arg in typing.get_args(hint))
+    return False
 
 
 def _list_field_names(cls: type) -> list[str]:
@@ -229,3 +237,51 @@ def test_a_tuple_annotation_is_not_a_collection() -> None:
     """
     assert not _is_list_hint(tuple)
     assert not _is_list_hint(tuple[str, ...])
+
+
+@pytest.mark.unit
+def test_a_container_whose_values_are_lists_is_not_a_collection() -> None:
+    """A field holding a dict of lists holds a dict, and is not a row set.
+
+    ``get_origin(dict[str, list[str]])`` is ``dict`` — neither ``list`` nor
+    ``None`` — so unwrapping every generic rather than a named few reaches the
+    ``list[str]`` in its arguments and reports the field a collection.
+    ``row_set_field`` tests the value with ``isinstance(value, list)`` and
+    rejects the dict, so the sweep would demand a declaration the runtime would
+    never honour, and worse, would accept ``@row_set`` naming that field:
+    ``test_a_declared_row_set_names_a_collection`` asks whether the declared
+    name is in ``_list_field_names``, and the same over-count that put it there
+    is what makes the check pass. The mismatch would then surface only on the
+    first production call — the failure this module exists to move earlier.
+
+    No payload is shaped this way today, so this fixes no live miscount; it
+    holds the helper to the equivalence its docstring claims.
+    """
+    assert not _is_list_hint(dict[str, list[str]])
+    assert not _is_list_hint(tuple[list[str], ...])
+    assert not _is_list_hint(set[str])
+
+
+@pytest.mark.unit
+def test_the_wrappers_the_payloads_use_are_still_unwrapped() -> None:
+    """Every wrapper the sweep unwraps keeps a case here.
+
+    ``_is_list_hint`` names the wrappers it unwraps instead of recursing into
+    any generic, which makes dropping one a one-line edit that silently empties
+    part of the sweep rather than failing. ``Annotated`` is the case that would
+    hurt: every field in ``moneybin.privacy.payloads.system`` carries
+    ``Annotated[T, DataClass.X]``, so losing it would take
+    ``TransformPlanPayload`` and its four ``Annotated[list[str], ...]`` fields
+    out of the scan while the suite stayed green.
+    """
+    assert _is_list_hint(typing.Annotated[list[str], "metadata"])
+    assert _is_list_hint(typing.Annotated[list[str] | None, "metadata"])
+    assert not _is_list_hint(typing.Annotated[str, "metadata"])
+
+    # `X | None` evaluates to `types.UnionType`, so the legacy spelling is the
+    # only way to reach the `typing.Union` sentinel. Ruff's UP045 keeps it out
+    # of the tree, which makes that branch defensive rather than live — and
+    # exercising it here is what says so, instead of leaving a reader to guess
+    # whether it is dead.
+    legacy_optional = typing.Optional[list[str]]  # noqa: UP045  # branch under test
+    assert _is_list_hint(legacy_optional)

--- a/tests/moneybin/test_protocol/test_row_set_declaration_coverage.py
+++ b/tests/moneybin/test_protocol/test_row_set_declaration_coverage.py
@@ -62,7 +62,7 @@ def _list_field_names(cls: type) -> list[str]:
         names = [item.name for item in fields(cls)]
     elif issubclass(cls, BaseModel):
         names = list(cls.model_fields)
-    else:  # pragma: no cover - filtered out by _payload_classes_with_collections
+    else:  # pragma: no cover - filtered out by _payload_classes
         return []
     return [name for name in names if _is_list_hint(hints.get(name))]
 
@@ -115,20 +115,38 @@ _PAYLOADS_WITH_DECLARATIONS = [
 def test_the_scan_reaches_the_payloads_it_is_meant_to_guard() -> None:
     """A discovery bug would make every case below vacuously pass.
 
-    The three payloads the declaration was designed against must be in the
-    scanned set, one class from each non-package root must be too — a root
-    dropped from the list above is otherwise invisible — and the set must be
+    Both derived sets need this and for the same reason: each drives a
+    parametrization, and an empty parametrization is a green test that asserts
+    nothing. They fail independently, so checking one does not cover the other.
+    The declaration set is the easier one to empty by accident — it turns on
+    ``declared_row_set`` reading the right ``__dict__`` key, so a change to how
+    the declaration is stored would zero it while the collection set, which
+    reads annotations, stayed exactly as it is.
+
+    For each set: the payloads the contract was designed against must be
+    present, one class from each non-package root must be too — a root dropped
+    from ``_payload_module_names`` is otherwise invisible — and the set must be
     substantial rather than a handful the import walk happened to reach.
     """
-    names = {cls.__name__ for cls in _PAYLOADS_WITH_COLLECTIONS}
+    carrying = {cls.__name__ for cls in _PAYLOADS_WITH_COLLECTIONS}
     assert {
         "ReportResultPayload",
         "ImportInboxSyncPayload",
         "NetWorthSnapshotPayload",
         "ExportDestinationsOutput",
         "ReportResult",
-    } <= names
+    } <= carrying
     assert len(_PAYLOADS_WITH_COLLECTIONS) > 100
+
+    declaring = {cls.__name__ for cls in _PAYLOADS_WITH_DECLARATIONS}
+    assert {
+        "AccountListPayload",  # the payload package
+        "ExportDestinationsOutput",  # moneybin.cli.output
+        "ReportResult",  # moneybin.reports._framework.execute
+    } <= declaring
+    # 104 today. The floor catches a collapse to nothing, not ordinary churn:
+    # pinning it near the census would fail on any legitimate payload removal.
+    assert len(_PAYLOADS_WITH_DECLARATIONS) > 75
 
 
 @pytest.mark.unit

--- a/tests/moneybin/test_protocol/test_row_set_declaration_coverage.py
+++ b/tests/moneybin/test_protocol/test_row_set_declaration_coverage.py
@@ -12,8 +12,13 @@ the payload package, plus the two modules that define envelope payloads outside
 it. A new such module has to be added here, which is why the anti-vacuity test
 below names a class from each root.
 
-Payloads with no list field are exempt: there is nothing to name, and adding a
-list later brings the class into this test's scope in the same commit.
+A payload is in scope for carrying a collection *or* for declaring one, and the
+two sets are deliberately not nested. Carrying a list means the class owes a
+declaration; declaring a name means that name owes a list. A class doing
+neither is exempt — there is nothing to name, and adding a list later brings it
+into scope in the same commit — but a declaration naming a scalar leaves its
+class carrying no collection at all, so scoping this file to collections alone
+would let exactly that case through.
 """
 
 from __future__ import annotations
@@ -30,7 +35,18 @@ from moneybin.protocol.row_set import declared_row_set
 
 
 def _is_list_hint(hint: object) -> bool:
-    """True when ``hint`` is a list, or a union / Annotated wrapping one."""
+    """True when ``hint`` is a list, or a union / Annotated wrapping one.
+
+    Counts exactly what ``row_set_field`` counts — it decides with
+    ``isinstance(value, list)`` — so ``tuple`` and other sequences are not
+    collections here. Making the two disagree about what a collection is is
+    the defect, whichever direction the disagreement runs.
+    """
+    # Bare ``list``: ``get_origin`` reports ``None`` for an unparameterized
+    # annotation, so testing origin alone would call ``rows: list`` a scalar
+    # and drop its class out of the sweep.
+    if hint is list:
+        return True
     origin = typing.get_origin(hint)
     if origin is list:
         return True
@@ -67,8 +83,8 @@ def _payload_module_names() -> list[str]:
     ]
 
 
-def _payload_classes_with_collections() -> list[type]:
-    """Every payload dataclass / model in those modules that carries a list."""
+def _payload_classes() -> list[type]:
+    """Every payload dataclass / model defined in those modules."""
     out: list[type] = []
     for module_name in _payload_module_names():
         mod = importlib.import_module(module_name)
@@ -78,12 +94,21 @@ def _payload_classes_with_collections() -> list[type]:
                 continue
             if not (is_dataclass(obj) or issubclass(obj, BaseModel)):
                 continue
-            if _list_field_names(obj):
-                out.append(obj)
+            out.append(obj)
     return out
 
 
-_PAYLOADS_WITH_COLLECTIONS = _payload_classes_with_collections()
+_ALL_PAYLOADS = _payload_classes()
+
+# Carries a collection, so it owes a declaration.
+_PAYLOADS_WITH_COLLECTIONS = [cls for cls in _ALL_PAYLOADS if _list_field_names(cls)]
+
+# Declares a named row set, so that name owes a collection. Deliberately not a
+# subset of the list above: a declaration naming a scalar leaves its class with
+# no collection at all, which is exactly the case that would otherwise escape.
+_PAYLOADS_WITH_DECLARATIONS = [
+    cls for cls in _ALL_PAYLOADS if isinstance(declared_row_set(cls), str)
+]
 
 
 @pytest.mark.unit
@@ -119,3 +144,70 @@ def test_payload_declares_its_row_set(payload_cls: type) -> None:
         f"@row_set('<field>') for the collection it returns, or "
         f"@row_set(NO_ROW_SET) when no single field is that collection."
     )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "payload_cls", _PAYLOADS_WITH_DECLARATIONS, ids=lambda c: c.__name__
+)
+def test_a_declared_row_set_names_a_collection(payload_cls: type) -> None:
+    """A declaration names a *list* field, not merely a field that exists.
+
+    ``@row_set`` checks at class definition that the name is one of the
+    payload's fields, and ``row_set_field`` checks at call time that the value
+    is a list. Between those sits a payload whose declaration names a real but
+    scalar field: the name check passes, and the class carries no list field so
+    the sweep above never collects it. Nothing fails until the first production
+    call.
+
+    That is the shape a rebound decorator leaves behind. When a class inserted
+    directly above a decorated one steals its ``@row_set``, the class that lost
+    the decorator is caught twice over — undeclared here, and raising at
+    runtime — but the thief keeps a declaration nobody wrote for it. If the
+    thief happens to carry a field of the declared name, the steal is invisible
+    from its side, and a diagnostic list that should have been ``NO_ROW_SET``
+    silently becomes the row set: a wrong ``returned_count``, which is the
+    defect this whole contract exists to remove.
+    """
+    declaration = declared_row_set(payload_cls)
+    assert isinstance(declaration, str)
+    list_fields = _list_field_names(payload_cls)
+    assert declaration in list_fields, (
+        f"{payload_cls.__name__} declares row set {declaration!r}, which is "
+        f"not one of its collection fields ({list_fields or 'none'}). Either "
+        f"the declaration names the wrong field, or it was rebound to this "
+        f"class by an edit that inserted it below an existing @row_set."
+    )
+
+
+@pytest.mark.unit
+def test_a_bare_list_annotation_counts_as_a_collection() -> None:
+    """``rows: list`` is a collection, though ``get_origin`` reports ``None``.
+
+    ``typing.get_origin(list)`` is ``None`` for an unparameterized annotation,
+    so a helper keyed only on ``get_origin(hint) is list`` filters such a class
+    out of the sweep entirely and reports it exempt. ``row_set_field`` still
+    raises, because it tests the value with ``isinstance``, not the annotation
+    — which inverts this module's stated design: the sweep is meant to fire
+    first, and for this shape it never fires at all.
+
+    No payload is annotated this way today and no lint rule forbids it, so the
+    guard has to carry the case rather than rely on the tree staying clean.
+    """
+    assert _is_list_hint(list)
+    assert _is_list_hint(list[str])
+    assert _is_list_hint(list[str] | None)
+
+
+@pytest.mark.unit
+def test_a_tuple_annotation_is_not_a_collection() -> None:
+    """The sweep counts exactly what ``row_set_field`` counts, and no more.
+
+    ``row_set_field`` decides with ``isinstance(value, list)``, so a tuple
+    field can never be a row set and can never trigger its raise. Counting
+    tuples here would make the sweep demand a declaration for a class the
+    runtime would never object to — a second disagreement in place of the one
+    being fixed.
+    """
+    assert not _is_list_hint(tuple)
+    assert not _is_list_hint(tuple[str, ...])


### PR DESCRIPTION
## Summary

The sweep that makes every payload declare its row set is meant to fire *before*
the runtime raise in `moneybin.protocol.row_set`. For two shapes it never fires
at all, and the raise reaches a caller instead. Both are agreement failures
between the sweep's notion of "carries a collection" and `row_set_field`'s.

**A bare `list` annotation is invisible.** `typing.get_origin(list)` returns
`None` for an unparameterized annotation, so a helper keyed on `get_origin(hint)
is list` calls `rows: list` a scalar and drops the class out of the sweep.
`row_set_field` still raises, because it tests the *value* with `isinstance`.
No payload is annotated this way today and no lint rule forbids it.

**A declaration naming a scalar passes both gates.** `@row_set` checks at class
definition that the name is one of the payload's fields — never that it is a
list. A class carrying no list field is filtered out of the sweep, so nothing
fails until the first production call.

## Why the second case matters more than it reads

It is the shape a rebound decorator leaves behind. When a class inserted
directly above a decorated one steals its `@row_set`, the class that *lost* the
decorator is caught twice over — undeclared by the sweep, and raising at runtime.
The thief is the silent half: it keeps a declaration nobody wrote for it, and if
it happens to carry a field of the declared name, a diagnostic list becomes the
row set. That is a wrong `returned_count`, which is the defect this whole
contract exists to remove.

The issue proposed having `@row_set` record the qualified name it decorated and
assert the match. That cannot work: in a steal the decorator genuinely *does*
decorate the thief — Python binds it to whatever definition syntactically
follows — so the assertion compares a value against itself, and the inserted
class leaves no runtime trace. Intent is unrecoverable at runtime; only
coherence is. Decoration-time type checking is out for a separate reason: every
payload module uses `from __future__ import annotations`, so `get_type_hints`
fails on forward references at class-creation time. The sweep is the right home.

## What changed

- `_is_list_hint` counts bare `list`. It still does **not** count `tuple`:
  `row_set_field` decides with `isinstance(value, list)`, so counting tuples
  would demand a declaration for a class the runtime would never object to —
  a second disagreement in place of the one being fixed.
- A new sweep over payloads that *declare* a row set, asserting the declared
  name is one of the class's list fields. Deliberately not a subset of the
  classes with collections, since the escaping case has none.

## Test plan

Both halves were proved by mutation rather than by a green run.

- Injected both defect shapes as probe classes into a real payload module. Each
  guard fired, naming the class and the wrong field:
  `_MutationProbeBareList carries ['rows'] but declares no row set`;
  `_MutationProbeScalarDeclaration declares row set 'label', which is not one of
  its collection fields (none)`.
- Reverted **only** the `if hint is list:` line with both probes still in place.
  The bare-list probe vanished from the failure list, leaving just the scalar
  one — so that line causes the catch, and the two guards are independent rather
  than one masking the other.
- Collection reconciles rather than merely looking green: the file went 147 →
  253 collected, +106, which is the new 104-case parametrization plus the two
  standalone tests. `test_payload_declares_its_row_set` is unchanged at 146.
- `make check` — ruff clean, bare repo-wide `uv run pyright` 0 errors (3
  pre-existing `reportlab` stub warnings in a file this diff does not touch).
- `make test` — 11178 passed, 4 skipped. The 4 skips are pre-existing and
  environmental; none touch `row_set.py` or this test.

## Review evidence caveat

`chatgpt-codex-connector[bot]` reported at 2026-09-07T00:49:06Z that it has hit
its Codex usage limit and cannot review until credits are added. That is
account-wide, so an absent codex review on this PR is a non-verdict, not the
usual 👍-and-no-review-object clean signal. Please don't read silence from it as
a pass.

Closes MB-176.
