### PR TITLE
Count the NULLs in a protected column without masking the count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   alias: `NULLIF(substr(col, 1, 1), '0') AS d` makes `d IS NULL` an equality
   probe in nullity's spelling, so an occurrence is exempt only if it resolves
   to a catalog column — a CTE or derived-table alias, or a reference lineage
-  cannot resolve at all, keeps masking. (MB-102)
+  cannot resolve at all, keeps masking. Neither does a name a `PIVOT` /
+  `UNPIVOT` generated: those output columns are computed at execution time, so
+  one can answer to a catalog name while holding whichever expression the
+  author put in each arm, and a pivot anywhere in the occurrence's scope keeps
+  masking too. (MB-102)
 
 ### Changed
 - **An investment account fed by two sources at once no longer publishes wrong

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **`sql_query` no longer masks a count of how many rows are missing a
+  protected value.** `COUNT(col)` has always collapsed to a plain aggregate, so
+  `COUNT(*) - COUNT(last_four)` already returned the number of accounts with no
+  last-four unmasked. Two other spellings of that same number did not:
+  `SUM(CASE WHEN last_four IS NULL THEN 1 ELSE 0 END)` and `COUNT(*) FILTER
+  (WHERE last_four IS NULL)` traced to a CRITICAL column and came back `*****`,
+  so a data-completeness question was answerable only if phrased one particular
+  way, and an agent that missed the workaround reported the data as
+  unavailable. A **base catalog column** reaching the output solely as the
+  operand of an `IS NULL` / `IS NOT NULL` test inside a `FILTER (WHERE …)` or a
+  `CASE`/`IF` condition now contributes no class. A nullity test on a base
+  column has one answer per row, so repeating it yields copies of one bit
+  rather than more of the value — except on an outer join's optional side,
+  where a null-extended row makes `IS NULL` report the `ON` predicate instead
+  of the column. That exception is not specific to this rule: the shipped
+  `COUNT(col)` collapse has it identically, so it is tracked against both
+  (MB-179) rather than closed for one spelling. Comparisons do not share that
+  cap and are
+  unchanged, so `SUM(CASE WHEN last_four = '5678' THEN 1 ELSE 0 END)` still
+  masks, as do `MAX(CASE WHEN … THEN routing_number END)`,
+  `SUM(CAST(last_four AS INT))`, and `MAX(x) FILTER (WHERE …)`. Neither does an
+  alias: `NULLIF(substr(col, 1, 1), '0') AS d` makes `d IS NULL` an equality
+  probe in nullity's spelling, so an occurrence is exempt only if it resolves
+  to a catalog column — a CTE or derived-table alias, or a reference lineage
+  cannot resolve at all, keeps masking. (MB-102)
+
 ### Changed
 - **An investment account fed by two sources at once no longer publishes wrong
   numbers.** A broker import and a connector sync covering one account leave two

--- a/docs/specs/privacy-data-classification.md
+++ b/docs/specs/privacy-data-classification.md
@@ -375,6 +375,7 @@ The `sql_query` MCP tool accepts arbitrary read-only SQL, so its output columns 
 | `COUNT(*)`, `COUNT(col)`, `COUNT(DISTINCT col)` | `AGGREGATE` (LOW) — counts destroy individual values |
 | `SUM`, `AVG`, `STDDEV`, `VARIANCE` over `col` | Source column's class — numerically derived from individuals |
 | `MIN`, `MAX`, `FIRST`, `LAST`, `ANY_VALUE` over `col` | Source column's class — surfaces an individual value |
+| `col IS NULL` / `col IS NOT NULL` inside a condition slot — the `FILTER (WHERE …)` predicate, a `CASE`/`IF` branch condition, or a simple-`CASE` operand — where `col` resolves to a **base catalog column** | `AGGREGATE` (LOW) — one bit per row, capped except on an outer join's optional side (see "Null tests inside a condition" below) |
 | Multi-column expression (`CONCAT`, `+`, `\|\|`) | `max(tier)` over all referenced columns; highest-tier class |
 | Literal-only (`'hi'`, `1`) | `AGGREGATE` (LOW) |
 | `COLUMNS('regex')`, `COLUMNS(c -> …)` | Conservative fallback — sqlglot models the argument, never the columns DuckDB expands it to |
@@ -388,6 +389,60 @@ literal and of an expression we could not decompose, and the last three rows
 above are the second kind.
 
 5. **Query tier** — `derive_query_tier(output_classes)` takes the max `Tier` across all output columns.
+
+### Null tests inside a condition
+
+`COUNT(col)` has collapsed to `AGGREGATE` since this classifier shipped, so `SELECT COUNT(*) - COUNT(last_four) FROM core.dim_accounts` already returns the number of NULL last-fours unmasked. Two other spellings of that same number did not: `SUM(CASE WHEN last_four IS NULL THEN 1 ELSE 0 END)` and `COUNT(*) FILTER (WHERE last_four IS NULL)` traced to a CRITICAL column and came back `*****` (MB-102). Two guards together close that gap: `_only_null_tested` (the occurrence sits as the operand of an `IS NULL` / `IS NOT NULL` test inside a `_CONDITION_SLOTS` slot) **and** `_capped_null_test` (that occurrence resolves to a catalog column with a known class). Both are required, and the second is not a formality — see "The cap is a claim about base columns" below.
+
+The exemption is nullity, **not** "any condition", and the difference is a cap rather than a preference. `IS NULL` has one answer per row per base column whose NULLness is its own, so N projections of it return N copies of one bit. A comparison does not: each literal asks about a different piece of the value, and a `CASE` branch may return the literal it just matched —
+
+```sql
+CASE WHEN substr(routing_number,1,1)='0' THEN '0'
+     WHEN substr(routing_number,1,1)='1' THEN '1' … END
+```
+
+— so ten branches recover one character and nine concatenated projections recover the whole number from one query. `MAX('0') FILTER (WHERE substr(routing_number,1,1)='0')` does it without a `CASE`, and `CASE substr(routing_number,1,1) WHEN '0' THEN '0' …` through the operand slot. A rule keyed on position alone returned a real routing number at LOW; it was caught in pre-push review and never shipped.
+
+#### The cap is not absolute: outer joins
+
+An outer join null-extends its optional side. A column read from that side is a genuine catalog column, but its NULLness reports the `ON` predicate — which the author writes — rather than anything about the column:
+
+```sql
+SELECT COUNT(*) FILTER (WHERE j.routing_number IS NULL) AS n
+FROM core.dim_accounts a
+LEFT JOIN core.dim_accounts j
+       ON j.account_id = a.account_id
+      AND substr(a.routing_number, 1, 1) = '0'
+```
+
+Ninety such arms recover a routing number in one query, at LOW.
+
+This is written down rather than closed, and the reason is that it is **not specific to this rule**. The counting-aggregate collapse has it identically: `COUNT(j.account_id)` over the same joins yields the same ninety bits, with no `IS NULL` anywhere, and has done since long before MB-102. `COUNT(col)` counts non-NULLs, which is the same one bit per row in a different spelling. Closing it for the newer spelling alone would leave two behaviours for one question — the failure mode `design-principles.md` names as the largest source of rot.
+
+It is therefore tracked as MB-179, against **both** rules, and belongs to whichever change closes both. What MB-102 changed is which spellings reach it, not whether it is reachable.
+
+#### The cap is a claim about base columns
+
+"One answer per row per column" is true of a *column*. An alias is a name for an arbitrary expression, and the author chooses the expression, so the same sentence is false of an alias:
+
+```sql
+WITH t AS (SELECT NULLIF(substr(routing_number,1,1),'0') AS d FROM core.dim_accounts)
+SELECT SUM(CASE WHEN d IS NULL THEN 1 ELSE 0 END) AS n FROM t
+```
+
+`d IS NULL` is spelled as nullity and means `substr(routing_number,1,1) = '0'`. The cap becomes one bit per *literal the author chose* rather than one per column, and ninety such projections recover a routing number from a single query — the same reconstruction, one indirection away. A second pre-push review round caught this; the position test alone cannot see it.
+
+So an occurrence is exempt only when it resolves, at that point, to a catalog column carrying a known class. Three failures are treated alike, because each leaves the identity unestablished rather than establishing a safe one: it resolves inside a CTE or derived-table scope; `_column_key` cannot name it (an unresolvable reference must keep reaching the conservative fallback, not be quietly dropped — a `routing_number` alias past `_MAX_SCOPE_DEPTH` answered `AGGREGATE` while the same projection without the null test answered `UNRESOLVED`); or the key resolves with no class, which is a coverage gap.
+
+This is deliberately conservative in one honest case: `WITH t AS (SELECT routing_number AS d …)` really is a base column and its null test really is capped, but proving that means classifying the CTE's own projection first. It masks instead — which is what it did before this rule existed, so nothing regresses.
+
+Three further properties bound what shipped:
+
+- **Per occurrence, not per column name.** `MAX(routing_number) FILTER (WHERE routing_number IS NOT NULL)` still masks — the aggregate's occurrence returns the value whatever the predicate does with its own.
+- **The column's own parent, not the enclosing condition.** `COALESCE(routing_number, '') IS NULL` is a nullity test on an expression over the column, and the sibling argument can carry the value, so that occurrence stays classified.
+- **A condition slot must lie between.** A bare `SELECT last_four IS NULL` keeps its class: the `Is` node *is* the projection, so nothing separates the test from the output. That is a deliberately conservative edge, not a claim that the bit differs.
+
+The opaque-node veto still outranks this rule, as it does the counting aggregate: `COLUMNS(…)` inside a condition takes the conservative fallback, because it distributes into sibling projections lineage never named.
 
 ### Conservative fallback
 

