### PR TITLE
Collect changelog entries in independent release fragments

### DIFF
--- a/.claude/rules/mcp.md
+++ b/.claude/rules/mcp.md
@@ -336,8 +336,8 @@ Any PR that adds, renames, or removes a tool (MCP) or command (CLI) MUST update 
 Reviewers verify both updates AND that the capability's user-language description matches what the surface actually does.
 
 - Reviewers grep for `@mcp_tool` diffs and Typer command registrations and verify each touches both specs.
-- Removed tools/commands require both spec updates AND a CHANGELOG.md `Removed` entry under `Unreleased`.
-- Renamed tools/commands require updating every reference in the surface-specific spec, updating the relevant row in the capabilities map, plus tests, plus a `Changed` entry in the CHANGELOG.
+- Removed tools/commands require both spec updates AND a `removed` changelog fragment per `changelog.d/README.md`.
+- Renamed tools/commands require updating every reference in the surface-specific spec, updating the relevant row in the capabilities map, plus tests, plus a `changed` changelog fragment.
 - Exempting a surface (e.g., CLI-only by secret-material policy) requires citing the category by number from "When CLI-only is justified" above; the citation must match the exemption-category index in the capabilities map.
 
 ## Description requirements

--- a/.claude/rules/shipping.md
+++ b/.claude/rules/shipping.md
@@ -1,6 +1,6 @@
 ---
 description: "Post-implementation checklist: CHANGELOG, roadmap, features, README updates, pre-push /code-review pass"
-paths: ["CHANGELOG.md", "README.md", "docs/roadmap.md", "docs/features.md", "docs/specs/INDEX.md"]
+paths: ["CHANGELOG.md", "changelog.d/**", "README.md", "docs/roadmap.md", "docs/features.md", "docs/specs/INDEX.md"]
 ---
 
 # Shipping & Public Documentation
@@ -11,9 +11,11 @@ An `implemented` spec stays where it is. `docs/specs/archived/` is only for spec
 
 After marking a spec as `implemented` (in both the spec file and `INDEX.md`), update public-facing documentation in this order:
 
-### 1. CHANGELOG.md (user-visible changes)
+### 1. Changelog fragment (user-visible changes)
 
-If the change is user-visible, add a bullet to `CHANGELOG.md`'s `Unreleased` section under the appropriate category:
+If the change is user-visible, add a unique fragment as described in
+[`changelog.d/README.md`](../../changelog.d/README.md). Feature PRs leave
+`CHANGELOG.md` to release preparation. Choose the appropriate category:
 
 - **Added** — new features, new commands, new tools, new import formats
 - **Changed** — behavior changes users will notice (default flag changes, schema changes, breaking changes)
@@ -22,7 +24,7 @@ If the change is user-visible, add a bullet to `CHANGELOG.md`'s `Unreleased` sec
 - **Fixed** — bug fixes (only those that affect user behavior)
 - **Security** — security-relevant fixes
 
-Cite PR numbers. Keep entries to one or two sentences each.
+Cite PR numbers when known. Keep entries to one or two sentences each.
 
 **What does NOT need a CHANGELOG entry:**
 
@@ -33,7 +35,9 @@ Cite PR numbers. Keep entries to one or two sentences each.
 - ADR additions (the ADR itself is the durable artifact)
 - Private knowledge or internal coordination changes
 
-When in doubt: if a user reading the changelog would benefit from knowing about it, add an entry. If it's purely internal, skip it.
+When in doubt: if a user reading the changelog would benefit from knowing about
+it, add a fragment. For internal-only work, explain the exemption in the PR
+description and apply `skip-changelog` for review.
 
 ### 2. docs/roadmap.md (milestone status)
 
@@ -102,7 +106,10 @@ free.
 
 When all sub-milestones in a tier close (e.g., M2A + M2B + M2C + M2D + M2E all ship → M2 closes; M3A through M3E all close → launch):
 
-1. Move the `Unreleased` block in `CHANGELOG.md` into a new dated section: `## [M2A] — YYYY-MM-DD`. Reset `Unreleased` to a placeholder like `(no changes since M2A)`.
+1. If preparing a versioned release, assemble fragments using
+   [`changelog.d/README.md`](../../changelog.d/README.md), including its
+   first-release legacy reconciliation. Milestone-only updates leave fragments
+   for release preparation.
 2. Update `docs/roadmap.md` milestone status row.
 3. Update README status callout.
 4. Tag the commit (`git tag M2A` or similar) for cross-reference.

