### PR TITLE
Align the ruff select comment column

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,17 +253,17 @@ preview = true
 [tool.ruff.lint]
 # Documentation: https://docs.astral.sh/ruff/rules/
 select = [
-    "E",   # pycodestyle errors
-    "W",   # pycodestyle warnings
-    "F",   # pyflakes
-    "I",   # isort
-    "B",   # flake8-bugbear
-    "C4",  # flake8-comprehensions
-    "UP",  # pyupgrade
-    "N",   # pep8-naming
-    "D",   # pydocstring
-    "S",   # flake8-bandit (security)
-    "T20", # flake8-print
+    "E",      # pycodestyle errors
+    "W",      # pycodestyle warnings
+    "F",      # pyflakes
+    "I",      # isort
+    "B",      # flake8-bugbear
+    "C4",     # flake8-comprehensions
+    "UP",     # pyupgrade
+    "N",      # pep8-naming
+    "D",      # pydocstring
+    "S",      # flake8-bandit (security)
+    "T20",    # flake8-print
     "RUF100", # unused-noqa: a noqa directive that suppresses nothing
 ]
 ignore = [


### PR DESCRIPTION
## Summary

Follow-up to the one 🔵 NIT on #571, which merged before it was addressed.

`RUF100` is wider than every other entry in ruff's `select` list, so its trailing comment sat three columns right of the other eleven. This re-aligns the whole block on the longest entry.

Comments-only, in TOML. No behavior change — verified with `uv run ruff check .` → `All checks passed!`, which also confirms the config still parses.

## Before

```toml
    "S",   # flake8-bandit (security)
    "T20", # flake8-print
    "RUF100", # unused-noqa: a noqa directive that suppresses nothing
```

## After

```toml
    "S",      # flake8-bandit (security)
    "T20",    # flake8-print
    "RUF100", # unused-noqa: a noqa directive that suppresses nothing
```

All twelve `#` characters now start at column 15.