--- a/docs/specs/privacy-data-classification.md
+++ b/docs/specs/privacy-data-classification.md
@@ -375,7 +375,7 @@ The `sql_query` MCP tool accepts arbitrary read-only SQL, so its output columns 
 | `COUNT(*)`, `COUNT(col)`, `COUNT(DISTINCT col)` | `AGGREGATE` (LOW) — counts destroy individual values |
 | `SUM`, `AVG`, `STDDEV`, `VARIANCE` over `col` | Source column's class — numerically derived from individuals |
 | `MIN`, `MAX`, `FIRST`, `LAST`, `ANY_VALUE` over `col` | Source column's class — surfaces an individual value |
-| `col IS NULL` / `col IS NOT NULL` inside a condition slot — the `FILTER (WHERE …)` predicate, a `CASE`/`IF` branch condition, or a simple-`CASE` operand — where `col` resolves to a **base catalog column** | `AGGREGATE` (LOW) — one bit per row, capped except on an outer join's optional side (see "Null tests inside a condition" below) |
+| `col IS NULL` / `col IS NOT NULL` inside a condition slot — the `FILTER (WHERE …)` predicate, a `CASE`/`IF` branch condition, or a simple-`CASE` operand — where `col` resolves to a **base catalog column** and no `PIVOT` / `UNPIVOT` is in its scope | `AGGREGATE` (LOW) — one bit per row, capped except on an outer join's optional side (see "Null tests inside a condition" below) |
 | Multi-column expression (`CONCAT`, `+`, `\|\|`) | `max(tier)` over all referenced columns; highest-tier class |
 | Literal-only (`'hi'`, `1`) | `AGGREGATE` (LOW) |
 | `COLUMNS('regex')`, `COLUMNS(c -> …)` | Conservative fallback — sqlglot models the argument, never the columns DuckDB expands it to |
@@ -432,9 +432,26 @@ SELECT SUM(CASE WHEN d IS NULL THEN 1 ELSE 0 END) AS n FROM t
 
 `d IS NULL` is spelled as nullity and means `substr(routing_number,1,1) = '0'`. The cap becomes one bit per *literal the author chose* rather than one per column, and ninety such projections recover a routing number from a single query — the same reconstruction, one indirection away. A second pre-push review round caught this; the position test alone cannot see it.
 
-So an occurrence is exempt only when it resolves, at that point, to a catalog column carrying a known class. Three failures are treated alike, because each leaves the identity unestablished rather than establishing a safe one: it resolves inside a CTE or derived-table scope; `_column_key` cannot name it (an unresolvable reference must keep reaching the conservative fallback, not be quietly dropped — a `routing_number` alias past `_MAX_SCOPE_DEPTH` answered `AGGREGATE` while the same projection without the null test answered `UNRESOLVED`); or the key resolves with no class, which is a coverage gap.
+So an occurrence is exempt only when it resolves, at that point, to a catalog column carrying a known class. Four failures are treated alike, because each leaves the identity unestablished rather than establishing a safe one: it resolves inside a CTE or derived-table scope; its scope draws from a `PIVOT` / `UNPIVOT` source (see below); `_column_key` cannot name it (an unresolvable reference must keep reaching the conservative fallback, not be quietly dropped — a `routing_number` alias past `_MAX_SCOPE_DEPTH` answered `AGGREGATE` while the same projection without the null test answered `UNRESOLVED`); or the key resolves with no class, which is a coverage gap.
 
 This is deliberately conservative in one honest case: `WITH t AS (SELECT routing_number AS d …)` really is a base column and its null test really is capped, but proving that means classifying the CTE's own projection first. It masks instead — which is what it did before this rule existed, so nothing regresses.
+
+#### A pivot generates the name as well as the value
+
+A `PIVOT` / `UNPIVOT` source's output columns are computed by DuckDB at execution time, so the catalog cannot say what one holds — only what its name *would* mean if the name were the catalog's. `UNPIVOT` lets the author name the generated value column and choose every arm feeding it:
+
+```sql
+SELECT COUNT(*) FILTER (WHERE last_four IS NULL) AS c
+FROM core.dim_accounts
+UNPIVOT INCLUDE NULLS (
+    last_four FOR arm IN (
+        last_four, NULLIF(substr(routing_number,1,1),'0') AS d0, … AS d9))
+GROUP BY arm ORDER BY arm
+```
+
+Listing the real `last_four` among the arms is what frees the bare name: the pivot consumes that column, so DuckDB stops disambiguating the collision to `last_four_1` and the generated column answers to `last_four`. It then resolves against the catalog, its scope is no CTE, and every check above passes — while each row's value is whichever arm the author wrote. Ten arms recover a digit and nine groups a routing number. This is the alias exploit with a pivot for the indirection; a third review round caught it, and it returned a real routing digit at LOW before the fix.
+
+Deciding case by case would mean re-deriving each pivot output's provenance through the pivot's field list. Every wrong answer there is a value leak and every wrong answer the other way is an over-mask, so a pivot anywhere in the occurrence's scope declines the exemption — including the honest `IN (last_four, account_id)` form, whose count really is one bit per row. The conservative-fallback section below already takes this position for the `Star` a pivot source stops `qualify()` from expanding; this is the same reasoning reaching the one name that survives expansion.
 
 Three further properties bound what shipped:
 

--- a/src/moneybin/privacy/sql_lineage.py
+++ b/src/moneybin/privacy/sql_lineage.py
@@ -1177,6 +1177,43 @@ def _has_uncounted_opaque(inner: exp.Expr) -> bool:
     )
 
 
