### PR TITLE
Fix large_transactions doc: per-currency top-100, add 2 columns

### DIFF
--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -559,14 +559,16 @@ All non-transfer transactions with z-scores against account and category baselin
 |---|---|---|
 | `transaction_id` | VARCHAR | Joinable to `core.fct_transactions.transaction_id`. |
 | `account_id` | VARCHAR | Owning account. |
+| `merchant_id` | VARCHAR | FK → `core.dim_merchants.merchant_id`. NULL when no canonical merchant was resolved. |
 | `account_name` | VARCHAR | Resolved display name. |
 | `merchant_normalized` | VARCHAR | Resolved merchant; NULL when not curated. |
 | `description` | VARCHAR | Source description. |
 | `category` | VARCHAR | Spending category; NULL if uncategorized. |
+| `currency_code` | VARCHAR | ISO 4217 the amount is denominated in; NULL is the unknown-currency segment, never resolved to the home currency. |
 | `txn_date` | DATE | Transaction date. |
 | `amount_zscore_account` | DECIMAL | Modified z-score relative to account median + MAD. NULL when MAD = 0. |
 | `amount_zscore_category` | DECIMAL | Modified z-score relative to category median + MAD; NULL when category has fewer than 5 transactions or MAD = 0. |
-| `is_top_100` | BOOLEAN | TRUE if in the top 100 by `ABS(amount)` overall. |
+| `is_top_100` | BOOLEAN | TRUE if in the top 100 by `ABS(amount)` among transactions sharing this `currency_code`. |
 | `amount` | DECIMAL(18,2) | Signed (source sign preserved). |
 
 ### `reports.balance_drift`


### PR DESCRIPTION
## Summary

- Fix `docs/reference/data-model.md`'s `is_top_100` description: the model ranks per `currency_code` (`ROW_NUMBER() OVER (PARTITION BY currency_code ...)`), not globally by `ABS(amount)`.
- Add the `merchant_id` and `currency_code` rows the doc table omitted (11 documented columns vs. 13 actually projected by `large_transactions.sql`), placed in the model's actual projection order and worded from the SQL's own inline comments and existing doc precedent for those columns elsewhere in the file.
- Verified the summary-level `is_top_100` mention (data-model.md's Q&A table) does not repeat the "overall" error — no change needed there.

## Test plan

- `uv run pytest tests/test_documentation_policy.py -v` — 43 passed.
- Diff is documentation-only (`git diff --stat` shows one file, `docs/reference/data-model.md`); no `.py` or `.sql` touched, so no other gate applies.

Closes #509
