### PR TITLE
Remove the inert Pylint suppressions and correct false cycle claims

### DIFF
--- a/.claude/rules/cli.md
+++ b/.claude/rules/cli.md
@@ -95,9 +95,14 @@ Every E2E test, every shell autocomplete, and every CLI invocation pays the full
   ```python
   @app.command("serve")
   def serve(...) -> None:
-      from moneybin.mcp.server import build_server  # noqa: PLC0415 — defer import
+      from moneybin.mcp.server import build_server  # fastmcp is not cold-start cheap
       build_server(...).run()
   ```
+
+  Say *why* in a plain comment, and never reach for `# noqa: PLC0415`. Ruff's
+  `select` omits `PL`, so that marker suppresses nothing — it only looks
+  official, which is how 17 wrong justifications rode one unchallenged until
+  MB-168 tested them. `test_no_inert_pylint_suppression_markers` now rejects it.
 
 - **Verify with `importtime`.** When adding a new command module, confirm the cold-start path stays clean:
 

--- a/docs/reference/cli-startup-flow.md
+++ b/docs/reference/cli-startup-flow.md
@@ -75,12 +75,17 @@ Heavy transitive imports MUST be deferred inside the function that needs them:
 @app.command("list-prompts")
 def mcp_list_prompts(...) -> None:
     from moneybin.mcp.server import (
-        mcp,  # noqa: PLC0415 — defer fastmcp import to subcommand body
+        mcp,  # defer fastmcp import to subcommand body
     )
     ...
 ```
 
-The `# noqa: PLC0415` suppression is the grep-able marker for the pattern. The same pattern applies to anything that pulls a parser, ORM, or large package graph: `fastmcp`, `sqlmesh`, `polars`.
+A plain comment naming the cost is the whole convention — there is no
+suppression to add. Ruff's `select` omits `PL`, so a `# noqa: PLC0415` would
+suppress nothing, and `test_no_inert_pylint_suppression_markers` rejects it. The
+pattern itself is greppable by structure: an `import` indented inside a
+function body. The same applies to anything that pulls a parser, ORM, or large
+package graph: `fastmcp`, `sqlmesh`, `polars`.
 
 The non-obvious failure mode: `from x import Y` at module top of any command file (including transitive imports from helper modules those files load) loads the heavy graph for *every* invocation — `--help`, autocomplete, every E2E subprocess. The CLI feels fine in isolation but the test suite slows by a factor of N over time. The CI guard described below catches regressions early.
 
@@ -289,4 +294,4 @@ Before opening the PR, verify cold start stays clean:
 uv run pytest tests/moneybin/test_cli/test_cold_start.py tests/moneybin/test_cli/test_help_no_wizard.py -v
 ```
 
-If your new command needs a heavy import, put it inside the function body with `# noqa: PLC0415 — defer <dep> import` per the pattern in `mcp.py` and `transform.py`. See CONTRIBUTING.md → "Adding a new CLI command" for the full recipe (test layer expectations, JSON-output parity, `--help` audit).
+If your new command needs a heavy import, put it inside the function body with a plain comment naming the cost — `# <dep> is not cold-start cheap` — per the pattern in `mcp.py` and `transform.py`. See CONTRIBUTING.md → "Adding a new CLI command" for the full recipe (test layer expectations, JSON-output parity, `--help` audit).