+def _reads_a_pivot(col: exp.Column, col_scope: Scope | None) -> bool:
+    """True if ``col``'s scope draws from a ``PIVOT`` / ``UNPIVOT`` source.
+
+    A pivot's output columns are computed by DuckDB at execution time, so the
+    catalog cannot say what one holds — only what its name would mean if the
+    name were the catalog's. An ``UNPIVOT`` names its generated value column,
+    and the author picks both that name and every arm feeding it::
+
+        SELECT COUNT(*) FILTER (WHERE last_four IS NULL) AS c
+        FROM core.dim_accounts
+        UNPIVOT INCLUDE NULLS (
+            last_four FOR arm IN (
+                last_four, NULLIF(substr(routing_number, 1, 1), '0') AS d0, …))
+        GROUP BY arm ORDER BY arm
+
+    Listing the real ``last_four`` among the arms is what frees the bare name:
+    the pivot consumes that column, so DuckDB stops suffixing the collision to
+    ``last_four_1`` and the generated column answers to ``last_four``. It
+    resolves against the catalog, its own scope is no CTE, and every check
+    ``_capped_null_test`` had passed — while each row's value is whichever arm
+    the author wrote. Ten arms recover a digit and nine such groups a routing
+    number, so this is the alias exploit again with a pivot for the
+    indirection.
+
+    Deciding case-by-case would mean re-deriving each pivot output's provenance
+    through ``exp.Pivot``'s field list; every wrong answer there is a value
+    leak, while every wrong answer here is an over-mask. So the presence of a
+    pivot anywhere in the column's scope declines the exemption, including for
+    the honest ``IN (last_four, account_id)`` form whose count really is one
+    bit per row. ``_OPAQUE_PROJECTION_NODES`` already takes this position for
+    the ``Star`` a pivot source stops ``qualify()`` from expanding; this is the
+    same reasoning reaching the one name that survives expansion.
+    """
+    root = col_scope.expression if col_scope is not None else col.root()
+    return root.find(exp.Pivot) is not None
+
+
 def _capped_null_test(
     col: exp.Column,
     inner: exp.Expr,
@@ -1202,11 +1239,15 @@ def _capped_null_test(
     indirection away. A review caught it; the position test alone cannot.
 
     So the occurrence must resolve, HERE, to a catalog column with a known
-    class. Three failures are all treated the same, because each leaves the
+    class. Four failures are all treated the same, because each leaves the
     identity unestablished rather than establishing a safe one:
 
       * it resolves inside a CTE or derived-table scope (``_source_scope_of``),
         where the projection behind the name may be any expression;
+      * its scope draws from a ``PIVOT`` / ``UNPIVOT`` source
+        (``_reads_a_pivot``), whose output columns DuckDB computes at execution
+        time — a generated column may ANSWER to a catalog name while holding
+        the author's expression;
       * ``_column_key`` cannot name it at all — an unresolvable reference must
         keep reaching ``_conservative_floor``, not be quietly dropped;
       * the key resolves but carries no class, which is a coverage gap and the
@@ -1225,10 +1266,10 @@ def _capped_null_test(
     predicate's answer — see :func:`_only_null_tested` for the worked example
     and for why it is not closed here.
     """
-    if (
-        _source_scope_of(col, _scope_of_column(col, inner, scope, subscopes))
-        is not None
-    ):
+    col_scope = _scope_of_column(col, inner, scope, subscopes)
+    if _source_scope_of(col, col_scope) is not None:
+        return False
+    if _reads_a_pivot(col, col_scope):
         return False
     key = _column_key(col, alias_map, ctx.snapshot, ctx.shadowed)
     return key is not None and _class_of_key(key) is not None

--- a/src/moneybin/privacy/sql_lineage.py
+++ b/src/moneybin/privacy/sql_lineage.py
@@ -79,6 +79,32 @@ logger = logging.getLogger(__name__)
 # already produces — so only the counting set needs an explicit check.
 _COUNTING_AGGS: tuple[type[exp.Expr], ...] = (exp.Count,)
 
+# (node type, argument) pairs naming an expression slot that holds a CONDITION
+# rather than a returned value. A BASE COLUMN NULL-tested inside one contributes
+# no class (MB-102) — see ``_only_null_tested`` for why nullity, and only
+# nullity, is safe there, and ``_capped_null_test`` for why the occurrence must
+# also resolve to a catalog column before the cap can be claimed.
+#
+#   * ``Filter.expression`` — the ``FILTER (WHERE …)`` clause, which narrows
+#     which rows the aggregate sees. ``Filter.this`` (the aggregate itself) is
+#     deliberately absent: `MAX(routing_number) FILTER (WHERE …)` returns the
+#     column.
+#   * ``If.this`` — the condition of ``CASE WHEN c THEN …`` and of DuckDB's
+#     ``IF(c, a, b)``. The returned value comes from ``true`` / ``false``. In a
+#     SIMPLE ``CASE x WHEN v``, this slot holds ``v`` — the compared value, not
+#     a boolean — which is still never returned.
+#   * ``Case.this`` — the operand slot ``x`` of that simple form, compared
+#     against each ``WHEN`` value; the result is the matching branch's. Note
+#     what this does and does not reach: a bare ``CASE routing_number WHEN …``
+#     is NOT exempt, because `_only_null_tested` requires the column's own
+#     parent to be the ``Is`` node. The slot matters only for a NULL test
+#     SITTING IN it — ``CASE (routing_number IS NULL) WHEN TRUE THEN …``.
+_CONDITION_SLOTS: tuple[tuple[type[exp.Expr], str], ...] = (
+    (exp.Filter, "expression"),
+    (exp.If, "this"),
+    (exp.Case, "this"),
+)
+
 
 # ---------------------------------------------------------------------------
 # Errors
@@ -769,6 +795,99 @@ def _within_subquery(node: exp.Expr, stop: exp.Expr) -> bool:
     return False
 
 
+def _is_null_test_operand(node: exp.Expr) -> bool:
+    """True if ``node`` is the operand of an ``IS NULL`` / ``IS NOT NULL`` test.
+
+    Read from ``node``'s OWN parent, never from the enclosing condition:
+    ``COALESCE(routing_number, '') IS NULL`` is a null test on an expression
+    over the column, and its sibling argument can carry the value.
+    ``IS NOT NULL`` differs only by an ``exp.Not`` above the ``exp.Is``, which
+    the caller's upward walk passes through.
+    """
+    parent = node.parent
+    return isinstance(parent, exp.Is) and any(
+        isinstance(parent.args.get(side), exp.Null)
+        and parent.args.get(side) is not node
+        for side in ("this", "expression")
+    )
+
+
+def _only_null_tested(node: exp.Expr, stop: exp.Expr) -> bool:
+    """True if ``node`` reaches ``stop`` only as the operand of a NULL test.
+
+    **Why nullity and not "any condition".** The tempting rule — a column in a
+    condition slot contributes no class, because only the predicate's truth
+    value escapes — is FALSE, and a review caught it returning a real routing
+    number at LOW. A ``CASE`` branch chooses a literal, and nothing stops that
+    literal from being the digit the condition just tested:
+
+        CASE WHEN substr(routing_number,1,1)='0' THEN '0'
+             WHEN substr(routing_number,1,1)='1' THEN '1' … END
+
+    Ten branches recover one character and nine concatenated projections
+    recover the whole number, from one query. ``MAX('0') FILTER (WHERE
+    substr(routing_number,1,1)='0')`` does it with no ``CASE`` at all, and
+    ``CASE substr(routing_number,1,1) WHEN '0' THEN '0' …`` through the operand
+    slot. "Only compared" does not imply "cannot reach the output".
+
+    Nullity is exempt because it is capped, not because it is a condition:
+    ``IS NULL`` has ONE answer per row per base column WHOSE NULLNESS IS ITS
+    OWN, so N projections of it return N copies of one bit, while ``substr(col,
+    i, 1) = 'd'`` interrogates a different piece of the value each time. That
+    cap is what the general rule lacked.
+
+    Every qualifier in that sentence is load-bearing, and this function
+    establishes NONE of them — it answers position only. An alias names any
+    expression, so ``d IS NULL`` over ``NULLIF(substr(col,1,1),'0')`` is an
+    equality probe in nullity's spelling. The caller pairs this with
+    :func:`_capped_null_test`, which establishes that the occurrence is a
+    catalog column; neither is sufficient alone.
+
+    THE CAP IS NOT ABSOLUTE, and the exception is written down rather than
+    hidden. An outer join null-extends its optional side, so on that side
+    ``IS NULL`` reports the ``ON`` predicate — which the author writes — instead
+    of the column::
+
+        SELECT COUNT(*) FILTER (WHERE j.routing_number IS NULL) …
+        FROM core.dim_accounts a
+        LEFT JOIN core.dim_accounts j
+               ON j.account_id = a.account_id
+              AND substr(a.routing_number, 1, 1) = '0'
+
+    Ninety such arms recover the value. This is NOT a hole this rule opened: the
+    shipped counting-aggregate collapse has it identically — ``COUNT(j.account_id)``
+    over the same joins returns the same ninety bits at LOW, with no ``IS NULL``
+    anywhere — so closing it here alone would leave two behaviours for one
+    question. It belongs to whichever change closes both; see MB-179.
+
+    It also discloses nothing new. ``COUNT(col)`` has collapsed to AGGREGATE
+    since long before this rule, so ``COUNT(*) - COUNT(last_four)`` already
+    returns the NULL count unmasked — the exact number MB-102 asked for. This
+    accepts two further spellings of a published number rather than opening a
+    channel.
+
+    Terminates AT ``stop`` (the projection root) rather than at the tree root,
+    so a condition in an enclosing query can never exempt a column this
+    projection returns — the trap ``_within_subquery`` documents from the other
+    direction. A bare ``SELECT last_four IS NULL`` therefore stays classified:
+    its ``Is`` IS the projection, so no condition slot lies between.
+    """
+    if not _is_null_test_operand(node):
+        return False
+    child = node.parent
+    while child is not None and child is not stop:
+        parent = child.parent
+        if parent is None:
+            return False
+        if any(
+            isinstance(parent, kind) and parent.args.get(slot) is child
+            for kind, slot in _CONDITION_SLOTS
+        ):
+            return True
+        child = parent
+    return False
+
+
 def _within_counting_agg(node: exp.Expr, stop: exp.Expr) -> bool:
     """True if ``node`` sits inside a counting aggregate at or below ``stop``.
 
@@ -1058,6 +1177,63 @@ def _has_uncounted_opaque(inner: exp.Expr) -> bool:
     )
 
 
+def _capped_null_test(
+    col: exp.Column,
+    inner: exp.Expr,
+    scope: Scope | None,
+    subscopes: dict[int, Scope],
+    alias_map: dict[str, tuple[str, str]],
+    ctx: _ResolveCtx,
+) -> bool:
+    """True if ``col`` is a NULL test whose one-bit cap actually holds.
+
+    ``_only_null_tested`` answers a question about POSITION; this adds the
+    question about IDENTITY, and the cap needs both. "One answer per row per
+    column" is a statement about a *base column* — an alias is a name for an
+    arbitrary expression, and the author picks the expression:
+
+        WITH t AS (SELECT NULLIF(substr(routing_number, 1, 1), '0') AS d …)
+        SELECT SUM(CASE WHEN d IS NULL THEN 1 ELSE 0 END) …
+
+    ``d IS NULL`` is spelled as nullity and means ``substr(…) = '0'``. The cap
+    becomes one bit per LITERAL THE AUTHOR CHOSE rather than one per column, and
+    ninety such projections recover a routing number from a single query — the
+    very reconstruction the nullity narrowing was supposed to close, one
+    indirection away. A review caught it; the position test alone cannot.
+
+    So the occurrence must resolve, HERE, to a catalog column with a known
+    class. Three failures are all treated the same, because each leaves the
+    identity unestablished rather than establishing a safe one:
+
+      * it resolves inside a CTE or derived-table scope (``_source_scope_of``),
+        where the projection behind the name may be any expression;
+      * ``_column_key`` cannot name it at all — an unresolvable reference must
+        keep reaching ``_conservative_floor``, not be quietly dropped;
+      * the key resolves but carries no class, which is a coverage gap and the
+        floor's business, not a licence to exempt.
+
+    This is deliberately conservative about one honest case: a plain
+    ``SELECT routing_number AS d`` passed through a CTE really is a base column,
+    and its null test really is capped, but proving that means classifying the
+    CTE's own projection first. It masks instead — which is exactly what it did
+    before this rule existed, so nothing regresses.
+
+    It is deliberately PERMISSIVE about one dishonest case, which is the more
+    important half to know about: this establishes that the occurrence names a
+    catalog column, NOT that the row reaching it came from that table. An outer
+    join's optional side is a catalog column whose NULLness is the ``ON``
+    predicate's answer — see :func:`_only_null_tested` for the worked example
+    and for why it is not closed here.
+    """
+    if (
+        _source_scope_of(col, _scope_of_column(col, inner, scope, subscopes))
+        is not None
+    ):
+        return False
+    key = _column_key(col, alias_map, ctx.snapshot, ctx.shadowed)
+    return key is not None and _class_of_key(key) is not None
+
+
 def _resolve_projection(
     proj: exp.Expr,
     scope: Scope | None,
@@ -1119,13 +1295,48 @@ def _resolve_projection(
     # nothing is False, and the projection collapsed to AGGREGATE beside a row
     # count. Same shape of vacuous pass as the opaque-node veto above.
     bound: list[DataClass] = []
+    #
+    # The null-test exemption needs no identity check here, unlike the column
+    # loop below: a placeholder IS the value the caller bound, so there is no
+    # alias indirection to smuggle an expression behind. `NULLIF($acct, 'x') IS
+    # NULL` fails the position test anyway — the placeholder's own parent is the
+    # NULLIF, not the Is.
     for node in inner.find_all(*PLACEHOLDER_NODES):
-        if _within_counting_agg(node, inner):
+        if _within_counting_agg(node, inner) or _only_null_tested(node, inner):
             continue
         # A positional `?` names nothing, so no map can answer for it; a named one
         # absent from the map was never declared. Both fail closed.
         found = ctx.placeholder_classes.get(placeholder_name(node))
         bound.append(FAIL_CLOSED_CLASS if found is None else found)
+
+    # Built only when the projection actually nests a SELECT (a scalar or IN
+    # subquery); the common case pays nothing. Built BEFORE the column list
+    # because the null-test exemption below needs to resolve each occurrence,
+    # and resolving needs the subquery scopes.
+    subscopes: dict[int, Scope] = (
+        _subquery_scopes_by_select(scope)
+        if scope is not None and inner.find(exp.Select) is not None
+        else {}
+    )
+
+    # Columns whose value can reach the output. An occurrence only NULL-tested
+    # inside a condition is dropped here, ONCE, so every rule below reads the
+    # same list — two notions of "which columns count" beside each other is how
+    # the vacuous passes above got in.
+    #
+    # Both halves of the guard are load-bearing: `_only_null_tested` answers
+    # where the occurrence sits, `_capped_null_test` answers what it names. The
+    # position alone is not enough — an alias over `NULLIF(...)` is a nullity
+    # test in spelling only, and dropping it reopened the reconstruction this
+    # whole rule exists to prevent.
+    cols = [
+        c
+        for c in inner.find_all(exp.Column)
+        if not (
+            _only_null_tested(c, inner)
+            and _capped_null_test(c, inner, scope, subscopes, alias_map, ctx)
+        )
+    ]
 
     # A counting aggregate at the projection's TOP level collapses values to a
     # count — but it only governs the projection when EVERY column reference is
@@ -1140,19 +1351,28 @@ def _resolve_projection(
             isinstance(n, _COUNTING_AGGS) and not _within_subquery(n, inner)
             for n in inner.find_all(exp.AggFunc)
         )
-        and not any(
-            not _within_counting_agg(c, inner) for c in inner.find_all(exp.Column)
-        )
+        and not any(not _within_counting_agg(c, inner) for c in cols)
         and not bound
     ):
         return DataClass.AGGREGATE
 
-    cols = list(inner.find_all(exp.Column))
     if not cols:
         # THE INVARIANT: a projection is classified LOW only when we positively
-        # established what it is. "No exp.Column node" is NOT that proof — it
-        # conflates a genuine literal with an expression we could not
+        # established what it is. "No surfacing exp.Column" is NOT that proof —
+        # it conflates a genuine literal with an expression we could not
         # decompose, and the two must not share an answer.
+        #
+        # Reaching here with an emptied `cols` IS that proof in one further
+        # case: every column was dropped by the null-test guard, which is a
+        # positive finding about each occurrence — it resolved to a known
+        # catalog column AND sits as the operand of a NULL test inside a
+        # condition, so it yields one bit, capped except on an outer join's
+        # optional side (`_only_null_tested`). That is why the guard resolves
+        # before it drops (`_capped_null_test`): a drop keyed on position alone
+        # would empty this list for occurrences nothing was ever established
+        # about, and this branch would read that silence as proof. It did — a
+        # `routing_number` alias past `_MAX_SCOPE_DEPTH` answered AGGREGATE
+        # while the same projection without the null test answered UNRESOLVED.
         #
         # The opacity gate is `_has_uncounted_opaque` above, and it is the ONLY
         # one: reaching this line already proves every opaque node here is a
@@ -1167,14 +1387,6 @@ def _resolve_projection(
         # A bound placeholder is the one thing here that is neither a literal nor
         # a column, so it answers for the projection when nothing else can.
         return _combined_class(bound) if bound else DataClass.AGGREGATE
-
-    # Built only when the projection actually nests a SELECT (a scalar or IN
-    # subquery); the common case pays nothing.
-    subscopes: dict[int, Scope] = (
-        _subquery_scopes_by_select(scope)
-        if scope is not None and inner.find(exp.Select) is not None
-        else {}
-    )
 
     classes: list[DataClass] = []
     for col in cols:

--- a/tests/privacy/fixtures/sql_lineage_corpus.yaml
+++ b/tests/privacy/fixtures/sql_lineage_corpus.yaml
@@ -250,8 +250,18 @@
   expected_output_classes: {name: description}
   expected_query_tier: medium
 
-- description: CASE WHEN on category column yields LOW category class
+- description: CASE WHEN equality on a column keeps that column's class (branches can echo the tested literal)
   sql: SELECT CASE WHEN category = 'Food' THEN 'food' ELSE 'other' END AS cat FROM core.fct_transactions
+  expected_output_classes: {cat: category}
+  expected_query_tier: low
+
+- description: CASE WHEN on a NULL test carries no class from the tested column
+  sql: SELECT CASE WHEN category IS NULL THEN 'none' ELSE 'some' END AS cat FROM core.fct_transactions
+  expected_output_classes: {cat: aggregate}
+  expected_query_tier: low
+
+- description: CASE WHEN whose branch returns the column keeps that column's class
+  sql: SELECT CASE WHEN category = 'Food' THEN category ELSE 'other' END AS cat FROM core.fct_transactions
   expected_output_classes: {cat: category}
   expected_query_tier: low
 

--- a/tests/privacy/test_sql_lineage.py
+++ b/tests/privacy/test_sql_lineage.py
@@ -1501,6 +1501,62 @@ def test_a_null_test_on_an_unresolvable_alias_takes_the_floor(
     assert derive_query_tier(out) is Tier.CRITICAL
 
 
+def test_a_null_test_on_an_unpivot_value_column_is_not_exempt(
+    populated_db: Database,
+) -> None:
+    """An UNPIVOT names its generated value column, and the author picks its input.
+
+    A third door into the same reconstruction, found in review. A pivot's output
+    columns are computed by DuckDB at execution time, so a generated column
+    NAMED after a catalog column is not that column: here every arm but the
+    first holds ``NULLIF(substr(routing_number, 1, 1), <digit>)``, so
+    ``last_four IS NULL`` is once again one bit per literal the author chose.
+
+    Listing the real ``last_four`` among the arms is what makes the bare name
+    available. Without it DuckDB suffixes the collision to ``last_four_1``, the
+    bare name keeps binding to the base column, and the query is the honest
+    one-bit-per-row question the exemption exists for.
+    """
+    arms = ", ".join(
+        f"NULLIF(substr(routing_number, 1, 1), '{digit}') AS d{digit}"
+        for digit in range(10)
+    )
+    out = _classes(
+        "SELECT COUNT(*) FILTER (WHERE last_four IS NULL) AS c "  # noqa: S608  # test input string, not executing SQL
+        "FROM core.dim_accounts "
+        f"UNPIVOT INCLUDE NULLS (last_four FOR arm IN (last_four, {arms})) "
+        "GROUP BY arm",
+        populated_db,
+    )
+
+    assert out == {"c": DataClass.INSTITUTION_ACCOUNT_NUMBER}
+    assert derive_query_tier(out) is Tier.CRITICAL
+
+
+def test_a_null_test_is_not_exempt_anywhere_a_pivot_is_in_scope(
+    populated_db: Database,
+) -> None:
+    """The guard is the pivot's presence, not a pattern in the arm list.
+
+    Deliberately conservative, and this pins the conservatism so it cannot be
+    narrowed back to the exploit's shape. Nothing here is generated — the value
+    column is ``last_four`` fed by real catalog columns, and the count really is
+    one bit per row per column. It still masks, because deciding otherwise means
+    re-deriving each pivot output's provenance, and every wrong answer there is
+    a value leak rather than an over-mask.
+    """
+    out = _classes(
+        "SELECT COUNT(*) FILTER (WHERE last_four IS NULL) AS c "
+        "FROM core.dim_accounts "
+        "UNPIVOT INCLUDE NULLS (last_four FOR arm IN (last_four, account_id)) "
+        "GROUP BY arm",
+        populated_db,
+    )
+
+    assert out == {"c": DataClass.INSTITUTION_ACCOUNT_NUMBER}
+    assert derive_query_tier(out) is Tier.CRITICAL
+
+
 # ---------------------------------------------------------------------------
 # The counting aggregate must not outrank the opaque-node veto
 #

--- a/tests/privacy/test_sql_lineage.py
+++ b/tests/privacy/test_sql_lineage.py
@@ -1051,6 +1051,457 @@ def test_scalar_subquery_count_does_not_downgrade(populated_db: Database) -> Non
 
 
 # ---------------------------------------------------------------------------
+# A column only ever asked whether it is NULL
+#
+# `COUNT(col)` has collapsed to AGGREGATE since this classifier shipped, so
+# `COUNT(*) - COUNT(last_four)` already returns the number of NULL last-fours
+# unmasked. Two other spellings of that same number did not — the ones MB-102
+# reported — and these pin the rule that makes them agree.
+#
+# The cap is what makes nullity safe, not its being a condition: `IS NULL` has
+# one answer per row per column. The block further down holds the
+# counterexamples that bound it, and the value positions it must never reach.
+# ---------------------------------------------------------------------------
+
+
+def test_sum_over_a_case_condition_on_a_critical_column_is_aggregate(
+    populated_db: Database,
+) -> None:
+    """MB-102's first reported spelling: a count of NULL last-fours.
+
+    The projection returns a row count, and `last_four` reaches it only as the
+    operand of an `IS NULL` test — one answer per row, no part of the value.
+    `COUNT(*) - COUNT(last_four)` already published this exact number, so
+    classifying this spelling INSTITUTION_ACCOUNT_NUMBER masked an integer the
+    surface hands over when asked differently.
+    """
+    out = _classes(
+        "SELECT SUM(CASE WHEN last_four IS NULL THEN 1 ELSE 0 END) AS n "
+        "FROM core.dim_accounts",
+        populated_db,
+    )
+    assert out == {"n": DataClass.AGGREGATE}
+
+
+def test_count_filtered_on_a_critical_column_is_aggregate(
+    populated_db: Database,
+) -> None:
+    """MB-102's second reported spelling, which the first fix must also cover.
+
+    A different aggregate and a different clause, the same null test. The
+    ticket's follow-up rejects an allowlist of aggregate spellings, so the rule
+    keys on the predicate and its slot, never on which aggregate wraps them.
+    """
+    out = _classes(
+        "SELECT COUNT(*) FILTER (WHERE last_four IS NULL) AS n FROM core.dim_accounts",
+        populated_db,
+    )
+    assert out == {"n": DataClass.AGGREGATE}
+
+
+def test_a_relocated_predicate_classifies_as_its_where_clause_twin(
+    populated_db: Database,
+) -> None:
+    """The invariant behind the rule: one question, one answer, either spelling.
+
+    These two queries return the identical integer. The WHERE form has always
+    been AGGREGATE because only the projection is classified;
+    the FILTER form differing from it was the defect, not the WHERE form's
+    permissiveness.
+    """
+    relocated = _classes(
+        "SELECT COUNT(*) FILTER (WHERE last_four IS NULL) AS n FROM core.dim_accounts",
+        populated_db,
+    )
+    in_where = _classes(
+        "SELECT COUNT(*) AS n FROM core.dim_accounts WHERE last_four IS NULL",
+        populated_db,
+    )
+    assert relocated == in_where
+
+
+def test_a_case_condition_is_exempt_inside_a_window_frame(
+    populated_db: Database,
+) -> None:
+    """The rule is positional, so the surrounding aggregate is irrelevant.
+
+    A windowed `SUM(CASE …) OVER ()` is a third spelling of the same count.
+    Anything keyed on the aggregate function would have to enumerate it.
+    """
+    out = _classes(
+        "SELECT SUM(CASE WHEN last_four IS NULL THEN 1 ELSE 0 END) OVER () AS n "
+        "FROM core.dim_accounts",
+        populated_db,
+    )
+    assert out == {"n": DataClass.AGGREGATE}
+
+
+def test_a_simple_case_operand_equality_still_masks(
+    populated_db: Database,
+) -> None:
+    """`CASE <col> WHEN v` is an equality probe wearing different syntax.
+
+    The operand is only ever compared, but each `WHEN` asks about a different
+    value, so the branches compose exactly as the searched-CASE form does — see
+    ``test_a_simple_case_mapping_values_to_literals_still_masks``. Being
+    "compared, never returned" is not sufficient; being capped at one answer is.
+    """
+    out = _classes(
+        "SELECT SUM(CASE last_four WHEN '5678' THEN 1 ELSE 0 END) AS n "
+        "FROM core.dim_accounts",
+        populated_db,
+    )
+    assert out == {"n": DataClass.INSTITUTION_ACCOUNT_NUMBER}
+
+
+def test_a_null_test_sitting_in_the_simple_case_operand_is_exempt(
+    populated_db: Database,
+) -> None:
+    """The one shape `(exp.Case, "this")` actually reaches, pinned.
+
+    Read beside the test above, which is the same slot and the opposite answer.
+    The slot does NOT exempt a simple-CASE operand — `_only_null_tested`
+    requires the column's own parent to be the `Is` node, so `CASE last_four
+    WHEN …` stays classified. It exempts a NULL TEST placed in that slot, where
+    the operand is the one-bit boolean and the `WHEN` arms match against it.
+
+    Without this the entry is dead weight: removing it from `_CONDITION_SLOTS`
+    leaves every other test in this file green, which is how an unused rule in
+    security-critical code survives a rename or a refactor unnoticed.
+    """
+    out = _classes(
+        "SELECT SUM(CASE (last_four IS NULL) WHEN TRUE THEN 1 ELSE 0 END) AS n "
+        "FROM core.dim_accounts",
+        populated_db,
+    )
+    assert out == {"n": DataClass.AGGREGATE}
+
+
+def test_a_critical_column_in_a_case_result_still_masks(
+    populated_db: Database,
+) -> None:
+    """THE boundary: a `THEN` branch returns the column's VALUE.
+
+    Same CASE, same aggregate, one slot over — and the digits reach the output.
+    A rule that read "appears anywhere under a CASE" would publish them.
+    """
+    out = _classes(
+        "SELECT MAX(CASE WHEN account_type = 'checking' THEN last_four ELSE NULL END) "
+        "AS m FROM core.dim_accounts",
+        populated_db,
+    )
+    assert out == {"m": DataClass.INSTITUTION_ACCOUNT_NUMBER}
+    assert derive_query_tier(out) is Tier.CRITICAL
+
+
+def test_a_critical_column_in_a_case_default_still_masks(
+    populated_db: Database,
+) -> None:
+    """The `ELSE` branch is a value position too, and reached by a different arg."""
+    out = _classes(
+        "SELECT MAX(CASE WHEN account_type = 'checking' THEN 'x' ELSE routing_number END) "
+        "AS m FROM core.dim_accounts",
+        populated_db,
+    )
+    assert out == {"m": DataClass.ROUTING_NUMBER}
+
+
+def test_a_filter_exempts_its_predicate_not_the_aggregate_argument(
+    populated_db: Database,
+) -> None:
+    """`FILTER` narrows which rows an aggregate sees; it does not launder them.
+
+    The predicate here is harmless and the aggregate argument is the CRITICAL
+    column — the inverse of the reported shape, and the case a rule that
+    exempted the whole `Filter` node would leak.
+    """
+    out = _classes(
+        "SELECT MAX(routing_number) FILTER (WHERE account_type = 'checking') AS m "
+        "FROM core.dim_accounts",
+        populated_db,
+    )
+    assert out == {"m": DataClass.ROUTING_NUMBER}
+
+
+def test_a_column_in_both_a_condition_and_a_value_position_still_masks(
+    populated_db: Database,
+) -> None:
+    """The exemption is per OCCURRENCE, not per column name.
+
+    `routing_number` is asked a question in the FILTER and returned by the
+    aggregate. Deciding "this column is only ever a predicate" by name would
+    take the exemption from the first occurrence and publish the second.
+    """
+    out = _classes(
+        "SELECT MAX(routing_number) FILTER (WHERE routing_number IS NOT NULL) AS m "
+        "FROM core.dim_accounts",
+        populated_db,
+    )
+    assert out == {"m": DataClass.ROUTING_NUMBER}
+
+
+def test_a_bare_projected_comparison_still_masks(populated_db: Database) -> None:
+    """The deliberate outer edge: a condition slot must lie between.
+
+    The `Is` node here IS the projection, so nothing separates the test from
+    the output and `_only_null_tested`'s walk finds no condition slot. The bit
+    is the same one `COUNT(last_four)` already publishes, so this edge is
+    conservatism rather than a claim that the bit differs — moving it is a
+    decision to take on its own, not a gap to close by accident.
+    """
+    out = _classes("SELECT last_four IS NULL AS n FROM core.dim_accounts", populated_db)
+    assert out == {"n": DataClass.INSTITUTION_ACCOUNT_NUMBER}
+
+
+def test_an_opaque_node_inside_a_condition_still_takes_the_floor(
+    populated_db: Database,
+) -> None:
+    """The opaque-node veto outranks the condition exemption, as it does the count.
+
+    `COLUMNS(…)` DISTRIBUTES: this projection becomes one sibling per matched
+    column at runtime, so a single confident class certifies output columns
+    lineage never named — true whatever the class is.
+    """
+    out = _classes(
+        "SELECT SUM(CASE WHEN COLUMNS('routing.*') IS NULL THEN 1 ELSE 0 END) AS n "
+        "FROM core.dim_accounts",
+        populated_db,
+    )
+    assert out == {"n": FAIL_CLOSED_CLASS}
+
+
+def test_a_parameter_confined_to_a_condition_stays_aggregate(
+    populated_db: Database,
+) -> None:
+    """A bound parameter null-tested in a predicate is tested, not returned.
+
+    The twin of ``test_a_parameter_confined_inside_a_count_stays_aggregate``:
+    without the exemption, `COUNT(*) FILTER (WHERE $acct IS NULL)` masks a row
+    count because a placeholder was seen. Placeholders take the identical
+    nullity rule columns do — an equality probe against one is not exempt, so
+    `WHERE last_four = $acct` still classifies from `last_four`.
+    """
+    out = _classes_bound(
+        "SELECT COUNT(*) FILTER (WHERE $acct IS NULL) AS n FROM core.dim_accounts",
+        populated_db,
+        {"acct": DataClass.INSTITUTION_ACCOUNT_NUMBER},
+    )
+    assert out == {"n": DataClass.AGGREGATE}
+
+
+def test_a_parameter_equality_probe_is_not_exempt(populated_db: Database) -> None:
+    """`WHERE <col> = $p` probes the column, so the column still classifies."""
+    out = _classes_bound(
+        "SELECT COUNT(*) FILTER (WHERE last_four = $acct) AS n FROM core.dim_accounts",
+        populated_db,
+        {"acct": DataClass.INSTITUTION_ACCOUNT_NUMBER},
+    )
+    assert out == {"n": DataClass.INSTITUTION_ACCOUNT_NUMBER}
+
+
+def test_a_parameter_in_a_case_result_still_surfaces(
+    populated_db: Database,
+) -> None:
+    """Guards the boundary of the placeholder half: a `THEN` returns the binding."""
+    out = _classes_bound(
+        "SELECT MAX(CASE WHEN account_type = 'checking' THEN $acct ELSE '' END) AS m "
+        "FROM core.dim_accounts",
+        populated_db,
+        {"acct": DataClass.ROUTING_NUMBER},
+    )
+    assert out == {"m": DataClass.ROUTING_NUMBER}
+
+
+# ---------------------------------------------------------------------------
+# A branch can map a predicate's answer back to the value
+#
+# These are the counterexamples that bound the rule above. A `CASE`/`IF` branch
+# chooses a LITERAL, and nothing stops that literal from being the very digit
+# the condition just tested — so "only compared" does not imply "cannot reach
+# the output". Ten branches recover one character; nine such projections
+# concatenated recover a routing number from a single query, at LOW.
+#
+# Nullity is the exception, and the reason is arithmetic rather than taste:
+# `IS NULL` has ONE answer per row per column, so N projections of it return N
+# copies of one bit and compose into nothing. `substr(col, i, 1) = 'd'` tests a
+# different piece of the value each time, which is what makes it amplify.
+# ---------------------------------------------------------------------------
+
+
+def _reconstructing_case(column: str, position: int) -> str:
+    """A CASE whose branches return the digit each branch just matched."""
+    branches = " ".join(
+        f"WHEN substr({column}, {position}, 1) = '{digit}' THEN '{digit}'"
+        for digit in range(10)
+    )
+    return f"CASE {branches} ELSE '?' END"  # noqa: S608  # test input string, not executing SQL
+
+
+def test_a_case_branch_returning_the_tested_literal_still_masks(
+    populated_db: Database,
+) -> None:
+    """The counterexample that bounds the exemption to nullity.
+
+    Every occurrence of `routing_number` sits in a `WHEN` condition, so a rule
+    keyed on position alone empties the column list and answers AGGREGATE — and
+    this projection returns the routing number's first digit in the clear.
+    """
+    out = _classes(
+        f"SELECT {_reconstructing_case('routing_number', 1)} AS d FROM core.dim_accounts",  # noqa: S608  # test input string, not executing SQL
+        populated_db,
+    )
+    assert out == {"d": DataClass.ROUTING_NUMBER}
+    assert derive_query_tier(out) is Tier.CRITICAL
+
+
+def test_a_filtered_aggregate_over_a_literal_still_masks(
+    populated_db: Database,
+) -> None:
+    """The same reconstruction through `FILTER`, with no CASE and no count.
+
+    `MAX('0') FILTER (WHERE …= '0')` is a predicate-to-literal map too, so
+    exempting the FILTER predicate alone reopens the hole a CASE-only fix
+    would close.
+    """
+    arms = ", ".join(
+        f"MAX('{digit}') FILTER (WHERE substr(routing_number, 1, 1) = '{digit}')"
+        for digit in range(10)
+    )
+    out = _classes(
+        f"SELECT account_id, COALESCE({arms}) AS d FROM core.dim_accounts "  # noqa: S608  # test input string, not executing SQL
+        "GROUP BY account_id",
+        populated_db,
+    )
+    assert out["d"] is DataClass.ROUTING_NUMBER
+
+
+def test_a_simple_case_mapping_values_to_literals_still_masks(
+    populated_db: Database,
+) -> None:
+    """The simple-CASE spelling of the same map, through the operand slot."""
+    branches = " ".join(f"WHEN '{digit}' THEN '{digit}'" for digit in range(10))
+    out = _classes(
+        f"SELECT CASE substr(routing_number, 1, 1) {branches} END AS d "  # noqa: S608  # test input string, not executing SQL
+        "FROM core.dim_accounts",
+        populated_db,
+    )
+    assert out == {"d": DataClass.ROUTING_NUMBER}
+
+
+def test_an_equality_condition_does_not_exempt_its_column(
+    populated_db: Database,
+) -> None:
+    """The general boundary, in its smallest form.
+
+    An equality probe answers "is it THIS value" — a different question per
+    literal, so a caller can walk the space. Only a nullity test is capped at
+    one answer, and only nullity is exempt.
+    """
+    out = _classes(
+        "SELECT SUM(CASE WHEN last_four = '5678' THEN 1 ELSE 0 END) AS n "
+        "FROM core.dim_accounts",
+        populated_db,
+    )
+    assert out == {"n": DataClass.INSTITUTION_ACCOUNT_NUMBER}
+
+
+def test_a_null_test_wrapped_in_a_function_is_not_exempt(
+    populated_db: Database,
+) -> None:
+    """The exemption reads the column's OWN parent, not the enclosing condition.
+
+    `COALESCE(routing_number, '') IS NULL` is a nullity test on an expression
+    over the column, not on the column. Its sibling argument can carry the
+    value, so the occurrence stays classified.
+    """
+    out = _classes(
+        "SELECT SUM(CASE WHEN COALESCE(routing_number, '') IS NULL THEN 1 ELSE 0 END) "
+        "AS n FROM core.dim_accounts",
+        populated_db,
+    )
+    assert out == {"n": DataClass.ROUTING_NUMBER}
+
+
+def test_is_not_null_is_exempt_like_is_null(populated_db: Database) -> None:
+    """`IS NOT NULL` is the same single bit, negated — and the same count.
+
+    `COUNT(col)` already returns it, so the two spellings must agree.
+    """
+    out = _classes(
+        "SELECT COUNT(*) FILTER (WHERE last_four IS NOT NULL) AS n "
+        "FROM core.dim_accounts",
+        populated_db,
+    )
+    assert out == {"n": DataClass.AGGREGATE}
+
+
+def test_a_null_test_on_a_derived_alias_is_not_exempt(
+    populated_db: Database,
+) -> None:
+    """An alias can name an EXPRESSION, and then `IS NULL` is not a nullity test.
+
+    `NULLIF(substr(routing_number, 1, 1), '0')` is NULL exactly when the first
+    digit is '0', so testing the alias asks an EQUALITY wearing nullity's
+    clothes. The cap the exemption rests on is one answer per row per *column*;
+    an alias over an expression has one answer per row per *literal the author
+    chose*, and ninety such projections recover the whole number from one query.
+
+    So the exemption additionally requires the tested occurrence to resolve
+    against the catalog. A CTE or derived-table alias never does — it resolves
+    inside its source scope, where this projection is `ROUTING_NUMBER`.
+    """
+    out = _classes(
+        "WITH t AS (SELECT NULLIF(substr(routing_number, 1, 1), '0') AS d "
+        "FROM core.dim_accounts) "
+        "SELECT SUM(CASE WHEN d IS NULL THEN 1 ELSE 0 END) AS n FROM t",
+        populated_db,
+    )
+    assert out == {"n": DataClass.ROUTING_NUMBER}
+    assert derive_query_tier(out) is Tier.CRITICAL
+
+
+def test_a_null_test_on_a_derived_table_alias_is_not_exempt(
+    populated_db: Database,
+) -> None:
+    """The same smuggling without a WITH — the alias arrives from a subquery.
+
+    Pins that the rule keys on "this occurrence resolves against the catalog",
+    not on the syntax that introduced the name.
+    """
+    out = _classes(
+        "SELECT COUNT(*) FILTER (WHERE d IS NULL) AS n FROM "
+        "(SELECT NULLIF(substr(routing_number, 1, 1), '0') AS d "
+        "FROM core.dim_accounts)",
+        populated_db,
+    )
+    assert out == {"n": DataClass.ROUTING_NUMBER}
+    assert derive_query_tier(out) is Tier.CRITICAL
+
+
+def test_a_null_test_on_an_unresolvable_alias_takes_the_floor(
+    populated_db: Database,
+) -> None:
+    """An occurrence lineage cannot resolve must reach the floor, not AGGREGATE.
+
+    The twin of the leak above, in the form that bites hardest: dropping the
+    column before resolving it empties the column list, and the empty-list
+    branch reads that emptiness as a positive finding. It is only positive when
+    the occurrence was checked and found to be a base column — here the chain
+    exhausts ``_MAX_SCOPE_DEPTH`` and nothing was established at all, so the
+    plain projection's UNRESOLVED must survive the null test being applied to it.
+    """
+    sql = _with_query(
+        _routing_chain_ctes(_MAX_SCOPE_DEPTH + 4),
+        f"SELECT SUM(CASE WHEN v IS NULL THEN 1 ELSE 0 END) AS n FROM c{_MAX_SCOPE_DEPTH + 4}",  # noqa: S608  # test input string, not executing SQL
+    )
+
+    out = _classes(sql, populated_db)
+
+    assert out["n"] is DataClass.UNRESOLVED
+    assert derive_query_tier(out) is Tier.CRITICAL
+
+
+# ---------------------------------------------------------------------------
 # The counting aggregate must not outrank the opaque-node veto
 #
 # The counting-aggregate collapse governs a projection only when EVERY column

--- a/tests/privacy/test_sql_query.py
+++ b/tests/privacy/test_sql_query.py
@@ -1885,6 +1885,43 @@ def test_a_null_test_on_an_aliased_expression_cannot_reconstruct_a_value(
     assert set(result.records[0].values()) == {"*****"}
 
 
+def test_an_unpivot_value_column_cannot_reconstruct_a_value(
+    populated_db: Database,
+) -> None:
+    """The same reconstruction reached through a pivot, at the caller's boundary.
+
+    An ``UNPIVOT`` generates its value column, and its name is the author's to
+    pick: listing the real ``last_four`` among the arms frees that name, so the
+    generated column both answers to a catalog name and holds whatever
+    expression each arm supplies. One row per arm then carries one bit about a
+    literal the author chose, and ``ORDER BY`` puts them in his order.
+
+    The tier alone would not catch a regression, because the leak's whole point
+    is that each arm comes back individually. So this asserts on the rows the
+    caller receives, and on the ground truth that makes them a leak: the base
+    profile's routing number starts with the digit the unmasked shape reports.
+    """
+    _seed_account(populated_db)
+    arms = ", ".join(
+        f"NULLIF(substr(routing_number, 1, 1), '{digit}') AS d{digit}"
+        for digit in range(10)
+    )
+    result = execute_sql_query(
+        populated_db,
+        "SELECT COUNT(*) FILTER (WHERE last_four IS NULL) AS c "  # noqa: S608  # test input string, not executing SQL
+        "FROM core.dim_accounts "
+        f"UNPIVOT INCLUDE NULLS (last_four FOR arm IN (last_four, {arms})) "
+        "GROUP BY arm ORDER BY arm",
+        max_rows=100,
+    )
+
+    assert result.tier is Tier.CRITICAL
+    # The security property, not the mask's spelling: every arm must come back
+    # indistinguishable from every other, so no row carries a bit.
+    assert len(result.records) == 11
+    assert len({record["c"] for record in result.records}) == 1
+
+
 # --------------------------------------------------------------------------
 # CRITICAL transforms are not interchangeable
 #

--- a/tests/privacy/test_sql_query.py
+++ b/tests/privacy/test_sql_query.py
@@ -1787,6 +1787,104 @@ def test_unresolvable_expression_does_not_over_mask(populated_db: Database) -> N
     assert result.tier is Tier.LOW
 
 
+def test_count_of_null_last_fours_returns_the_integer(
+    populated_db: Database,
+) -> None:
+    """MB-102's reported symptom, at the boundary the agent actually calls.
+
+    The lineage tests pin the class; this pins the VALUE. What came back was
+    ``'*****'`` where the number is 1 — an integer count that cannot carry a
+    digit of ``last_four``, withheld because lineage saw the column name.
+    """
+    _seed_account(populated_db)
+    result = execute_sql_query(
+        populated_db,
+        "SELECT SUM(CASE WHEN last_four IS NULL THEN 1 ELSE 0 END) AS n "
+        "FROM core.dim_accounts",
+        max_rows=100,
+    )
+    assert result.records[0]["n"] == 1
+    assert result.tier is Tier.LOW
+
+
+def test_a_relocated_predicate_returns_what_its_where_clause_twin_returns(
+    populated_db: Database,
+) -> None:
+    """Both spellings of one question must return one answer.
+
+    ``COUNT(*) FILTER (WHERE …)`` and ``COUNT(*) … WHERE …`` are the same count
+    over the same rows. The WHERE form has always returned it; the FILTER form
+    returning ``'*****'`` is what made the surface answer differently depending
+    on how the agent phrased itself.
+    """
+    _seed_account(populated_db, last_four="1234")
+    relocated = execute_sql_query(
+        populated_db,
+        "SELECT COUNT(*) FILTER (WHERE last_four IS NULL) AS n FROM core.dim_accounts",
+        max_rows=100,
+    )
+    in_where = execute_sql_query(
+        populated_db,
+        "SELECT COUNT(*) AS n FROM core.dim_accounts WHERE last_four IS NULL",
+        max_rows=100,
+    )
+    assert relocated.records == in_where.records == [{"n": 0}]
+    assert relocated.tier is in_where.tier is Tier.LOW
+
+
+def test_a_critical_column_returned_by_a_case_branch_is_still_masked(
+    populated_db: Database,
+) -> None:
+    """The value-position boundary, at the same boundary — masked, not counted.
+
+    One CASE, one slot over from the test above, and the account number itself
+    is the result. A rule that exempted the whole CASE would publish it.
+    """
+    _seed_account(populated_db)
+    result = execute_sql_query(
+        populated_db,
+        "SELECT MAX(CASE WHEN account_type = 'checking' THEN routing_number END) AS m "
+        "FROM core.dim_accounts",
+        max_rows=100,
+    )
+    assert result.records[0]["m"] == "*****"
+    assert result.tier is Tier.CRITICAL
+
+
+def test_a_null_test_on_an_aliased_expression_cannot_reconstruct_a_value(
+    populated_db: Database,
+) -> None:
+    """The reconstruction attempt itself, at the boundary that has to stop it.
+
+    `NULLIF(substr(routing_number, n, 1), 'd')` is NULL exactly when digit `n`
+    is `d`, so a null test on the alias is an equality oracle wearing nullity's
+    spelling. Ten arms identify one character and nine such groups recover the
+    whole number — the exact shape the nullity narrowing was meant to close,
+    reached one alias indirection away.
+
+    Asserting the tier alone would not catch a regression here, because the
+    leak's whole point is that the ARMS come back true or false individually.
+    So this asserts on what the caller actually receives.
+    """
+    _seed_account(populated_db)
+    arms = ", ".join(
+        f"NULLIF(substr(routing_number, 1, 1), '{digit}') AS d{digit}"
+        for digit in range(10)
+    )
+    probes = ", ".join(
+        f"CASE WHEN d{digit} IS NULL THEN 1 ELSE 0 END AS is{digit}"
+        for digit in range(10)
+    )
+    result = execute_sql_query(
+        populated_db,
+        f"WITH t AS (SELECT {arms} FROM core.dim_accounts) SELECT {probes} FROM t",  # noqa: S608  # test input string, not executing SQL
+        max_rows=100,
+    )
+
+    assert result.tier is Tier.CRITICAL
+    assert set(result.records[0].values()) == {"*****"}
+
+
 # --------------------------------------------------------------------------
 # CRITICAL transforms are not interchangeable
 #


### PR DESCRIPTION
## Summary

The agent-safe SQL surface (`sql_query`, `moneybin sql query`) classifies every projection a query returns and masks the ones whose lineage reaches a CRITICAL column. That resolver reads the projection expression as a whole, so a column mentioned anywhere inside it — including inside a condition that only ever asks whether the column is NULL — pushed the output to CRITICAL. Counting rows with a missing last four therefore came back `*****` instead of a number.

That mattered because the same number was already answerable. `COUNT(col)` collapses to a plain aggregate, so `SELECT COUNT(*) - COUNT(last_four)` has always returned it unmasked. Two other spellings of the identical question did not: `SUM(CASE WHEN last_four IS NULL THEN 1 ELSE 0 END)` and `COUNT(*) FILTER (WHERE last_four IS NULL)`. A data-completeness check was answerable only when phrased one particular way, and an agent that wrote either of the natural spellings read the masked result as "the data is unavailable" rather than "ask differently."

A column occurrence now contributes no class when it satisfies **both** halves of a guard: it is the operand of an `IS NULL` / `IS NOT NULL` test sitting inside a condition slot — the `FILTER (WHERE …)` predicate, a `CASE WHEN` / `IF` branch condition, or a simple-`CASE` operand — **and** it resolves, at that point, to a catalog column carrying a known class. Both reported spellings return the count, and the `WHERE`-clause form of the same predicate now classifies the way its relocated twin does.

The exemption is deliberately narrower than "a column used only in a condition," and the reason is a cap rather than a preference. `IS NULL` has exactly one answer per row per base column, so forty projections of it return forty copies of one bit. A comparison has no such cap: each literal interrogates a different piece of the value, and a `CASE` branch may return the literal it just matched, so a per-character `CASE` over `substr(col, n, 1)` recovers one character and enough concatenated projections recover the whole value from a single query. `MAX(<literal>) FILTER (WHERE substr(col, n, 1) = <literal>)` does the same with no `CASE` at all, and the simple-`CASE` operand slot does it too. Comparisons are therefore unchanged and still mask, as do value positions: `MAX(CASE WHEN … THEN col END)`, `SUM(CAST(col AS INT))`, and `MAX(col) FILTER (WHERE …)`.

"Base column" is the load-bearing half of the guard, not a formality, and position alone does not establish it. An alias names an arbitrary expression, so `NULLIF(substr(col, 1, 1), '0') AS d` makes `d IS NULL` an equality probe wearing nullity's spelling — one bit per literal the author chose rather than one per column, which is the same reconstruction reached one indirection away. Resolving before dropping also keeps an unresolvable reference reaching the conservative fallback: an alias chained past `_MAX_SCOPE_DEPTH` answered `AGGREGATE` where the same projection without the null test answered `UNRESOLVED`. An occurrence that resolves inside a CTE or derived-table scope, that lineage cannot name at all, or whose key carries no class is therefore not exempt.

A `PIVOT` / `UNPIVOT` generates the name as well as the value, and that is the same defect through a third door — found by review on this branch. A pivot's output columns are computed by DuckDB at execution time, so the catalog cannot say what one holds, only what its name would mean if the name were the catalog's. `UNPIVOT` lets the author name the generated value column *and* choose every arm feeding it; listing the real `last_four` among the arms frees the bare name, because the pivot consumes that column and DuckDB stops disambiguating the collision to `last_four_1`. The generated column then resolves against the catalog, its scope is no CTE, and every check above passes — while each row holds whichever expression the author wrote. Ten arms recover a digit; it returned one at LOW before the fix. So a pivot anywhere in the occurrence's scope now declines the exemption, deliberately including the honest `IN (last_four, account_id)` form: deciding case by case means re-deriving each pivot output's provenance, where a wrong answer is a value leak while a wrong answer the other way is only an over-mask. That is the position the resolver already takes for the `Star` a pivot source stops `qualify()` from expanding.

The cap has one exception, and it is documented rather than closed. An outer join null-extends its optional side, so a column read from there is a genuine catalog column whose NULLness reports the `ON` predicate the author wrote — ninety arms of `COUNT(*) FILTER (WHERE j.col IS NULL)` over ten-per-position `LEFT JOIN`s recover a value at LOW. That is not specific to this rule. The shipped counting-aggregate collapse has it identically: `COUNT(j.account_id)` over the same joins returns the same ninety bits, with no `IS NULL` anywhere, and has done since long before this ticket — `COUNT(col)` counts non-NULLs, which is the same one bit per row in another spelling. Closing it for the newer spelling alone would leave two behaviours for one question, so it is filed against both as [MB-179](https://linear.app/moneybin/issue/MB-179/sql-query-an-outer-join-breaks-the-one-bit-cap-behind-both-aggregate) and every place that states the cap now names this exception instead of claiming it cannot happen.

Two further properties bound it. The test is read from each occurrence's own parent, so a column both tested and returned still masks, and `COALESCE(col, '') IS NULL` — a null test on an expression over the column, whose sibling argument can carry the value — is not exempt. And a condition slot must lie between the test and the output, so a bare `SELECT col IS NULL` keeps its class.

Resolves [MB-102 — `sql_query` masks a count whose lineage traces to a critical column](https://linear.app/moneybin/issue/MB-102/sql-query-masks-a-count-whose-lineage-traces-to-a-critical-column).

Three adjacent defects surfaced during review and are deliberately out of scope, each filed with a runnable reproduction. [MB-177](https://linear.app/moneybin/issue/MB-177/sql-query-predicate-positions-are-an-unguarded-oracle-on-critical) — this classifier inspects projections only and never predicates, so `WHERE` / `HAVING` / `JOIN ON` / `ORDER BY` conditions over a CRITICAL column are an unguarded oracle at LOW, on `main` today and unchanged here; it needs a threat-model decision rather than a bug fix. [MB-178](https://linear.app/moneybin/issue/MB-178/sql-query-a-valuesunnest-alias-named-after-a-catalog-table-returns-a) — a `VALUES` or `UNNEST` source aliased with a catalog table's name and read from a correlated subquery returns a CRITICAL value verbatim at LOW; also present on `main`, and the reproduction contains no `IS NULL`, so this rule cannot fire on it. [MB-179](https://linear.app/moneybin/issue/MB-179/sql-query-an-outer-join-breaks-the-one-bit-cap-behind-both-aggregate) — the outer-join exception described above, filed against both aggregate-collapse rules.

## Test plan

Verified at `cc1c29b4`.

Local, all green: `uv run pyright` (0 errors, 3 pre-existing `reportMissingModuleSource` warnings for `reportlab` in a PDF fixture builder), `make test` (11,105 passed, 4 pre-existing skips), `make test-integration` (592 passed), and `make check` via the pre-commit hooks on each commit. CI was green on the previous head; this push re-runs it.

New coverage sits in three places. `tests/privacy/test_sql_lineage.py` pins the rule at the resolver — seven cases that must now classify as `AGGREGATE` (both reported spellings, the relocated-predicate twin, `IS NOT NULL`, a condition inside a window frame, a null test sitting in the simple-`CASE` operand slot, and a parameter confined to a condition), and nineteen that must still classify CRITICAL. `tests/privacy/test_sql_query.py` adds five cases at the `execute_sql_query` boundary, so the assertion is on the rows the caller actually receives and their tier rather than on an intermediate classification. `tests/privacy/fixtures/sql_lineage_corpus.yaml` gains the nullity case beside the existing equality one, which is left untouched.

The masking cases are leak regressions, not decoration, and each was found by an adversarial review round rather than written speculatively. An early iteration exempted any column appearing in a condition slot, and was demonstrated to return a full protected value at LOW through a per-character `CASE`, through the `FILTER` predicate, and through the simple-`CASE` operand. Narrowing to nullity closed those three and reopened the channel one alias away, through `NULLIF(...)` in a CTE or derived table; the same defect also let an occurrence past `_MAX_SCOPE_DEPTH` fail open from `UNRESOLVED` to `AGGREGATE`. Both iterations were corrected before this branch was pushed, and all of those shapes are now tests, along with the equality probe, a value in a `THEN`, a value in an `ELSE`, a cast inside the aggregate, a bare projected comparison, a column in both a condition and a value position, a null test wrapped in a function, an opaque node inside a condition, and both pivot shapes.

Each exemption test was written first and watched fail against the old classifier, the pivot pair included: both returned `AGGREGATE`, and the end-to-end pivot case returned tier LOW with the arms individually readable. The masking tests are guards rather than red-first tests — the base classifier masks those shapes too, so disabling the new rule leaves them green and proves nothing. The mutation that exercises them is widening, so each was proved that way: with the base-column half of the guard forced to always pass, the three alias tests and the end-to-end reconstruction test all fail, and with the whole rule widened to any condition slot, the reconstruction and equality-probe cases return LOW. The remaining value-position cases mask under every variant and stand as guards against a future widening.

Behavior was also checked end to end through `execute_sql_query` on a synthetic profile. The two ticket spellings, the `WHERE` twin, `COUNT(*) - COUNT(last_four)`, `IS NOT NULL`, and a windowed condition return LOW; an equality probe, a value in a `THEN`, a cast inside the aggregate, a bare boolean projection, and a ten-arm `NULLIF` reconstruction through a CTE all return CRITICAL with every value masked.

No report changed classification, and `test_generated_classes_are_current` passes unchanged. Two report definitions briefly needed their `class_downgrades` waivers removed under the earlier, broader rule; those columns threshold on comparisons rather than nullity, so they are untouched here.

Every entry in `_CONDITION_SLOTS` is now individually mutation-proved: removing any one of the three fails at least one test, and the `Case.this` entry failed none until this branch added the case it actually reaches (a NULL test *sitting in* the simple-`CASE` operand slot, which is not the same thing as a simple-`CASE` operand — a bare `CASE col WHEN …` is correctly still masked).

Known gaps, by decision and not by oversight: the three defects filed as MB-177, MB-178 and MB-179 are not covered by this change or its tests. MB-179 in particular is deliberately un-tested here — a test asserting today's behaviour would have to be deleted by the change that fixes it.
