### PR TITLE
Add positive AugAssign controls to the table-literal guard

### DIFF
--- a/tests/moneybin/test_architecture/test_table_reference_literals.py
+++ b/tests/moneybin/test_architecture/test_table_reference_literals.py
@@ -1671,6 +1671,29 @@ def test_augassign_does_not_alias_its_rhs_name(tmp_path: Path) -> None:
     assert _scan_source(tmp_path, source) == []
 
 
+def test_augassign_records_the_added_text_within_a_function(tmp_path: Path) -> None:
+    """Positive control for the test above — `x += "..."` records the literal.
+
+    Pairs with `test_augassign_does_not_alias_its_rhs_name`: that test pins
+    what the `ast.AugAssign` branch must NOT do (alias a Name RHS), this one
+    pins what it DOES do — record a literal RHS onto the target name so it
+    still reaches `execute()`.
+    """
+    source = (
+        "def f(db):\n"
+        '    query = ""\n'
+        '    query += "SELECT * FROM core.foo"\n'
+        "    db.execute(query)\n"
+    )
+    assert _scan_source(tmp_path, source) == [(3, "FROM", "core.foo")]
+
+
+def test_augassign_records_the_added_text_at_module_scope(tmp_path: Path) -> None:
+    """Control for the test above — the same recording holds at module scope."""
+    source = 'query = ""\nquery += "SELECT * FROM core.foo"\ndb.execute(query)\n'
+    assert _scan_source(tmp_path, source) == [(2, "FROM", "core.foo")]
+
+
 def test_fstring_interpolation_placeholder_does_not_hide_adjacent_literal(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Pin the missing positive case for `ast.AugAssign` in the table-literal guard's `_collect_scope`: `query += "SELECT * FROM core.foo"` must still reach `db.execute(...)` and be reported, mirroring the existing negative test (`test_augassign_does_not_alias_its_rhs_name`) that only pins what the branch must NOT do.
- Adds two tests, matching the file's existing scope-pair convention (two separate non-parametrized functions, e.g. `test_module_constant_used_inside_a_function_is_deliberately_not_reported` / `test_module_constant_used_at_module_scope_is_still_reported`): one for function scope, one for module scope.
- No production change — the guard's implementation (`_collect_scope`) lives inside this same test file, not under `src/`; `git diff src/` is empty on this branch.

Closes #550

## Verification

- `make check` (repo-wide): passes clean — 0 ruff/pyright errors (3 pre-existing, unrelated pyright warnings on an unrelated fixture file).
- `uv run pytest tests/moneybin/test_architecture/test_table_reference_literals.py -v`: 68 passed (up from a 66-test baseline before this change — confirms both new tests actually collected).
- `make test`: 11558 passed, 4 skipped.
- Mutation check (temporary, reverted): disabled the `ast.AugAssign` branch's recording call in `_collect_scope` and reran the two new tests — both failed:
  - `AssertionError: assert [] == [(3, 'FROM', 'core.foo')]`
  - `AssertionError: assert [] == [(2, 'FROM', 'core.foo')]`

  The pre-existing negative test (`test_augassign_does_not_alias_its_rhs_name`) still passed under the same mutation, confirming the new tests isolate the recording path rather than double-covering the alias-refusal path. The mutation was fully reverted before committing.
