### PR TITLE
Key the net-worth snapshot column types by name

### DIFF
--- a/.claude/rules/column-ordering.md
+++ b/.claude/rules/column-ordering.md
@@ -35,16 +35,16 @@ _SNAPSHOT_COLUMNS]` directly into its execution, so for `core:networth` and
 `core:networth_history` the declared order is what JSON, MCP, `--wide`, and every
 export emit. Reordering that tuple is a user-visible change, not a cosmetic one.
 
-A service report in fact carries **three** parallel orderings, and reordering one
-means reordering all three:
+A service report in fact carries **three** positions that must stay in
+agreement, but only two of them are separate lists an author reorders by hand:
 
 1. The `columns` tuple — sets `result.columns`, drives `--wide`.
-2. A `column_types` list. Both `core:networth` and `core:networth_history` key
-   their types by column name (`_SNAPSHOT_COLUMN_TYPES_BY_NAME`,
+2. A `column_types` sequence. Both `core:networth` and `core:networth_history`
+   key their types by column name (`_SNAPSHOT_COLUMN_TYPES_BY_NAME`,
    `_execute_networth_history`'s local `types_by_name`) and project them
    through their own columns tuple (`_SNAPSHOT_COLUMNS`, `_HISTORY_COLUMNS`),
-   so reordering the columns tuple carries the types with it — an ordering
-   derived once beats an ordering duplicated and checked.
+   so this one is derived, not a second hand-kept ordering — reordering the
+   columns tuple carries the types with it automatically.
    `core:networth_history`'s `_decimal_column_type(rows, "net_worth", …)`
    entries additionally name their column in an argument, since its types
    depend on the resolved `Decimal` precision rather than being static.

--- a/.claude/rules/column-ordering.md
+++ b/.claude/rules/column-ordering.md
@@ -252,7 +252,7 @@ reorders it expecting an effect and gets none.
 
 A **service-backed** report has nothing to mirror against — its tuple is already
 the projection, per the exception above. Rules B and C govern it directly, and
-the `column_types` list beside it moves with it.
+the derived `column_types` moves with it automatically.
 
 ## Enforcement
 

--- a/.claude/rules/column-ordering.md
+++ b/.claude/rules/column-ordering.md
@@ -39,15 +39,15 @@ A service report in fact carries **three** parallel orderings, and reordering on
 means reordering all three:
 
 1. The `columns` tuple — sets `result.columns`, drives `--wide`.
-2. A `column_types` list. `core:networth`'s `_SNAPSHOT_COLUMN_TYPES` is parallel
-   **by index alone**: reorder one without the other and every column is handed
-   the type of whichever column now occupies its slot — a silent mis-typing whose
-   only guard is the tripwire under Enforcement. `core:networth_history` carried
-   the same hazard in a subtler form, its `_decimal_column_type(rows,
-   "net_worth", …)` entries naming their column in an argument while position was
-   what bound. It now keys the types by name and projects them through
-   `_HISTORY_COLUMNS`, which is the shape to copy: an ordering derived once beats
-   an ordering duplicated and checked.
+2. A `column_types` list. Both `core:networth` and `core:networth_history` key
+   their types by column name (`_SNAPSHOT_COLUMN_TYPES_BY_NAME`,
+   `_execute_networth_history`'s local `types_by_name`) and project them
+   through their own columns tuple (`_SNAPSHOT_COLUMNS`, `_HISTORY_COLUMNS`),
+   so reordering the columns tuple carries the types with it — an ordering
+   derived once beats an ordering duplicated and checked.
+   `core:networth_history`'s `_decimal_column_type(rows, "net_worth", …)`
+   entries additionally name their column in an argument, since its types
+   depend on the resolved `Decimal` precision rather than being static.
 3. The **record dict literals** built in the row comprehensions. The envelope
    carries `data=records` and Python dicts preserve insertion order, so those
    keys — not the `columns` tuple — are what `--output json` and every MCP caller
@@ -260,22 +260,18 @@ Honest about what is and is not caught.
 
 **Guarded, unit tier — the report specs.** `DataClass` and `money_kind` supply
 the categories Rule B needs, and both live on `OutputColumn`, so a spec can be
-checked with no database. Three assertions:
+checked with no database. Two assertions:
 
 1. `ReportSpec.columns` is non-decreasing under Rule B.
 2. `default_columns` is non-decreasing under Rule B.
-3. `_SNAPSHOT_COLUMN_TYPES` is the same length as `_SNAPSHOT_COLUMNS`, and the
-   three entries most likely to drift (`balance_date`, `net_worth`,
-   `account_count`) still pair with the column they name.
 
-Read the third one narrowly. It is a tripwire on `core:networth`, not a
-derivation: it does not check every column against its declared class. It is now
-also the last place the hazard lives — `core:networth_history` derives its
-`column_types` from `_HISTORY_COLUMNS` by name, so it has no second list to keep
-in step and needs no assertion. Giving `_SNAPSHOT_COLUMN_TYPES` the same
-treatment would retire this assertion entirely; it is a module constant read
-from more than one place, so that is a change to make deliberately rather than
-in passing.
+There used to be a third: a tripwire pairing `_SNAPSHOT_COLUMN_TYPES`'s three
+entries most likely to drift (`balance_date`, `net_worth`, `account_count`)
+against `_SNAPSHOT_COLUMNS`, because the two were parallel by position alone.
+Both `core:networth` and `core:networth_history` now derive `column_types`
+from a name-keyed dict projected through their own columns tuple, so neither
+has a second list to keep in step, and neither needs an assertion — the
+tripwire retired along with the hazard it guarded.
 
 **The SQL-backed mirror is checked per report, not globally.** A runner builds
 its own `SELECT` over the view rather than inheriting the model's projection, so

--- a/docs/specs/reports-net-worth-sql-surface.md
+++ b/docs/specs/reports-net-worth-sql-surface.md
@@ -616,8 +616,9 @@ tests named in §Testing Strategy.
 - `src/moneybin/metrics/registry.py` — rate-spine coverage counters.
 - `docs/specs/INDEX.md`, `docs/roadmap.md` — status and milestone entries.
 - `.claude/rules/column-ordering.md` — the "service-backed report is the
-  exception" passages, and Enforcement item 3's `_SNAPSHOT_COLUMN_TYPES`
-  tripwire, both retire with the deletion below.
+  exception" passages retire with the deletion below. (Enforcement item 3's
+  `_SNAPSHOT_COLUMN_TYPES` tripwire already retired separately, when the
+  snapshot path was keyed by name — issue #511.)
 
 ### Files to Delete
 

--- a/docs/specs/reports-net-worth-sql-surface.md
+++ b/docs/specs/reports-net-worth-sql-surface.md
@@ -616,9 +616,12 @@ tests named in §Testing Strategy.
 - `src/moneybin/metrics/registry.py` — rate-spine coverage counters.
 - `docs/specs/INDEX.md`, `docs/roadmap.md` — status and milestone entries.
 - `.claude/rules/column-ordering.md` — the "service-backed report is the
-  exception" passages retire with the deletion below. (Enforcement item 3's
-  `_SNAPSHOT_COLUMN_TYPES` tripwire already retired separately, when the
-  snapshot path was keyed by name — issue #511.)
+  exception" passages retire with the deletion below, including the
+  parallel-positions list that names `_SNAPSHOT_COLUMN_TYPES_BY_NAME`,
+  `_HISTORY_COLUMNS`, and `types_by_name` — every symbol it cites disappears
+  in this deletion too. (Enforcement item 3's `_SNAPSHOT_COLUMN_TYPES`
+  tripwire already retired separately, when the snapshot path was keyed by
+  name — issue #511.)
 
 ### Files to Delete
 

--- a/src/moneybin/reports/service_reports.py
+++ b/src/moneybin/reports/service_reports.py
@@ -106,9 +106,9 @@ _SNAPSHOT_COLUMN_TYPES_BY_NAME = {
     "total_liabilities": "DECIMAL(18,2)",
     "net_worth": "DECIMAL(18,2)",
 }
-_SNAPSHOT_COLUMN_TYPES = [
+_SNAPSHOT_COLUMN_TYPES = tuple(
     _SNAPSHOT_COLUMN_TYPES_BY_NAME[column.name] for column in _SNAPSHOT_COLUMNS
-]
+)
 _SNAPSHOT_CLASSES = {column.name: column.data_class for column in _SNAPSHOT_COLUMNS}
 _SNAPSHOT_SEMANTICS = ReportSemantics(
     unit="currency",
@@ -386,9 +386,8 @@ def _execute_networth_history(
         for point in payload.points
     ]
     # Keyed by column name and projected through _HISTORY_COLUMNS, so reordering
-    # that tuple carries the types with it. The positional form this replaced
-    # had to be reordered in lockstep by hand, and nothing checked it — unlike
-    # `_SNAPSHOT_COLUMN_TYPES`, whose parallel list a test does hold down.
+    # that tuple carries the types with it — the same shape `_SNAPSHOT_COLUMN_TYPES`
+    # uses for `_SNAPSHOT_COLUMNS`.
     types_by_name = {
         "currency_code": "VARCHAR",
         "period": "VARCHAR",

--- a/src/moneybin/reports/service_reports.py
+++ b/src/moneybin/reports/service_reports.py
@@ -91,22 +91,24 @@ _SNAPSHOT_COLUMNS = (
     ),
 )
 
-# Parallel to _SNAPSHOT_COLUMNS **by position alone** — nothing here names a
-# column. Reorder one without the other and every column is handed the type of
-# whichever column took its slot, silently. `test_column_ordering.py` is the
-# only thing between that and a caller.
-_SNAPSHOT_COLUMN_TYPES = (
-    "VARCHAR",
-    "VARCHAR",
-    "VARCHAR",
-    "VARCHAR",
-    "DATE",
-    "BIGINT",
-    "DECIMAL(18,2)",
-    "DECIMAL(18,2)",
-    "DECIMAL(18,2)",
-    "DECIMAL(18,2)",
-)
+# Keyed by column name and projected through _SNAPSHOT_COLUMNS, so reordering
+# that tuple carries the types with it — the same shape
+# `_execute_networth_history` uses for `_HISTORY_COLUMNS`.
+_SNAPSHOT_COLUMN_TYPES_BY_NAME = {
+    "account_id": "VARCHAR",
+    "account_name": "VARCHAR",
+    "currency_code": "VARCHAR",
+    "observation_source": "VARCHAR",
+    "balance_date": "DATE",
+    "account_count": "BIGINT",
+    "account_balance": "DECIMAL(18,2)",
+    "total_assets": "DECIMAL(18,2)",
+    "total_liabilities": "DECIMAL(18,2)",
+    "net_worth": "DECIMAL(18,2)",
+}
+_SNAPSHOT_COLUMN_TYPES = [
+    _SNAPSHOT_COLUMN_TYPES_BY_NAME[column.name] for column in _SNAPSHOT_COLUMNS
+]
 _SNAPSHOT_CLASSES = {column.name: column.data_class for column in _SNAPSHOT_COLUMNS}
 _SNAPSHOT_SEMANTICS = ReportSemantics(
     unit="currency",

--- a/tests/moneybin/test_reports/test_column_ordering.py
+++ b/tests/moneybin/test_reports/test_column_ordering.py
@@ -1,4 +1,4 @@
-"""Rule B and the service-report type parity, from `.claude/rules/column-ordering.md`."""
+"""Rule B, from `.claude/rules/column-ordering.md`."""
 
 from __future__ import annotations
 
@@ -21,11 +21,7 @@ from moneybin.reports._framework.catalog import RegisteredReport
 from moneybin.reports._framework.cli_register import resolve_default_columns
 from moneybin.reports._framework.contract import OutputColumn
 from moneybin.reports._framework.registry import discover_reports, spec_of
-from moneybin.reports.service_reports import (
-    _SNAPSHOT_COLUMN_TYPES,  # pyright: ignore[reportPrivateUsage]  # the pair under test
-    _SNAPSHOT_COLUMNS,  # pyright: ignore[reportPrivateUsage]  # the pair under test
-    SERVICE_REPORTS,
-)
+from moneybin.reports.service_reports import SERVICE_REPORTS
 
 pytestmark = pytest.mark.unit
 
@@ -101,22 +97,3 @@ def test_default_columns_follow_grain_first(spec: RegisteredReport) -> None:
         f"{spec.report_id} orders default_columns out of Rule B order: "
         + ", ".join(f"{name}={rank}" for name, rank in ranked)
     )
-
-
-def test_snapshot_column_types_stay_parallel() -> None:
-    """A service report's `column_types` is positional beside its columns tuple.
-
-    Reordering one without the other hands every column the type of whichever
-    column took its slot. This is the only thing standing between that and a
-    caller, so it asserts length and the three anchors most likely to drift.
-    """
-    columns = [column.name for column in _SNAPSHOT_COLUMNS]
-    types = _SNAPSHOT_COLUMN_TYPES
-    assert len(columns) == len(types), (
-        f"_SNAPSHOT_COLUMNS has {len(columns)} entries and _SNAPSHOT_COLUMN_TYPES "
-        f"has {len(types)}; they are matched by position"
-    )
-    by_type = dict(zip(columns, types, strict=True))
-    assert by_type["balance_date"] == "DATE"
-    assert by_type["net_worth"] == "DECIMAL(18,2)"
-    assert by_type["account_count"] == "BIGINT"


### PR DESCRIPTION
## Summary

- `_SNAPSHOT_COLUMN_TYPES` was a bare tuple parallel to `_SNAPSHOT_COLUMNS` **by position alone**. Reorder one without the other and every column is silently handed the type of whichever column took its slot.
- Key the types by column name (`_SNAPSHOT_COLUMN_TYPES_BY_NAME`) and project them through `_SNAPSHOT_COLUMNS` — the same shape `_execute_networth_history` already uses for `_HISTORY_COLUMNS`. Reordering the columns tuple now carries the types with it.
- Retire `test_snapshot_column_types_stay_parallel`: it was a tripwire on a hazard that no longer exists.
- `.claude/rules/column-ordering.md` named this exact change in advance — "Giving `_SNAPSHOT_COLUMN_TYPES` the same treatment would retire this assertion entirely; it is a module constant read from more than one place, so that is a change to make deliberately rather than in passing." This is that deliberate change, so the rule's hazard passage and Enforcement item 3 are updated with it.
- `docs/specs/reports-net-worth-sql-surface.md` listed that tripwire among the things its own future deletion would retire; the cross-reference now points at this change instead.

## Test plan

- `make check` — ruff format and lint clean, pyright 0 errors (3 pre-existing unrelated warnings in `tests/moneybin/test_extractors/test_pdf/_make_fixture.py`).
- `make test` — 11538 passed, 4 skipped.
- Branch rebased onto current `main` (includes the duplicate-dict-key lint fix), so the gate above ran against what CI sees.

Closes #511
