### PR TITLE
Remove the duplicated FX accounting metric domain entry

### DIFF
--- a/src/moneybin/metrics/registry.py
+++ b/src/moneybin/metrics/registry.py
@@ -1173,7 +1173,6 @@ METRIC_DOMAINS: dict[str, str] = {
     "moneybin_fx_accounting_rows": "Multi-currency integrity",
     "moneybin_profile_currencies": "Multi-currency integrity",
     "moneybin_unknown_currency_rows": "Multi-currency integrity",
-    "moneybin_fx_accounting_rows": "Multi-currency integrity",
     # Exchange rates
     "moneybin_fx_rate_rows_written": "Exchange rates",
     "moneybin_fx_rate_resolution": "Exchange rates",


### PR DESCRIPTION
## Summary

`main` is red. `uv run ruff check .` fails on `main` at `1ac3caaa`:

```
error[F601]: Dictionary key literal `"moneybin_fx_accounting_rows"` repeated
    --> src/moneybin/metrics/registry.py:1176:5
```

This removes the duplicate. One line.

## How it got in

Merge skew, the same shape that produced #569:

- **#569** added `"moneybin_fx_accounting_rows": "Multi-currency integrity"` to `_METRIC_DOMAINS`, to fix a *different* red-main failure (`test_every_metric_declares_a_domain`).
- **#568** added the identical entry independently, as one of its six repaired review findings.

Neither CI run could see the other's line — each evaluated a base that did not yet carry it — so both merged green and only the combined tree has the key twice. `F601` is a pyflakes rule and has always been in `select`; nothing was misconfigured. No individual PR was wrong, and no reviewer could have caught it from either diff alone.

## Which copy survives

The one at line 1173, which keeps the `# Multi-currency integrity` group in alphabetical order:

```python
# Multi-currency integrity
"moneybin_fx_accounting_rows": "Multi-currency integrity",
"moneybin_profile_currencies": "Multi-currency integrity",
"moneybin_unknown_currency_rows": "Multi-currency integrity",
```

The removed copy sat after `moneybin_unknown_currency_rows`, breaking that order. Both mapped to the same value, so the runtime behavior is identical either way — this is purely about which line reads correctly.

## Test plan

- `uv run ruff check .` — `All checks passed!` (was `Found 1 error.`)
- `uv run pytest tests/moneybin/test_cli/test_stats.py` — 12 passed, including `test_every_metric_declares_a_domain`
- Key now appears exactly once in `_METRIC_DOMAINS`

## Note

This is blocking #571, whose CI failure is entirely this defect and not its own diff.