--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -94,7 +94,7 @@ a stamp.
 ### From-scratch reconciliation
 
 - Trigger: explicit user request — `everything`, `from-scratch`, `clean update`, or a named list of docs paired with framing language ("clean update," "from scratch," "as if writing fresh").
-- Behavior: read current code state (CLI surface, MCP tools, schema, CHANGELOG `Unreleased`); treat the existing doc as **reference only** — structural inspiration, voice, length budget, anti-pattern list — but write what the doc should say from current truth. Don't be bound by the existing wording when current state contradicts it.
+- Behavior: read current code state (CLI surface, MCP tools, schema, pending `changelog.d` fragments and legacy CHANGELOG `Unreleased`); treat the existing doc as **reference only** — structural inspiration, voice, length budget, anti-pattern list — but write what the doc should say from current truth. Don't be bound by the existing wording when current state contradicts it.
 - Use when: a milestone closes; many features have shipped since the doc was last touched; the doc's "Last reviewed" stamp predates a tide of merged PRs; the user explicitly asks for a clean pass.
 - Heavier: a full from-scratch sweep across the doc surface is a multi-wave, multi-hour exercise. **Confirm scope with the user before launching** and prefer wave-by-wave execution with checkpoint review between waves.
 
@@ -115,7 +115,7 @@ For "not yet for you" cases, point honestly to alternatives (`docs/audience.md` 
 | File | Primary persona | Tone | Length budget |
 |---|---|---|---|
 | `README.md` | Power-user migrant + AI-native dev | Storefront — what is it, why care, how to start | ~160–180 lines (measured 158–171 across 2026-05 → 2026-09; the earlier "220–260" figure was never measured) |
-| `CHANGELOG.md` | All users | Factual, one bullet per user-visible change, cite PR | One section per release / Unreleased |
+| `changelog.d/` → `CHANGELOG.md` at release | All users | Factual, one fragment per user-visible change, cite PR | See `changelog.d/README.md` |
 | `CONTRIBUTING.md` | Self-hoster, OSS contributor | Concrete steps to land a change | As short as possible |
 | `docs/architecture.md` | AI-native dev, technical migrant | Guarantees → diagram → contract → negative space | One page |
 | `docs/audience.md` | Anyone evaluating | Honest "this is and isn't for you" | Tight |
@@ -144,7 +144,7 @@ subagent verbatim. They keep accidentally regrowing:
 
   **Exceptions — milestone codes ARE allowed and expected in:**
   - `docs/roadmap.md` (its structure IS milestones)
-  - `CHANGELOG.md` (sections are tagged by milestone)
+  - `changelog.d/` (pending changes) and `CHANGELOG.md` (preserved history)
   - `docs/specs/`, `docs/decisions/` (internal — out of scope anyway)
 
   When used in the exception files, the canonical milestone set is **whatever `docs/roadmap.md`'s milestone-overview table lists** — that table is the single source of truth (per `.claude/rules/shipping.md`), so this rule can't go stale as milestones are added. As of this writing that's `M0`, `M1`, `M2A`–`M2E`, `M3A`–`M3E`, plus `Post-launch`; treat the live roadmap table as authoritative if it has moved on. Don't introduce a code that isn't in the roadmap table, and don't strip one that is — if a doc and the roadmap disagree, the roadmap wins.
@@ -166,7 +166,7 @@ Resolve scope in this order; first match wins:
 
 Print a one-line scope summary before doing anything:
 
-> Scope: 4 source files changed (1 new MCP tool, 1 new CLI command); evaluating 3 docs: README.md, docs/guides/cli.md, CHANGELOG.md.
+> Scope: 4 source files changed (1 new MCP tool, 1 new CLI command); evaluating README.md, docs/guides/cli.md, and changelog.d fragments.
 
 ## Process
 
@@ -175,11 +175,11 @@ Print a one-line scope summary before doing anything:
 For each in-scope code change, identify what a *user* (not a developer)
 would notice. Common mappings:
 
-- New CLI command → README "What works today" reference + relevant guide + CHANGELOG `Added`
-- New MCP tool → MCP guide + features.md + CHANGELOG `Added`
-- New import format → import guide + features.md + CHANGELOG `Added`
-- Behavior change in existing command → relevant guide + CHANGELOG `Changed`
-- Bug fix users will notice → CHANGELOG `Fixed`
+- New CLI command → README "What works today" reference + relevant guide + `added` fragment
+- New MCP tool → MCP guide + features.md + `added` fragment
+- New import format → import guide + features.md + `added` fragment
+- Behavior change in existing command → relevant guide + `changed` fragment
+- Bug fix users will notice → `fixed` fragment
 - Internal refactor with no user-visible effect → no doc change; do not invent one
 
 If a change has no user-visible effect, say so in the report and move on.
@@ -218,7 +218,7 @@ the failure modes the author subagent can't see from inside its own pass:
 unfamiliar jargon, missing context, jobs-to-be-done that aren't answered,
 information present that the persona doesn't care about.
 
-**Skip for:** `CHANGELOG.md` (mechanical), trivial diff-only edits in
+**Skip for:** changelog fragments and release assembly (mechanical), trivial diff-only edits in
 incremental mode (one bullet added, no narrative change).
 
 For each touched doc, pick 2–3 personas from `docs/audience.md` weighted
@@ -279,7 +279,7 @@ revisions, leave the stamp from step 3.
 
 Per `.claude/rules/shipping.md`:
 
-- **CHANGELOG entry** under `Unreleased` in the correct category (Added / Changed / Deprecated / Removed / Fixed / Security). Cite the PR. Skip if the change is internal-only (refactors, CI tweaks, style, test-only PRs, ADR additions, private knowledge changes).
+- **Changelog fragment** following `changelog.d/README.md`; release preparation assembles `CHANGELOG.md`. Follow the documented exemption for internal-only changes.
 - **`docs/roadmap.md`** — move the feature row from 📐 designed / 🗓️ planned to ✅ shipped. Update milestone status if a sub-milestone just closed.
 - **`docs/features.md`** — add or update the entry if it's a user-facing capability.
 - **`README.md`** status callout — update only if a milestone closed or a previously-promised feature now exists. Do not re-add an in-README roadmap matrix.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,4 +5,6 @@
 
 ## Test plan
 
+<!-- Add a changelog.d fragment for user-visible changes. For internal-only work, explain why here and apply skip-changelog. Only release-preparation PRs assemble CHANGELOG.md; see changelog.d/README.md. -->
+
 <!-- State meaningful checks, results, tested revision, and remaining gaps. Distinguish local checks, pending CI, and live observations. Describe verification data by shape, never by real holdings or identifiers. Add sections only when they help review this change. -->

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,34 @@
+name: Changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  fragments:
+    name: Changelog fragments
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v7
+      - name: Validate fragments and release scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          SKIP_CHANGELOG: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+          RELEASE_PREPARATION: ${{ contains(github.event.pull_request.labels.*.name, 'release-preparation') }}
+        run: |
+          if [ "$RELEASE_PREPARATION" != "true" ]; then
+            if ! git diff --quiet "$BASE_SHA...HEAD" -- CHANGELOG.md; then
+              echo 'CHANGELOG.md is assembled only in a release-preparation PR. Add a changelog.d fragment instead.'
+              exit 1
+            fi
+          fi
+          uv run --locked towncrier build --draft --version validation
+          if [ "$SKIP_CHANGELOG" != "true" ] && [ "$RELEASE_PREPARATION" != "true" ]; then
+            uv run --locked towncrier check --compare-with "$BASE_SHA"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+New changes are collected in [changelog fragments](changelog.d/README.md).
+The legacy entries below are retained for the next release preparation.
+
 ### Fixed
 - **Profile configuration now honors database, data, and logging overrides.**
   `MONEYBIN_DATABASE__*`, `MONEYBIN_DATA__*`, and `MONEYBIN_LOGGING__*` values
@@ -4369,6 +4372,8 @@ M2 closing out and M3 underway. M2A curator state shipped (transaction notes, ta
 ---
 
 
+
+<!-- towncrier release notes start -->
 
 ## [M1] — 2026-05-04 (Data Integrity)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,16 +212,17 @@ re-summons a review on demand.
 If the change is user-visible, update the docs surface per
 [`.claude/rules/shipping.md`](.claude/rules/shipping.md):
 
-- Add a line to `CHANGELOG.md` under `Unreleased`. New MCP tools and new CLI
-  commands go under `Added`; renames and behavior changes go under `Changed`.
+- Add a unique [changelog fragment](changelog.d/README.md). New MCP tools and
+  CLI commands use `added`; renames and behavior changes use `changed`.
+  `CHANGELOG.md` is assembled during release preparation.
 - Move the spec to `implemented` in both the spec file and
   [`docs/specs/INDEX.md`](docs/specs/INDEX.md).
 - Update [`docs/roadmap.md`](docs/roadmap.md) and
   [`docs/features.md`](docs/features.md) if the capability surface changed.
 - Add or update a guide under `docs/guides/` for new user-facing features.
 
-Internal refactors, CI tweaks, and code-style changes don't need a CHANGELOG
-entry.
+Internal refactors, CI tweaks, and code-style changes may use the documented
+`skip-changelog` exemption with a reason in the PR description.
 
 ## Specs and roadmap
 

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,49 @@
+# Changelog fragments
+
+Each user-visible change adds a unique Markdown fragment here. Feature PRs
+leave `CHANGELOG.md` to release preparation so concurrent changes do not edit
+the same section.
+
+Use `<PR>.<category>.md` when the PR number is known, or
+`+<unique-change-slug>.<category>.md` before opening the PR. Categories are
+`added`, `changed`, `deprecated`, `removed`, `fixed`, and `security`.
+Use separate slugs for independent changes. Keep the fragment to one or two
+sentences describing the user-visible result, without a heading or bullet.
+Towncrier links numeric filenames to the PR; orphan (`+`) fragments can cite
+the PR in their text once it exists. Never include private account details.
+
+```sh
+uv run towncrier create +profile-overrides.fixed.md -c "Profile environment overrides now take precedence over profile defaults."
+uv run towncrier check --compare-with origin/main
+uv run towncrier build --draft --version 0.1.0
+```
+
+CI requires a fragment, or a reviewed `skip-changelog` label with the reason
+in the PR description for internal-only work. A `release-preparation` label
+identifies a PR that assembles notes and permits editing `CHANGELOG.md`.
+Reviewers verify the exemption reason and release scope; labels are not a
+substitute for that review. Even exempt PRs validate pending fragment names
+and rendering. Add the label in GitHub if it does not yet exist.
+
+## Prepare a release
+
+1. Update the version in `pyproject.toml` and its lockfile. Preview the matching
+   version with `uv run towncrier build --draft --version 0.1.0` (substitute
+   the actual version).
+2. Run `uv run towncrier build --yes --version 0.1.0`. Towncrier inserts the
+   release after the marker and removes consumed fragments. Review both the
+   generated notes and fragment deletions in the release PR.
+3. **First release after adoption:** move the legacy bullets currently under
+   `[Unreleased]` into the matching categories of the generated release,
+   preserving their text and relative order. This is a manual reconciliation:
+   Towncrier does not import those bullets. Keep one heading per category and
+   leave the `[Unreleased]` heading, pending-fragment link, and marker above
+   the generated release. Preserve all older dated milestone sections.
+4. Run `uv run pytest tests/test_documentation_policy.py` and
+   `uv run python scripts/check_release_metadata.py --tag v0.1.0` with the
+   actual version. Confirm every pending change is accounted for, then review
+   and merge the release PR before creating its version tag.
+
+The existing tag-triggered release workflow publishes the prepared changelog;
+it does not build or consume fragments. Milestone-only documentation updates
+do not consume release fragments.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,7 @@ moneybin = "moneybin.cli.main:main"
 # Documentation: https://peps.python.org/pep-0735/
 # Modern dependency groups standard (PEP 735) for optional/development dependencies
 dev = [
+    "towncrier>=26.9.0,<27",
     # Code quality and formatting
     "ruff>=0.15.10",
     "pyright>=1.1.408",

--- a/tests/test_documentation_policy.py
+++ b/tests/test_documentation_policy.py
@@ -34,6 +34,48 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def _unreleased_category_problems(text: str) -> list[str]:
+    allowed = {"Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"}
+    seen: set[str] = set()
+    problems: list[str] = []
+    in_unreleased = False
+    for line in text.splitlines():
+        if line.startswith("## "):
+            in_unreleased = line.strip() == "## [Unreleased]"
+        elif in_unreleased and line.startswith("### "):
+            category = line.removeprefix("### ").strip()
+            if category not in allowed:
+                problems.append(f"Unknown category: {category}")
+            elif category in seen:
+                problems.append(f"Duplicate category: {category}")
+            seen.add(category)
+    return problems
+
+
+@pytest.mark.parametrize(
+    "heading", ["Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"]
+)
+def test_unreleased_rejects_duplicate_categories(heading: str) -> None:
+    text = f"## [Unreleased]\n### {heading}\n- First\n### {heading}\n- Second\n"
+    assert _unreleased_category_problems(text) == [f"Duplicate category: {heading}"]
+
+
+def test_unreleased_rejects_unknown_categories() -> None:
+    assert _unreleased_category_problems("## [Unreleased]\n### Fixes\n") == [
+        "Unknown category: Fixes"
+    ]
+
+
+def test_unreleased_ignores_released_history() -> None:
+    text = "## [Unreleased]\n### Fixed\n## [M1]\n### Fixed\n### Fixed\n### Other\n"
+    assert _unreleased_category_problems(text) == []
+
+
+def test_unreleased_changelog_categories() -> None:
+    problems = _unreleased_category_problems((_REPO_ROOT / "CHANGELOG.md").read_text())
+    assert not problems, "CHANGELOG.md [Unreleased]: " + "; ".join(problems)
+
+
 def _git_executable() -> str:
     executable = shutil.which("git")
     if executable is None:

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,0 +1,22 @@
+[tool.towncrier]
+name = "MoneyBin"
+directory = "changelog.d"
+filename = "CHANGELOG.md"
+start_string = "<!-- towncrier release notes start -->\n"
+title_format = "## [{version}] — {project_date}"
+issue_format = "[#{issue}](https://github.com/bsaffel/moneybin/pull/{issue})"
+issue_pattern = '^(\d+|\+[a-z0-9][a-z0-9-]*)$'
+ignore = []
+
+[[tool.towncrier.type]]
+name = "Added"
+[[tool.towncrier.type]]
+name = "Changed"
+[[tool.towncrier.type]]
+name = "Deprecated"
+[[tool.towncrier.type]]
+name = "Removed"
+[[tool.towncrier.type]]
+name = "Fixed"
+[[tool.towncrier.type]]
+name = "Security"

--- a/uv.lock
+++ b/uv.lock
@@ -1677,6 +1677,7 @@ dev = [
     { name = "respx" },
     { name = "ruff" },
     { name = "sqlmesh", extra = ["lsp"] },
+    { name = "towncrier" },
 ]
 server = [
     { name = "fastapi" },
@@ -1743,6 +1744,7 @@ dev = [
     { name = "respx", specifier = ">=0.21" },
     { name = "ruff", specifier = ">=0.15.10" },
     { name = "sqlmesh", extras = ["lsp"], specifier = ">=0.200.0" },
+    { name = "towncrier", specifier = ">=26.9.0,<27" },
 ]
 server = [
     { name = "fastapi", specifier = ">=0.115.0" },
@@ -3493,6 +3495,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
+]
+
+[[package]]
+name = "towncrier"
+version = "26.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "jinja2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/d4/e85ce614bf45b1a7fe13b82cc687819c2eaac5a1dd94b84834322095fd98/towncrier-26.9.0.tar.gz", hash = "sha256:ace9031631c718cc0709107b8755e6e31350eb8acdc877af43df3177addb9a55", size = 79338, upload-time = "2026-09-04T12:57:25.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/88/f9340b545dafa64de053798e760515a2736fbb60092cf9aa6b146ccf3ede/towncrier-26.9.0-py3-none-any.whl", hash = "sha256:ae4d223e6aadaff98d29b7f09e58d9c9ccf4cd3b455a2d2e0486d432cd8bf660", size = 67030, upload-time = "2026-09-04T12:57:23.986Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Feature PRs add independent Towncrier fragments instead of competing over `CHANGELOG.md`. CI validates pending notes and requires either a fragment or a reviewed exemption; release preparation owns consolidation. A documentation-policy check rejects duplicate or unknown categories under `Unreleased`, while leaving released history exempt.

Existing notes are preserved. The first release requires the documented manual reconciliation of legacy `Unreleased` entries. This adoption PR uses `release-preparation` solely to add the insertion marker; it does not publish a release. Contribution and agent instructions now point to the fragment workflow.

## Test plan

- 52 documentation-policy tests passed.
- `make check` passed: zero type errors, three existing ReportLab warnings.
- Eight Towncrier behavior checks passed, covering categories, malformed filenames, non-mutating previews, consumption, and history preservation.
- Five workflow branches passed, including validation of malformed fragments despite an exemption.
- Pre-commit checks passed. Independent review of `ebaf61686c23aba99733a208d28c467f6aed1319` found no MUST FIX or CONSIDER findings. Instruction review establishes source consistency, not cross-harness behavioral efficacy.
- Hosted CI and PR review pending.
