### PR TITLE
Declare a domain for the FX accounting rows metric

### DIFF
--- a/src/moneybin/metrics/registry.py
+++ b/src/moneybin/metrics/registry.py
@@ -1170,6 +1170,7 @@ METRIC_DOMAINS: dict[str, str] = {
     "moneybin_transfer_matches_proposed": "Transfer detection",
     "moneybin_transfer_match_confidence": "Transfer detection",
     # Multi-currency integrity
+    "moneybin_fx_accounting_rows": "Multi-currency integrity",
     "moneybin_profile_currencies": "Multi-currency integrity",
     "moneybin_unknown_currency_rows": "Multi-currency integrity",
     # Exchange rates


### PR DESCRIPTION
`main` is red at `2bae56cd`. On a clean checkout:

```
FAILED tests/moneybin/test_cli/test_stats.py::test_every_metric_declares_a_domain
AssertionError: metrics with no declared domain: ['moneybin_fx_accounting_rows']
```

This declares the missing domain. One line.

## How main broke with two green PRs

Neither contributing change was wrong on its own:

- **#521** (`c358dc74`, realized FX gain/loss foundation) added the `moneybin_fx_accounting_rows` gauge.
- **#561** (`2bae56cd`, stats units and grouping) added `test_every_metric_declares_a_domain`, which requires every registered metric to appear in `METRIC_DOMAINS`.

They were in flight at the same time, so each PR's CI ran its own change against a base that did not contain the other. Both merged green, and the combination first executed on `main`.

The guard did its job on the first run that saw both. An undeclared metric renders under `Other` in `moneybin stats` — a silent demotion that no reviewer would catch in a diff, since the declaration that omits the domain looks complete on its own. That is the failure mode requirement 25 exists to prevent, and it caught a real instance immediately.

## Why `Multi-currency integrity`

The gauge counts derived FX accounting rows by grain and coverage reason across currency lots, currency conversions, and realized FX gains (`set_fx_accounting_rows` is called from all three SQLMesh core models). It belongs with `moneybin_profile_currencies` and `moneybin_unknown_currency_rows`; its coverage reasons (`unknown_currency`, `missing_home_currency`, `missing_valuation_rate`) are integrity signals, not rate-sourcing ones, so `Exchange rates` would be the wrong group.

## Test plan

- `uv run pytest tests/moneybin/test_cli/test_stats.py` → **12 passed**

Red before the one-line change and green after, on the same tree — the guard's own failure is the proof that the fix is load-bearing rather than cosmetic.

## No CHANGELOG entry

Both contributing changes are unreleased. This corrects a feature before it ships rather than changing behaviour a user has seen.

## Note

This blocks any PR that runs the full unit suite, so it wants to land ahead of the queued MB-181 sweep.