--- a/src/moneybin/cli/commands/accounts/links.py
+++ b/src/moneybin/cli/commands/accounts/links.py
@@ -75,7 +75,7 @@ def links_pending(
     payload = AccountLinksPendingPayload.from_service(groups, n_pending)
 
     if output == OutputFormat.JSON:
-        from moneybin.cli.output import render_or_json  # noqa: PLC0415 — defer import
+        from moneybin.cli.output import render_or_json
 
         render_or_json(
             build_envelope(data=payload),
@@ -220,7 +220,7 @@ def _report_rematch(rematch: RefreshResult | None) -> None:
     # Deferred, and below the guard: matching_service pulls duckdb and the match
     # engine, this module is on the CLI cold-start path (.claude/rules/cli.md),
     # and the reject path reaches here needing none of it.
-    from moneybin.services.matching_service import (  # noqa: PLC0415
+    from moneybin.services.matching_service import (
         PENDING_MATCHES_HINT,
     )
 
@@ -316,10 +316,12 @@ def _plan_merge(
     """Resolve the merge against ``db``, the way MCP plans the same decision."""
     # Deferred: the identity contracts and decision service are not worth loading
     # on every CLI invocation to gate one subcommand.
-    from moneybin.protocol.write_contracts import (  # noqa: PLC0415 — keep off the cold-start path
+    from moneybin.protocol.write_contracts import (  # keep off the cold-start path
         AccountLinkDecisionRequest,
     )
-    from moneybin.services.review_decisions_service import (  # noqa: PLC0415 — keep off the cold-start path
+
+    # keep off the cold-start path
+    from moneybin.services.review_decisions_service import (
         ReviewDecisionsService,
     )
 
@@ -536,7 +538,7 @@ def links_history(
     payload = AccountLinksHistoryPayload.from_rows(rows)
 
     if output == OutputFormat.JSON:
-        from moneybin.cli.output import render_or_json  # noqa: PLC0415 — defer import
+        from moneybin.cli.output import render_or_json
 
         render_or_json(
             build_envelope(data=payload),
@@ -624,7 +626,7 @@ def links_run(
     )
 
     if output == OutputFormat.JSON:
-        from moneybin.cli.output import render_or_json  # noqa: PLC0415 — defer import
+        from moneybin.cli.output import render_or_json
 
         render_or_json(
             build_envelope(data=payload),

--- a/src/moneybin/cli/commands/categories/__init__.py
+++ b/src/moneybin/cli/commands/categories/__init__.py
@@ -141,10 +141,10 @@ def categories_delete(
     --force is passed. Default (seeded) categories cannot be deleted — disable
     them with `moneybin categories set <id> --inactive` instead.
     """
-    from moneybin.privacy.payloads.categories import (  # noqa: PLC0415
+    from moneybin.privacy.payloads.categories import (
         CategoryDeletePayload,
     )
-    from moneybin.services.categorization import (  # noqa: PLC0415
+    from moneybin.services.categorization import (
         CategorizationService,
     )
 

--- a/src/moneybin/cli/commands/db.py
+++ b/src/moneybin/cli/commands/db.py
@@ -65,8 +65,8 @@ def _load_encryption_key() -> Generator[str, None, None]:
     but ``del`` here prevents this frame from extending the object's lifetime
     beyond the yield.
     """
-    from moneybin.database import database_key_error_hint  # noqa: PLC0415
-    from moneybin.secrets import (  # noqa: PLC0415
+    from moneybin.database import database_key_error_hint
+    from moneybin.secrets import (
         SecretNotFoundError,
         SecretStore,
         SecretUnavailableError,
@@ -653,7 +653,7 @@ def db_lock() -> None:
     store = SecretStore()
     try:
         store.delete_key("DATABASE__ENCRYPTION_KEY")
-        from moneybin.database import (  # noqa: PLC0415 — defer to avoid cold-start cost
+        from moneybin.database import (  # defer to avoid cold-start cost
             invalidate_encryption_key_cache,
         )
 
@@ -739,7 +739,7 @@ def db_unlock() -> None:
     try:
         with Database(settings.database.path, secret_store=store, read_only=True):
             pass
-        from moneybin.database import (  # noqa: PLC0415 — defer to avoid cold-start cost
+        from moneybin.database import (  # defer to avoid cold-start cost
             invalidate_encryption_key_cache,
         )
 
@@ -862,7 +862,7 @@ def db_key_rotate(
 
     # Rotation changes the encryption key, so the in-process cache is stale.
     # Clear it so subsequent Database() calls fetch the new key from the keychain.
-    from moneybin.database import (  # noqa: PLC0415 — defer to avoid cold-start cost
+    from moneybin.database import (  # defer to avoid cold-start cost
         invalidate_encryption_key_cache,
     )
 

--- a/src/moneybin/cli/commands/export.py
+++ b/src/moneybin/cli/commands/export.py
@@ -131,7 +131,7 @@ def _validate_delivery_options(
 
 def _parse_sheets_workbook_id(url: str) -> str:
     """Validate a Sheets URL and return its workbook identity without needing a tab."""
-    from moneybin.connectors.gsheet.url_parser import parse_sheet_url  # noqa: PLC0415
+    from moneybin.connectors.gsheet.url_parser import parse_sheet_url
 
     workbook_url = urlparse(url)._replace(fragment="gid=0").geturl()
     spreadsheet_id, _ = parse_sheet_url(workbook_url)
@@ -215,8 +215,8 @@ def _run_export(
     )
     redaction_mode = _redaction_mode(unredacted=unredacted, yes=yes)
 
-    from moneybin.exports.models import local_export_publish_error  # noqa: PLC0415
-    from moneybin.exports.service import ExportService  # noqa: PLC0415
+    from moneybin.exports.models import local_export_publish_error
+    from moneybin.exports.service import ExportService
 
     cli_actor = f"export_{subject_kind}"
 
@@ -337,8 +337,8 @@ def export_report(
     output: OutputFormat = output_option,
 ) -> None:
     """Export one catalog report and typed parameter binding."""
-    from moneybin.cli.report_params import parse_report_parameters  # noqa: PLC0415
-    from moneybin.reports._framework.catalog import (  # noqa: PLC0415
+    from moneybin.cli.report_params import parse_report_parameters
+    from moneybin.reports._framework.catalog import (
         open_report_catalog,
     )
 
@@ -372,10 +372,10 @@ def destination_list(
     quiet: bool = quiet_option,  # noqa: ARG001  # list output is data-only
 ) -> None:
     """List derived and saved export destinations with readiness."""
-    from moneybin.config import get_settings  # noqa: PLC0415
-    from moneybin.database import get_database  # noqa: PLC0415
-    from moneybin.exports.service import ExportService  # noqa: PLC0415
-    from moneybin.repositories.export_destinations_repo import (  # noqa: PLC0415
+    from moneybin.config import get_settings
+    from moneybin.database import get_database
+    from moneybin.exports.service import ExportService
+    from moneybin.repositories.export_destinations_repo import (
         ExportDestinationsRepo,
     )
 
@@ -445,8 +445,8 @@ def destination_add_local(
     output: OutputFormat = output_option,
 ) -> None:
     """Add or replace a local artifact destination."""
-    from moneybin.database import get_database  # noqa: PLC0415
-    from moneybin.repositories.export_destinations_repo import (  # noqa: PLC0415
+    from moneybin.database import get_database
+    from moneybin.repositories.export_destinations_repo import (
         ExportDestinationsRepo,
     )
 
@@ -479,10 +479,10 @@ def destination_add_sheets(
     output: OutputFormat = output_option,
 ) -> None:
     """Authorize and add or replace a Google Sheets destination."""
-    from moneybin.connectors.gsheet.service_factory import (  # noqa: PLC0415
+    from moneybin.connectors.gsheet.service_factory import (
         build_oauth_client,
     )
-    from moneybin.exports.service import ExportService  # noqa: PLC0415
+    from moneybin.exports.service import ExportService
 
     with handle_cli_errors(
         cli_actor="export_destination_add_sheets",
@@ -514,15 +514,15 @@ def destination_remove(
     output: OutputFormat = output_option,
 ) -> None:
     """Remove MoneyBin configuration without deleting destination content."""
-    from moneybin.database import get_database  # noqa: PLC0415
-    from moneybin.repositories.export_destinations_repo import (  # noqa: PLC0415
+    from moneybin.database import get_database
+    from moneybin.repositories.export_destinations_repo import (
         ExportDestinationsRepo,
     )
 
     if not yes and not typer.confirm(f"Remove destination configuration {name!r}?"):
         raise typer.Exit(0)
 
-    from moneybin.services.entity_reference import (  # noqa: PLC0415
+    from moneybin.services.entity_reference import (
         AmbiguousEntity,
         MissingEntity,
     )

--- a/src/moneybin/cli/commands/fx.py
+++ b/src/moneybin/cli/commands/fx.py
@@ -70,7 +70,8 @@ def fx_rate(
     # exits 2 (usage) rather than 1 (the command ran and failed).
     requested = parse_cli_date(rate_date, "RATE_DATE") if rate_date else date.today()  # noqa: DTZ011  # a calendar date, not an instant
     with handle_cli_errors(cli_actor="fx_rate", payload_type=FxRatePayload):
-        from moneybin.services.currency_service import (  # noqa: PLC0415  # polars is not cold-start cheap
+        # polars is not cold-start cheap
+        from moneybin.services.currency_service import (
             build_currency_service,
         )
 
@@ -120,7 +121,8 @@ def fx_list(
     """
     start = parse_cli_date(since, "--since") if since else None
     with handle_cli_errors(cli_actor="fx_list", payload_type=FxRatesPayload):
-        from moneybin.services.currency_service import (  # noqa: PLC0415  # polars is not cold-start cheap
+        # polars is not cold-start cheap
+        from moneybin.services.currency_service import (
             build_currency_service,
             canonical_currency,
         )
@@ -178,7 +180,8 @@ def fx_set(
     parsed_date = parse_cli_date(rate_date, "RATE_DATE")
     parsed_rate = parse_cli_decimal(rate, "RATE")
     with handle_cli_errors(cli_actor="fx_set", payload_type=FxOverridePayload):
-        from moneybin.services.currency_service import (  # noqa: PLC0415  # polars is not cold-start cheap
+        # polars is not cold-start cheap
+        from moneybin.services.currency_service import (
             build_currency_service,
             canonical_currency,
         )
@@ -228,7 +231,8 @@ def fx_delete(
     """
     parsed_date = parse_cli_date(rate_date, "RATE_DATE")
     with handle_cli_errors(cli_actor="fx_delete", payload_type=FxOverridePayload):
-        from moneybin.services.currency_service import (  # noqa: PLC0415  # polars is not cold-start cheap
+        # polars is not cold-start cheap
+        from moneybin.services.currency_service import (
             build_currency_service,
             canonical_currency,
         )

--- a/src/moneybin/cli/commands/gsheet.py
+++ b/src/moneybin/cli/commands/gsheet.py
@@ -249,7 +249,7 @@ def gsheet_connect(
     signature, and (by default) runs the initial pull. Use --adapter=seed
     --alias=<name> to land arbitrary tabular data into raw.gsheet_<alias>.
     """
-    from moneybin.connectors.gsheet.connection_service import (  # noqa: PLC0415
+    from moneybin.connectors.gsheet.connection_service import (
         ConnectionRequest,
     )
 
@@ -321,11 +321,11 @@ def gsheet_pull(
     quiet: bool = quiet_option,
 ) -> None:
     """Pull a single connection by ID, or every healthy connection."""
-    from moneybin.adapters.refresh_adapters import (  # noqa: PLC0415
+    from moneybin.adapters.refresh_adapters import (
         refresh_steps_fields,
     )
-    from moneybin.orchestration.refresh import refresh as run_refresh  # noqa: PLC0415
-    from moneybin.orchestration.refresh import step_outcome  # noqa: PLC0415
+    from moneybin.orchestration.refresh import refresh as run_refresh
+    from moneybin.orchestration.refresh import step_outcome
 
     refresh_error: str | None = None
     transfers_retired = 0

--- a/src/moneybin/cli/commands/import_cmd.py
+++ b/src/moneybin/cli/commands/import_cmd.py
@@ -113,7 +113,7 @@ def _parse_kv(
     # not every issuer's numbering. Harmless for --override, whose keys are field
     # names with no digit run to find. Same mask the service-layer refusals use,
     # so a key is never disclosed to two different depths.
-    from moneybin.services.import_service import (  # noqa: PLC0415 — defer import
+    from moneybin.services.import_service import (
         mask_embedded_account_number,
     )
 
@@ -456,7 +456,7 @@ def import_files_command(
             "envelopes, then ratify with `moneybin import confirm <file>`."
         )
 
-    from moneybin.database import get_database  # noqa: PLC0415 — deferred import
+    from moneybin.database import get_database
 
     files_list: list[dict[str, Any]] = []
     data: dict[str, Any] = {}
@@ -600,12 +600,12 @@ def import_files_command(
                         files_list, data = _batch_payload(batch_result)
                         refresh_steps = batch_result.refresh_steps
     except Exception as _exc:  # noqa: BLE001 — dispatch on type below
-        from moneybin.services.import_confirmation import (  # noqa: PLC0415
+        from moneybin.services.import_confirmation import (
             ImportConfirmationRequiredError,
             header_row_consumed_recovery,
             unreadable_date_recovery,
         )
-        from moneybin.services.import_service import (  # noqa: PLC0415 — defer import
+        from moneybin.services.import_service import (
             ImportRefreshError,
         )
 
@@ -793,10 +793,13 @@ def import_files_command(
 
     classes_returned: list[str] | None = None
     if any(_gates_an_account(f) for f in files_list):
-        from moneybin.privacy.classified_envelope import (  # noqa: PLC0415 — defer import to keep CLI cold-start light
+        # defer import to keep CLI cold-start light
+        from moneybin.privacy.classified_envelope import (
             classify,
         )
-        from moneybin.privacy.payloads.imports import (  # noqa: PLC0415 — defer import to keep CLI cold-start light
+
+        # defer import to keep CLI cold-start light
+        from moneybin.privacy.payloads.imports import (
             ImportConfirmationPayload,
         )
 
@@ -885,10 +888,13 @@ def _batch_payload(
     `confirmation_payload` would start arriving as `null` on every row. That is
     why the one field carrying a real account number is masked explicitly.
     """
-    from moneybin.privacy.payloads.imports import (  # noqa: PLC0415 — defer import to keep CLI cold-start light
+    # defer import to keep CLI cold-start light
+    from moneybin.privacy.payloads.imports import (
         ImportConfirmationPayload,
     )
-    from moneybin.privacy.redaction import (  # noqa: PLC0415 — defer import to keep CLI cold-start light
+
+    # defer import to keep CLI cold-start light
+    from moneybin.privacy.redaction import (
         redact_typed,
     )
 
@@ -1020,7 +1026,7 @@ def _single_file_success(
     ``_batch_payload`` so `moneybin import files a.csv` and
     `moneybin import files a.csv b.csv` describe a file identically.
     """
-    from moneybin.services.import_service import (  # noqa: PLC0415 — defer import
+    from moneybin.services.import_service import (
         BatchImportResult,
         PerFileResult,
     )
@@ -1057,7 +1063,7 @@ def _single_file_failure(file_path: Path, exc: Exception) -> BatchImportResult:
     identical whichever surface asked. ``per_file_failure`` is also what keeps
     raw ``str(e)`` off the wire for anything it cannot classify.
     """
-    from moneybin.services.import_service import (  # noqa: PLC0415 — defer import
+    from moneybin.services.import_service import (
         BatchImportResult,
         PerFileResult,
         per_file_failure,
@@ -1107,10 +1113,13 @@ def _confirmation_envelope_data(
     classes for it. MoneyBin's own minted account ids stay readable through the
     same walk: they are RECORD_ID, and they are what an answer names.
     """
-    from moneybin.privacy.payloads.imports import (  # noqa: PLC0415 — defer import to keep CLI cold-start light
+    # defer import to keep CLI cold-start light
+    from moneybin.privacy.payloads.imports import (
         CLIConfirmationRequiredPayload,
     )
-    from moneybin.services.import_confirmation import (  # noqa: PLC0415 — defer import to keep CLI cold-start light
+
+    # defer import to keep CLI cold-start light
+    from moneybin.services.import_confirmation import (
         confirmation_payload_dict,
     )
 
@@ -1166,10 +1175,13 @@ def _echo_account_proposals(outcome: ConfirmationRequired, *, err: bool) -> None
     disambiguator when one file proposes several accounts, and it is not
     typeable. ``proposal_ref`` is the answer, on every channel.
     """
-    from moneybin.privacy.payloads.imports import (  # noqa: PLC0415 — defer import to keep CLI cold-start light
+    # defer import to keep CLI cold-start light
+    from moneybin.privacy.payloads.imports import (
         ImportConfirmationAccountProposal,
     )
-    from moneybin.privacy.redaction import (  # noqa: PLC0415 — defer import to keep CLI cold-start light
+
+    # defer import to keep CLI cold-start light
+    from moneybin.privacy.redaction import (
         redact_typed,
     )
 
@@ -1230,7 +1242,7 @@ def _import_files_account_args(
     Returns a leading-space-prefixed fragment (or ``""``) so callers can splice
     it into a sentence without emitting a double space when nothing is set.
     """
-    import shlex  # noqa: PLC0415
+    import shlex
 
     parts: list[str] = []
     if institution is not None:
@@ -1250,7 +1262,7 @@ def _import_files_account_args(
     # account and discloses nothing, a raw key cannot be printed, and
     # `_sign_recovery_note` tells the caller what to re-supply rather than
     # letting the pin vanish.
-    from moneybin.services.import_service import (  # noqa: PLC0415 — defer import
+    from moneybin.services.import_service import (
         is_proposal_ref,
     )
 
@@ -1280,7 +1292,7 @@ def _sign_recovery_note(
     pastes a command that looks complete, the raw-keyed pin is gone, and the
     import binds whatever matching infers.
     """
-    from moneybin.services.import_service import (  # noqa: PLC0415 — defer import
+    from moneybin.services.import_service import (
         is_proposal_ref,
     )
 
@@ -1329,7 +1341,7 @@ def _import_confirm_command(
     command refuses alongside it. The bridge takes ``--confirm``, not
     ``--accept``, so the two are mutually exclusive here as well.
     """
-    import shlex  # noqa: PLC0415
+    import shlex
 
     parts = ["moneybin", "import", "confirm", file_path_str]
     if bridge_response is not None:
@@ -1494,9 +1506,9 @@ def _sign_recovery_commands(
             f"Keep amounts exactly as printed: {native_command}",
         ]
 
-    import shlex  # noqa: PLC0415
+    import shlex
 
-    from moneybin.services.import_confirmation import (  # noqa: PLC0415
+    from moneybin.services.import_confirmation import (
         sign_convention_effect,
     )
 
@@ -1562,7 +1574,8 @@ def _sign_direction(
     ``(None, None)`` when the outcome isn't a sign proposal, which keeps the
     default first-contact framing.
     """
-    from moneybin.services.import_confirmation import (  # noqa: PLC0415  # module-scope import is TYPE_CHECKING-only (cold-start hygiene)
+    # module-scope import is TYPE_CHECKING-only (cold-start hygiene)
+    from moneybin.services.import_confirmation import (
         SignConventionProposal,
     )
 
@@ -1660,9 +1673,9 @@ def _render_confirmation_prompt(
     to a future task.  This v1 implementation shows the proposal and instructs
     the user to re-run with the appropriate flags.
     """
-    import shlex  # noqa: PLC0415
+    import shlex
 
-    from moneybin.services.import_confirmation import (  # noqa: PLC0415
+    from moneybin.services.import_confirmation import (
         ProposedMapping,
         SignConventionProposal,
     )
@@ -1885,11 +1898,11 @@ def import_confirm_command(
         moneybin import confirm ~/Downloads/card.csv --accept --sign negative_is_expense
         moneybin import confirm ~/Downloads/card.pdf --bridge-response response.json --confirm
     """
-    from moneybin.cli.output import render_or_json  # noqa: PLC0415
+    from moneybin.cli.output import render_or_json
     from moneybin.cli.utils import handle_cli_errors
-    from moneybin.database import get_database  # noqa: PLC0415
-    from moneybin.protocol.envelope import build_envelope  # noqa: PLC0415
-    from moneybin.services.import_service import ImportService  # noqa: PLC0415
+    from moneybin.database import get_database
+    from moneybin.protocol.envelope import build_envelope
+    from moneybin.services.import_service import ImportService
 
     if bridge_response is not None:
         if accept or mapping or confirm_sign or sign:
@@ -2167,7 +2180,7 @@ def import_confirm_command(
                 )
             raise typer.Exit(1)
 
-        from moneybin.services.inbox_service import InboxService  # noqa: PLC0415
+        from moneybin.services.inbox_service import InboxService
 
         InboxService.for_active_profile_no_db().archive_confirmed_file(file_path)
         data = {
@@ -2207,7 +2220,7 @@ def import_confirm_command(
     # drop the .pending.yml sidecar (no-op for a path that never entered the
     # inbox, e.g. a file passed directly to `import files`).
     from moneybin.services.inbox_service import (
-        InboxService,  # noqa: PLC0415 — defer import
+        InboxService,
     )
 
     InboxService.for_active_profile_no_db().archive_confirmed_file(file_path)
@@ -2306,7 +2319,7 @@ def import_history(
     """
     from moneybin.cli.output import render_or_json
     from moneybin.cli.utils import handle_cli_errors
-    from moneybin.database import get_database  # noqa: PLC0415 — deferred import
+    from moneybin.database import get_database
     from moneybin.extractors.tabular import TabularExtractor
     from moneybin.protocol.envelope import build_envelope
 
@@ -2375,7 +2388,7 @@ def import_revert(
         moneybin import revert abc123-... --yes
     """
     from moneybin.cli.utils import handle_cli_errors
-    from moneybin.database import get_database  # noqa: PLC0415 — deferred import
+    from moneybin.database import get_database
     from moneybin.services.import_service import ImportRevertPlan, ImportService
 
     with handle_cli_errors():
@@ -2434,16 +2447,16 @@ def _preview_pdf(source: Path) -> None:
     ``read_only=False`` matches the MCP path: a bridge escalation writes the
     Req 14 egress audit row before raising.
     """
-    from moneybin.database import (  # noqa: PLC0415
+    from moneybin.database import (
         DatabaseKeyError,
         database_key_error_hint,
         get_database,
     )
-    from moneybin.services.import_confirmation import (  # noqa: PLC0415
+    from moneybin.services.import_confirmation import (
         ImportConfirmationRequiredError,
         SignConventionProposal,
     )
-    from moneybin.services.import_service import ImportService  # noqa: PLC0415
+    from moneybin.services.import_service import ImportService
 
     try:
         with get_database(read_only=False) as db:
@@ -2613,7 +2626,7 @@ def import_preview(
 
         # Stage 3: Column mapping — load built-in + user-saved formats
         matched_format = None
-        from moneybin.database import (  # noqa: PLC0415
+        from moneybin.database import (
             DatabaseKeyError,
             DatabaseNotInitializedError,
             get_database,
@@ -2674,7 +2687,7 @@ def import_preview(
             for field, col in matched_format.field_mapping.items():
                 typer.echo(f"  {field} ← {col}")
         else:
-            from moneybin.config import get_settings  # noqa: PLC0415
+            from moneybin.config import get_settings
 
             bands = get_settings().import_.confidence
             mapping_result = map_columns(
@@ -2883,7 +2896,7 @@ def formats_show(
         moneybin import formats show chase_a1b2c3d4e5f6
     """
     from moneybin.database import get_database
-    from moneybin.privacy.payloads.imports import (  # noqa: PLC0415 — defer import
+    from moneybin.privacy.payloads.imports import (
         ImportPdfFormatDetail,
     )
     from moneybin.services.import_service import ImportService
@@ -3025,7 +3038,7 @@ def formats_delete(
     """
     from moneybin import error_codes
     from moneybin.cli.utils import handle_cli_errors
-    from moneybin.database import get_database  # noqa: PLC0415 — deferred import
+    from moneybin.database import get_database
     from moneybin.errors import UserError
     from moneybin.extractors.tabular.formats import load_builtin_formats
     from moneybin.services.import_service import ImportService
@@ -3076,13 +3089,13 @@ def import_status(
     from moneybin.cli.output import render_or_json
     from moneybin.cli.utils import handle_cli_errors
     from moneybin.config import get_settings
-    from moneybin.database import get_database  # noqa: PLC0415 — deferred import
+    from moneybin.database import get_database
     from moneybin.privacy.payloads.imports import (
         ImportRawSummaryPayload,
         ImportRawTableRow,
     )
     from moneybin.protocol.envelope import build_envelope
-    from moneybin.services.import_service import ImportService  # noqa: PLC0415
+    from moneybin.services.import_service import ImportService
 
     db_path = get_settings().database.path
 

--- a/src/moneybin/cli/commands/import_inbox.py
+++ b/src/moneybin/cli/commands/import_inbox.py
@@ -67,7 +67,8 @@ def _print_sync_text(result: InboxSyncResult) -> None:
     # Deferred: import_cmd imports this module at its own module level, so a
     # top-level import here would close the cycle. Reused rather than re-rendered
     # because one wrong-account recovery hint is hard enough to keep correct.
-    from moneybin.cli.commands.import_cmd import (  # noqa: PLC0415
+    # deferred: module-scope import would cycle
+    from moneybin.cli.commands.import_cmd import (
         echo_accounts_created,
         format_account_candidate,
     )
@@ -167,9 +168,9 @@ def inbox_default(
     """Default action: drain the inbox."""
     if ctx.invoked_subcommand is not None:
         return
-    from moneybin.cli.utils import handle_cli_errors  # noqa: PLC0415
-    from moneybin.config import get_settings  # noqa: PLC0415
-    from moneybin.database import get_database  # noqa: PLC0415
+    from moneybin.cli.utils import handle_cli_errors
+    from moneybin.config import get_settings
+    from moneybin.database import get_database
 
     with handle_cli_errors(cli_actor="inbox_default"):
         with get_database(read_only=False) as db:
@@ -180,14 +181,14 @@ def inbox_default(
     # user's own decision is neither. The drain is the least supervised surface
     # reaching the reconciliation, so this is the one it can least afford to
     # swallow — and --output json is the mode an unattended caller actually uses.
-    from moneybin.adapters.refresh_adapters import (  # noqa: PLC0415
+    from moneybin.adapters.refresh_adapters import (
         refresh_steps_fields,
     )
-    from moneybin.cli.utils import (  # noqa: PLC0415
+    from moneybin.cli.utils import (
         warn_refresh_steps,
         warn_transfers_retired,
     )
-    from moneybin.matching.reconciliation import (  # noqa: PLC0415
+    from moneybin.matching.reconciliation import (
         RETIRED_SIDES_COLLAPSED,
     )
 

--- a/src/moneybin/cli/commands/import_inbox.py
+++ b/src/moneybin/cli/commands/import_inbox.py
@@ -67,7 +67,6 @@ def _print_sync_text(result: InboxSyncResult) -> None:
     # Deferred: import_cmd imports this module at its own module level, so a
     # top-level import here would close the cycle. Reused rather than re-rendered
     # because one wrong-account recovery hint is hard enough to keep correct.
-    # deferred: module-scope import would cycle
     from moneybin.cli.commands.import_cmd import (
         echo_accounts_created,
         format_account_candidate,

--- a/src/moneybin/cli/commands/investments/prices.py
+++ b/src/moneybin/cli/commands/investments/prices.py
@@ -144,8 +144,8 @@ def investments_prices_pull(
     ):
         # Deferred: the adapters pull in httpx, which every CLI invocation would
         # otherwise pay for at import time (cli.md cold-start hygiene).
-        from moneybin.orchestration import refresh as refresh_module  # noqa: PLC0415
-        from moneybin.services.price_service import build_price_service  # noqa: PLC0415
+        from moneybin.orchestration import refresh as refresh_module
+        from moneybin.services.price_service import build_price_service
 
         start = parse_cli_date(since, "--since") if since else None
         with get_database(read_only=False) as db:
@@ -261,8 +261,8 @@ def investments_prices_set(
         cli_actor="investments_prices_set",
         payload_type=InvestmentPriceMarkPayload,
     ):
-        from moneybin.orchestration import refresh as refresh_module  # noqa: PLC0415
-        from moneybin.services.price_service import build_price_service  # noqa: PLC0415
+        from moneybin.orchestration import refresh as refresh_module
+        from moneybin.services.price_service import build_price_service
 
         with get_database(read_only=False) as db:
             service = build_price_service(db, actor="investments_prices_set")
@@ -340,8 +340,8 @@ def investments_prices_delete(
         cli_actor="investments_prices_delete",
         payload_type=InvestmentPriceMarkPayload,
     ):
-        from moneybin.orchestration import refresh as refresh_module  # noqa: PLC0415
-        from moneybin.services.price_service import build_price_service  # noqa: PLC0415
+        from moneybin.orchestration import refresh as refresh_module
+        from moneybin.services.price_service import build_price_service
 
         with get_database(read_only=False) as db:
             service = build_price_service(db, actor="investments_prices_delete")
@@ -414,7 +414,7 @@ def investments_prices_list(
         cli_actor="investments_prices_list",
         payload_type=InvestmentPricesPayload,
     ):
-        from moneybin.services.price_service import build_price_service  # noqa: PLC0415
+        from moneybin.services.price_service import build_price_service
 
         with get_database(read_only=True) as db:
             service = build_price_service(db, actor="investments_prices_list")
@@ -476,7 +476,7 @@ def investments_prices_token(
         typer.echo("error: token must not be empty", err=True)
         raise typer.Exit(2)
     with handle_cli_errors(cli_actor="investments_prices_token"):
-        from moneybin.secrets import (  # noqa: PLC0415  # keyring import is not cold-start cheap
+        from moneybin.secrets import (  # keyring import is not cold-start cheap
             TIINGO_API_TOKEN_KEY,
             SecretStore,
         )

--- a/src/moneybin/cli/commands/investments/security_links.py
+++ b/src/moneybin/cli/commands/investments/security_links.py
@@ -68,7 +68,7 @@ def links_pending(
     payload = SecurityLinksPendingPayload.from_service(groups, n_pending)
 
     if output == OutputFormat.JSON:
-        from moneybin.cli.output import render_or_json  # noqa: PLC0415 — defer import
+        from moneybin.cli.output import render_or_json
 
         render_or_json(
             build_envelope(data=payload),
@@ -214,7 +214,7 @@ def links_history(
     payload = SecurityLinksHistoryPayload.from_rows(rows)
 
     if output == OutputFormat.JSON:
-        from moneybin.cli.output import render_or_json  # noqa: PLC0415 — defer import
+        from moneybin.cli.output import render_or_json
 
         render_or_json(
             build_envelope(data=payload),

--- a/src/moneybin/cli/commands/mcp.py
+++ b/src/moneybin/cli/commands/mcp.py
@@ -622,7 +622,7 @@ def _print_client_notes(client: str) -> None:
         # counts come from moneybin.mcp.surface (plain constants, no FastMCP import
         # — resolving them live would make `mcp install` boot the server), and a
         # test asserts them against the live registry so they can't go stale.
-        from moneybin.mcp.surface import (  # noqa: PLC0415 — keep it off the CLI cold-start path
+        from moneybin.mcp.surface import (  # keep it off the CLI cold-start path
             VISIBLE_TOOL_COUNT,
             WINDSURF_ACTIVE_TOOL_CAP,
         )
@@ -737,7 +737,7 @@ def mcp_list_prompts(
     """
     from moneybin.mcp.server import (
         init_db,
-        mcp,  # noqa: PLC0415 — defer fastmcp import to subcommand body
+        mcp,  # defer fastmcp import to subcommand body
     )
 
     init_db()

--- a/src/moneybin/cli/commands/merchants/links.py
+++ b/src/moneybin/cli/commands/merchants/links.py
@@ -52,7 +52,7 @@ def links_pending(
     payload = MerchantLinksPendingPayload.from_service(groups, n_pending)
 
     if output == OutputFormat.JSON:
-        from moneybin.cli.output import render_or_json  # noqa: PLC0415 — defer import
+        from moneybin.cli.output import render_or_json
 
         render_or_json(
             build_envelope(data=payload),
@@ -153,7 +153,7 @@ def links_history(
     payload = MerchantLinksHistoryPayload.from_rows(rows)
 
     if output == OutputFormat.JSON:
-        from moneybin.cli.output import render_or_json  # noqa: PLC0415 — defer import
+        from moneybin.cli.output import render_or_json
 
         render_or_json(
             build_envelope(data=payload),
@@ -213,7 +213,7 @@ def links_run(
     payload = MerchantLinksRunPayload(bound=result.bound, conflicts=result.conflicts)
 
     if output == OutputFormat.JSON:
-        from moneybin.cli.output import render_or_json  # noqa: PLC0415 — defer import
+        from moneybin.cli.output import render_or_json
 
         render_or_json(
             build_envelope(data=payload),

--- a/src/moneybin/cli/commands/refresh.py
+++ b/src/moneybin/cli/commands/refresh.py
@@ -133,12 +133,12 @@ def refresh_command(
     not answer is reported and retried next run. Only a SQLMesh apply error
     exits non-zero.
     """
-    from moneybin.adapters.refresh_adapters import (  # noqa: PLC0415
+    from moneybin.adapters.refresh_adapters import (
         refresh_envelope,
     )
-    from moneybin.cli.output import render_or_json  # noqa: PLC0415
-    from moneybin.database import get_database  # noqa: PLC0415
-    from moneybin.orchestration.refresh import (  # noqa: PLC0415
+    from moneybin.cli.output import render_or_json
+    from moneybin.database import get_database
+    from moneybin.orchestration.refresh import (
         expand_steps,
         refresh,
         step_outcome,

--- a/src/moneybin/cli/commands/reports/networth.py
+++ b/src/moneybin/cli/commands/reports/networth.py
@@ -44,7 +44,7 @@ def reports_networth(
 ) -> None:
     """Show current or as-of net worth + per-account breakdown."""
     with handle_cli_errors():
-        from moneybin.reports._framework.catalog import (  # noqa: PLC0415 — defer catalog import
+        from moneybin.reports._framework.catalog import (
             get_report_catalog,
             profile_home_currency,
         )
@@ -136,7 +136,7 @@ def reports_networth_history(
 ) -> None:
     """Net worth time series with period-over-period change."""
     with handle_cli_errors():
-        from moneybin.reports._framework.catalog import (  # noqa: PLC0415 — defer catalog import
+        from moneybin.reports._framework.catalog import (
             get_report_catalog,
             profile_home_currency,
         )

--- a/src/moneybin/cli/commands/sql.py
+++ b/src/moneybin/cli/commands/sql.py
@@ -74,11 +74,11 @@ def sql_query_command(
     """
     # Deferred: execute_sql_query pulls in sqlglot (a SQL parser); keep it off
     # the CLI cold-start path per .claude/rules/cli.md "Cold-Start Hygiene".
-    from moneybin.privacy.sensitivity import (  # noqa: PLC0415
+    from moneybin.privacy.sensitivity import (
         get_max_rows,
         tier_to_sensitivity,
     )
-    from moneybin.privacy.sql_query import execute_sql_query  # noqa: PLC0415
+    from moneybin.privacy.sql_query import execute_sql_query
 
     # render_or_json stays inside handle_cli_errors so a rendering/serialization
     # failure (e.g. an unusual DuckDB column type) surfaces as a clean CLI error

--- a/src/moneybin/cli/commands/sync.py
+++ b/src/moneybin/cli/commands/sync.py
@@ -37,9 +37,9 @@ logger = logging.getLogger(__name__)
 
 def _build_sync_client():
     """Construct a SyncClient from current settings. Extracted for test mocking."""
-    from moneybin.config import get_settings  # noqa: PLC0415
-    from moneybin.connectors.sync_client import SyncClient  # noqa: PLC0415
-    from moneybin.utils.user_config import get_or_create_profile_id  # noqa: PLC0415
+    from moneybin.config import get_settings
+    from moneybin.connectors.sync_client import SyncClient
+    from moneybin.utils.user_config import get_or_create_profile_id
 
     settings = get_settings()
     if settings.sync.server_url is None:
@@ -56,9 +56,9 @@ def _build_sync_client():
 @contextmanager
 def _build_sync_service():
     """Yield a SyncService with an active Database connection (per ADR-010)."""
-    from moneybin.database import get_database  # noqa: PLC0415
-    from moneybin.extractors.plaid import PlaidExtractor  # noqa: PLC0415
-    from moneybin.services.sync_service import SyncService  # noqa: PLC0415
+    from moneybin.database import get_database
+    from moneybin.extractors.plaid import PlaidExtractor
+    from moneybin.services.sync_service import SyncService
 
     client = _build_sync_client()
     with get_database(read_only=False) as db:
@@ -183,7 +183,7 @@ def sync_link(
                 # Event-driven: emit initiate response and exit. Agent verifies
                 # completion via `sync link-status` after the user finishes
                 # the Plaid Hosted Link flow out-of-band.
-                from moneybin.adapters.sync_adapters import (  # noqa: PLC0415 — defer import
+                from moneybin.adapters.sync_adapters import (
                     sync_link_envelope,
                 )
 
@@ -258,7 +258,7 @@ def sync_link_status(
         result = client.get_link_status(session_id)
 
     if output == OutputFormat.JSON:
-        from moneybin.adapters.sync_adapters import (  # noqa: PLC0415 — defer import
+        from moneybin.adapters.sync_adapters import (
             sync_link_status_envelope,
         )
 
@@ -350,7 +350,7 @@ def sync_disconnect(
         with _build_sync_service() as service:
             service.disconnect(institution=institution)
     if output == OutputFormat.JSON:
-        from moneybin.adapters.sync_adapters import (  # noqa: PLC0415 — defer import
+        from moneybin.adapters.sync_adapters import (
             sync_disconnect_envelope,
         )
 
@@ -412,7 +412,7 @@ def sync_pull(
     warn_refresh_steps(result.refresh_steps)
 
     if output == OutputFormat.JSON:
-        from moneybin.adapters.sync_adapters import (  # noqa: PLC0415 — defer import
+        from moneybin.adapters.sync_adapters import (
             sync_pull_envelope,
         )
 
@@ -545,7 +545,7 @@ def sync_status(
             connections = service.list_connections()
 
     if output == OutputFormat.JSON:
-        from moneybin.adapters.sync_adapters import (  # noqa: PLC0415 — defer import
+        from moneybin.adapters.sync_adapters import (
             sync_status_envelope,
         )
 

--- a/src/moneybin/cli/commands/synthetic.py
+++ b/src/moneybin/cli/commands/synthetic.py
@@ -61,10 +61,10 @@ def _run_generate(
     try:
         with handle_cli_errors():
             from moneybin.database import (
-                get_database,  # noqa: PLC0415 — deferred import
+                get_database,
             )
             from moneybin.tables import (
-                OFX_TRANSACTIONS,  # noqa: PLC0415 — deferred import
+                OFX_TRANSACTIONS,
                 TABULAR_TRANSACTIONS,
             )
 
@@ -200,7 +200,7 @@ def synthetic_reset(
     try:
         with handle_cli_errors():
             from moneybin.database import (
-                get_database,  # noqa: PLC0415 — deferred import
+                get_database,
             )
 
             with get_database(read_only=False) as db:

--- a/src/moneybin/cli/commands/transactions/categorize/__init__.py
+++ b/src/moneybin/cli/commands/transactions/categorize/__init__.py
@@ -132,7 +132,7 @@ def categorize_pending(
         if not records:
             logger.info("No uncategorized transactions.")
             return
-        from moneybin.cli.render import Money, render_rows  # noqa: PLC0415 — defer
+        from moneybin.cli.render import Money, render_rows
 
         cols = list(records[0].keys())
         rows = [tuple(r.values()) for r in records]

--- a/src/moneybin/cli/commands/transactions/categorize/rules.py
+++ b/src/moneybin/cli/commands/transactions/categorize/rules.py
@@ -186,7 +186,8 @@ def rules_create(
     A 'contains' rule whose pattern is too short to discriminate is refused
     unless --allow-broad is passed — see --allow-broad help.
     """
-    from moneybin.services.categorization import (  # noqa: PLC0415 — defer import; CLI cold-start hygiene
+    # defer import; CLI cold-start hygiene
+    from moneybin.services.categorization import (
         CategorizationService,
         validate_rule_items,
     )
@@ -320,7 +321,8 @@ def rules_delete(
     strip categorizations written by this rule and re-evaluate those rows
     against remaining active matchers.
     """
-    from moneybin.services.categorization import (  # noqa: PLC0415 — defer import; CLI cold-start hygiene
+    # defer import; CLI cold-start hygiene
+    from moneybin.services.categorization import (
         CategorizationService,
     )
 
@@ -384,7 +386,8 @@ def rules_list_conflicts(
     wide: bool = wide_option,
 ) -> None:
     """Show categorization rules refused because another rule owns the matcher."""
-    from moneybin.services.categorization import (  # noqa: PLC0415 — defer import; CLI cold-start hygiene
+    # defer import; CLI cold-start hygiene
+    from moneybin.services.categorization import (
         CategorizationService,
     )
 
@@ -462,7 +465,8 @@ _RESOLUTIONS: tuple[str, ...] = ("replace", "reprioritize", "cancel")
 
 def _decision_from_row(index: int, row: object) -> "ConflictDecision":
     """Validate one batch-file row into a typed decision, naming its position."""
-    from moneybin.services.categorization import (  # noqa: PLC0415 — defer import; CLI cold-start hygiene
+    # defer import; CLI cold-start hygiene
+    from moneybin.services.categorization import (
         ConflictDecision,
     )
 
@@ -566,7 +570,8 @@ def rules_resolve(
     A conflict recorded against a rule that has since been edited is refused
     as stale — re-read the queue with `rules list-conflicts` and decide again.
     """
-    from moneybin.services.categorization import (  # noqa: PLC0415 — defer import; CLI cold-start hygiene
+    # defer import; CLI cold-start hygiene
+    from moneybin.services.categorization import (
         CategorizationService,
         ConflictDecision,
     )

--- a/src/moneybin/cli/commands/transactions/matches.py
+++ b/src/moneybin/cli/commands/transactions/matches.py
@@ -71,7 +71,7 @@ def matches_pending(
             rows = service.get_pending(match_type=match_type, limit=limit)
 
             if output == OutputFormat.JSON:
-                from moneybin.adapters.matching_adapters import (  # noqa: PLC0415 — defer import
+                from moneybin.adapters.matching_adapters import (
                     matches_pending_envelope,
                 )
 
@@ -211,7 +211,7 @@ def matches_history(
             entries = MatchingService(db).get_log(limit=limit, match_type=match_type)
 
             if output == OutputFormat.JSON:
-                from moneybin.adapters.matching_adapters import (  # noqa: PLC0415 — defer import
+                from moneybin.adapters.matching_adapters import (
                     matches_history_envelope,
                 )
 

--- a/src/moneybin/cli/commands/transform.py
+++ b/src/moneybin/cli/commands/transform.py
@@ -39,10 +39,10 @@ def transform_plan(
         transform_apply(output=output, quiet=quiet)
         return
 
-    from moneybin.cli.output import render_or_json  # noqa: PLC0415
-    from moneybin.database import get_database  # noqa: PLC0415
-    from moneybin.protocol.envelope import build_envelope  # noqa: PLC0415
-    from moneybin.services.transform_service import TransformService  # noqa: PLC0415
+    from moneybin.cli.output import render_or_json
+    from moneybin.database import get_database
+    from moneybin.protocol.envelope import build_envelope
+    from moneybin.services.transform_service import TransformService
 
     with handle_cli_errors(), get_database(read_only=True) as db:
         plan = TransformService(db).plan()
@@ -91,10 +91,10 @@ def transform_apply(
     Equivalent to 'moneybin transform plan --apply'. Rebuilds only changed
     models since the last run.
     """
-    from moneybin.cli.output import render_or_json  # noqa: PLC0415
-    from moneybin.database import get_database  # noqa: PLC0415
-    from moneybin.protocol.envelope import build_envelope  # noqa: PLC0415
-    from moneybin.services.transform_service import TransformService  # noqa: PLC0415
+    from moneybin.cli.output import render_or_json
+    from moneybin.database import get_database
+    from moneybin.protocol.envelope import build_envelope
+    from moneybin.services.transform_service import TransformService
 
     with (
         handle_cli_errors(cli_actor="transform_apply"),
@@ -151,10 +151,10 @@ def transform_status(
     quiet: bool = quiet_option,
 ) -> None:
     """Show current model state and environment."""
-    from moneybin.cli.output import render_or_json  # noqa: PLC0415
-    from moneybin.database import get_database  # noqa: PLC0415
-    from moneybin.protocol.envelope import build_envelope  # noqa: PLC0415
-    from moneybin.services.transform_service import TransformService  # noqa: PLC0415
+    from moneybin.cli.output import render_or_json
+    from moneybin.database import get_database
+    from moneybin.protocol.envelope import build_envelope
+    from moneybin.services.transform_service import TransformService
 
     with handle_cli_errors(), get_database(read_only=True) as db:
         status = TransformService(db).status()
@@ -213,10 +213,10 @@ def transform_validate(
     quiet: bool = quiet_option,
 ) -> None:
     """Check that model SQL parses and resolves without errors."""
-    from moneybin.cli.output import render_or_json  # noqa: PLC0415
-    from moneybin.database import get_database  # noqa: PLC0415
-    from moneybin.protocol.envelope import build_envelope  # noqa: PLC0415
-    from moneybin.services.transform_service import TransformService  # noqa: PLC0415
+    from moneybin.cli.output import render_or_json
+    from moneybin.database import get_database
+    from moneybin.protocol.envelope import build_envelope
+    from moneybin.services.transform_service import TransformService
 
     with handle_cli_errors(), get_database(read_only=True) as db:
         result = TransformService(db).validate()
@@ -255,10 +255,10 @@ def transform_audit(
     quiet: bool = quiet_option,
 ) -> None:
     """Run data quality assertions defined in transform models."""
-    from moneybin.cli.output import render_or_json  # noqa: PLC0415
-    from moneybin.database import get_database  # noqa: PLC0415
-    from moneybin.protocol.envelope import build_envelope  # noqa: PLC0415
-    from moneybin.services.transform_service import TransformService  # noqa: PLC0415
+    from moneybin.cli.output import render_or_json
+    from moneybin.database import get_database
+    from moneybin.protocol.envelope import build_envelope
+    from moneybin.services.transform_service import TransformService
 
     with handle_cli_errors(), get_database(read_only=False) as db:
         result = TransformService(db).audit(start, end)

--- a/src/moneybin/cli/output.py
+++ b/src/moneybin/cli/output.py
@@ -147,7 +147,7 @@ class OutputFormat(StrEnum):
 
 def _set_output_flag(value: OutputFormat) -> OutputFormat:
     from moneybin.cli.utils import (
-        set_output_flag,  # noqa: PLC0415 — defer to break import cycle
+        set_output_flag,  # deferred: module-scope import would cycle
     )
 
     return set_output_flag(value)

--- a/src/moneybin/cli/render.py
+++ b/src/moneybin/cli/render.py
@@ -218,8 +218,8 @@ class Placeholder:
 
 
 def _cell_width(cell: RenderableType) -> int:
-    from rich.cells import cell_len  # noqa: PLC0415 — defer heavy import
-    from rich.text import Text  # noqa: PLC0415 — defer heavy import
+    from rich.cells import cell_len  # defer heavy import
+    from rich.text import Text  # defer heavy import
 
     return cell_len(cell.plain if isinstance(cell, Text) else str(cell))
 
@@ -405,8 +405,8 @@ def render_rows(
     repeated rows; collapsing them here would make the output look right while
     the total stayed wrong, removing the symptom that finds the defect.
     """
-    from rich.console import Console  # noqa: PLC0415 — defer heavy import
-    from rich.table import Table  # noqa: PLC0415 — defer heavy import
+    from rich.console import Console  # defer heavy import
+    from rich.table import Table  # defer heavy import
 
     declared = money or {}
     # Formatting and atomicity are separate declarations. A per-unit price is
@@ -579,7 +579,7 @@ def render_note(message: str, *, quiet: bool = False, warn: bool = False) -> Non
     if quiet:
         return
     if warn and color_enabled(sys.stderr, os.environ):
-        from rich.console import Console  # noqa: PLC0415 — defer heavy import
+        from rich.console import Console  # defer heavy import
 
         Console(stderr=True, markup=False, highlight=False).print(
             message, style=Style.WARNING
@@ -608,7 +608,7 @@ def _cells(
     happens to equal the placeholder — which is the distinction ``--output
     json`` preserves by carrying the NULL through untouched.
     """
-    from rich.text import Text  # noqa: PLC0415 — defer heavy import
+    from rich.text import Text  # defer heavy import
 
     cells: list[RenderableType] = []
     # strict: a row and its header are built together at every call site, so a

--- a/src/moneybin/cli/utils.py
+++ b/src/moneybin/cli/utils.py
@@ -47,8 +47,8 @@ def _error_audit_classification(payload_type: type | None) -> tuple[str, list[st
     """
     if payload_type is None:
         return "high", []
-    from moneybin.privacy.classified_envelope import classify  # noqa: PLC0415
-    from moneybin.privacy.introspection import PrivacyContractError  # noqa: PLC0415
+    from moneybin.privacy.classified_envelope import classify
+    from moneybin.privacy.introspection import PrivacyContractError
 
     classification = classify(payload_type)
     try:
@@ -114,7 +114,7 @@ def handle_cli_errors(
                 # Mirror the MCP decorator's error-path audit emission so
                 # JSON-mode failures appear in privacy.log.jsonl alongside
                 # success rows.
-                from moneybin.privacy.log import (  # noqa: PLC0415 — defer import
+                from moneybin.privacy.log import (
                     build_tool_call_event,
                     write_privacy_event,
                 )
@@ -345,7 +345,7 @@ def sqlmesh_command(
         success: Custom success message after ``✅ ``. Defaults to
             ``f"{label} completed"``.
     """
-    from moneybin.database import get_database  # noqa: PLC0415 — defer heavy import
+    from moneybin.database import get_database  # defer heavy import
 
     logger.info(f"⚙️  {label}...")
     try:

--- a/src/moneybin/config.py
+++ b/src/moneybin/config.py
@@ -1306,7 +1306,8 @@ def set_current_profile(profile: str) -> None:
             # Each profile has its own encryption key; clear the process-level
             # key cache so the next Database() open fetches the correct key.
             from moneybin.database import (
-                invalidate_encryption_key_cache,  # noqa: PLC0415
+                # deferred: module-scope import would cycle
+                invalidate_encryption_key_cache,
             )
 
             invalidate_encryption_key_cache()
@@ -1330,7 +1331,8 @@ def clear_current_profile() -> None:
     _current_settings = None  # Invalidate settings cache
     # Each profile has its own encryption key; clear the process-level key cache so
     # the next Database() open fetches the correct one.
-    from moneybin.database import invalidate_encryption_key_cache  # noqa: PLC0415
+    # deferred: module-scope import would cycle
+    from moneybin.database import invalidate_encryption_key_cache
 
     invalidate_encryption_key_cache()
 

--- a/src/moneybin/connectors/gsheet/adapters/transactions.py
+++ b/src/moneybin/connectors/gsheet/adapters/transactions.py
@@ -294,7 +294,7 @@ def _key_not_already_owned(label: str, taken: set[str]) -> str:
     collide with a stored account. Two *live* labels that slugify alike still
     share a key, which is a separate known defect and not this one.
     """
-    from moneybin.services.import_service import (  # noqa: PLC0415  # avoids an import cycle: services imports connectors
+    from moneybin.services.import_service import (
         label_account_key,
     )
 
@@ -454,13 +454,13 @@ def _link_sheet_accounts(
     for the account-link review queue. Accepting that decision later re-points
     the link, so rows already loaded follow rather than stranding.
     """
-    from moneybin.services.account_display_name import (  # noqa: PLC0415  # avoids an import cycle: services imports connectors
+    from moneybin.services.account_display_name import (
         AccountNameFacts,
     )
     from moneybin.services.account_resolution_types import (
-        SourceAccount,  # noqa: PLC0415
+        SourceAccount,
     )
-    from moneybin.services.account_resolver import AccountResolver  # noqa: PLC0415
+    from moneybin.services.account_resolver import AccountResolver
 
     resolver = AccountResolver(db)
     for key, (display, clean_name, last_four) in parsed.items():
@@ -498,7 +498,7 @@ def _register_sheet_accounts(
     every pull rather than written once: a sheet is live, and an account renamed
     in it re-labels the row already on that key rather than minting a second.
     """
-    from moneybin.services.import_service import (  # noqa: PLC0415  # avoids an import cycle: services imports connectors
+    from moneybin.services.import_service import (
         authored_label_parts,
     )
 

--- a/src/moneybin/connectors/gsheet/connection_service.py
+++ b/src/moneybin/connectors/gsheet/connection_service.py
@@ -365,7 +365,7 @@ class GSheetConnectionService:
         resolved_account_id: str | None = req.account_id
         if target_adapter == "transactions" and not resolved_account_id:
             if req.account_name:
-                from moneybin.services.account_service import (  # noqa: PLC0415
+                from moneybin.services.account_service import (
                     AccountService,
                 )
 

--- a/src/moneybin/connectors/gsheet/service_factory.py
+++ b/src/moneybin/connectors/gsheet/service_factory.py
@@ -24,11 +24,11 @@ if TYPE_CHECKING:
 
 def build_oauth_client() -> Any:
     """Construct a GoogleOAuthClient from current settings + SecretStore."""
-    from moneybin.config import get_settings  # noqa: PLC0415
-    from moneybin.connectors.gsheet.oauth_client import (  # noqa: PLC0415
+    from moneybin.config import get_settings
+    from moneybin.connectors.gsheet.oauth_client import (
         GoogleOAuthClient,
     )
-    from moneybin.secrets import SecretStore  # noqa: PLC0415
+    from moneybin.secrets import SecretStore
 
     return GoogleOAuthClient(secrets=SecretStore(), settings=get_settings())
 
@@ -36,11 +36,11 @@ def build_oauth_client() -> Any:
 @contextmanager
 def build_connection_service() -> Generator[GSheetConnectionService, None, None]:
     """Yield a GSheetConnectionService with an active Database connection."""
-    from moneybin.connectors.gsheet.connection_service import (  # noqa: PLC0415
+    from moneybin.connectors.gsheet.connection_service import (
         GSheetConnectionService,
     )
-    from moneybin.connectors.gsheet.sheets_api import SheetsClient  # noqa: PLC0415
-    from moneybin.database import get_database  # noqa: PLC0415
+    from moneybin.connectors.gsheet.sheets_api import SheetsClient
+    from moneybin.database import get_database
 
     oauth_client = build_oauth_client()
     sheets_client = SheetsClient(oauth=oauth_client)
@@ -53,11 +53,11 @@ def build_connection_service() -> Generator[GSheetConnectionService, None, None]
 @contextmanager
 def build_pull_service() -> Generator[GSheetPullService, None, None]:
     """Yield a GSheetPullService with an active Database connection."""
-    from moneybin.connectors.gsheet.pull_service import (  # noqa: PLC0415
+    from moneybin.connectors.gsheet.pull_service import (
         GSheetPullService,
     )
-    from moneybin.connectors.gsheet.sheets_api import SheetsClient  # noqa: PLC0415
-    from moneybin.database import get_database  # noqa: PLC0415
+    from moneybin.connectors.gsheet.sheets_api import SheetsClient
+    from moneybin.database import get_database
 
     oauth_client = build_oauth_client()
     sheets_client = SheetsClient(oauth=oauth_client)
@@ -76,11 +76,11 @@ def build_pull_service_with_db() -> Generator[
     The CLI uses this variant to chain `refresh_run()` on the post-pull DB
     handle without re-acquiring the write lock.
     """
-    from moneybin.connectors.gsheet.pull_service import (  # noqa: PLC0415
+    from moneybin.connectors.gsheet.pull_service import (
         GSheetPullService,
     )
-    from moneybin.connectors.gsheet.sheets_api import SheetsClient  # noqa: PLC0415
-    from moneybin.database import get_database  # noqa: PLC0415
+    from moneybin.connectors.gsheet.sheets_api import SheetsClient
+    from moneybin.database import get_database
 
     oauth_client = build_oauth_client()
     sheets_client = SheetsClient(oauth=oauth_client)

--- a/src/moneybin/connectors/gsheet/sheets_api.py
+++ b/src/moneybin/connectors/gsheet/sheets_api.py
@@ -413,10 +413,10 @@ class SheetsClient:
         Reuses the cached service while the access token is unchanged;
         a token rotation invalidates the cache and rebuilds.
         """
-        import google_auth_httplib2  # noqa: PLC0415
-        import httplib2  # noqa: PLC0415
-        from google.oauth2.credentials import Credentials  # noqa: PLC0415
-        from googleapiclient.discovery import build  # noqa: PLC0415
+        import google_auth_httplib2
+        import httplib2
+        from google.oauth2.credentials import Credentials
+        from googleapiclient.discovery import build
 
         token = self._oauth.get_access_token(require_write=require_write)
         cached = self._cached_services.get(require_write)
@@ -426,7 +426,7 @@ class SheetsClient:
         creds = Credentials(token=token)
         timeout = self._timeout_seconds
         if timeout is None:
-            from moneybin.config import get_settings  # noqa: PLC0415
+            from moneybin.config import get_settings
 
             timeout = get_settings().gsheet.api_timeout_seconds
         # Wrap httplib2.Http with the timeout, then bind credentials via

--- a/src/moneybin/database.py
+++ b/src/moneybin/database.py
@@ -580,7 +580,7 @@ class Database:
 
         store = secret_store or SecretStore()
 
-        global _cached_encryption_key  # noqa: PLW0603
+        global _cached_encryption_key
         # An explicitly-passed secret_store is authoritative: read its key and
         # neither consult nor populate the process cache. The cache only spares
         # the default (secret_store=None) path repeat keyring lookups; letting it
@@ -1118,7 +1118,7 @@ class Database:
         nulled before invocation so a re-entrant close raised from an
         exception handler cannot double-release.
         """
-        global _active_write_conn  # noqa: PLW0603
+        global _active_write_conn
 
         release = self._lock_release
         self._lock_release = None
@@ -1181,7 +1181,7 @@ def invalidate_encryption_key_cache() -> None:
     Called by key rotation so subsequent Database() calls fetch the new key
     from the keychain instead of reusing the pre-rotation cached value.
     """
-    global _cached_encryption_key  # noqa: PLW0603
+    global _cached_encryption_key
     _cached_encryption_key = None
 
 
@@ -1308,7 +1308,7 @@ def get_database(
     acquiring the writer lock so a concurrent deletion cannot turn maintenance
     into implicit database creation.
     """
-    global _database_written, _active_write_conn  # noqa: PLW0603
+    global _database_written, _active_write_conn
 
     # Lazy import: db_lock.lock imports DatabaseLockError from this module,
     # so deferring the import past module-load time breaks the cycle.

--- a/src/moneybin/errors.py
+++ b/src/moneybin/errors.py
@@ -269,10 +269,10 @@ def classify_user_error(exc: BaseException) -> UserError | None:
     # Classification runs on the failure path, where a one-time module load
     # costs nothing and the module that raised is already loaded.
     # Guarded by tests/moneybin/test_architecture/test_errors_is_import_light.py.
-    from moneybin.connectors.sync_errors import (  # noqa: PLC0415 — keeps errors.py import-light
+    from moneybin.connectors.sync_errors import (  # keeps errors.py import-light
         SyncError,
     )
-    from moneybin.database import (  # noqa: PLC0415 — keeps errors.py import-light
+    from moneybin.database import (  # keeps errors.py import-light
         DatabaseCryptoError,
         DatabaseKeyError,
         DatabaseLockError,
@@ -280,7 +280,7 @@ def classify_user_error(exc: BaseException) -> UserError | None:
         SchemaDriftError,
         database_key_error_hint,
     )
-    from moneybin.secrets import (  # noqa: PLC0415 — keeps errors.py import-light
+    from moneybin.secrets import (  # keeps errors.py import-light
         SecretNotFoundError,
         SecretStorageUnavailableError,
         SecretUnavailableError,
@@ -468,7 +468,7 @@ def _is_match_run_error(exc: BaseException) -> bool:
     Kept in its own function rather than joining that block so only an exception
     that matched no branch above pays the import.
     """
-    from moneybin.matching.engine import (  # noqa: PLC0415 — keeps errors.py import-light
+    from moneybin.matching.engine import (  # keeps errors.py import-light
         MatchRunError,
     )
 

--- a/src/moneybin/exports/service.py
+++ b/src/moneybin/exports/service.py
@@ -157,12 +157,12 @@ class ExportService:
         }
         started_at = perf_counter()
         try:
-            from moneybin.config import get_settings  # noqa: PLC0415
-            from moneybin.database import get_database  # noqa: PLC0415
-            from moneybin.exports.workbook_roles import (  # noqa: PLC0415
+            from moneybin.config import get_settings
+            from moneybin.database import get_database
+            from moneybin.exports.workbook_roles import (
                 workbook_role_lease,
             )
-            from moneybin.repositories.export_destinations_repo import (  # noqa: PLC0415
+            from moneybin.repositories.export_destinations_repo import (
                 ExportDestinationsRepo,
             )
 
@@ -213,7 +213,7 @@ class ExportService:
                 if lifetime is not None:
                     lifetime.raise_if_cancelled()
                 if destination.kind == "local":
-                    from moneybin.exports.local import (  # noqa: PLC0415
+                    from moneybin.exports.local import (
                         LocalExportPublisher,
                     )
 
@@ -279,10 +279,10 @@ class ExportService:
         actually failed, logs it, and counts it in
         ``EXPORT_RECEIPT_FAILURES_TOTAL``.
         """
-        from moneybin.database import get_database  # noqa: PLC0415
-        from moneybin.errors import exception_origin  # noqa: PLC0415
-        from moneybin.services.audit_service import AuditService  # noqa: PLC0415
-        from moneybin.services.request_lifetime import (  # noqa: PLC0415
+        from moneybin.database import get_database
+        from moneybin.errors import exception_origin
+        from moneybin.services.audit_service import AuditService
+        from moneybin.services.request_lifetime import (
             publication_barrier,
         )
 
@@ -388,13 +388,13 @@ class ExportService:
 
     def resolve_destination(self, reference: str) -> ExportDestination:
         """Resolve one explicit kind:name reference without accepting a path."""
-        from moneybin import error_codes  # noqa: PLC0415
-        from moneybin.config import get_settings  # noqa: PLC0415
-        from moneybin.errors import UserError  # noqa: PLC0415
-        from moneybin.repositories.export_destinations_repo import (  # noqa: PLC0415
+        from moneybin import error_codes
+        from moneybin.config import get_settings
+        from moneybin.errors import UserError
+        from moneybin.repositories.export_destinations_repo import (
             ExportDestinationsRepo,
         )
-        from moneybin.services.entity_reference import (  # noqa: PLC0415
+        from moneybin.services.entity_reference import (
             AmbiguousEntity,
             MissingEntity,
         )
@@ -487,11 +487,11 @@ class ExportService:
 
     @staticmethod
     def _sheets_publisher() -> _SheetsPublisher:
-        from moneybin.connectors.gsheet.service_factory import (  # noqa: PLC0415
+        from moneybin.connectors.gsheet.service_factory import (
             build_oauth_client,
         )
-        from moneybin.connectors.gsheet.sheets_api import SheetsClient  # noqa: PLC0415
-        from moneybin.exports.sheets import SheetsExportPublisher  # noqa: PLC0415
+        from moneybin.connectors.gsheet.sheets_api import SheetsClient
+        from moneybin.exports.sheets import SheetsExportPublisher
 
         return SheetsExportPublisher(
             sheets_client=SheetsClient(oauth=build_oauth_client()),
@@ -503,7 +503,7 @@ class ExportService:
         sheets_authorization: _SheetsReadiness | None = None,
     ) -> ExportReadinessStatus:
         """Return destination readiness without target identities or locations."""
-        from moneybin.repositories.export_destinations_repo import (  # noqa: PLC0415
+        from moneybin.repositories.export_destinations_repo import (
             ExportDestinationSpreadsheetConflictError,
             ExportDestinationsRepo,
         )
@@ -513,7 +513,7 @@ class ExportService:
         sheets_write_capable = False
         if any(destination.kind == "sheets" for destination in stored):
             if sheets_authorization is None:
-                from moneybin.connectors.gsheet.service_factory import (  # noqa: PLC0415
+                from moneybin.connectors.gsheet.service_factory import (
                     build_oauth_client,
                 )
 
@@ -525,7 +525,7 @@ class ExportService:
                 require_write=True
             )
 
-        from moneybin.config import get_settings  # noqa: PLC0415
+        from moneybin.config import get_settings
 
         default_path = get_settings().profile_exports_dir.expanduser().resolve()
         default_reasons = _local_path_validation_reasons(default_path)
@@ -572,16 +572,16 @@ class ExportService:
         oauth_client: SheetsAuthorization | None = None,
     ) -> AuditEvent:
         """Validate, authorize without DuckDB, then persist one Sheets target."""
-        from moneybin.connectors.gsheet.errors import GSheetAuthError  # noqa: PLC0415
-        from moneybin.database import get_database  # noqa: PLC0415
-        from moneybin.exports.sheets import validate_managed_tab_prefix  # noqa: PLC0415
-        from moneybin.repositories.export_destinations_repo import (  # noqa: PLC0415
+        from moneybin.connectors.gsheet.errors import GSheetAuthError
+        from moneybin.database import get_database
+        from moneybin.exports.sheets import validate_managed_tab_prefix
+        from moneybin.repositories.export_destinations_repo import (
             ExportDestinationsRepo,
         )
 
         client: SheetsAuthorization
         if oauth_client is None:
-            from moneybin.connectors.gsheet.service_factory import (  # noqa: PLC0415
+            from moneybin.connectors.gsheet.service_factory import (
                 build_oauth_client,
             )
 
@@ -834,7 +834,7 @@ def _destination_validation_reasons(
     destination: ExportDestination,
 ) -> tuple[str, ...]:
     """Return fixed structural reason codes shared by run and status."""
-    from moneybin.exports.sheets import validate_managed_tab_prefix  # noqa: PLC0415
+    from moneybin.exports.sheets import validate_managed_tab_prefix
 
     reasons: list[str] = []
     if not destination.name.strip():

--- a/src/moneybin/extractors/tabular/formats.py
+++ b/src/moneybin/extractors/tabular/formats.py
@@ -186,7 +186,8 @@ def save_format_to_db(
             format saved during import, ``"cli"``/``"mcp"`` for an explicit save).
         in_outer_txn: Join a transaction already owned by the caller.
     """
-    from moneybin.repositories.tabular_formats_repo import (  # noqa: PLC0415 — deferred to avoid a runtime database import in this loader module
+    # deferred to avoid a runtime database import in this loader module
+    from moneybin.repositories.tabular_formats_repo import (
         TabularFormatsRepo,
     )
 
@@ -306,7 +307,8 @@ def delete_format_from_db(db: Database, name: str, *, actor: str) -> bool:
     Returns:
         True if the format was found and deleted, False if not found.
     """
-    from moneybin.repositories.tabular_formats_repo import (  # noqa: PLC0415 — deferred to avoid a runtime database import in this loader module
+    # deferred to avoid a runtime database import in this loader module
+    from moneybin.repositories.tabular_formats_repo import (
         TabularFormatsRepo,
     )
 

--- a/src/moneybin/matching/aliasing.py
+++ b/src/moneybin/matching/aliasing.py
@@ -467,8 +467,8 @@ def restore_forwarded_curation(
     # and `undo_service` pulls in that same registry — both re-enter
     # `services.__init__` and back into this package, the cycle the forwarding
     # defers around.
-    from moneybin.services.undo_dispatch import repo_for  # noqa: PLC0415
-    from moneybin.services.undo_service import UndoService  # noqa: PLC0415
+    from moneybin.services.undo_dispatch import repo_for
+    from moneybin.services.undo_service import UndoService
 
     audit = AuditService(db)
     undo_service = UndoService(db)
@@ -628,7 +628,7 @@ def _reversed_alias_edges(db: Database) -> frozenset[str]:
     # Deferred import: `undo_service` pulls in the dispatch registry, which
     # imports every repository module — the same cycle the rest of this module
     # defers around.
-    from moneybin.services.undo_service import UndoService  # noqa: PLC0415
+    from moneybin.services.undo_service import UndoService
 
     rows = db.execute(
         _ALIAS_INSERT_OPERATIONS_SQL,
@@ -674,16 +674,16 @@ def _curation_repos(db: Database) -> tuple[Any, ...]:
     # Deferred imports: the repos' base → services.audit_service chain re-enters
     # `services.__init__`, which imports this package's engine — a module-top
     # import would cycle, the same reason `engine.py` defers its repo import.
-    from moneybin.repositories.transaction_categories_repo import (  # noqa: PLC0415
+    from moneybin.repositories.transaction_categories_repo import (
         TransactionCategoriesRepo,
     )
-    from moneybin.repositories.transaction_notes_repo import (  # noqa: PLC0415
+    from moneybin.repositories.transaction_notes_repo import (
         TransactionNotesRepo,
     )
-    from moneybin.repositories.transaction_splits_repo import (  # noqa: PLC0415
+    from moneybin.repositories.transaction_splits_repo import (
         TransactionSplitsRepo,
     )
-    from moneybin.repositories.transaction_tags_repo import (  # noqa: PLC0415
+    from moneybin.repositories.transaction_tags_repo import (
         TransactionTagsRepo,
     )
 
@@ -697,7 +697,7 @@ def _curation_repos(db: Database) -> tuple[Any, ...]:
 
 def _forward(db: Database, *, actor: str) -> AliasForwardResult:
     """Write the derived aliases and move each superseded id's curation."""
-    from moneybin.repositories.transaction_id_aliases_repo import (  # noqa: PLC0415
+    from moneybin.repositories.transaction_id_aliases_repo import (
         TransactionIdAliasesRepo,  # deferred for the cycle `_curation_repos` names
     )
 

--- a/src/moneybin/matching/engine.py
+++ b/src/moneybin/matching/engine.py
@@ -156,7 +156,7 @@ class TransactionMatcher:
         # Deferred import: engine is loaded via services.__init__ →
         # matching_service → engine, and the repo's base → services.audit_service
         # chain re-enters that path; a module-top import here would cycle.
-        from moneybin.repositories.match_decisions_repo import (  # noqa: PLC0415
+        from moneybin.repositories.match_decisions_repo import (
             MatchDecisionsRepo,
         )
 

--- a/src/moneybin/mcp/decorator.py
+++ b/src/moneybin/mcp/decorator.py
@@ -32,7 +32,7 @@ from contextvars import ContextVar
 from typing import Any, cast
 
 from moneybin import error_codes
-from moneybin.database import (  # noqa: PLC2701 — private import for per-call tracking
+from moneybin.database import (  # private import for per-call tracking
     _call_conn_holder,  # pyright: ignore[reportPrivateUsage]
     interrupt_and_reset_database,
 )

--- a/src/moneybin/mcp/tools/gsheet.py
+++ b/src/moneybin/mcp/tools/gsheet.py
@@ -254,7 +254,7 @@ async def gsheet_connect(
     inline and retries internally only after explicit confirmation. The agent
     cannot ratify that inference through this tool's parameters.
     """
-    from moneybin.connectors.gsheet.connection_service import (  # noqa: PLC0415
+    from moneybin.connectors.gsheet.connection_service import (
         ConnectionRequest,
     )
 
@@ -272,7 +272,7 @@ async def gsheet_connect(
     try:
         result = await asyncio.to_thread(_connect, req)
     except GSheetSignConfirmationRequiredError as error:
-        from moneybin.mcp.elicitation import confirm_or_raise  # noqa: PLC0415
+        from moneybin.mcp.elicitation import confirm_or_raise
 
         await confirm_or_raise(
             _sign_confirmation_message(error),
@@ -475,7 +475,7 @@ async def gsheet_reconnect(
             yes=yes,
         )
     except GSheetSignConfirmationRequiredError as error:
-        from moneybin.mcp.elicitation import confirm_or_raise  # noqa: PLC0415
+        from moneybin.mcp.elicitation import confirm_or_raise
 
         await confirm_or_raise(
             _sign_confirmation_message(error),

--- a/src/moneybin/mcp/tools/import_inbox.py
+++ b/src/moneybin/mcp/tools/import_inbox.py
@@ -90,7 +90,7 @@ def import_inbox_sync(refresh: bool = True) -> ResponseEnvelope[ImportInboxSyncP
     # the surface has to name what it created. Same helper as import_files —
     # unattended drain is where an unannounced account is least likely to be
     # noticed, not where a weaker hint is acceptable.
-    from moneybin.mcp.tools.import_tools import accounts_created_action  # noqa: PLC0415
+    from moneybin.mcp.tools.import_tools import accounts_created_action
 
     if minted_action := accounts_created_action(_minted_count(sync_result.processed)):
         actions.insert(0, minted_action)

--- a/src/moneybin/mcp/tools/import_tools.py
+++ b/src/moneybin/mcp/tools/import_tools.py
@@ -183,7 +183,7 @@ def _reject_unsupported_pdf_account_signals(
     never forwards these two arguments to a service call at all — there is no
     later point at which the service could see them.
     """
-    from moneybin.services.import_service import (  # noqa: PLC0415 — defer import
+    from moneybin.services.import_service import (
         reject_unhonored_account_signals,
     )
 
@@ -1349,7 +1349,7 @@ async def import_revert(
             ``mutation_confirmation_required`` refusal, for clients that cannot
             elicit.
     """
-    from moneybin.services.import_service import ImportService  # noqa: PLC0415
+    from moneybin.services.import_service import ImportService
 
     with get_database(read_only=True) as db:
         plan = ImportService(db).plan_revert(import_id)
@@ -1413,7 +1413,7 @@ async def _delete_saved_format(
     confirmation_token: str | None,
 ) -> ResponseEnvelope[ImportSavedFormatDeletePayload]:
     """Confirm and audit-delete one exact user-saved tabular format."""
-    from moneybin.services.import_service import ImportService  # noqa: PLC0415
+    from moneybin.services.import_service import ImportService
 
     with get_database(read_only=True) as db:
         plan = ImportService(db).plan_saved_format_delete(format_name)
@@ -1469,7 +1469,7 @@ def import_formats() -> ResponseEnvelope[ImportFormatsPayload]:
     kind, routing target, and replay statistics. Filter by ``type`` to narrow.
     Use ``import_preview`` to test a tabular format against a specific file.
     """
-    from moneybin.services.import_service import ImportService  # noqa: PLC0415
+    from moneybin.services.import_service import ImportService
 
     pdf_format_rows: list[ImportFormatEntry] = []
     # `list_formats` hands back the built-ins as a mapping; only membership is
@@ -1480,7 +1480,7 @@ def import_formats() -> ResponseEnvelope[ImportFormatsPayload]:
             formats, builtin, pdf_formats = ImportService(db).list_formats()
             pdf_format_rows = [pdf_format_row(pf) for pf in pdf_formats]
     except Exception:  # noqa: BLE001 -- DB may not exist; fall back to built-in only
-        from moneybin.extractors.tabular.formats import (  # noqa: PLC0415
+        from moneybin.extractors.tabular.formats import (
             load_builtin_formats,
         )
 

--- a/src/moneybin/mcp/tools/sync.py
+++ b/src/moneybin/mcp/tools/sync.py
@@ -70,9 +70,9 @@ def _build_sync_client() -> Any:
     slot. (The two builders are duplicated; consolidating them is tracked as a
     follow-up.)
     """
-    from moneybin.config import get_settings  # noqa: PLC0415
-    from moneybin.connectors.sync_client import SyncClient  # noqa: PLC0415
-    from moneybin.utils.user_config import get_or_create_profile_id  # noqa: PLC0415
+    from moneybin.config import get_settings
+    from moneybin.connectors.sync_client import SyncClient
+    from moneybin.utils.user_config import get_or_create_profile_id
 
     settings = get_settings()
     if settings.sync.server_url is None:
@@ -88,7 +88,7 @@ def _build_sync_client() -> Any:
 
 def _build_sync_auth_service() -> Any:
     """Construct profile-scoped nonblocking authentication orchestration."""
-    from moneybin.connectors.sync_auth import SyncAuthService  # noqa: PLC0415
+    from moneybin.connectors.sync_auth import SyncAuthService
 
     return SyncAuthService(client=_build_sync_client())
 
@@ -96,9 +96,9 @@ def _build_sync_auth_service() -> Any:
 @contextmanager
 def _build_sync_service() -> Generator[Any, None, None]:
     """Context manager yielding a SyncService with active Database connection."""
-    from moneybin.database import get_database  # noqa: PLC0415
-    from moneybin.extractors.plaid import PlaidExtractor  # noqa: PLC0415
-    from moneybin.services.sync_service import SyncService  # noqa: PLC0415
+    from moneybin.database import get_database
+    from moneybin.extractors.plaid import PlaidExtractor
+    from moneybin.services.sync_service import SyncService
 
     client = _build_sync_client()
     with get_database(read_only=False) as db:

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -859,8 +859,8 @@ def _unavailable_section(section: str, exc: Exception) -> SectionUnavailable:
 
 def _export_status_section() -> ExportsStatus:
     """Load export readiness synchronously inside one database lifetime."""
-    from moneybin.database import get_database  # noqa: PLC0415
-    from moneybin.exports.service import ExportService  # noqa: PLC0415
+    from moneybin.database import get_database
+    from moneybin.exports.service import ExportService
 
     with get_database(read_only=True) as db:
         readiness = ExportService(db).status()

--- a/src/moneybin/mcp/tools/transactions.py
+++ b/src/moneybin/mcp/tools/transactions.py
@@ -824,7 +824,7 @@ def transactions_matches_run() -> ResponseEnvelope[MatchRunPayload]:
     not read `auto_merged=0` as "nothing changed". A non-zero count undoes a
     decision the user made: report it and point at `system_audit_undo`.
     """
-    from moneybin.matching.engine import MatchRunError  # noqa: PLC0415 — cycle
+    from moneybin.matching.engine import MatchRunError
 
     with get_database(read_only=False) as db:
         try:

--- a/src/moneybin/orchestration/refresh.py
+++ b/src/moneybin/orchestration/refresh.py
@@ -479,18 +479,18 @@ def _run_gsheet_step(db: Database) -> list[Any]:
     """Best-effort GSheet pull step. Failures log-only — never propagated."""
     # Deferred as one block: GSheetPullService reaches polars (+252 modules on
     # this module's import), and this module is on the CLI cold-start path.
-    from moneybin.config import get_settings  # noqa: PLC0415
+    from moneybin.config import get_settings
     from moneybin.connectors.gsheet.oauth_client import (
-        GoogleOAuthClient,  # noqa: PLC0415
+        GoogleOAuthClient,
     )
     from moneybin.connectors.gsheet.pull_service import (
-        GSheetPullService,  # noqa: PLC0415
+        GSheetPullService,
     )
-    from moneybin.connectors.gsheet.sheets_api import SheetsClient  # noqa: PLC0415
-    from moneybin.repositories.gsheet_connections_repo import (  # noqa: PLC0415
+    from moneybin.connectors.gsheet.sheets_api import SheetsClient
+    from moneybin.repositories.gsheet_connections_repo import (
         GSheetConnectionsRepo,
     )
-    from moneybin.secrets import SecretStore  # noqa: PLC0415
+    from moneybin.secrets import SecretStore
 
     gsheet_start = time.monotonic()
     try:
@@ -541,8 +541,8 @@ def _run_categorize_step(db: Database) -> StageOutcome:
     """
     # Deferred: the categorization stack costs +77 modules on this module's
     # import, and this module is on the CLI cold-start path.
-    from moneybin.services.auto_rule_service import AutoRuleService  # noqa: PLC0415
-    from moneybin.services.categorization import CategorizationService  # noqa: PLC0415
+    from moneybin.services.auto_rule_service import AutoRuleService
+    from moneybin.services.categorization import CategorizationService
 
     cat_start = time.monotonic()
     # Only the categorization write itself decides this stage's error. The
@@ -615,13 +615,13 @@ def _run_rates_step(db: Database) -> tuple[RateBackfillResult | None, str | None
     # currency_service (+348 modules on this module's import) and the
     # Frankfurter adapter pulls httpx (+121); this module is on the CLI
     # cold-start path.
-    from moneybin.connectors.rates.frankfurter import (  # noqa: PLC0415
+    from moneybin.connectors.rates.frankfurter import (
         FrankfurterRateAdapter,
     )
-    from moneybin.repositories.profile_settings_repo import (  # noqa: PLC0415
+    from moneybin.repositories.profile_settings_repo import (
         ProfileSettingsRepo,
     )
-    from moneybin.services.rate_backfill import (  # noqa: PLC0415
+    from moneybin.services.rate_backfill import (
         RateBackfillNotReadyError,
         run_rate_backfill,
     )
@@ -671,10 +671,10 @@ def _run_identity_step(db: Database) -> tuple[StageOutcome, tuple[str, ...]]:
     """
     # Deferred: the two link services cost +44…49 modules on this module's
     # import, and this module is on the CLI cold-start path.
-    from moneybin.services.account_links_service import (  # noqa: PLC0415
+    from moneybin.services.account_links_service import (
         AccountLinksService,
     )
-    from moneybin.services.merchant_links_service import (  # noqa: PLC0415
+    from moneybin.services.merchant_links_service import (
         MerchantLinksService,
     )
 

--- a/src/moneybin/privacy/redaction.py
+++ b/src/moneybin/privacy/redaction.py
@@ -375,7 +375,7 @@ def has_active_transform(payload_type: Any) -> bool:
     every payload carrying it starts being walked. Avoids the documented trap
     where a CRITICAL-only gate silently skips newly-maskable HIGH/MEDIUM tools.
     """
-    from moneybin.privacy.introspection import (  # noqa: PLC0415 — avoid import cycle
+    from moneybin.privacy.introspection import (
         extract_data_classes,
     )
 

--- a/src/moneybin/privacy/report_class_derivation.py
+++ b/src/moneybin/privacy/report_class_derivation.py
@@ -223,7 +223,7 @@ def derive_report_classes(
     partial map and never falls back to a permissive default — an unresolvable
     model is a CI failure, not a silent AGGREGATE.
     """
-    from moneybin.database import SQLMESH_ROOT  # noqa: PLC0415  # avoid import cycle
+    from moneybin.database import SQLMESH_ROOT
 
     root = models_root or (SQLMESH_ROOT / "models" / REPORTS_SCHEMA)
     out, _excluded = _derive_view_classes(root, exclude_non_derivable=False)
@@ -245,7 +245,7 @@ def derive_core_view_classes(
     ``tests/privacy/test_report_class_derivation.py`` for the pinned set —
     rather than a side effect of silently dropping what didn't fit.
     """
-    from moneybin.database import SQLMESH_ROOT  # noqa: PLC0415  # avoid import cycle
+    from moneybin.database import SQLMESH_ROOT
 
     root = models_root or (SQLMESH_ROOT / "models" / _CORE_SCHEMA)
     return _derive_view_classes(root, exclude_non_derivable=True)

--- a/src/moneybin/privacy/seeding.py
+++ b/src/moneybin/privacy/seeding.py
@@ -58,7 +58,7 @@ def get_redaction_key() -> bytes:
     contaminate HMAC identifiers — a key-confusion defect once PR 3's
     hash-placeholder transforms land.
     """
-    from moneybin.config import (  # noqa: PLC0415 — defer to avoid import cycle
+    from moneybin.config import (
         get_current_profile,
     )
 

--- a/src/moneybin/privacy/sql_lineage.py
+++ b/src/moneybin/privacy/sql_lineage.py
@@ -2039,9 +2039,9 @@ def reports_class_map() -> dict[tuple[str, str], dict[str, DataClass]]:
     Backstop: ``test_reports_classification.py`` fails if any *deployed*
     ``reports.*`` view is uncovered here.
     """
-    from moneybin.reports._framework.registry import spec_of  # noqa: PLC0415
-    from moneybin.reports.definitions import ALL_REPORTS  # noqa: PLC0415
-    from moneybin.reports.definitions._derived_classes import (  # noqa: PLC0415
+    from moneybin.reports._framework.registry import spec_of
+    from moneybin.reports.definitions import ALL_REPORTS
+    from moneybin.reports.definitions._derived_classes import (
         DERIVED_REPORT_CLASSES,
     )
 

--- a/src/moneybin/reports/_framework/catalog.py
+++ b/src/moneybin/reports/_framework/catalog.py
@@ -243,7 +243,7 @@ def pending_dedup_caveat(db: Database, provenance: Iterable[str]) -> DedupCaveat
         # The CLI half is `PENDING_MATCHES_HINT` verbatim, so it cannot drift
         # from the command a test executes; imported inside the function because
         # the service module drags the matching engine into every catalog import.
-        from moneybin.services.matching_service import (  # noqa: PLC0415
+        from moneybin.services.matching_service import (
             PENDING_MATCHES_HINT,
         )
 

--- a/src/moneybin/repositories/account_link_decisions_repo.py
+++ b/src/moneybin/repositories/account_link_decisions_repo.py
@@ -49,7 +49,6 @@ _PRE_V051_COLS = ", ".join(
 
 def _refresh_account_link_pending_gauge(db: Database) -> None:
     """Avoid a repository-to-service import cycle until the gauge is needed."""
-    # deferred: module-scope import would cycle
     from moneybin.services.account_resolver import (
         refresh_account_link_pending_gauge,
     )

--- a/src/moneybin/repositories/account_link_decisions_repo.py
+++ b/src/moneybin/repositories/account_link_decisions_repo.py
@@ -49,7 +49,8 @@ _PRE_V051_COLS = ", ".join(
 
 def _refresh_account_link_pending_gauge(db: Database) -> None:
     """Avoid a repository-to-service import cycle until the gauge is needed."""
-    from moneybin.services.account_resolver import (  # noqa: PLC0415 — repo→service import must stay lazy
+    # deferred: module-scope import would cycle
+    from moneybin.services.account_resolver import (
         refresh_account_link_pending_gauge,
     )
 

--- a/src/moneybin/repositories/merchant_link_decisions_repo.py
+++ b/src/moneybin/repositories/merchant_link_decisions_repo.py
@@ -40,7 +40,8 @@ _MERCHANT_LINK_DECISIONS_COLUMNS = (
 
 def _refresh_merchant_link_pending_gauge(db: Database) -> None:
     """Avoid a repository-to-service import cycle until the gauge is needed."""
-    from moneybin.services.merchant_resolver import (  # noqa: PLC0415 — repo→service import must stay lazy
+    # deferred: module-scope import would cycle
+    from moneybin.services.merchant_resolver import (
         refresh_merchant_link_pending_gauge,
     )
 

--- a/src/moneybin/repositories/merchant_link_decisions_repo.py
+++ b/src/moneybin/repositories/merchant_link_decisions_repo.py
@@ -40,7 +40,6 @@ _MERCHANT_LINK_DECISIONS_COLUMNS = (
 
 def _refresh_merchant_link_pending_gauge(db: Database) -> None:
     """Avoid a repository-to-service import cycle until the gauge is needed."""
-    # deferred: module-scope import would cycle
     from moneybin.services.merchant_resolver import (
         refresh_merchant_link_pending_gauge,
     )

--- a/src/moneybin/repositories/security_link_decisions_repo.py
+++ b/src/moneybin/repositories/security_link_decisions_repo.py
@@ -42,7 +42,6 @@ _SECURITY_LINK_DECISIONS_COLUMNS = (
 
 def _refresh_security_link_pending_gauge(db: Database) -> None:
     """Avoid a repository-to-service import cycle until the gauge is needed."""
-    # deferred: module-scope import would cycle
     from moneybin.services.security_resolver import (
         refresh_security_link_pending_gauge,
     )

--- a/src/moneybin/repositories/security_link_decisions_repo.py
+++ b/src/moneybin/repositories/security_link_decisions_repo.py
@@ -42,7 +42,8 @@ _SECURITY_LINK_DECISIONS_COLUMNS = (
 
 def _refresh_security_link_pending_gauge(db: Database) -> None:
     """Avoid a repository-to-service import cycle until the gauge is needed."""
-    from moneybin.services.security_resolver import (  # noqa: PLC0415 — repo→service import must stay lazy
+    # deferred: module-scope import would cycle
+    from moneybin.services.security_resolver import (
         refresh_security_link_pending_gauge,
     )
 

--- a/src/moneybin/repositories/transaction_categories_repo.py
+++ b/src/moneybin/repositories/transaction_categories_repo.py
@@ -172,7 +172,8 @@ class TransactionCategoriesRepo(BaseRepo):
         # A module-level import would form a cycle; by call time the package is
         # initialized. The precedence ladder is the table's write contract, so
         # the CASE is generated from the same SOURCE_PRIORITY the engine uses.
-        from moneybin.services.categorization._shared import (  # noqa: PLC0415
+        # deferred: module-scope import would cycle
+        from moneybin.services.categorization._shared import (
             priority_case_sql,
         )
 
@@ -242,7 +243,8 @@ class TransactionCategoriesRepo(BaseRepo):
         """Apply guarded engine categorizations with one write and row-grain audits."""
         if not categorizations:
             return set()
-        from moneybin.services.categorization._shared import (  # noqa: PLC0415
+        # deferred: module-scope import would cycle
+        from moneybin.services.categorization._shared import (
             priority_case_sql,
         )
 
@@ -473,7 +475,8 @@ class TransactionCategoriesRepo(BaseRepo):
         # imports the applier, which imports this repo — a module-level import
         # would cycle. The ladder is the table's write contract, so reusing it
         # keeps the merge tiebreak and the upsert guard from drifting apart.
-        from moneybin.services.categorization._shared import (  # noqa: PLC0415
+        # deferred: module-scope import would cycle
+        from moneybin.services.categorization._shared import (
             SOURCE_PRIORITY,
         )
 

--- a/src/moneybin/repositories/transaction_categories_repo.py
+++ b/src/moneybin/repositories/transaction_categories_repo.py
@@ -172,7 +172,6 @@ class TransactionCategoriesRepo(BaseRepo):
         # A module-level import would form a cycle; by call time the package is
         # initialized. The precedence ladder is the table's write contract, so
         # the CASE is generated from the same SOURCE_PRIORITY the engine uses.
-        # deferred: module-scope import would cycle
         from moneybin.services.categorization._shared import (
             priority_case_sql,
         )
@@ -475,7 +474,6 @@ class TransactionCategoriesRepo(BaseRepo):
         # imports the applier, which imports this repo — a module-level import
         # would cycle. The ladder is the table's write contract, so reusing it
         # keeps the merge tiebreak and the upsert guard from drifting apart.
-        # deferred: module-scope import would cycle
         from moneybin.services.categorization._shared import (
             SOURCE_PRIORITY,
         )

--- a/src/moneybin/services/account_links_service.py
+++ b/src/moneybin/services/account_links_service.py
@@ -77,7 +77,7 @@ def _resolve_display_name(db: Database, account_id: str) -> str:
     # Function-local for the same reason as run() below: a module-level import
     # of account_resolver cycles (AccountResolver <- AccountLinkDecisionsRepo
     # <- AccountLinksService).
-    from moneybin.services.account_resolver import (  # noqa: PLC0415 — circular-import avoidance
+    from moneybin.services.account_resolver import (
         fetch_display_name,
     )
 
@@ -86,7 +86,7 @@ def _resolve_display_name(db: Database, account_id: str) -> str:
 
 def _resolve_display_names(db: Database, account_ids: Iterable[str]) -> dict[str, str]:
     """Batched twin of ``_resolve_display_name`` — same resolver, same fallbacks."""
-    from moneybin.services.account_resolver import (  # noqa: PLC0415 — circular-import avoidance
+    from moneybin.services.account_resolver import (
         fetch_display_names,
     )
 
@@ -97,7 +97,7 @@ def _resolve_core_display_names(
     db: Database, account_ids: Iterable[str]
 ) -> dict[str, str]:
     """Constructed names only — the half that is safe to write down."""
-    from moneybin.services.account_resolver import (  # noqa: PLC0415 — circular-import avoidance
+    from moneybin.services.account_resolver import (
         fetch_core_display_names,
     )
 
@@ -468,7 +468,7 @@ class AccountLinksService:
         """
         # Import here to avoid a circular-import at module level
         # (AccountResolver ← AccountLinkDecisionsRepo ← AccountLinksService would cycle).
-        from moneybin.services.account_resolver import (  # noqa: PLC0415
+        from moneybin.services.account_resolver import (
             AccountResolver,
             refresh_account_link_pending_gauge,
         )
@@ -594,7 +594,7 @@ class AccountLinksService:
         past answer is not a permanent veto, and a reject is the cheapest
         decision to make by mistake.
         """
-        from moneybin.services.account_resolver import (  # noqa: PLC0415  # circular at module level
+        from moneybin.services.account_resolver import (
             AccountResolver,
             refresh_account_link_pending_gauge,
         )
@@ -603,7 +603,7 @@ class AccountLinksService:
         # import_service's graph. It is on the CLI cold path today only through
         # inbox_service, and a module-level import here would keep it there
         # even after that one is deferred. Only the refusal below needs it.
-        from moneybin.services.import_service import (  # noqa: PLC0415  # cold-start hygiene
+        from moneybin.services.import_service import (  # cold-start hygiene
             mask_embedded_account_number,
         )
 
@@ -692,7 +692,7 @@ class AccountLinksService:
 
     def record_committed_outer_decisions(self) -> None:
         """Refresh metrics after an enclosing transaction commits."""
-        from moneybin.services.account_resolver import (  # noqa: PLC0415
+        from moneybin.services.account_resolver import (
             refresh_account_link_pending_gauge,
         )
 
@@ -906,7 +906,7 @@ class AccountLinksService:
             return None
         # Accept/reject changed the pending count — refresh the gauge (only
         # reached on a successful commit; the except above re-raises).
-        from moneybin.services.account_resolver import (  # noqa: PLC0415
+        from moneybin.services.account_resolver import (
             refresh_account_link_pending_gauge,
         )
 
@@ -957,7 +957,7 @@ class AccountLinksService:
         # their tops. Deferring keeps that out of a cycle; it does not make the
         # dependency go away, and test_orchestration_layering enumerates it as
         # an inversion either way.
-        from moneybin.orchestration.refresh import refresh  # noqa: PLC0415
+        from moneybin.orchestration.refresh import refresh
 
         collapsed = self._transfers_retired_by_collapse
         self._transfers_retired_by_collapse = 0

--- a/src/moneybin/services/account_resolver.py
+++ b/src/moneybin/services/account_resolver.py
@@ -901,7 +901,8 @@ class AccountResolver:
             if existing != account_id:
                 # Imported here, not at module scope: import_service imports this
                 # module, so a top-level import closes the cycle.
-                from moneybin.services.import_service import (  # noqa: PLC0415
+                # deferred: module-scope import would cycle
+                from moneybin.services.import_service import (
                     mask_embedded_account_number,
                 )
 

--- a/src/moneybin/services/account_resolver.py
+++ b/src/moneybin/services/account_resolver.py
@@ -901,7 +901,6 @@ class AccountResolver:
             if existing != account_id:
                 # Imported here, not at module scope: import_service imports this
                 # module, so a top-level import closes the cycle.
-                # deferred: module-scope import would cycle
                 from moneybin.services.import_service import (
                     mask_embedded_account_number,
                 )

--- a/src/moneybin/services/account_service.py
+++ b/src/moneybin/services/account_service.py
@@ -406,7 +406,7 @@ class AccountService:
         # account_service → repo, still mid-init), a module-level import here fails
         # with "partially initialized module". budget_service can import its repo
         # at module level only because it is NOT re-exported by services/__init__.
-        from moneybin.repositories.account_settings_repo import (  # noqa: PLC0415
+        from moneybin.repositories.account_settings_repo import (
             AccountSettingsRepo,
         )
 

--- a/src/moneybin/services/balance_service.py
+++ b/src/moneybin/services/balance_service.py
@@ -135,7 +135,7 @@ class BalanceService:
         # account_service.__init__. `services/__init__` eagerly re-exports this
         # module, so a repo-first import order (e.g. a repo test) would hit a
         # partially-initialized module on a module-level repo import here.
-        from moneybin.repositories.balance_assertions_repo import (  # noqa: PLC0415
+        from moneybin.repositories.balance_assertions_repo import (
             BalanceAssertionsRepo,
         )
 

--- a/src/moneybin/services/categorization/orchestrator.py
+++ b/src/moneybin/services/categorization/orchestrator.py
@@ -175,7 +175,8 @@ class CategorizationOrchestrator:
             # mirrors the apply_merchant_categories tail call). Runs
             # unconditionally — even a precedence-skipped row's rung-3
             # proposal must not leave the gauge stale until the next batch op.
-            from moneybin.services.merchant_resolver import (  # noqa: PLC0415 — deferred to avoid circular import
+            # deferred: module-scope import would cycle
+            from moneybin.services.merchant_resolver import (
                 refresh_merchant_link_pending_gauge,
             )
 
@@ -269,7 +270,8 @@ class CategorizationOrchestrator:
         txn_ids = [item.transaction_id for item in items]
         # Lazy import keeps the module-level dependency one-way
         # (auto_rule_service → categorization).
-        from moneybin.services.auto_rule_service import (  # noqa: PLC0415 — deferred to avoid circular import
+        # deferred: module-scope import would cycle
+        from moneybin.services.auto_rule_service import (
             AutoRuleService,
             RecordingContext,
             TxnRow,
@@ -546,7 +548,8 @@ class CategorizationOrchestrator:
         MerchantResolver imports back into this package's applier, so a
         top-level import cycles.
         """
-        from moneybin.services.merchant_resolver import (  # noqa: PLC0415 — deferred to avoid circular import
+        # deferred: module-scope import would cycle
+        from moneybin.services.merchant_resolver import (
             MerchantResolver,
         )
 
@@ -857,7 +860,8 @@ class CategorizationOrchestrator:
         # when nothing changed — a single COUNT(*) that degrades to 0 when the
         # decisions table is absent.
         if resolver is not None:
-            from moneybin.services.merchant_resolver import (  # noqa: PLC0415 — deferred to avoid circular import
+            # deferred: module-scope import would cycle
+            from moneybin.services.merchant_resolver import (
                 refresh_merchant_link_pending_gauge,
             )
 

--- a/src/moneybin/services/categorization/orchestrator.py
+++ b/src/moneybin/services/categorization/orchestrator.py
@@ -270,7 +270,6 @@ class CategorizationOrchestrator:
         txn_ids = [item.transaction_id for item in items]
         # Lazy import keeps the module-level dependency one-way
         # (auto_rule_service → categorization).
-        # deferred: module-scope import would cycle
         from moneybin.services.auto_rule_service import (
             AutoRuleService,
             RecordingContext,
@@ -548,7 +547,6 @@ class CategorizationOrchestrator:
         MerchantResolver imports back into this package's applier, so a
         top-level import cycles.
         """
-        # deferred: module-scope import would cycle
         from moneybin.services.merchant_resolver import (
             MerchantResolver,
         )

--- a/src/moneybin/services/currency_service.py
+++ b/src/moneybin/services/currency_service.py
@@ -594,7 +594,7 @@ def build_currency_service(db: Database, *, actor: str = "system") -> CurrencySe
     Frankfurter is keyless, so unlike the price feeds there is nothing here that
     can fail because a token is missing.
     """
-    from moneybin.connectors.rates.frankfurter import (  # noqa: PLC0415  # httpx is not cold-start cheap
+    from moneybin.connectors.rates.frankfurter import (  # httpx is not cold-start cheap
         FrankfurterRateAdapter,
     )
 

--- a/src/moneybin/services/doctor_service.py
+++ b/src/moneybin/services/doctor_service.py
@@ -2220,7 +2220,7 @@ class DoctorService:
         # package, which is unnecessary cost for doctor runs against installs
         # whose pdf_formats table is empty (the no-rows branch above returns
         # early).
-        from moneybin.extractors.pdf.recipe import Recipe  # noqa: PLC0415
+        from moneybin.extractors.pdf.recipe import Recipe
 
         bad: list[str] = []
         for name_, recipe_json in rows:

--- a/src/moneybin/services/import_service.py
+++ b/src/moneybin/services/import_service.py
@@ -982,7 +982,7 @@ def label_account_key(account_name: str) -> str:
     key across files and across pinned and unpinned imports — the property the
     slug already had for names the slug survives.
     """
-    from moneybin.utils import slugify  # noqa: PLC0415 — matches the call sites
+    from moneybin.utils import slugify
 
     slug = slugify(account_name)
     if slug:
@@ -1034,7 +1034,7 @@ def _bare_account_key(
     confirm round-trip (same bytes → same key) and idempotent on an exact
     re-import. The digest is a disambiguator, NOT an identity claim.
     """
-    from moneybin.utils import slugify  # noqa: PLC0415 — matches _pdf_alias
+    from moneybin.utils import slugify
 
     content = file_path.read_bytes() if source_bytes is None else source_bytes
     digest = hashlib.sha256(content).hexdigest()[:12]
@@ -2050,7 +2050,7 @@ class ImportService:
         ``"transaction"``) additionally report a date range, read from
         ``date_posted`` for OFX tables and ``transaction_date`` otherwise.
         """
-        from sqlglot import exp  # noqa: PLC0415
+        from sqlglot import exp
 
         tables = self._db.execute("""
             SELECT table_schema, table_name
@@ -6335,7 +6335,7 @@ class ImportService:
         list["PdfFormat"],
     ]:
         """Return the complete tabular/PDF format catalog for either surface."""
-        from moneybin.extractors.tabular.formats import (  # noqa: PLC0415
+        from moneybin.extractors.tabular.formats import (
             load_builtin_formats,
             load_formats_from_db,
             merge_formats,
@@ -6352,10 +6352,10 @@ class ImportService:
 
     def plan_saved_format_delete(self, format_name: str) -> SavedFormatDeletePlan:
         """Return the exact current saved-format state for confirmation binding."""
-        from moneybin.extractors.tabular.formats import (  # noqa: PLC0415
+        from moneybin.extractors.tabular.formats import (
             load_builtin_formats,
         )
-        from moneybin.repositories.tabular_formats_repo import (  # noqa: PLC0415
+        from moneybin.repositories.tabular_formats_repo import (
             TabularFormatsRepo,
         )
 
@@ -6389,7 +6389,7 @@ class ImportService:
         verify: Callable[[SavedFormatDeletePlan], None],
     ) -> str:
         """Revalidate and audit-delete one saved format in the same transaction."""
-        from moneybin.repositories.tabular_formats_repo import (  # noqa: PLC0415
+        from moneybin.repositories.tabular_formats_repo import (
             TabularFormatsRepo,
         )
 
@@ -6423,8 +6423,8 @@ class ImportService:
             import_id: UUID of the import batch in ``raw.import_log``.
         """
         # REVERT_TABLES is owned by import_log because begin_import also consults it.
-        from moneybin.loaders.import_log import REVERT_TABLES  # noqa: PLC0415
-        from moneybin.tables import IMPORT_LOG  # noqa: PLC0415
+        from moneybin.loaders.import_log import REVERT_TABLES
+        from moneybin.tables import IMPORT_LOG
 
         row = self._db.execute(
             f"SELECT source_type, status, source_file, started_at, source_origin "
@@ -6525,13 +6525,13 @@ class ImportService:
         """
         # Deferred with the rest: `matching.aliasing` reaches back into the
         # repositories, whose base -> audit chain re-enters this package.
-        from moneybin.loaders.import_log import REVERT_TABLES  # noqa: PLC0415
-        from moneybin.matching.aliasing import (  # noqa: PLC0415
+        from moneybin.loaders.import_log import REVERT_TABLES
+        from moneybin.matching.aliasing import (
             AliasForwardResult,
             forward_rekeyed_transaction_ids,
             record_committed_alias_forwarding,
         )
-        from moneybin.tables import IMPORT_LOG  # noqa: PLC0415
+        from moneybin.tables import IMPORT_LOG
 
         forwarding = AliasForwardResult()
         self._db.begin()
@@ -6585,7 +6585,7 @@ class ImportService:
                 [live.source_origin, import_id],
             ).fetchone()
             if other_row is not None and other_row[0] == 0:
-                from sqlglot import exp  # noqa: PLC0415
+                from sqlglot import exp
 
                 safe_view = exp.to_identifier(
                     f"pdf_{live.source_origin}", quoted=True

--- a/src/moneybin/services/inbox_service.py
+++ b/src/moneybin/services/inbox_service.py
@@ -90,7 +90,7 @@ def _sign_sidecar_actions(
     recipe can re-derive to either polarity, and the card framing would then name
     the wrong direction and leave no command that keeps the convention in force.
     """
-    from moneybin.services.import_confirmation import (  # noqa: PLC0415  # avoid an import cycle at module scope
+    from moneybin.services.import_confirmation import (
         sign_convention_effect,
     )
 
@@ -466,10 +466,10 @@ class InboxService:
         is invoked once and the SQLMesh-step timing/error fields land in
         the result.
         """
-        from moneybin.orchestration.refresh import (  # noqa: PLC0415
+        from moneybin.orchestration.refresh import (
             refresh as run_refresh,
         )
-        from moneybin.orchestration.refresh import (  # noqa: PLC0415
+        from moneybin.orchestration.refresh import (
             step_outcome,
         )
 
@@ -945,11 +945,11 @@ class InboxService:
         (``sign_sample_rows``) so the flip is visible before anyone ratifies it.
         Mirrors the MCP ``_sign_confirm_actions`` treatment.
         """
-        from moneybin.privacy.payloads.imports import (  # noqa: PLC0415  # avoid an import cycle at module scope
+        from moneybin.privacy.payloads.imports import (
             ImportConfirmationAccountProposal,
         )
-        from moneybin.privacy.redaction import redact_typed  # noqa: PLC0415
-        from moneybin.services.import_confirmation import (  # noqa: PLC0415  # avoid an import cycle at module scope
+        from moneybin.privacy.redaction import redact_typed
+        from moneybin.services.import_confirmation import (
             header_row_consumed_recovery,
             unreadable_date_recovery,
         )

--- a/src/moneybin/services/investment_service.py
+++ b/src/moneybin/services/investment_service.py
@@ -2078,7 +2078,8 @@ class InvestmentService:
             return amount, code, ()
         # Deferred: currency_service imports polars, and this module is on the
         # CLI's eager import chain (tests/moneybin/test_cli/test_cold_start.py).
-        from moneybin.services.currency_service import (  # noqa: PLC0415 — defer to avoid cold-start cost
+        # defer to avoid cold-start cost
+        from moneybin.services.currency_service import (
             RateUnavailableError,
             build_cache_only_currency_service,
             require_currency,

--- a/src/moneybin/services/matching_service.py
+++ b/src/moneybin/services/matching_service.py
@@ -144,7 +144,7 @@ class MatchingService:
         ``base`` → ``services.audit_service`` chain re-enters that path; a
         module-top import would cycle.
         """
-        from moneybin.repositories.match_decisions_repo import (  # noqa: PLC0415
+        from moneybin.repositories.match_decisions_repo import (
             MatchDecisionsRepo,
         )
 

--- a/src/moneybin/services/merchant_links_service.py
+++ b/src/moneybin/services/merchant_links_service.py
@@ -109,7 +109,7 @@ class MerchantLinksService:
         ``count_pending_merchant_link_decisions`` (imported lazily — the
         resolver must not import this service back).
         """
-        from moneybin.services.merchant_resolver import (  # noqa: PLC0415
+        from moneybin.services.merchant_resolver import (
             count_pending_merchant_link_decisions,
         )
 
@@ -290,7 +290,7 @@ class MerchantLinksService:
         """
         # Import here to avoid a circular-import at module level
         # (the resolver pulls in the categorization stack, which reaches back here).
-        from moneybin.services.merchant_resolver import (  # noqa: PLC0415
+        from moneybin.services.merchant_resolver import (
             MerchantResolver,
             refresh_merchant_link_pending_gauge,
         )
@@ -307,7 +307,7 @@ class MerchantLinksService:
         """Record metrics after an enclosing transaction commits."""
         for outcome in outcomes:
             MERCHANT_LINK_OUTCOMES_TOTAL.labels(outcome=outcome).inc()
-        from moneybin.services.merchant_resolver import (  # noqa: PLC0415
+        from moneybin.services.merchant_resolver import (
             refresh_merchant_link_pending_gauge,
         )
 
@@ -474,7 +474,7 @@ class MerchantLinksService:
 
         # Accept/reject changed the pending count — refresh the gauge.
         MERCHANT_LINK_OUTCOMES_TOTAL.labels(outcome=outcome).inc()
-        from moneybin.services.merchant_resolver import (  # noqa: PLC0415
+        from moneybin.services.merchant_resolver import (
             refresh_merchant_link_pending_gauge,
         )
 

--- a/src/moneybin/services/merchant_resolver.py
+++ b/src/moneybin/services/merchant_resolver.py
@@ -89,7 +89,7 @@ class MerchantResolver:
 
     def load_bindings(self) -> dict[tuple[str, str], str]:
         """(source_type, ref_value) -> merchant_id for all accepted bindings (batch cache)."""
-        from moneybin.tables import MERCHANT_LINKS  # noqa: PLC0415
+        from moneybin.tables import MERCHANT_LINKS
 
         rows = self._db.execute(
             f"SELECT source_type, ref_value, merchant_id FROM {MERCHANT_LINKS.full_name} "  # noqa: S608  # TableRef constant

--- a/src/moneybin/services/price_service.py
+++ b/src/moneybin/services/price_service.py
@@ -594,7 +594,7 @@ class PriceService:
         and resolution to happen once at the service boundary, and two resolvers
         for one question would drift.
         """
-        from moneybin.services.investment_service import (  # noqa: PLC0415  # avoids an import cycle
+        from moneybin.services.investment_service import (
             InvestmentService,
         )
 
@@ -1366,12 +1366,12 @@ def build_price_service(db: Database, *, actor: str = "system") -> PriceService:
     Kept out of ``PriceService.__init__`` so tests inject fakes without a
     production seam, matching ``connectors/gsheet/service_factory.py``.
     """
-    from moneybin.connectors.prices.coingecko import (  # noqa: PLC0415  # httpx is not cold-start cheap
+    from moneybin.connectors.prices.coingecko import (  # httpx is not cold-start cheap
         CoinGeckoPriceAdapter,
     )
-    from moneybin.connectors.prices.tiingo import TiingoPriceAdapter  # noqa: PLC0415
+    from moneybin.connectors.prices.tiingo import TiingoPriceAdapter
     from moneybin.secrets import (
-        SecretStore,  # noqa: PLC0415  # keyring import is deferred too
+        SecretStore,  # keyring import is deferred too
     )
 
     # One clock for the whole pull. The service derives its complete-day cutoff

--- a/src/moneybin/services/profile_settings_service.py
+++ b/src/moneybin/services/profile_settings_service.py
@@ -39,7 +39,7 @@ class ProfileSettingsService:
 
     def __init__(self, db: Database, *, audit: AuditService | None = None) -> None:
         """Initialize with an open Database; composes the audited settings repo."""
-        from moneybin.repositories.profile_settings_repo import (  # noqa: PLC0415 — mirrors AccountService: avoids a services/__init__ import cycle
+        from moneybin.repositories.profile_settings_repo import (
             ProfileSettingsRepo,
         )
 

--- a/src/moneybin/services/security_links_service.py
+++ b/src/moneybin/services/security_links_service.py
@@ -505,7 +505,7 @@ class SecurityLinksService:
             f"ref_kind={decision['ref_kind']}"
         )
 
-        from moneybin.services.security_resolver import (  # noqa: PLC0415
+        from moneybin.services.security_resolver import (
             refresh_security_link_pending_gauge,
         )
 
@@ -556,7 +556,7 @@ class SecurityLinksService:
         logger.info(f"security merge rejected: decision={decision_id}")
 
         # Rejecting changed the pending count — refresh the gauge.
-        from moneybin.services.security_resolver import (  # noqa: PLC0415
+        from moneybin.services.security_resolver import (
             refresh_security_link_pending_gauge,
         )
 
@@ -566,7 +566,7 @@ class SecurityLinksService:
         """Record metrics after an enclosing transaction commits."""
         for outcome in outcomes:
             SECURITY_LINK_DECISION_OUTCOMES_TOTAL.labels(outcome=outcome).inc()
-        from moneybin.services.security_resolver import (  # noqa: PLC0415
+        from moneybin.services.security_resolver import (
             refresh_security_link_pending_gauge,
         )
 
@@ -751,7 +751,7 @@ class SecurityLinksService:
 
         # Accepting changed the pending count (the named decision plus its
         # auto-rejected siblings) — refresh the gauge.
-        from moneybin.services.security_resolver import (  # noqa: PLC0415
+        from moneybin.services.security_resolver import (
             refresh_security_link_pending_gauge,
         )
 

--- a/src/moneybin/synthetic/writer.py
+++ b/src/moneybin/synthetic/writer.py
@@ -80,7 +80,7 @@ class SyntheticWriter:
 
     def _create_synthetic_schema(self) -> None:
         """Create the synthetic schema and ground_truth table on demand."""
-        global _ground_truth_ddl  # noqa: PLW0603 — module-level cache, read once
+        global _ground_truth_ddl  # module-level cache, read once
         if _ground_truth_ddl is None:
             _ground_truth_ddl = _GROUND_TRUTH_DDL_PATH.read_text()
         self._db.execute(_ground_truth_ddl)

--- a/tests/cli_command_helpers.py
+++ b/tests/cli_command_helpers.py
@@ -45,7 +45,7 @@ def assert_published_commands_resolve(text: str) -> None:
     failure, not a pass — a guard whose predicate never ran is indistinguishable
     from one that held.
     """
-    from moneybin.cli.main import app  # noqa: PLC0415 — keep collection-time light
+    from moneybin.cli.main import app  # keep collection-time light
 
     invocations = moneybin_invocations(text)
     assert invocations, f"no `moneybin ...` command published in {text!r}"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -131,7 +131,7 @@ def run_cli(
     # to prevent the first-run setup wizard and isolate from the user's
     # real profile. The fallback profile dir is created on first use.
     if env is None:
-        global _fallback_profile_created  # noqa: PLW0603 — lazy init for module-level state
+        global _fallback_profile_created  # lazy init for module-level state
         if not _fallback_profile_created:
             Path(_FALLBACK_HOME, "profiles", _FALLBACK_PROFILE).mkdir(
                 parents=True, exist_ok=True

--- a/tests/integration/test_integration_existing.py
+++ b/tests/integration/test_integration_existing.py
@@ -164,7 +164,7 @@ class TestKeyRotation:
 
         # Clear any cached key from a prior xdist worker test to prevent it
         # being used when opening this test's fresh DB.
-        import moneybin.database as _db_mod  # noqa: PLC0415
+        import moneybin.database as _db_mod
 
         monkeypatch.setattr(_db_mod, "_cached_encryption_key", None)
 

--- a/tests/moneybin/db_helpers.py
+++ b/tests/moneybin/db_helpers.py
@@ -610,7 +610,8 @@ def seed_pending_dedup_pair(db: Database) -> None:
     it, so both rows stay in ``core.fct_transactions`` and every total covering
     them counts the payment twice. Needs the core tables already created.
     """
-    from moneybin.repositories.match_decisions_repo import (  # noqa: PLC0415  # keep the repo off this helper module's import path
+    # keep the repo off this helper module's import path
+    from moneybin.repositories.match_decisions_repo import (
         MatchDecisionsRepo,
     )
 

--- a/tests/moneybin/matching/test_assignment.py
+++ b/tests/moneybin/matching/test_assignment.py
@@ -279,7 +279,7 @@ def _edge(
     )
 
 
-def _edge_f(  # noqa: PLR0913  # explicit per-side fields keep the fixture readable
+def _edge_f(  # explicit per-side fields keep the fixture readable
     st_a: str,
     stid_a: str,
     sf_a: str,

--- a/tests/moneybin/test_architecture/test_no_inert_pylint_suppressions.py
+++ b/tests/moneybin/test_architecture/test_no_inert_pylint_suppressions.py
@@ -7,10 +7,11 @@ the justifications riding on them, 17 comments claiming a deferred import
 avoided a circular import were wrong, and an audit took one of those claims at
 face value and had to be retracted. This guard stops the next one appearing.
 
-**Scope.** A plain text scan for the marker across `src/`, `tests/`, and
-`scripts/`. It deliberately does not reason about whether a deferred import is
-justified — only that it is not justified by citing a rule that is switched
-off. Correcting a wrong justification is a review question, not a test.
+**Scope.** A plain text scan for the marker across every tracked Python file,
+which is the surface CI lints with `ruff check .`. It deliberately does not
+reason about whether a deferred import is justified — only that it is not
+justified by citing a rule that is switched off. Correcting a wrong
+justification is a review question, not a test.
 
 The flake8-compatible file-level spelling is out of scope on purpose, not by
 oversight: ruff treats it as a blanket suppression and discards the codes
@@ -25,6 +26,8 @@ import subprocess  # noqa: S404 — asks ruff for its own resolved rule set
 import sys
 from collections.abc import Iterator
 
+import pytest
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 
 # Any Pylint-family code, not just PLC0415: the whole `PL` prefix is disabled,
@@ -35,12 +38,32 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 # file-level variant for other codes, so omitting it would leave a way back in.
 MARKER = re.compile(r"#\s*(?:ruff:\s*)?noqa:[^\n]*\bPL[CREW]\d+", re.IGNORECASE)
 
-SCANNED_TREES = ("src", "tests", "scripts")
+# The cases below interpolate these rather than spelling a marker out, so that
+# this file does not trip its own scan and need an exemption from it.
+_C, _C2, _W, _R = "PLC0415", "PLC2701", "PLW0603", "PLR0913"
 
 
 def _python_files() -> Iterator[pathlib.Path]:
-    for tree in SCANNED_TREES:
-        yield from sorted((REPO_ROOT / tree).rglob("*.py"))
+    """Every tracked Python file, which is the surface CI lints with `ruff check .`.
+
+    Asking git rather than walking a fixed list of directories: a hardcoded
+    `("src", "tests", "scripts")` silently omits root-level files such as
+    `conftest.py`, so a marker could re-enter there with this guard still green.
+    """
+    result = subprocess.run(  # noqa: S603  # fixed argv, no shell, no user input
+        ["git", "ls-files", "*.py"],  # noqa: S607  # git resolves from PATH
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        timeout=120,
+    )
+    assert result.returncode == 0, f"git ls-files failed: {result.stderr}"
+
+    paths = [REPO_ROOT / line for line in result.stdout.split()]
+    # An empty listing must never read as "nothing to check" — that would make
+    # this guard pass vacuously anywhere git is unavailable.
+    assert len(paths) > 100, f"expected the whole tracked tree, got {len(paths)} files"
+    return iter(paths)
 
 
 def test_pylint_family_is_not_enabled() -> None:
@@ -84,6 +107,47 @@ def test_pylint_family_is_not_enabled() -> None:
         "`noqa` citing one can suppress a real diagnostic. This guard's premise "
         "no longer holds — delete it instead of adding exemptions."
     )
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        f"import json  # noqa: {_C}",
+        f"import json  # noqa: {_C} — defer import",
+        f"from x import (  # noqa: {_C}  # polars is not cold-start cheap",
+        f"import json  # noqa: {_C},{_C2}",
+        f"    global _cache  # noqa: {_W}",
+        f"def f(  # noqa: {_R}",
+        f"# ruff: noqa: {_C}",
+        f"#ruff:noqa:{_C}",
+        f"import json  # NOQA: {_C.lower()}",
+    ],
+)
+def test_marker_matches_every_spelling_it_must_catch(line: str) -> None:
+    """The scan below only ever asserts an empty list, so it cannot prove the regex works.
+
+    Without these, swapping `MARKER` for one that never matches leaves the whole
+    guard green — a check whose predicate never fires is indistinguishable from
+    one that passed (`.claude/rules/testing.md`, "A Fixture That Never Reaches
+    the Predicate Proves Nothing").
+    """
+    assert MARKER.search(line), f"marker not detected in: {line}"
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "import subprocess  # noqa: S404 — a rule that is actually enabled",
+        "except Exception:  # noqa: BLE001",
+        "# ruff: noqa: S101",
+        "sql = 'SELECT 1'  # noqa: S608  # TableRef constant",
+        f"# {_C} is not enabled, which is why this comment is prose",
+        "import json  # deferred: module-scope import would cycle",
+    ],
+)
+def test_marker_leaves_everything_else_alone(line: str) -> None:
+    """A live suppression, or prose merely naming a code, must not be flagged."""
+    assert not MARKER.search(line), f"false positive on: {line}"
 
 
 def test_no_inert_pylint_suppression_markers() -> None:

--- a/tests/moneybin/test_architecture/test_no_inert_pylint_suppressions.py
+++ b/tests/moneybin/test_architecture/test_no_inert_pylint_suppressions.py
@@ -11,6 +11,12 @@ face value and had to be retracted. This guard stops the next one appearing.
 `scripts/`. It deliberately does not reason about whether a deferred import is
 justified — only that it is not justified by citing a rule that is switched
 off. Correcting a wrong justification is a review question, not a test.
+
+The flake8-compatible file-level spelling is out of scope on purpose, not by
+oversight: ruff treats it as a blanket suppression and discards the codes
+after it, so it cannot cite a Pylint rule the way this guard polices. A blanket
+file-level suppression is a larger problem that belongs to review. None exist
+in this repo today.
 """
 
 import pathlib
@@ -23,7 +29,11 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 
 # Any Pylint-family code, not just PLC0415: the whole `PL` prefix is disabled,
 # so a marker naming PLR/PLW/PLE is equally inert.
-MARKER = re.compile(r"#\s*noqa:[^\n]*\bPL[CREW]\d+", re.IGNORECASE)
+#
+# Two spellings, both of which ruff honours: the line-level directive, and the
+# file-level variant that puts `ruff:` ahead of it. The repo already uses the
+# file-level variant for other codes, so omitting it would leave a way back in.
+MARKER = re.compile(r"#\s*(?:ruff:\s*)?noqa:[^\n]*\bPL[CREW]\d+", re.IGNORECASE)
 
 SCANNED_TREES = ("src", "tests", "scripts")
 

--- a/tests/moneybin/test_architecture/test_no_inert_pylint_suppressions.py
+++ b/tests/moneybin/test_architecture/test_no_inert_pylint_suppressions.py
@@ -15,9 +15,9 @@ off. Correcting a wrong justification is a review question, not a test.
 
 import pathlib
 import re
-import tomllib
+import subprocess  # noqa: S404 — asks ruff for its own resolved rule set
+import sys
 from collections.abc import Iterator
-from typing import cast
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 
@@ -39,20 +39,35 @@ def test_pylint_family_is_not_enabled() -> None:
     Without this, enabling `PL` would leave the guard below still passing while
     its stated reason had quietly become false — the exact failure mode MB-168
     exists to correct.
+
+    Ruff is asked for its *resolved* rule set rather than having `select`,
+    `extend-select` and `ignore` re-implemented here. Those interact by prefix
+    specificity — `select = ["ALL"]` with `ignore = ["PL"]` leaves the family
+    off, while `select = ["PLC0415"]` with `ignore = ["PL"]` leaves that one on
+    — and a hand-rolled model of that gets the answer wrong in both directions.
     """
-    config = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
-    lint: dict[str, object] = config["tool"]["ruff"]["lint"]
+    ruff = pathlib.Path(sys.executable).parent / "ruff"
+    result = subprocess.run(  # noqa: S603  # fixed argv, no shell, no user input
+        [str(ruff), "check", "--show-settings", "src/moneybin/config.py"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        timeout=120,
+    )
+    assert result.returncode == 0, f"ruff --show-settings failed: {result.stderr}"
 
-    # Both keys, because `extend-select` enables rules just as `select` does, and
-    # reading only one lets the premise go stale without this test noticing —
-    # which is the failure it exists to prevent. `ALL` sweeps in the family too.
-    enabled: list[str] = []
-    for key in ("select", "extend-select"):
-        value = lint.get(key)
-        if isinstance(value, list):
-            enabled.extend(str(code) for code in cast(list[object], value))
+    block = result.stdout.partition("linter.rules.enabled = [")[2].partition("]")[0]
+    codes = re.findall(r"\(([A-Z]+\d+)\)", block)
 
-    offenders = [c for c in enabled if c.startswith("PL") or c == "ALL"]
+    # Fail loudly if the output shape changed. Parsing nothing must never read as
+    # "no Pylint rule is enabled" — that is this guard's own failure mode.
+    assert codes, (
+        "could not read `linter.rules.enabled` out of `ruff check "
+        "--show-settings`; its output shape changed, so this premise check is "
+        "no longer measuring anything. Fix the parse before trusting it."
+    )
+
+    offenders = sorted({c for c in codes if c.startswith("PL")})
 
     assert not offenders, (
         f"ruff now enables a Pylint-family rule ({', '.join(offenders)}), so a "

--- a/tests/moneybin/test_architecture/test_no_inert_pylint_suppressions.py
+++ b/tests/moneybin/test_architecture/test_no_inert_pylint_suppressions.py
@@ -17,6 +17,7 @@ import pathlib
 import re
 import tomllib
 from collections.abc import Iterator
+from typing import cast
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 
@@ -40,12 +41,23 @@ def test_pylint_family_is_not_enabled() -> None:
     exists to correct.
     """
     config = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
-    selected = config["tool"]["ruff"]["lint"]["select"]
+    lint: dict[str, object] = config["tool"]["ruff"]["lint"]
 
-    assert not any(code.startswith("PL") for code in selected), (
-        "ruff now selects a Pylint-family rule, so `# noqa: PL…` markers can "
-        "suppress a real diagnostic. This guard's premise no longer holds — "
-        "delete it instead of adding exemptions."
+    # Both keys, because `extend-select` enables rules just as `select` does, and
+    # reading only one lets the premise go stale without this test noticing —
+    # which is the failure it exists to prevent. `ALL` sweeps in the family too.
+    enabled: list[str] = []
+    for key in ("select", "extend-select"):
+        value = lint.get(key)
+        if isinstance(value, list):
+            enabled.extend(str(code) for code in cast(list[object], value))
+
+    offenders = [c for c in enabled if c.startswith("PL") or c == "ALL"]
+
+    assert not offenders, (
+        f"ruff now enables a Pylint-family rule ({', '.join(offenders)}), so a "
+        "`noqa` citing one can suppress a real diagnostic. This guard's premise "
+        "no longer holds — delete it instead of adding exemptions."
     )
 
 

--- a/tests/moneybin/test_architecture/test_no_inert_pylint_suppressions.py
+++ b/tests/moneybin/test_architecture/test_no_inert_pylint_suppressions.py
@@ -1,0 +1,64 @@
+"""Structural guardrail: no `# noqa: PLC…` marker, because none of them suppress.
+
+Ruff's `select` in `pyproject.toml` does not list `PL`, so every Pylint-family
+code is disabled and a `noqa` citing one never silenced a diagnostic. MB-168
+removed 363 of them. They were not harmless: because no linter ever evaluated
+the justifications riding on them, 17 comments claiming a deferred import
+avoided a circular import were wrong, and an audit took one of those claims at
+face value and had to be retracted. This guard stops the next one appearing.
+
+**Scope.** A plain text scan for the marker across `src/`, `tests/`, and
+`scripts/`. It deliberately does not reason about whether a deferred import is
+justified — only that it is not justified by citing a rule that is switched
+off. Correcting a wrong justification is a review question, not a test.
+"""
+
+import pathlib
+import re
+import tomllib
+from collections.abc import Iterator
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+
+# Any Pylint-family code, not just PLC0415: the whole `PL` prefix is disabled,
+# so a marker naming PLR/PLW/PLE is equally inert.
+MARKER = re.compile(r"#\s*noqa:[^\n]*\bPL[CREW]\d+", re.IGNORECASE)
+
+SCANNED_TREES = ("src", "tests", "scripts")
+
+
+def _python_files() -> Iterator[pathlib.Path]:
+    for tree in SCANNED_TREES:
+        yield from sorted((REPO_ROOT / tree).rglob("*.py"))
+
+
+def test_pylint_family_is_not_enabled() -> None:
+    """The premise. If `PL` is ever enabled, delete this guard rather than fight it.
+
+    Without this, enabling `PL` would leave the guard below still passing while
+    its stated reason had quietly become false — the exact failure mode MB-168
+    exists to correct.
+    """
+    config = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    selected = config["tool"]["ruff"]["lint"]["select"]
+
+    assert not any(code.startswith("PL") for code in selected), (
+        "ruff now selects a Pylint-family rule, so `# noqa: PL…` markers can "
+        "suppress a real diagnostic. This guard's premise no longer holds — "
+        "delete it instead of adding exemptions."
+    )
+
+
+def test_no_inert_pylint_suppression_markers() -> None:
+    """No file cites a Pylint code in a noqa, since none of them are enabled."""
+    offenders: list[str] = []
+    for path in _python_files():
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            if MARKER.search(line):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}")
+
+    assert not offenders, (
+        "These `# noqa: PL…` markers suppress nothing — the `PL` rules are not "
+        "enabled. Drop the marker; if the deferred import needs explaining, "
+        "write a plain comment saying why:\n  " + "\n  ".join(offenders)
+    )

--- a/tests/moneybin/test_cli/test_render.py
+++ b/tests/moneybin/test_cli/test_render.py
@@ -1538,13 +1538,13 @@ def _declared_tables() -> list[tuple[str, Sequence[Any], Sequence[str]]]:
     the command modules pull in service code that `render.py` deliberately does
     not.
     """
-    from moneybin.cli.commands.import_cmd import (  # noqa: PLC0415, PLC2701
+    from moneybin.cli.commands.import_cmd import (
         _HISTORY_COLUMNS,  # pyright: ignore[reportPrivateUsage]
         _HISTORY_DEFAULT,  # pyright: ignore[reportPrivateUsage]
         _PDF_FORMAT_COLUMNS,  # pyright: ignore[reportPrivateUsage]
         _PDF_FORMAT_DEFAULT,  # pyright: ignore[reportPrivateUsage]
     )
-    from moneybin.cli.commands.investments import (  # noqa: PLC0415, PLC2701
+    from moneybin.cli.commands.investments import (
         _EVENTS_COLUMNS,  # pyright: ignore[reportPrivateUsage]
         _EVENTS_DEFAULT,  # pyright: ignore[reportPrivateUsage]
         _GAINS_COLUMNS,  # pyright: ignore[reportPrivateUsage]
@@ -1552,7 +1552,7 @@ def _declared_tables() -> list[tuple[str, Sequence[Any], Sequence[str]]]:
         _HOLDINGS_COLUMNS,  # pyright: ignore[reportPrivateUsage]
         _HOLDINGS_DEFAULT,  # pyright: ignore[reportPrivateUsage]
     )
-    from moneybin.cli.commands.investments.lots import (  # noqa: PLC0415, PLC2701
+    from moneybin.cli.commands.investments.lots import (
         _LOTS_ALL_DEFAULT,  # pyright: ignore[reportPrivateUsage]
         _LOTS_COLUMNS,  # pyright: ignore[reportPrivateUsage]
         _LOTS_DEFAULT,  # pyright: ignore[reportPrivateUsage]

--- a/tests/moneybin/test_connectors/test_gsheet/test_adapter_raw_seed.py
+++ b/tests/moneybin/test_connectors/test_gsheet/test_adapter_raw_seed.py
@@ -89,7 +89,7 @@ def test_infer_type_rejects_non_castable_floats() -> None:
     so a view emitting those casts fails at query time. They fall to VARCHAR.
     """
     from moneybin.connectors.gsheet.adapters.raw_seed import (
-        _infer_type,  # pyright: ignore[reportPrivateUsage]  # noqa: PLC0415
+        _infer_type,  # pyright: ignore[reportPrivateUsage]
     )
 
     assert _infer_type(pl.Series(["inf", "1.0"])) == "VARCHAR"

--- a/tests/moneybin/test_extractors/test_institution_resolution.py
+++ b/tests/moneybin/test_extractors/test_institution_resolution.py
@@ -124,7 +124,7 @@ class TestSharedInstitutionRegistry:
     def test_every_registry_fid_resolves(self) -> None:
         """Each FID in the shared CSV resolves via the FID branch of the chain."""
         from moneybin.extractors.institution_resolution import (
-            _fid_to_slug,  # noqa: PLC0415  # pyright: ignore[reportPrivateUsage]
+            _fid_to_slug,  # pyright: ignore[reportPrivateUsage]
         )
 
         registry = _fid_to_slug()
@@ -141,9 +141,9 @@ class TestSharedInstitutionRegistry:
 
     def test_registry_carries_a_display_name_for_every_slug(self) -> None:
         """seeds.institutions is also the display-name source; no row may lack one."""
-        import csv  # noqa: PLC0415
-        import io  # noqa: PLC0415
-        from importlib import resources  # noqa: PLC0415
+        import csv
+        import io
+        from importlib import resources
 
         raw = (
             resources
@@ -168,7 +168,7 @@ class TestSharedInstitutionRegistry:
         lookup — from the same CSV, so the two cannot disagree about a bank's
         name.
         """
-        from moneybin.extractors.institution_resolution import (  # noqa: PLC0415
+        from moneybin.extractors.institution_resolution import (
             _fid_to_slug,  # pyright: ignore[reportPrivateUsage]
             display_name_for_fid,
         )
@@ -181,9 +181,9 @@ class TestSharedInstitutionRegistry:
         assert display_name_for_fid(None) is None
 
     def _registry_rows(self) -> list[dict[str, str]]:
-        import csv  # noqa: PLC0415
-        import io  # noqa: PLC0415
-        from importlib import resources  # noqa: PLC0415
+        import csv
+        import io
+        from importlib import resources
 
         raw = (
             resources
@@ -211,9 +211,9 @@ class TestSharedInstitutionRegistry:
         round-trip lossless. If an institution ever needs a non-numeric fid,
         this guard must be replaced by forcing the column's dtype, not relaxed.
         """
-        import csv  # noqa: PLC0415
-        import io  # noqa: PLC0415
-        from importlib import resources  # noqa: PLC0415
+        import csv
+        import io
+        from importlib import resources
 
         raw = (
             resources

--- a/tests/moneybin/test_extractors/test_ofx_extractor.py
+++ b/tests/moneybin/test_extractors/test_ofx_extractor.py
@@ -709,7 +709,7 @@ class TestOFXAccountTypeDerivation:
 
     @staticmethod
     def _account(account_type: str, kind: int) -> object:
-        import ofxparse  # noqa: PLC0415
+        import ofxparse
 
         acct = ofxparse.Account()
         acct.account_type = account_type
@@ -733,7 +733,7 @@ class TestOFXAccountTypeDerivation:
     def test_type_falls_back_to_the_statement_container(
         self, declared: str, kind: int, expected: str | None
     ) -> None:
-        from moneybin.extractors.ofx.extractor import (  # noqa: PLC0415
+        from moneybin.extractors.ofx.extractor import (
             ofx_account_type,
         )
 

--- a/tests/moneybin/test_mcp/test_mcp_sync.py
+++ b/tests/moneybin/test_mcp/test_mcp_sync.py
@@ -358,7 +358,7 @@ async def test_sync_disconnect_refuses_confirmation_after_live_target_changes(
 @pytest.mark.unit
 def test_sync_review_prompt_content_includes_required_elements() -> None:
     """The sync_review prompt must guide an agent through a sync health check."""
-    from moneybin.mcp.prompts import sync_review  # noqa: PLC0415
+    from moneybin.mcp.prompts import sync_review
 
     text = sync_review()
     assert "sync_status" in text

--- a/tests/moneybin/test_privacy/test_redaction.py
+++ b/tests/moneybin/test_privacy/test_redaction.py
@@ -242,12 +242,12 @@ def test_redacts_pydantic_nested_list() -> None:
 
 def test_import_files_preserves_bridge_input_but_masks_explicit_account_keys() -> None:
     """Bridge prose stays usable while semantically typed account keys mask."""
-    from moneybin.privacy.introspection import derive_tier  # noqa: PLC0415
-    from moneybin.privacy.payloads.imports import (  # noqa: PLC0415
+    from moneybin.privacy.introspection import derive_tier
+    from moneybin.privacy.payloads.imports import (
         ImportFilesPayload,
         ImportPerFileRow,
     )
-    from moneybin.privacy.taxonomy import Tier  # noqa: PLC0415
+    from moneybin.privacy.taxonomy import Tier
 
     payload = ImportFilesPayload(
         imported_count=0,
@@ -326,7 +326,7 @@ def test_account_proposal_ref_survives_the_mask_that_hides_its_key() -> None:
     does not declare, so this fails if the field is missing as well as if it
     is classified into a masking class.
     """
-    from moneybin.privacy.payloads.imports import (  # noqa: PLC0415
+    from moneybin.privacy.payloads.imports import (
         ImportConfirmRequiredPayload,
     )
 
@@ -445,7 +445,7 @@ def test_transforms_covers_every_data_class() -> None:
     The redaction-module docstring promises "the unit tests will fail
     otherwise"; this test makes the promise enforceable.
     """
-    from moneybin.privacy.redaction import (  # noqa: PLC0415
+    from moneybin.privacy.redaction import (
         _TRANSFORMS,  # pyright: ignore[reportPrivateUsage]
     )
 
@@ -476,7 +476,7 @@ def test_every_masking_transform_returns_text_whatever_it_is_given() -> None:
     ``tests/moneybin/test_exports/test_redaction.py`` for the other half of
     this contract.
     """
-    from moneybin.privacy.redaction import (  # noqa: PLC0415
+    from moneybin.privacy.redaction import (
         _TRANSFORMS,  # pyright: ignore[reportPrivateUsage]
     )
 

--- a/tests/moneybin/test_services/test_import_binding.py
+++ b/tests/moneybin/test_services/test_import_binding.py
@@ -2099,7 +2099,7 @@ def test_the_ambiguous_ref_refusal_says_where_to_read_the_masked_key() -> None:
     # Private by design: this is the pure binding resolver, and reaching it
     # through import_file would need a two-account fixture whose first ACCTID is
     # literally "@1" to exercise one error string.
-    from moneybin.services.import_service import (  # noqa: PLC0415
+    from moneybin.services.import_service import (
         _resolve_binding_targets,  # pyright: ignore[reportPrivateUsage]
     )
 

--- a/tests/moneybin/test_services/test_schema_catalog.py
+++ b/tests/moneybin/test_services/test_schema_catalog.py
@@ -8,7 +8,9 @@ import duckdb
 import pytest
 
 import moneybin.services.schema_catalog as schema_catalog_module
-from moneybin.database import (  # noqa: PLC2701  # the single definition of "point a new cursor at the attached DB"
+
+# the single definition of "point a new cursor at the attached DB"
+from moneybin.database import (
     Database,
     _pin_cursor_to_moneybin,  # pyright: ignore[reportPrivateUsage]
 )

--- a/tests/scenarios/test_merchant_harvest.py
+++ b/tests/scenarios/test_merchant_harvest.py
@@ -334,7 +334,7 @@ def test_harvest_routes_conflict_to_review() -> None:
         # Reject the pending conflict the real way (user picks "new"), then
         # re-harvest: the rejected (non-reversed) decision must suppress
         # re-proposal so the queue drains instead of re-filling every run.
-        from moneybin.services.merchant_links_service import (  # noqa: PLC0415
+        from moneybin.services.merchant_links_service import (
             MerchantLinksService,
         )
 


### PR DESCRIPTION
Closes MB-168.

`pyproject.toml`'s ruff `select` does not list `PL`, so every Pylint-family code
is disabled and no `# noqa: PLC0415` ever suppressed a diagnostic. They were
documentation comments wearing a lint-suppression costume — and because no
linter evaluated the justifications riding on them, wrong ones survived
unchallenged. An audit took one at face value and had to be retracted.

This removes all 363 of them, keeps the justifications that earned it, and
corrects the ones that were false.

## The claims were audited by experiment, not by reading

The ticket warns that a module-level import graph cannot show a cycle that a
working deferral is holding open — it says whether a cycle exists *now*, not
whether the deferral is load-bearing. So each of the 325 deferred imports in
`src/` was tested by actually hoisting it to module scope and importing the
module in a clean interpreter, in both directions (a cycle `A<->B` surfaces
only from whichever module the interpreter enters first).

The harness was calibrated first against the cycles the ticket names as
genuine, with the expected verdict written down before running. The first run
returned "no cycle" for all of them — which was the harness truncating
parenthesised multi-line imports at the comment, hoisting `from x import (`.
Without that calibration step the result would have read as "every claim is
false." Fixed, all five reproduce as real, and a malformed rewrite now reports
as a tool error rather than as a clean result.

## What the experiment found

|                      | Real cycle | No cycle |
| -------------------- | ---------- | -------- |
| **Claims a cycle**   | 8          | **17 false** |
| **Says nothing**     | **7**      | 293      |

- **17 false claims removed.** The ticket predicted 19 of 24; the measured
  figure is 17 of 25. Hoisting any of them raises nothing.
- **7 silent load-bearing deferrals now documented.** These are the ones the
  ticket did not know about: bare markers holding a real cycle open with no
  comment at all — `config.py -> moneybin.database` (x2),
  `transaction_categories_repo -> services.categorization._shared` (x3),
  `account_resolver -> import_service`, `import_inbox -> import_cmd`. Anyone
  hoisting one breaks the import; nothing said so.
- **8 true claims kept**, reworded to the verified fact.

One of the ticket's six named cycles, `errors.py -> services.profile_service`,
no longer exists — MB-51 removed it. `errors.py` has no reference to it.

## Why this is not `ruff --fix`

Ruff can autofix unused directives, but it parses this repo's dominant em-dash
form as part of the directive and deletes the justification with it:

| Before | After `ruff --fix` |
| --- | --- |
| `# noqa: PLC0415` | removed |
| `# noqa: PLC0415  # polars is not cold-start cheap` | comment kept |
| `# noqa: PLC0415 — defer import to keep CLI cold-start light` | **justification destroyed** |

About 80 of the 107 justifications use the em-dash form, so the autofix would
have silently erased them. Survivors are normalised to a plain `# reason`
comment, which is both what AGENTS.md asks for and immune to a future autofix.

## Disposition of all 363 markers

- **279 dropped** — 218 bare, plus notes that only restate what the reader can
  already see ("defer import" on an import sitting inside a function).
- **51 kept** — genuine non-obvious whys: cold-start cost, import weight,
  a `TYPE_CHECKING`-only module-scope import.
- **15 rewritten** to the verified cycle fact.
- **17 false cycle claims removed.**
- **1 preserved verbatim** — a `# pyright: ignore[reportPrivateUsage]` riding
  on the same line.

### The retained cold-start claims were measured too

The hoist experiment answers "does this cycle?", not "is this import expensive?",
so the kept justifications would otherwise have been carried forward on their
face — the same defect in a different coat. Each named module was imported in a
clean interpreter against a 16 ms bare-interpreter baseline:

- **13 of 20 distinct targets cost 85–260 ms** — `services.currency_service`
  260 ms ("polars is not cold-start cheap"), `privacy.payloads.imports` 232 ms,
  `services.import_service` 223 ms. Well founded.
- **Four cost under 15 ms** — `rich.text` 13 ms, `mcp.surface` 11 ms,
  `rich.cells` 7 ms, `connectors.sync_errors` 4 ms.

I left the weak four alone rather than deleting them. A standalone measurement
overstates independence: `rich.cells` is co-loaded with `rich.console` (23 ms)
anyway, so its marginal cost in situ is not what the number above says. The
measurement is strong enough to confirm a claim, not to refute one, and the
deferral itself is harmless either way. Flagging it rather than acting on it.

**Only comments change. No import is moved**, so the runtime import graph is
byte-for-byte what it was. That is checked rather than asserted: every one of
the 83 changed files parses to a byte-identical AST against the branch base.
Comments are not nodes, so an unchanged AST means nothing executable moved.

## Beyond the ticket

Two things worth flagging, neither acted on here:

1. **The count was ~6x the estimate** — the ticket says "roughly 60"; the
   actual figure is 354 `PLC0415` plus 9 other `PL` codes.
2. **1,164 further inert `noqa` markers remain** outside the `PL` family
   (`S608` x706, `BLE001` x190, `ARG001` x96, `SLF001` x67, ...), measured with
   `ruff check --extend-select RUF100`. Enabling `RUF100` permanently would
   close the whole class, but it cannot go green until those are swept. Worth
   its own ticket.

## The guard

`test_no_inert_pylint_suppressions.py` stops the markers re-accreting. It also
asserts its own premise — that `PL` is absent from ruff `select` — so if the
family is ever enabled the guard says to delete it rather than quietly becoming
the next false claim. It caught 9 non-`PLC0415` markers I had missed on the
first pass, which is why the sweep covers the whole `PL` family.

This guard is an addition beyond the literal ask; it is a two-way door and easy
to drop if you would rather not carry it.

No CHANGELOG entry: `.claude/rules/shipping.md` excludes internal changes with
no behaviour change.

## Test plan

- `make check` — 0 ruff errors, 0 pyright errors.
- `make test`, `make test-integration`, `make test-scenarios`, `make test-e2e`.
- The guard verified red against the pre-change tree before being relied on.
- `grep` confirms zero `# noqa: PL…` markers remain outside the guard's own
  docstring.
