### PR TITLE
Clear ambient OAuth env vars in shipped-pair test

### DIFF
--- a/tests/moneybin/test_connectors/test_gsheet/test_oauth_client.py
+++ b/tests/moneybin/test_connectors/test_gsheet/test_oauth_client.py
@@ -624,6 +624,8 @@ def test_google_oauth_authorizes_with_the_shipped_client_id_and_secret_pair(
         granted_scopes=[GOOGLE_SHEETS_READ_SCOPE],
     )
     monkeypatch.setattr(InstalledAppFlow, "from_client_config", from_config)
+    monkeypatch.delenv("MONEYBIN_GSHEET__OAUTH_CLIENT_ID", raising=False)
+    monkeypatch.delenv("MONEYBIN_GSHEET__OAUTH_CLIENT_SECRET", raising=False)
     client = GoogleOAuthClient(_store_with({}), MoneyBinSettings.model_validate({}))
 
     client.authorize()


### PR DESCRIPTION
## Summary

`test_google_oauth_authorizes_with_the_shipped_client_id_and_secret_pair` (`tests/moneybin/test_connectors/test_gsheet/test_oauth_client.py`) built settings via a bare `MoneyBinSettings.model_validate({})` without first clearing `MONEYBIN_GSHEET__OAUTH_CLIENT_ID`/`MONEYBIN_GSHEET__OAUTH_CLIENT_SECRET`. A developer with either exported picks up their own value instead of the shipped default, the assertion fails, and pytest prints both sides of the comparison — leaking the developer's OAuth client id into the run's output.

Fix: add the same `monkeypatch.delenv(..., raising=False)` pair for both variables before that `model_validate({})` call, matching the pattern the three sibling tests in this file already use.

**Audit of the other two bare `MoneyBinSettings.model_validate({})` calls in this file** (the only other tree-wide matches):
- `test_google_oauth_refuses_write_authorization_with_the_shipped_client` — already calls `monkeypatch.delenv` for both variables a few lines above its `model_validate({})`. Left unchanged.
- `test_google_oauth_is_authorized_write_false_with_the_shipped_client` — same: both `delenv` calls already precede its `model_validate({})`. Left unchanged.

Note for reviewers: a repo-wide harness fix (#505) merged the day after this issue was filed and now clears every ambient `MONEYBIN_*` env var at `tests/conftest.py` import time, before any test runs. That already closes this leak class for a plain `uv run pytest` invocation. This per-test `delenv` is still the fix this issue asks for, keeps the test correct in isolation, and matches the established pattern in the other three tests in this file.

## Test plan

- `uv run pytest tests/moneybin/test_connectors/test_gsheet/test_oauth_client.py -v` — 42 passed.
- Because `tests/conftest.py` now strips ambient `MONEYBIN_*` vars before any test runs (#505), a plain `MONEYBIN_GSHEET__OAUTH_CLIENT_ID=<synthetic> uv run pytest <target test>` no longer reproduces the pre-fix failure through pytest itself — the harness-level fix already intercepts it. Confirmed the underlying mechanism directly with a standalone script (outside pytest) that sets the same synthetic env var and calls `MoneyBinSettings.model_validate({})`: it resolves to the synthetic value before an equivalent `delenv`, and to the shipped default after — the exact defect this fix closes at the test level.
- `make lint` / `make format` currently fail repo-wide on a pre-existing, unrelated `F601` duplicate-dict-key in `src/moneybin/metrics/registry.py` (present on `main`, untouched by this diff). `uv run pyright` (repo-wide type-check) passes clean: 0 errors. `uv run ruff check` scoped to the changed file passes clean.

Closes #491
