### PR TITLE
Scope categorization coverage to the transactions needing a category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   column or manual entry carried category text of its own, so the breakdown
   still sums to `categorized`. `transactions list --uncategorized` deliberately
   does not move: it means "MoneyBin never decided this one", which is the only
-  way to find those source-supplied labels.
+  way to find those source-supplied labels. (#563)
 - **`moneybin refresh` says what each pipeline step did.** A run that changed
   nothing and a run that recategorized 400 transactions both printed a single
   `✅ Refresh complete in 4.2s`, because the counts each step computed went to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **Categorization coverage counts the work you can actually do.** `moneybin
+  transactions categorize stats`, MCP `transactions_categorize_stats`, and the
+  `categorization_coverage` doctor check each derived their own "uncategorized"
+  figure, and none of them matched the one `moneybin review` hands you. Stats
+  counted every transaction in the ledger against every row in
+  `app.transaction_categories` — including transfer legs nobody is asked to
+  categorize, archived accounts nobody maintains, and categorizations orphaned
+  from transactions that no longer exist. Doctor counted a third population,
+  excluding transfer legs but not archived accounts. All of them now read the
+  population `core.uncategorized_queue` is drawn from, so the percentage
+  measures a backlog you can act on and every surface reports the same size for
+  it.
+
+  **The numbers move.** A ledger whose transfer legs and closed accounts made up
+  much of its "uncategorized" count will report a smaller backlog and a higher
+  percentage than before — the same data, described as work rather than as rows.
+  `total_transactions` in the MCP payload is now the size of that population
+  rather than a count of all transactions; the field name is unchanged, and its
+  description says so. `by_source` moves with it and gains a `source_supplied`
+  bucket for transactions that count as categorized only because their CSV
+  column or manual entry carried category text of its own, so the breakdown
+  still sums to `categorized`. `transactions list --uncategorized` deliberately
+  does not move: it means "MoneyBin never decided this one", which is the only
+  way to find those source-supplied labels.
 - **`moneybin refresh` says what each pipeline step did.** A run that changed
   nothing and a run that recategorized 400 transactions both printed a single
   `✅ Refresh complete in 4.2s`, because the counts each step computed went to

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -144,7 +144,7 @@ The display name is institution, account type, and last four. The account-number
 ```console
 $ uv run moneybin system doctor
 Using profile: personal
-⚠️  categorization_coverage — 100% of non-transfer transactions are uncategorized
+⚠️  categorization_coverage — 100% of the transactions needing a category are uncategorized
    💡 [suggested] transactions_categorize_run(methods=['rules', 'merchants']) — Run the deterministic categorization cascade (rules + merchants) to raise coverage above the 50% threshold. Suggested (not certain) because the cascade applies 0 rows when no active rules or merchant mappings match the remaining uncategorized transactions — re-run the doctor after to verify.
 
 61 invariants checked across 20 transactions — 60 passing, 1 warn, 0 skipped

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -175,7 +175,7 @@ What it audits, via `DoctorService`:
 - **SQLMesh named audits** attached to core models — FK integrity and sign convention on `core.fct_transactions`, the same two plus uniqueness on `core.fct_investment_transactions`, and transfer-pair balance on `core.bridge_transfers`.
 - **Transform model presence** — the SQLMesh models the pipeline expects are materialized.
 - **Dedup reconciliation** and **cross-source duplicates** — duplicate account overlap, plus cross-source duplicate transactions that have no merge proposal.
-- **Categorization coverage** — share of transactions with a category assigned. Warns (not fails) when under 50% of non-transfer rows are categorized.
+- **Categorization coverage** — share of the transactions that need a category that have one. Scoped to the population `core.uncategorized_queue` is drawn from, so transfer legs and archived accounts are out. Warns (not fails) when under 50%.
 - **Currency integrity** — profile currencies and rows carrying an unknown currency.
 - **Protected `app.*` audit coverage** — one check per repository-wrapped table (`user_categories`, `categorization_rules`, `account_settings`, `balance_assertions`, `imports`, and the rest), verifying every mutation left an audit-log row. Sampled over recent rows by default; `--full` scans the whole table.
 - **Orphaned app state** — `app.*` rows pointing at accounts, categories, or transactions that no longer exist.

--- a/docs/specs/moneybin-doctor.md
+++ b/docs/specs/moneybin-doctor.md
@@ -101,7 +101,7 @@ The `account_id` scoping is load-bearing in both. A source-native id is unique o
 
 Remedy: `moneybin refresh --step match --step transform` proposes the pairs and reflects any auto-merges into the ledger; `moneybin review --type matches` decides the rest. An accepted account-link merge now re-runs matching automatically (`AccountLinksService.rematch_after_merge()`), so this check should only fire on ledgers whose merges predate that behavior, or where a match pass failed.
 
-**`categorization_coverage`** — What percentage of non-transfer transactions have a category. Status is `warn` (not `fail`) when below 50%; `pass` otherwise. Never blocks exit 0 on its own.
+**`categorization_coverage`** — What percentage of the transactions that need a category have one. The population is the one `core.uncategorized_queue` is drawn from — confirmed transfer legs, archived accounts, and transactions whose account never resolved are excluded — so the ratio measures work `moneybin review` will actually offer, and it agrees with `moneybin transactions categorize stats`. Status is `warn` (not `fail`) when below 50%; `pass` otherwise. Never blocks exit 0 on its own.
 
 ### Investment reconciliation (M1G.4)
 
@@ -274,7 +274,7 @@ moneybin system doctor [--verbose] [--output text|json]
 ✅ fct_transactions_sign_convention
 ❌ bridge_transfers_balanced — 2 violation(s)
    Run with --verbose for affected pair IDs
-⚠️  categorization_coverage — 43% of non-transfer transactions are uncategorized
+⚠️  categorization_coverage — 43% of the transactions needing a category are uncategorized
 ✅ dedup_reconciliation
 
 5 invariants checked across 14,203 transactions — 1 failing
@@ -300,7 +300,7 @@ With `--verbose`, affected IDs appear under each failing line:
       {"name": "fct_transactions_fk_integrity", "status": "pass", "detail": null, "affected_ids": []},
       {"name": "fct_transactions_sign_convention", "status": "pass", "detail": null, "affected_ids": []},
       {"name": "bridge_transfers_balanced", "status": "fail", "detail": "2 violation(s)", "affected_ids": []},
-      {"name": "categorization_coverage", "status": "warn", "detail": "43% of non-transfer transactions are uncategorized", "affected_ids": []},
+      {"name": "categorization_coverage", "status": "warn", "detail": "43% of the transactions needing a category are uncategorized", "affected_ids": []},
       {"name": "dedup_reconciliation", "status": "pass", "detail": null, "affected_ids": []}
     ]
   },

--- a/src/moneybin/cli/commands/transactions/categorize/__init__.py
+++ b/src/moneybin/cli/commands/transactions/categorize/__init__.py
@@ -477,8 +477,13 @@ def stats(
         )
         return
 
-    logger.info("Categorization coverage:")
-    logger.info(f"  Total transactions:   {coverage.total}")
+    # The scope belongs in the header, not left for the reader to infer from a
+    # total that no longer counts every transaction: these figures cover what
+    # `moneybin review` will offer, so transfer legs and archived accounts are
+    # out. Without it "Transactions" reads as the whole ledger and the number
+    # looks wrong.
+    logger.info("Categorization coverage (excludes transfers, archived accounts):")
+    logger.info(f"  Transactions:         {coverage.total}")
     logger.info(
         f"  Categorized:          {coverage.categorized} "
         f"({coverage.percent_categorized:.1f}%)"

--- a/src/moneybin/cli/commands/transactions/categorize/__init__.py
+++ b/src/moneybin/cli/commands/transactions/categorize/__init__.py
@@ -482,7 +482,10 @@ def stats(
     # `moneybin review` will offer, so transfer legs and archived accounts are
     # out. Without it "Transactions" reads as the whole ledger and the number
     # looks wrong.
-    logger.info("Categorization coverage (excludes transfers, archived accounts):")
+    logger.info(
+        "Categorization coverage (excludes transfers, archived and "
+        "unresolved accounts):"
+    )
     logger.info(f"  Transactions:         {coverage.total}")
     logger.info(
         f"  Categorized:          {coverage.categorized} "

--- a/src/moneybin/mcp/tools/transactions_categorize.py
+++ b/src/moneybin/mcp/tools/transactions_categorize.py
@@ -334,13 +334,24 @@ def transactions_categorize_stats(
     category-source-bridge mapping yet (omitted when no Plaid data is
     present).
 
+    Every figure covers the transactions that need categorizing, not the whole
+    ledger: confirmed transfer legs, archived accounts, and transactions whose
+    account never resolved are excluded, matching core.uncategorized_queue. So
+    ``total_transactions`` is the size of that population rather than a count
+    of all transactions, ``uncategorized`` equals what reviews(kind=
+    'categorization') will hand back, and the three reconcile
+    (total = categorized + uncategorized).
+
     The source breakdown carries one bucket per persisted ``categorized_by``
     value (``user``, ``rule``, ``auto_rule``, ``migration``, ``ml``,
-    ``provider_native``, ``ai``) plus a reporting-only ``merchant_map``
-    bucket: rows written via merchant-pattern matching are split out of
-    ``rule`` here so the count reconciles with transactions_categorize_rules'
-    rule list, but the persisted ``categorized_by`` value on those rows is
-    still ``rule``.
+    ``provider_native``, ``ai``) plus two reporting-only buckets, and sums to
+    ``categorized``. Rows written via merchant-pattern matching are split out
+    of ``rule`` into ``merchant_map`` so the count reconciles with
+    transactions_categorize_rules' rule list, though the persisted
+    ``categorized_by`` value on those rows is still ``rule``. Rows counted as
+    categorized only because their source file supplied category text of its
+    own — a CSV column, a manual entry — have no ``categorized_by`` at all and
+    fall in ``source_supplied``; nobody confirmed those inside MoneyBin.
 
     Args:
         include_auto: When True, also return auto-rule health metrics

--- a/src/moneybin/mcp/tools/transactions_categorize.py
+++ b/src/moneybin/mcp/tools/transactions_categorize.py
@@ -334,13 +334,21 @@ def transactions_categorize_stats(
     category-source-bridge mapping yet (omitted when no Plaid data is
     present).
 
-    Every figure covers the transactions that need categorizing, not the whole
-    ledger: confirmed transfer legs, archived accounts, and transactions whose
-    account never resolved are excluded, matching core.uncategorized_queue. So
+    The coverage figures — everything except ``plaid_unmapped`` — cover the
+    transactions that need categorizing, not the whole ledger: confirmed
+    transfer legs, archived accounts, and transactions whose account never
+    resolved are excluded, matching core.uncategorized_queue. So
     ``total_transactions`` is the size of that population rather than a count
     of all transactions, ``uncategorized`` equals what reviews(kind=
     'categorization') will hand back, and the three reconcile
     (total = categorized + uncategorized).
+
+    ``plaid_unmapped`` is deliberately ledger-wide and sits outside that
+    reconciliation. It measures the category bridge, not this user's backlog —
+    whether a PFC code has a mapping does not depend on the transaction being
+    archived or a transfer leg — so it may legitimately exceed
+    ``total_transactions``. Do not subtract or compare it against the coverage
+    figures.
 
     The source breakdown carries one bucket per persisted ``categorized_by``
     value (``user``, ``rule``, ``auto_rule``, ``migration``, ``ml``,

--- a/src/moneybin/privacy/payloads/categorize.py
+++ b/src/moneybin/privacy/payloads/categorize.py
@@ -155,7 +155,13 @@ CategorizationRulesCoarsePayload = (
 
 @dataclass(frozen=True, slots=True)
 class CategorizeStatsPayload:
-    """Payload for transactions_categorize_stats — aggregate counts only."""
+    """Payload for transactions_categorize_stats — aggregate counts only.
+
+    Every count covers the population core.uncategorized_queue is drawn from,
+    so ``total_transactions`` is how many transactions need a category, not how
+    many exist. The three counts reconcile and ``by_source`` sums to
+    ``categorized``.
+    """
 
     total_transactions: Annotated[int, DataClass.AGGREGATE]
     categorized: Annotated[int, DataClass.AGGREGATE]

--- a/src/moneybin/privacy/payloads/categorize.py
+++ b/src/moneybin/privacy/payloads/categorize.py
@@ -157,10 +157,20 @@ CategorizationRulesCoarsePayload = (
 class CategorizeStatsPayload:
     """Payload for transactions_categorize_stats — aggregate counts only.
 
-    Every count covers the population core.uncategorized_queue is drawn from,
-    so ``total_transactions`` is how many transactions need a category, not how
+    The coverage counts — ``total_transactions``, ``categorized``,
+    ``uncategorized``, ``percent_categorized``, ``by_source`` — cover the
+    population core.uncategorized_queue is drawn from, so
+    ``total_transactions`` is how many transactions need a category, not how
     many exist. The three counts reconcile and ``by_source`` sums to
     ``categorized``.
+
+    ``plaid_unmapped`` is outside that reconciliation and is ledger-wide by
+    design. It counts Plaid rows whose category code has no bridge mapping,
+    which measures the bridge rather than this user's backlog: whether a code
+    is covered does not depend on the transaction sitting on an archived
+    account or being half of a transfer. So it can exceed
+    ``total_transactions``, and a reader must not subtract it from anything
+    here.
     """
 
     total_transactions: Annotated[int, DataClass.AGGREGATE]

--- a/src/moneybin/services/categorization/__init__.py
+++ b/src/moneybin/services/categorization/__init__.py
@@ -159,6 +159,7 @@ from moneybin.services.categorization.orchestrator import (
     CategorizationResult,
 )
 from moneybin.services.categorization.queries import (
+    CategorizationCoverage,
     CategorizationQueries,
     CategorizationStats,
 )
@@ -811,6 +812,10 @@ class CategorizationService:
     def count_uncategorized(self) -> int:
         """Return the size of the canonical ``core.uncategorized_queue``."""
         return self._queries.count_uncategorized()
+
+    def coverage(self) -> CategorizationCoverage:
+        """Count what needs categorizing, and how much of it already is."""
+        return self._queries.coverage()
 
     def categorization_stats(self) -> dict[str, int | float]:
         """Get summary statistics about categorization coverage."""

--- a/src/moneybin/services/categorization/queries.py
+++ b/src/moneybin/services/categorization/queries.py
@@ -595,7 +595,15 @@ class CategorizationQueries:
 
         # Plaid coverage gap (Tier-2b observability): count Plaid transactions
         # carrying a PFC code with no bridge mapping — the long-tail codes the
-        # two-tier bridge doesn't cover. Reads prep.stg_plaid__transactions (one
+        # two-tier bridge doesn't cover.
+        #
+        # Deliberately NOT scoped to _CATEGORIZABLE_POPULATION like everything
+        # above it. This measures the bridge, not the user's backlog, and a
+        # code's coverage does not depend on the transaction sitting on an
+        # archived account or being half of a transfer — narrowing it would
+        # under-report the gap and answer a question nobody asked. It can
+        # therefore exceed `total`, which is why both payload docstrings carve
+        # it out of their reconciliation claim rather than restating it. Reads prep.stg_plaid__transactions (one
         # row per Plaid transaction) — the natural grain for a per-transaction
         # coverage count, and a light view over the raw.plaid table rather than
         # the heavy multi-source int_transactions__merged pipeline (a stats call

--- a/src/moneybin/services/categorization/queries.py
+++ b/src/moneybin/services/categorization/queries.py
@@ -37,6 +37,7 @@ from moneybin.tables import (
     CATEGORIES,
     CATEGORIZATION_RULES,
     CORE_UNCATEGORIZED_QUEUE,
+    DIM_ACCOUNTS,
     FCT_TRANSACTIONS,
     INT_TRANSACTIONS_MATCHED,
     MATCH_DECISIONS,
@@ -46,6 +47,39 @@ from moneybin.tables import (
 )
 
 logger = logging.getLogger(__name__)
+
+# The population core.uncategorized_queue is drawn from, minus its own
+# `category IS NULL` filter: not a confirmed transfer leg, on an account that
+# is not archived, and resolving to a real account — the queue INNER JOINs
+# dim_accounts, so a transaction whose account_id never resolved is absent from
+# it and must be absent from any denominator compared against it.
+#
+# Repeated here rather than read off the view because the view holds only the
+# uncategorized rows and a coverage denominator needs the ones it filtered out.
+# The clauses are the view's, character for character, and
+# test_uncategorized_matches_the_canonical_queue builds that view from the
+# shipped model file and compares the two counts — so a divergence fails a test
+# instead of quietly publishing a coverage figure the review queue contradicts.
+_CATEGORIZABLE_POPULATION = f"""
+FROM {FCT_TRANSACTIONS.full_name} AS t
+INNER JOIN {DIM_ACCOUNTS.full_name} AS a
+  ON t.account_id = a.account_id
+WHERE NOT t.is_transfer AND NOT a.archived
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class CategorizationCoverage:
+    """How much of the work the review queue implies has been done.
+
+    ``categorizable`` is the whole population; the other two partition it, so
+    the three always reconcile. ``uncategorized`` is what ``moneybin review``
+    will actually hand the user.
+    """
+
+    categorizable: int
+    categorized: int
+    uncategorized: int
 
 
 @dataclass(slots=True)
@@ -453,18 +487,47 @@ class CategorizationQueries:
         except Exception:  # noqa: BLE001 — the view is absent before first refresh
             return 0
 
+    def coverage(self) -> CategorizationCoverage:
+        """Count what needs categorizing, and how much of it already is.
+
+        Scoped to :data:`_CATEGORIZABLE_POPULATION` — a coverage figure over
+        rows nobody is ever asked to categorize describes no work. A category
+        counts however it arrived: a row whose source file supplied its own
+        category text is one ``moneybin review`` skips, so coverage has to
+        agree that it is done.
+
+        Raises:
+            duckdb.CatalogException: the core layer is not built yet. Callers
+                decide whether that means "nothing to report" or "cannot
+                check" — the two surfaces here answer differently.
+        """
+        row = self._db.execute(
+            f"""
+            SELECT
+                COUNT(*) AS categorizable,
+                COUNT(*) FILTER (WHERE t.category IS NULL) AS uncategorized
+            {_CATEGORIZABLE_POPULATION}
+            """  # noqa: S608  # TableRef constants, no user input interpolated
+        ).fetchone()
+        categorizable = int(row[0]) if row else 0
+        uncategorized = int(row[1]) if row else 0
+        return CategorizationCoverage(
+            categorizable=categorizable,
+            categorized=categorizable - uncategorized,
+            uncategorized=uncategorized,
+        )
+
     def categorization_stats(self) -> dict[str, int | float]:
         """Get summary statistics about categorization coverage.
 
         Returns:
             Dict with total, categorized, uncategorized counts and
-            breakdown by categorized_by source.
+            breakdown by categorized_by source. All of them describe the
+            population that needs categorizing, not the whole ledger — see
+            :meth:`coverage`.
         """
         try:
-            total_result = self._db.execute(
-                f"SELECT COUNT(*) FROM {FCT_TRANSACTIONS.full_name}"
-            ).fetchone()
-            total = total_result[0] if total_result else 0
+            counts = self.coverage()
         except duckdb.CatalogException:
             return {
                 "total": 0,
@@ -473,44 +536,54 @@ class CategorizationQueries:
                 "pct_categorized": 0,
             }
 
-        try:
-            categorized_result = self._db.execute(
-                f"SELECT COUNT(*) FROM {TRANSACTION_CATEGORIES.full_name}"
-            ).fetchone()
-            categorized = categorized_result[0] if categorized_result else 0
-        except duckdb.CatalogException:
-            categorized = 0
-
-        uncategorized = total - categorized
-        pct = round((categorized / total * 100), 1) if total > 0 else 0.0
+        total = counts.categorizable
+        pct = round((counts.categorized / total * 100), 1) if total > 0 else 0.0
 
         stats: dict[str, int | float] = {
             "total": total,
-            "categorized": categorized,
-            "uncategorized": uncategorized,
+            "categorized": counts.categorized,
+            "uncategorized": counts.uncategorized,
             "pct_categorized": pct,
         }
 
-        # Breakdown by source. `categorized_by='rule'` is written by BOTH the
-        # rule engine and apply_merchant_categories — the latter deliberately
-        # stamps the 'rule' method rather than the merchant's authoring
-        # provenance, so machine writes don't leak into the auto-rule
-        # override-detection query (which counts 'user'/'ai' as human
-        # corrections). Correct storage, but it made a lone `by_rule: 298`
-        # unreconcilable with an empty rules[] list. Split them for reporting
-        # using columns already on the row — the persisted value is untouched.
+        # Breakdown by source, over the same population as the three counts
+        # above so the buckets still sum to `categorized` — the CLI prints them
+        # directly beneath it, and parts that don't reach the whole are the
+        # defect this population change exists to fix. Two consequences of
+        # scoping it that way: a categorization orphaned from its transaction
+        # stops counting as coverage (doctor keeps a separate invariant for
+        # those), and a row whose category came from its source file's own
+        # column gets the `source_supplied` bucket, since it is categorized but
+        # no assignment method describes it.
+        #
+        # `categorized_by='rule'` is written by BOTH the rule engine and
+        # apply_merchant_categories — the latter deliberately stamps the 'rule'
+        # method rather than the merchant's authoring provenance, so machine
+        # writes don't leak into the auto-rule override-detection query (which
+        # counts 'user'/'ai' as human corrections). Correct storage, but it made
+        # a lone `by_rule: 298` unreconcilable with an empty rules[] list. Split
+        # them for reporting using columns already on the row — the persisted
+        # value is untouched.
         try:
             source_rows = self._db.execute(
                 f"""
+                WITH categorizable AS (
+                  SELECT t.transaction_id, t.category
+                  {_CATEGORIZABLE_POPULATION}
+                )
                 SELECT
                   CASE
-                    WHEN categorized_by = 'rule' AND rule_id IS NULL
-                         AND merchant_id IS NOT NULL
+                    WHEN c.transaction_id IS NULL THEN 'source_supplied'
+                    WHEN c.categorized_by = 'rule' AND c.rule_id IS NULL
+                         AND c.merchant_id IS NOT NULL
                     THEN 'merchant_map'
-                    ELSE categorized_by
+                    ELSE c.categorized_by
                   END AS source,
                   COUNT(*) AS cnt
-                FROM {TRANSACTION_CATEGORIES.full_name}
+                FROM categorizable AS t
+                LEFT JOIN {TRANSACTION_CATEGORIES.full_name} AS c
+                  ON t.transaction_id = c.transaction_id
+                WHERE t.category IS NOT NULL
                 GROUP BY 1
                 ORDER BY cnt DESC
                 """  # noqa: S608  # TableRef constant

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -3187,7 +3187,11 @@ class DoctorService:
             return InvariantResult(
                 name="categorization_coverage",
                 status="skipped",
-                detail="fct_transactions not available",
+                # Names both models the delegated count reads: it joins
+                # dim_accounts to match the queue's population, so either being
+                # absent lands here and a reader sent to the wrong one looks
+                # for a table that is already there.
+                detail="fct_transactions or dim_accounts not available",
                 affected_ids=[],
             )
         if coverage.categorizable == 0:

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -24,6 +24,7 @@ from moneybin.services.account_resolution_types import (
     UNNAMED_ACCOUNT_LABEL,
     is_reserved_account_name,
 )
+from moneybin.services.categorization import CategorizationService
 from moneybin.services.import_service import mask_embedded_account_number
 from moneybin.sqlmesh_registry import model_presence
 from moneybin.staleness import (
@@ -3173,17 +3174,15 @@ class DoctorService:
         return InvariantResult(name=name, status="pass", detail=None, affected_ids=[])
 
     def _run_categorization_coverage(self) -> InvariantResult:
-        """Warn (not fail) when <50% of non-transfer transactions are categorized."""
+        """Warn (not fail) when <50% of the transactions needing a category have one.
+
+        Delegates the counting so this check and ``categorize stats`` cannot
+        report different coverage for the same database: one query, scoped to
+        the population ``core.uncategorized_queue`` is drawn from, so the
+        percentage describes work ``moneybin review`` will actually offer.
+        """
         try:
-            row = self._db.execute(
-                f"""
-                SELECT
-                    COUNT(*) FILTER (WHERE category IS NULL) AS uncategorized,
-                    COUNT(*) AS total
-                FROM {FCT_TRANSACTIONS.full_name}
-                WHERE NOT COALESCE(is_transfer, FALSE)
-                """  # noqa: S608 — TableRef constant, not user input
-            ).fetchone()
+            coverage = CategorizationService(self._db).coverage()
         except Exception:  # noqa: BLE001 — core schema may not exist before first transform
             return InvariantResult(
                 name="categorization_coverage",
@@ -3191,23 +3190,27 @@ class DoctorService:
                 detail="fct_transactions not available",
                 affected_ids=[],
             )
-        if not row or row[1] == 0:
+        if coverage.categorizable == 0:
             return InvariantResult(
                 name="categorization_coverage",
                 status="pass",
                 detail=None,
                 affected_ids=[],
             )
-        uncategorized, total = int(row[0]), int(row[1])
         # Use unrounded ratio for the threshold so values like 49.6% categorized
         # correctly trigger the warning instead of rounding up to 50 and passing.
-        pct_categorized = (total - uncategorized) / total * 100
+        pct_categorized = coverage.categorized / coverage.categorizable * 100
         if pct_categorized < 50:
-            pct_uncategorized = round(uncategorized / total * 100)
+            pct_uncategorized = round(
+                coverage.uncategorized / coverage.categorizable * 100
+            )
             return InvariantResult(
                 name="categorization_coverage",
                 status="warn",
-                detail=f"{pct_uncategorized}% of non-transfer transactions are uncategorized",
+                detail=(
+                    f"{pct_uncategorized}% of the transactions needing a "
+                    "category are uncategorized"
+                ),
                 affected_ids=[],
             )
         return InvariantResult(

--- a/tests/moneybin/test_services/test_categorization_service.py
+++ b/tests/moneybin/test_services/test_categorization_service.py
@@ -83,34 +83,64 @@ def _core_tables(db: Database) -> None:  # pyright: ignore[reportUnusedFunction]
     create_core_tables(db)
 
 
+def _reflect_categorizations_into_fact(db: Database) -> None:
+    """Mirror app.transaction_categories onto the fact table's category column.
+
+    core.fct_transactions is a SQLMesh view in production, and its category
+    column COALESCEs the categorization join — so a row in
+    app.transaction_categories (NOT NULL category) always shows up there. The
+    unit-test stand-in is a plain table with no such join, so a categorization
+    written through a production code path leaves the fact column NULL and
+    anything reading it sees an uncategorized row. This performs the join the
+    view would have.
+    """
+    db.execute(
+        """
+        UPDATE core.fct_transactions AS t
+        SET category = c.category
+        FROM app.transaction_categories AS c
+        WHERE c.transaction_id = t.transaction_id AND t.category IS NULL
+        """  # noqa: S608 — test input, not user data
+    )
+
+
 @pytest.fixture()
 def db_with_transactions(db: Database) -> Database:
     """DB with sample transactions in core.fct_transactions."""
+    # The accounts these transactions belong to, and an explicit is_transfer.
+    # Coverage figures are scoped to core.uncategorized_queue's population,
+    # which INNER JOINs core.dim_accounts and filters on `NOT is_transfer` —
+    # transactions with neither model a database that cannot exist, and would
+    # silently count as zero.
+    db.conn.execute("""
+        INSERT INTO core.dim_accounts (account_id, display_name, archived)
+        VALUES ('ACC001', 'Checking', false), ('ACC002', 'Savings', false)
+    """)
     db.conn.execute("""
         INSERT INTO core.fct_transactions (
             transaction_id, account_id, transaction_date, amount,
             amount_absolute, transaction_direction, description, memo,
             transaction_type, is_pending, currency_code, source_type,
-            source_extracted_at, loaded_at,
+            is_transfer, source_extracted_at, loaded_at,
             transaction_year, transaction_month, transaction_day,
             transaction_day_of_week, transaction_year_month,
             transaction_year_quarter
         ) VALUES
         ('TXN001', 'ACC001', '2025-06-15', -4.50, 4.50, 'expense',
          'SQ *STARBUCKS #1234 SEATTLE WA', 'Coffee', 'DEBIT', false,
-         'USD', 'ofx', '2025-01-24', CURRENT_TIMESTAMP,
+         'USD', 'ofx', false, '2025-01-24', CURRENT_TIMESTAMP,
          2025, 6, 15, 0, '2025-06', '2025-Q2'),
         ('TXN002', 'ACC001', '2025-06-20', 3000.00, 3000.00, 'income',
-         'ACME CORP PAYROLL', 'Payroll', 'CREDIT', false, 'USD', 'ofx',
+         'ACME CORP PAYROLL', 'Payroll', 'CREDIT', false, 'USD', 'ofx', false,
          '2025-01-24', CURRENT_TIMESTAMP,
          2025, 6, 20, 5, '2025-06', '2025-Q2'),
         ('TXN003', 'ACC001', '2025-06-25', -52.13, 52.13, 'expense',
-         'AMZN MKTP US*ABC123', 'Amazon order', 'DEBIT', false, 'USD', 'ofx',
+         'AMZN MKTP US*ABC123', 'Amazon order', 'DEBIT', false, 'USD', 'ofx', false,
          '2025-01-24', CURRENT_TIMESTAMP,
          2025, 6, 25, 3, '2025-06', '2025-Q2'),
         ('TXN004', 'ACC002', '2025-06-26', -150.00, 150.00, 'expense',
          'WHOLEFDS MKT 10234 AUSTIN TX 78701', 'Groceries', 'DEBIT', false,
-         'USD', 'ofx', '2025-01-24', CURRENT_TIMESTAMP,
+         'USD', 'ofx', false, '2025-01-24', CURRENT_TIMESTAMP,
          2025, 6, 26, 4, '2025-06', '2025-Q2')
     """)
     return db
@@ -724,6 +754,7 @@ class TestGetCategorizationStats:
             (transaction_id, category, categorized_by)
             VALUES ('TXN001', 'Food & Drink', 'user')
         """)
+        _reflect_categorizations_into_fact(db)
         stats = get_categorization_stats(db)
         assert stats["total"] == 4
         assert stats["categorized"] == 1
@@ -740,6 +771,15 @@ class TestGetCategorizationStats:
         That's correct storage, but it made stats report "rule: 298" against
         an empty rules[] list, which reads to an agent as data loss.
         """
+        # The transactions being categorized. The breakdown is scoped to the
+        # population that needs categorizing, so a categorization with no
+        # surviving transaction is not counted as coverage at all.
+        db.execute(
+            "INSERT INTO core.dim_accounts (account_id, display_name, archived) "
+            "VALUES ('acct', 'Checking', false)"
+        )
+        _insert_coverage_txn(db, "t_1", account_id="acct")
+        _insert_coverage_txn(db, "t_2", account_id="acct")
         # A real rule write: rule_id set.
         db.execute(
             "INSERT INTO app.transaction_categories "
@@ -752,11 +792,178 @@ class TestGetCategorizationStats:
             "(transaction_id, category, categorized_by, rule_id, merchant_id) "
             "VALUES ('t_2', 'Groceries', 'rule', NULL, 'm_1')"
         )
+        _reflect_categorizations_into_fact(db)
 
         stats = get_categorization_stats(db)
 
         assert stats["by_rule"] == 1
         assert stats["by_merchant_map"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Coverage over the population that needs categorizing
+# ---------------------------------------------------------------------------
+
+
+def _insert_coverage_txn(
+    db: Database,
+    transaction_id: str,
+    *,
+    account_id: str = "ACC_OPEN",
+    category: str | None = None,
+    is_transfer: bool = False,
+) -> None:
+    """Insert one core.fct_transactions row for the coverage-population tests.
+
+    ``is_transfer`` is written explicitly rather than left to default NULL.
+    Production derives it from two LEFT JOINs onto core.bridge_transfers and
+    the expression is never NULL there, but a NULL here meets the queue's
+    ``NOT is_transfer`` as NULL and drops the row — the queue would read empty
+    and every assertion below would pass without exercising anything.
+    """
+    db.execute(
+        """
+        INSERT INTO core.fct_transactions (
+            transaction_id, account_id, transaction_date, amount,
+            amount_absolute, transaction_direction, description,
+            transaction_type, is_pending, currency_code, source_type,
+            category, is_transfer, source_extracted_at, loaded_at,
+            transaction_year, transaction_month, transaction_day,
+            transaction_day_of_week, transaction_year_month,
+            transaction_year_quarter
+        ) VALUES (?, ?, '2026-02-01', -25.00, 25.00, 'expense', 'Test txn',
+                  'DEBIT', false, 'USD', 'ofx', ?, ?,
+                  CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
+                  2026, 2, 1, 0, '2026-02', '2026-Q1')
+        """,  # noqa: S608 — test input, not user data
+        [transaction_id, account_id, category, is_transfer],
+    )
+
+
+@pytest.fixture()
+def db_with_coverage_population(db: Database) -> Database:
+    """Every row shape the coverage figures have to classify, exactly once.
+
+    Five rows are eligible for categorization — an open account, not a
+    transfer leg. Two of those carry no category, two were categorized inside
+    MoneyBin, and one arrived from its source file already carrying category
+    text. Three further rows exist only to be excluded: a transfer leg, a row
+    on an archived account, and a row whose account never resolved. One
+    orphaned categorization points at a transaction that no longer exists.
+    """
+    for account_id, archived in (("ACC_OPEN", False), ("ACC_ARCHIVED", True)):
+        db.execute(
+            "INSERT INTO core.dim_accounts "
+            "(account_id, display_name, currency_code, archived) "
+            "VALUES (?, ?, 'USD', ?)",
+            [account_id, f"Account {account_id}", archived],
+        )
+
+    _insert_coverage_txn(db, "T_BARE_1")
+    _insert_coverage_txn(db, "T_BARE_2")
+    _insert_coverage_txn(db, "T_USER", category="Groceries")
+    _insert_coverage_txn(db, "T_RULE", category="Shopping")
+    _insert_coverage_txn(db, "T_FROM_FILE", category="Utilities")
+    _insert_coverage_txn(db, "T_TRANSFER", is_transfer=True)
+    _insert_coverage_txn(db, "T_ARCHIVED", account_id="ACC_ARCHIVED")
+    _insert_coverage_txn(db, "T_NO_ACCOUNT", account_id="ACC_GONE")
+
+    # T_FROM_FILE deliberately gets no row here — its category came from the
+    # source file's own column, which is the whole point of it. T_VANISHED has
+    # no fact row, the orphan shape doctor keeps a separate invariant for.
+    db.execute(
+        "INSERT INTO app.transaction_categories "
+        "(transaction_id, category, categorized_by, rule_id) VALUES "
+        "('T_USER', 'Groceries', 'user', NULL), "
+        "('T_RULE', 'Shopping', 'rule', 'r_1'), "
+        "('T_VANISHED', 'Food', 'user', NULL)"
+    )
+    install_uncategorized_queue_view(db)
+    return db
+
+
+class TestCoverageOverWhatNeedsCategorizing:
+    """The coverage figures describe the queue's population, not the whole ledger."""
+
+    @pytest.mark.unit
+    def test_the_population_excludes_rows_nobody_is_asked_to_categorize(
+        self, db_with_coverage_population: Database
+    ) -> None:
+        stats = get_categorization_stats(db_with_coverage_population)
+
+        # Eligible: T_BARE_1, T_BARE_2, T_USER, T_RULE, T_FROM_FILE. Excluded:
+        # the transfer leg, the archived account's row, and the row whose
+        # account_id resolves to no account.
+        assert stats["total"] == 5
+        assert stats["categorized"] == 3
+        assert stats["uncategorized"] == 2
+        assert stats["pct_categorized"] == 60.0
+
+    @pytest.mark.unit
+    def test_the_three_figures_sum(self, db_with_coverage_population: Database) -> None:
+        """Total = Categorized + Uncategorized, which is how the CLI renders them."""
+        stats = get_categorization_stats(db_with_coverage_population)
+
+        assert stats["categorized"] + stats["uncategorized"] == stats["total"]
+
+    @pytest.mark.unit
+    def test_uncategorized_matches_the_canonical_queue(
+        self, db_with_coverage_population: Database
+    ) -> None:
+        """The figure equals what ``moneybin review`` will actually hand the user.
+
+        The view under test is built from the shipped model file, so this fails
+        if core.uncategorized_queue's predicate and this query's ever diverge.
+        That divergence is what MB-155 exists to close and the one thing no
+        type check can see.
+        """
+        db = db_with_coverage_population
+        queue_count = db.execute(
+            "SELECT COUNT(*) FROM core.uncategorized_queue"
+        ).fetchone()
+
+        stats = get_categorization_stats(db)
+
+        assert queue_count is not None
+        assert stats["uncategorized"] == queue_count[0]
+
+    @pytest.mark.unit
+    def test_a_category_the_source_file_supplied_counts_as_categorized(
+        self, db_with_coverage_population: Database
+    ) -> None:
+        """It has a category, so the queue skips it — coverage has to agree.
+
+        It carries no app.transaction_categories row, so no assignment method
+        describes it. It gets its own bucket rather than dropping out of the
+        breakdown and leaving the parts short of the whole.
+        """
+        stats = get_categorization_stats(db_with_coverage_population)
+
+        assert stats["by_source_supplied"] == 1
+
+    @pytest.mark.unit
+    def test_the_breakdown_sums_to_categorized(
+        self, db_with_coverage_population: Database
+    ) -> None:
+        """The CLI prints the by-method lines directly beneath Categorized."""
+        stats = get_categorization_stats(db_with_coverage_population)
+
+        by_method = sum(v for k, v in stats.items() if k.startswith("by_"))
+
+        assert by_method == stats["categorized"]
+
+    @pytest.mark.unit
+    def test_a_categorization_of_a_vanished_transaction_is_not_coverage(
+        self, db_with_coverage_population: Database
+    ) -> None:
+        """An orphaned app.transaction_categories row used to inflate `categorized`.
+
+        Doctor keeps a whole invariant for these rows; counting them here
+        claimed completed work against transactions that no longer exist.
+        """
+        stats = get_categorization_stats(db_with_coverage_population)
+
+        assert stats["by_user"] == 1  # T_USER only — T_VANISHED has no fact row
 
 
 # ---------------------------------------------------------------------------
@@ -3062,10 +3269,20 @@ class TestPlaidCategorizerObservability:
             plaid_category="FOOD_AND_DRINK",
             category_confidence="HIGH",
         )
+        # The breakdown counts transactions, not categorization rows, so the
+        # gold-keyed fact row this write lands on has to exist — it is what
+        # `_insert_plaid_txn` means by "callers pass the same value used for
+        # the matching core.fct_transactions row".
+        db.execute(
+            "INSERT INTO core.dim_accounts (account_id, display_name, archived) "
+            "VALUES ('acct', 'Checking', false)"
+        )
+        _insert_coverage_txn(db, "t1", account_id="acct")
 
         n = apply_plaid_categories(db)
 
         assert n == 1
+        _reflect_categorizations_into_fact(db)
         stats = get_categorization_stats(db)
         assert stats["by_provider_native"] == 1
 

--- a/tests/moneybin/test_services/test_doctor_service.py
+++ b/tests/moneybin/test_services/test_doctor_service.py
@@ -107,21 +107,27 @@ def doctor_db(db: Database) -> Database:
                   'a.qfx', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
                   CURRENT_TIMESTAMP, 'Bank CHECKING', 'USD', FALSE, TRUE)
     """)  # noqa: S608 — test input, not user data
+    # is_transfer is written rather than left NULL: production computes it from
+    # two LEFT JOINs onto core.bridge_transfers and the expression never yields
+    # NULL, while a NULL here meets `NOT is_transfer` as NULL and silently drops
+    # the row from every transfer-excluding check.
     db.execute("""
         INSERT INTO core.fct_transactions (
             transaction_id, account_id, transaction_date, amount,
             amount_absolute, transaction_direction, description,
             transaction_type, is_pending, currency_code, source_type,
-            source_extracted_at, loaded_at,
+            is_transfer, source_extracted_at, loaded_at,
             transaction_year, transaction_month, transaction_day,
             transaction_day_of_week, transaction_year_month,
             transaction_year_quarter
         ) VALUES
         ('T1', 'ACC1', '2026-01-01', -50.00, 50.00, 'expense', 'Coffee',
-         'DEBIT', false, 'USD', 'ofx', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
+         'DEBIT', false, 'USD', 'ofx', FALSE,
+         CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
          2026, 1, 1, 3, '2026-01', '2026-Q1'),
         ('T2', 'ACC1', '2026-01-02', 1000.00, 1000.00, 'income', 'Paycheck',
-         'CREDIT', false, 'USD', 'ofx', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
+         'CREDIT', false, 'USD', 'ofx', FALSE,
+         CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
          2026, 1, 2, 4, '2026-01', '2026-Q1')
     """)  # noqa: S608 — test input, not user data
     return db
@@ -708,6 +714,64 @@ def test_categorization_coverage_passes_when_all_categorized(
     svc = DoctorService(doctor_db)
     report = svc.run_all()
     cat = next(r for r in report.invariants if r.name == "categorization_coverage")
+    assert cat.status == "pass"
+
+
+@pytest.mark.unit
+def test_categorization_coverage_ignores_archived_accounts(
+    doctor_db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A closed account's backlog must not drag the ratio down.
+
+    core.uncategorized_queue excludes archived accounts, so ``moneybin review``
+    never offers these rows. Counting them reported a coverage problem with no
+    action behind it: every route the recovery action suggests skips them.
+
+    The archived rows set ``is_transfer`` explicitly. Left NULL they would be
+    dropped by the transfer filter instead, and this would pass without ever
+    exercising the archived-account one.
+    """
+    doctor_db.execute("""
+        UPDATE core.fct_transactions
+        SET category = 'Food & Drink'
+        WHERE transaction_id IN ('T1', 'T2')
+    """)  # noqa: S608 — test input, not user data
+    doctor_db.execute(
+        "INSERT INTO core.dim_accounts "
+        "(account_id, display_name, currency_code, archived) "
+        "VALUES ('ACC_CLOSED', 'Closed Card', 'USD', TRUE)"
+    )
+    for i in range(10):
+        doctor_db.execute(
+            """
+            INSERT INTO core.fct_transactions (
+                transaction_id, account_id, transaction_date, amount,
+                amount_absolute, transaction_direction, description,
+                transaction_type, is_pending, currency_code, source_type,
+                is_transfer, source_extracted_at, loaded_at,
+                transaction_year, transaction_month, transaction_day,
+                transaction_day_of_week, transaction_year_month,
+                transaction_year_quarter
+            ) VALUES (?, 'ACC_CLOSED', '2026-01-03', -10.00, 10.00, 'expense',
+                      'Old charge', 'DEBIT', false, 'USD', 'ofx',
+                      FALSE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
+                      2026, 1, 3, 5, '2026-01', '2026-Q1')
+            """,  # noqa: S608 — test input, not user data
+            [f"T_CLOSED_{i}"],
+        )
+    mock_ctx = _make_mock_ctx(_CLEAN_AUDITS)
+
+    @contextmanager
+    def _fake_ctx(*args: Any, **kwargs: Any) -> Generator[Any, None, None]:
+        yield mock_ctx
+
+    monkeypatch.setattr("moneybin.audits.runner.sqlmesh_context", _fake_ctx)
+    svc = DoctorService(doctor_db)
+    report = svc.run_all()
+
+    cat = next(r for r in report.invariants if r.name == "categorization_coverage")
+    # Both live transactions carry a category; the 10 uncategorized rows all
+    # sit on the archived account. Counting them gives 2/12 = 17% and warns.
     assert cat.status == "pass"
 
 


### PR DESCRIPTION
Closes MB-155.

## The defect

Four surfaces answer "which transactions are uncategorized," and until now three of them disagreed:

| Surface | Population it counted |
|---|---|
| `core.uncategorized_queue` → `moneybin review` | `category IS NULL`, not a transfer leg, not an archived account |
| `categorization_coverage` doctor check | `category IS NULL`, not a transfer leg — archived accounts included |
| `categorize stats` / MCP `transactions_categorize_stats` | every transaction, against every row in `app.transaction_categories` |

So `categorize stats` could report a backlog of N while `moneybin review` handed the user a different number and then declared itself finished. MB-44 canonicalized the queue and deliberately left these two alone, because in each the word sits inside an arithmetic identity where swapping the numerator alone breaks the figure.

## The change

Both surfaces now read the population `core.uncategorized_queue` is drawn from, through **one** query rather than three hand-maintained predicates. `DoctorService._run_categorization_coverage` delegates to `CategorizationService.coverage()` instead of keeping its own SQL, so the two cannot report different coverage for the same database.

Three things fall out of scoping the denominator:

- **Transfer legs and archived accounts leave the count.** Neither is work anyone is asked to do, and `moneybin review` never offers them.
- **Categorizations orphaned from their transaction stop counting as coverage.** `categorized` was a row count over `app.transaction_categories`, which includes rows whose transaction no longer exists — doctor keeps a separate invariant for exactly those.
- **`by_source` gains a `source_supplied` bucket.** A transaction whose CSV column or manual entry carried category text of its own is categorized but has no assignment method. Without the bucket, the breakdown the CLI prints directly beneath `Categorized` would have stopped summing to it — the same reconciliation defect this PR fixes, one line lower.

## What users will notice

The numbers move, deliberately. A ledger whose transfer legs and closed accounts made up much of its "uncategorized" count now reports a smaller backlog and a higher percentage — the same data, described as work rather than as rows.

`total_transactions` in the MCP payload is now the size of that population rather than a count of all transactions. The field name is unchanged; its description, the payload docstring, and the CLI header all say what it now means (`Categorization coverage (excludes transfers, archived accounts):`).

## What deliberately did not move

`transactions list --uncategorized` still filters on `categorized_by IS NULL` — "MoneyBin never decided this one." It is the only surface that reveals categories a CSV or manual entry supplied but nobody confirmed; `moneybin review` skips those because they already carry text. Moving it would have made all four surfaces agree at the cost of the only window onto that population. Decided with Brandon rather than assumed, and the question underneath it — should the review queue be offering those labels for a quick keep/change at all? — is filed as MB-180.

## Test plan

Test-first; every assertion watched fail for its own reason before the implementation existed.

- `TestCoverageOverWhatNeedsCategorizing` (6 new unit tests) over a fixture holding every row shape the figures must classify exactly once — two bare rows, two categorized inside MoneyBin, one carrying source-supplied text, plus a transfer leg, an archived-account row, an unresolved-account row, and an orphaned categorization. Expected counts hand-derived before running (5 / 3 / 2, 60.0%).
- The anti-drift test builds `core.uncategorized_queue` from the **shipped model file** and asserts the stats figure equals its count, so a future divergence between the view's predicate and this query fails a test rather than quietly publishing a contradicted number.
- Two of the six assert the invariants that must survive the change (`total = categorized + uncategorized`; `by_source` sums to `categorized`). Both passed before and after — they are regression guards, not new behavior.
- `test_categorization_coverage_ignores_archived_accounts` for the doctor half. Its rows set `is_transfer` explicitly: left NULL they would be dropped by the transfer filter instead, and the test would have passed without exercising the archived-account one at all.
- Four pre-existing fixtures modeled databases that cannot exist — transactions with no `dim_accounts` row, categorizations with no transaction, an `app.transaction_categories` write not reflected on the fact table the production view COALESCEs it onto. Corrected rather than worked around; `_reflect_categorizations_into_fact` performs the join the view would have.

Gates run: `make check`, `tests/moneybin/test_services/test_categorization_service.py` (125 passed), `tests/moneybin/test_services/test_doctor_service.py` (125 passed), `make test`, `make test-integration`. `make generate-docs` produced no diff.
