### PR TITLE
Populate manifest.provenance on bundle exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- **A bundle export's manifest now names the build that produced it.**
+  `manifest.provenance` previously wrote `null` for a bundle export while a
+  report export populated it, leaving a bundle artifact with no record of
+  which code wrote it. Both subject kinds now carry the same version and
+  revision `system_status.overview.build` reports. (PR #TBD)
+
 - **Profile configuration now honors database, data, and logging overrides.**
   `MONEYBIN_DATABASE__*`, `MONEYBIN_DATA__*`, and `MONEYBIN_LOGGING__*` values
   from the environment or active profile dotenv now override profile defaults.

--- a/changelog.d/+bundle-export-provenance.fixed.md
+++ b/changelog.d/+bundle-export-provenance.fixed.md
@@ -1,0 +1,1 @@
+A bundle export's `manifest.provenance` now names the build that produced it instead of writing `null`, so an artifact can be interpreted against the code that wrote it after it leaves the machine. Report exports carry the same version and revision stamp that `system_status.overview.build` reports.

--- a/docs/specs/export.md
+++ b/docs/specs/export.md
@@ -82,10 +82,14 @@ format-neutral prepared snapshot. The snapshot contains:
 - the ordered data tables and typed columns;
 - the profile, UTC creation timestamp, export kind, and format version;
 - the selected redaction mode and output column classes;
-- row counts and per-table checksums; and
+- row counts and per-table checksums;
+- the build that produced it — package version and source revision, the same
+  pair `system_status.overview.build` reports; and
 - a generated data dictionary.
 
-For a report, the snapshot additionally carries its provenance receipt: report
+Both export subjects carry that build stamp — it is every artifact's only
+record of which code wrote it once the file leaves this machine. For a
+report, the snapshot additionally carries its provenance receipt: report
 identifier, resolved parameters, SQL, lineage, output classes, freshness,
 graduation eligibility, and classification-drift state. This is the same
 information exposed by the report verification surface, rendered as artifact
@@ -442,8 +446,19 @@ the active profile.
 The on-disk `manifest.json` and its equivalent workbook/Sheets metadata include
 a versioned artifact schema, export ID, subject, creation time, destination
 kind, redaction mode, table names and schemas, row counts, checksums, and data
-dictionary reference. Report manifests add report identifier, resolved
-parameters, query/provenance receipt, class map, and freshness information.
+dictionary reference.
+
+Every manifest carries a `provenance` block, populated for both subject kinds.
+Its `build` field names the version and source revision of the process that
+wrote the artifact — `{"version": "0.1.0", "revision": "a1b2c3d4…"}` — the same
+pair `system_status.overview.build` reports, derived from the one shared
+`moneybin.build_info` module so a manifest and a running server never disagree
+about which code produced them. Either key is `null` when unresolvable: an
+installed wheel carries no source revision, and a distribution installed
+outside a released version carries no package version. A bundle manifest's
+`provenance` holds only `build`, with `report_id` and `receipt` present as
+`null`. Report manifests add report identifier, resolved parameters,
+query/provenance receipt, class map, and freshness information.
 Parameters receive the same selected redaction policy as result columns; their
 classes travel with the manifest so a verifier can tell what was withheld.
 

--- a/src/moneybin/build_info.py
+++ b/src/moneybin/build_info.py
@@ -1,0 +1,121 @@
+"""The single source for the version and revision this process is running.
+
+``system_status``'s build block and every export manifest's provenance derive
+their build stamp from here. Never recompute either value at a second call
+site — see AGENTS.md's coherence rule.
+"""
+
+from __future__ import annotations
+
+import subprocess  # noqa: S404  # subprocess used for git rev-parse; static args only
+from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+#: Bound on the `git rev-parse` probe. Generous for a local repository read;
+#: it exists so a wedged git can never delay import indefinitely.
+_GIT_REVISION_TIMEOUT_SECONDS = 5.0
+
+
+@dataclass(frozen=True, slots=True)
+class BuildInfo:
+    """The version and source revision this process loaded at boot."""
+
+    version: str | None
+    revision: str | None
+
+
+def read_git_revision(root: Path) -> str | None:
+    """Return the commit ``root`` is checked out at, or None when it can't be read.
+
+    None covers every unreadable case, not just a non-repository: no ``git`` on
+    PATH, a launch failure, a timeout, an unparseable answer, or a ``root`` that
+    is inside a checkout rather than its top level.
+
+    Delegates to ``git`` rather than parsing ``.git`` by hand: a linked worktree
+    stores a *file* there pointing elsewhere, and a branch tip may live in
+    ``packed-refs`` rather than as a loose ref. Both are cases this project
+    actually runs in, and both are ones a hand-rolled reader gets wrong.
+
+    ``root`` must be the repository's own top level, and that is checked rather
+    than assumed. ``git`` answers about the nearest enclosing checkout, so an
+    installed wheel sitting under someone else's repository — a virtualenv
+    inside the user's own project, which is where ``uv`` puts one by default —
+    would otherwise report *that* project's HEAD as MoneyBin's build: a
+    confidently wrong stamp, worse than the documented ``null``.
+    """
+    try:
+        completed = subprocess.run(  # noqa: S603  # git with static args
+            [  # noqa: S607
+                "git",
+                "-C",
+                str(root),
+                "rev-parse",
+                "--show-toplevel",
+                "HEAD",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_REVISION_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        # No git on PATH, or it failed to launch. An unknown revision is a
+        # perfectly good answer here; a broken caller is not.
+        return None
+    if completed.returncode != 0:
+        return None
+    # Split on line terminators, never on arbitrary whitespace: git prints the
+    # top level unquoted, so a checkout path containing a space would otherwise
+    # parse as three tokens and silently blank the stamp — and a blank reads as
+    # a legitimate wheel install, hiding the failure.
+    lines = completed.stdout.splitlines()
+    if len(lines) != 2:
+        return None
+    toplevel, revision = lines
+    if Path(toplevel).resolve() != root.resolve():
+        return None
+    return revision or None
+
+
+#: Resolved once at import rather than per call. The whole point of reporting a
+#: revision is to name the code this process actually loaded, and a checkout
+#: can move underneath a long-lived server. A per-call read would then report
+#: the *new* commit while still running the old code, which is worse than
+#: reporting nothing: it would corroborate exactly the wrong conclusion.
+#:
+#: ``parents[2]`` is the checkout root of a source tree laid out as
+#: ``<root>/src/moneybin/build_info.py``; from an installed wheel it is some
+#: directory above ``site-packages``, which is not a repository top level and
+#: so answers None.
+_REVISION: str | None = read_git_revision(Path(__file__).resolve().parents[2])
+
+
+def read_package_version() -> str | None:
+    """Return the installed distribution version, or None when it has none.
+
+    Guarded rather than allowed to propagate: this value is resolved at import,
+    so an unreadable distribution would otherwise take down the whole process
+    at boot. A missing version is a fine answer here; a process that will not
+    start is not.
+    """
+    try:
+        return version("moneybin")
+    except PackageNotFoundError:
+        return None
+
+
+#: Captured at import for the same reason as ``_REVISION``, and it is the more
+#: dangerous of the two to read late. ``version()`` re-reads the installed
+#: distribution's metadata on every call, so upgrading the environment beneath a
+#: long-lived process reports the *new* version while it still runs the old
+#: modules — and a wheel install answers ``revision: None``, leaving this field
+#: as the only signal a caller has. Reading it per call therefore produces a
+#: confident wrong answer in precisely the stale-process case this module
+#: exists to diagnose.
+_VERSION: str | None = read_package_version()
+
+
+def get_build_info() -> BuildInfo:
+    """Return the version and revision this process loaded at boot."""
+    return BuildInfo(version=_VERSION, revision=_REVISION)

--- a/src/moneybin/exports/service.py
+++ b/src/moneybin/exports/service.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Final, Protocol, cast
 
 from pydantic import JsonValue
 
+from moneybin.build_info import get_build_info
 from moneybin.database import Database
 from moneybin.exports.models import (
     DestinationKind,
@@ -28,11 +29,11 @@ from moneybin.exports.models import (
 from moneybin.exports.redaction import apply_export_redaction
 from moneybin.exports.snapshot import (
     ARTIFACT_VERSION,
+    ExportProvenance,
     ExportSubject,
     PreparedColumn,
     PreparedExport,
     PreparedTable,
-    ReportExportProvenance,
     build_bundle_snapshot,
     build_data_dictionary,
     prepared_table_checksum,
@@ -753,6 +754,7 @@ class ExportService:
             ),
         )
         tables = (table,)
+        build = get_build_info()
         snapshot = PreparedExport(
             artifact_version=ARTIFACT_VERSION,
             export_id=None,
@@ -766,7 +768,8 @@ class ExportService:
             redaction_mode="unredacted",
             tables=tables,
             data_dictionary=build_data_dictionary(tables),
-            provenance=ReportExportProvenance(
+            provenance=ExportProvenance(
+                build={"version": build.version, "revision": build.revision},
                 report_id=execution.report_id,
                 receipt=receipt.as_mapping(),
             ),

--- a/src/moneybin/exports/snapshot.py
+++ b/src/moneybin/exports/snapshot.py
@@ -14,6 +14,7 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Literal, cast
 from uuid import UUID, uuid4
 
+from moneybin.build_info import get_build_info
 from moneybin.exports.catalog import BUNDLE_TABLES
 from moneybin.exports.models import RedactionMode
 from moneybin.privacy.taxonomy import CLASSIFICATION, DataClass
@@ -51,16 +52,31 @@ class ExportSubject:
 
 
 @dataclass(frozen=True, slots=True)
-class ReportExportProvenance:
-    """A report execution receipt, populated by report exports."""
+class ExportProvenance:
+    """The build that produced an export, plus a report execution receipt.
 
-    report_id: str
-    receipt: Mapping[str, object]
+    ``build`` names the version and revision ``system_status.overview.build``
+    reports — every export's only record of which code wrote it, once the
+    artifact leaves this machine. Populated for both subject kinds.
+    ``report_id``/``receipt`` add the execution receipt for a report subject
+    only; a bundle subject has neither.
+    """
+
+    build: Mapping[str, object]
+    report_id: str | None = None
+    receipt: Mapping[str, object] | None = None
 
     def __post_init__(self) -> None:
-        """Freeze nested report receipt metadata."""
-        frozen = cast(Mapping[str, object], _freeze_metadata(self.receipt))
-        object.__setattr__(self, "receipt", frozen)
+        """Freeze nested provenance metadata."""
+        object.__setattr__(
+            self, "build", cast(Mapping[str, object], _freeze_metadata(self.build))
+        )
+        if self.receipt is not None:
+            object.__setattr__(
+                self,
+                "receipt",
+                cast(Mapping[str, object], _freeze_metadata(self.receipt)),
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -99,7 +115,7 @@ class PreparedExport:
     redaction_mode: RedactionMode
     tables: tuple[PreparedTable, ...]
     _data_dictionary: Mapping[str, object] = field(repr=False)
-    provenance: ReportExportProvenance | None
+    provenance: ExportProvenance | None
 
     def __init__(
         self,
@@ -110,7 +126,7 @@ class PreparedExport:
         redaction_mode: RedactionMode,
         tables: tuple[PreparedTable, ...],
         data_dictionary: Mapping[str, object] | None = None,
-        provenance: ReportExportProvenance | None = None,
+        provenance: ExportProvenance | None = None,
         export_id: str | None = None,
         *,
         _data_dictionary: Mapping[str, object] | None = None,
@@ -209,6 +225,7 @@ def build_bundle_snapshot(
         )
 
     prepared_tables = tuple(tables)
+    build = get_build_info()
     return PreparedExport(
         artifact_version=ARTIFACT_VERSION,
         profile=profile,
@@ -217,7 +234,9 @@ def build_bundle_snapshot(
         redaction_mode="unredacted",
         tables=prepared_tables,
         data_dictionary=build_data_dictionary(prepared_tables),
-        provenance=None,
+        provenance=ExportProvenance(
+            build={"version": build.version, "revision": build.revision}
+        ),
         export_id=None,
     )
 
@@ -290,8 +309,12 @@ def _json_safe(value: object) -> object:
     if isinstance(value, (list, tuple)):
         sequence = cast(list[object] | tuple[object, ...], value)
         return [_json_safe(item) for item in sequence]
-    if isinstance(value, ReportExportProvenance):
-        return {"report_id": value.report_id, "receipt": _json_safe(value.receipt)}
+    if isinstance(value, ExportProvenance):
+        return {
+            "build": _json_safe(value.build),
+            "report_id": value.report_id,
+            "receipt": _json_safe(value.receipt),
+        }
     raise TypeError(f"Unsupported export metadata value: {type(value).__name__}")
 
 

--- a/src/moneybin/mcp/tools/system.py
+++ b/src/moneybin/mcp/tools/system.py
@@ -8,9 +8,7 @@ import inspect
 import json
 import logging
 import os
-import subprocess  # noqa: S404  # subprocess used for git rev-parse; static args only
 from collections.abc import Callable
-from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Annotated, Any, Literal, cast
 
@@ -19,6 +17,7 @@ from fastmcp import FastMCP
 from pydantic import Field
 
 from moneybin import error_codes
+from moneybin.build_info import get_build_info
 from moneybin.db_lock import lock_path_for
 from moneybin.errors import (
     UserError,
@@ -289,106 +288,14 @@ def _database_connections_block(db_path: Path) -> dict[str, Any]:
     return {"writers": writers, "readers": readers}
 
 
-#: Bound on the `git rev-parse` probe. Generous for a local repository read;
-#: it exists so a wedged git can never delay server import indefinitely.
-_GIT_REVISION_TIMEOUT_SECONDS = 5.0
-
-
-def _read_git_revision(root: Path) -> str | None:
-    """Return the commit ``root`` is checked out at, or None when it can't be read.
-
-    None covers every unreadable case, not just a non-repository: no ``git`` on
-    PATH, a launch failure, a timeout, an unparseable answer, or a ``root`` that
-    is inside a checkout rather than its top level.
-
-    Delegates to ``git`` rather than parsing ``.git`` by hand: a linked worktree
-    stores a *file* there pointing elsewhere, and a branch tip may live in
-    ``packed-refs`` rather than as a loose ref. Both are cases this project
-    actually runs in, and both are ones a hand-rolled reader gets wrong.
-
-    ``root`` must be the repository's own top level, and that is checked rather
-    than assumed. ``git`` answers about the nearest enclosing checkout, so an
-    installed wheel sitting under someone else's repository — a virtualenv
-    inside the user's own project, which is where ``uv`` puts one by default —
-    would otherwise report *that* project's HEAD as MoneyBin's build: a
-    confidently wrong stamp, worse than the documented ``null``.
-    """
-    try:
-        completed = subprocess.run(  # noqa: S603  # git with static args
-            [  # noqa: S607
-                "git",
-                "-C",
-                str(root),
-                "rev-parse",
-                "--show-toplevel",
-                "HEAD",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=_GIT_REVISION_TIMEOUT_SECONDS,
-            check=False,
-        )
-    except (OSError, subprocess.SubprocessError):
-        # No git on PATH, or it failed to launch. An unknown revision is a
-        # perfectly good answer here; a broken system_status is not.
-        return None
-    if completed.returncode != 0:
-        return None
-    # Split on line terminators, never on arbitrary whitespace: git prints the
-    # top level unquoted, so a checkout path containing a space would otherwise
-    # parse as three tokens and silently blank the stamp — and a blank reads as
-    # a legitimate wheel install, hiding the failure.
-    lines = completed.stdout.splitlines()
-    if len(lines) != 2:
-        return None
-    toplevel, revision = lines
-    if Path(toplevel).resolve() != root.resolve():
-        return None
-    return revision or None
-
-
-#: Resolved once at import — that is, at server boot — rather than per call.
-#: The whole point of reporting a revision is to name the code this process
-#: actually loaded, and a checkout can move underneath a long-lived server. A
-#: per-call read would then report the *new* commit while still running the old
-#: code, which is worse than reporting nothing: it would corroborate exactly the
-#: wrong conclusion.
-#:
-#: ``parents[4]`` is the checkout root of a source tree laid out as
-#: ``<root>/src/moneybin/mcp/tools/system.py``; from an installed wheel it is
-#: some directory above ``site-packages``, which is not a repository top level
-#: and so answers None.
-_REVISION: str | None = _read_git_revision(Path(__file__).resolve().parents[4])
-
-
-def _read_package_version() -> str | None:
-    """Return the installed distribution version, or None when it has none.
-
-    Guarded rather than allowed to propagate: this value is resolved at import,
-    so an unreadable distribution would otherwise take the whole server down at
-    boot. A missing version is a fine answer from a status tool; a server that
-    will not start is not.
-    """
-    try:
-        return version("moneybin")
-    except PackageNotFoundError:
-        return None
-
-
-#: Captured at import for the same reason as ``_REVISION``, and it is the more
-#: dangerous of the two to read late. ``version()`` re-reads the installed
-#: distribution's metadata on every call, so upgrading the environment beneath a
-#: live server reports the *new* version while the process still holds the old
-#: modules — and a wheel install answers ``revision: None``, leaving this field
-#: as the only signal a caller has. Reading it per call therefore produces a
-#: confident wrong answer in precisely the stale-server case the block exists to
-#: diagnose.
-_VERSION: str | None = _read_package_version()
-
-
 def _build_info() -> SystemStatusBuildInfo:
-    """Name the build this process is running."""
-    return SystemStatusBuildInfo(version=_VERSION, revision=_REVISION)
+    """Name the build this process is running.
+
+    Derivation lives in ``moneybin.build_info`` — export manifest provenance
+    (``exports/service.py``) reuses the same source rather than a second one.
+    """
+    build = get_build_info()
+    return SystemStatusBuildInfo(version=build.version, revision=build.revision)
 
 
 def _locked_status_envelope(

--- a/tests/moneybin/test_build_info.py
+++ b/tests/moneybin/test_build_info.py
@@ -1,0 +1,108 @@
+"""``moneybin.build_info`` is the single source for the running build stamp.
+
+Both ``system_status``'s build block and export manifest provenance derive
+from ``get_build_info()`` — these tests exercise the derivation itself.
+"""
+
+from __future__ import annotations
+
+import subprocess  # noqa: S404  # reads/writes git state to derive the expected value
+from importlib.metadata import PackageNotFoundError
+from pathlib import Path
+
+import pytest
+
+from moneybin.build_info import get_build_info, read_git_revision, read_package_version
+
+
+@pytest.mark.unit
+def test_version_is_resolved_at_import_not_per_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Upgrading the environment must not make a live process claim the new version.
+
+    ``importlib.metadata.version`` re-reads the installed distribution's
+    metadata on every call, so upgrading MoneyBin underneath a running process
+    would report the *new* version while the process still holds the old
+    modules. That is the stale-process scenario this module exists to
+    diagnose, and it is the worst place to be confidently wrong: an installed
+    wheel reports ``revision: null``, leaving ``version`` as the only signal.
+    """
+    captured = get_build_info().version
+
+    def _upgraded(_name: str) -> str:
+        return "99.99.99"
+
+    monkeypatch.setattr("moneybin.build_info.version", _upgraded)
+
+    assert get_build_info().version == captured
+
+
+@pytest.mark.unit
+def test_absent_distribution_metadata_reports_no_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unreadable metadata degrades the field; it must never fail the import.
+
+    The version is resolved at import, so an unguarded lookup would turn a
+    missing distribution into a process that cannot boot — trading a rare
+    degraded answer for a total outage on the one surface whose job is to keep
+    answering when everything else is broken.
+    """
+
+    def _missing(_name: str) -> str:
+        raise PackageNotFoundError("moneybin")
+
+    monkeypatch.setattr("moneybin.build_info.version", _missing)
+
+    assert read_package_version() is None
+
+
+@pytest.mark.unit
+def test_revision_is_absent_outside_a_source_checkout(tmp_path: Path) -> None:
+    """An installed wheel has no repository to interrogate; say so, don't guess."""
+    assert read_git_revision(tmp_path) is None
+
+
+@pytest.mark.unit
+def test_revision_is_absent_when_the_repository_is_merely_an_ancestor() -> None:
+    """A directory *inside* someone's checkout is not that checkout's build.
+
+    ``git`` answers about the nearest enclosing repository, so an installed
+    wheel under a virtualenv in the user's own project would otherwise stamp
+    MoneyBin's build with that project's HEAD — a confident wrong answer where
+    the contract promises ``null``.
+    """
+    assert read_git_revision(Path(__file__).resolve().parent) is None
+
+
+@pytest.mark.unit
+def test_revision_survives_a_checkout_path_containing_a_space(tmp_path: Path) -> None:
+    """A space in the checkout path must not silently blank the stamp.
+
+    ``git rev-parse --show-toplevel`` prints the path unquoted, so splitting its
+    two-line answer on arbitrary whitespace turns one such path into three
+    tokens and discards the revision. macOS paths routinely contain spaces, and
+    the failure is invisible: the field reads ``null``, which is also exactly
+    what a legitimate wheel install reports.
+    """
+    repo = tmp_path / "space test dir"
+    repo.mkdir()
+    for command in (
+        ["init", "-q"],
+        ["-c", "user.email=t@example.com", "-c", "user.name=t"]
+        + ["commit", "-q", "--allow-empty", "-m", "x"],
+    ):
+        subprocess.run(  # noqa: S603  # git with static args
+            ["git", "-C", str(repo), *command],  # noqa: S607
+            capture_output=True,
+            check=True,
+        )
+    head = subprocess.run(  # noqa: S603  # git with static args
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    assert read_git_revision(repo) == head

--- a/tests/moneybin/test_exports/test_bundle_snapshot.py
+++ b/tests/moneybin/test_exports/test_bundle_snapshot.py
@@ -10,6 +10,7 @@ from typing import cast
 
 import pytest
 
+from moneybin.build_info import get_build_info
 from moneybin.database import Database
 from moneybin.exports.catalog import BUNDLE_TABLES
 from moneybin.exports.service import ExportService
@@ -246,6 +247,32 @@ def test_prepare_bundle_builds_the_closed_typed_canonical_snapshot(
     )
     json.dumps(first.manifest)
     json.dumps(first.manifest["data_dictionary"])
+
+
+def test_prepare_bundle_populates_manifest_provenance_with_the_running_build(
+    db: Database,
+) -> None:
+    """A bundle names its build, the same version+revision ``system_status`` reports.
+
+    Regression for #448: a bundle export previously wrote ``manifest.provenance:
+    null``, leaving the artifact with no record of which code produced it.
+    """
+    _seed_bundle_rows(db)
+    snapshot = ExportService(db).prepare_bundle(
+        profile="test", redaction_mode="unredacted"
+    )
+    build = get_build_info()
+    expected_build = {"version": build.version, "revision": build.revision}
+
+    assert snapshot.provenance is not None
+    assert snapshot.provenance.build == expected_build
+    assert snapshot.provenance.report_id is None
+    assert snapshot.provenance.receipt is None
+
+    manifest_provenance = snapshot.manifest["provenance"]
+    assert manifest_provenance is not None
+    assert manifest_provenance["build"] == expected_build  # type: ignore[index]
+    json.dumps(snapshot.manifest)
 
 
 def test_data_dictionary_and_manifest_are_json_safe_isolated_receipts(

--- a/tests/moneybin/test_exports/test_renderers.py
+++ b/tests/moneybin/test_exports/test_renderers.py
@@ -29,11 +29,11 @@ from moneybin.exports.renderers import (
     render_xlsx,
 )
 from moneybin.exports.snapshot import (
+    ExportProvenance,
     ExportSubject,
     PreparedColumn,
     PreparedExport,
     PreparedTable,
-    ReportExportProvenance,
     build_data_dictionary,
     prepared_table_checksum,
 )
@@ -80,7 +80,8 @@ def make_snapshot(*, report: bool = False) -> PreparedExport:
         tables=tables,
         data_dictionary=build_data_dictionary(tables),
         provenance=(
-            ReportExportProvenance(
+            ExportProvenance(
+                build={"version": "0.0.0", "revision": "test"},
                 report_id="test:activity",
                 receipt={"lineage": ["reports.activity"], "sql": None},
             )
@@ -472,7 +473,8 @@ def test_xlsx_preserves_empty_strings_distinct_from_null(tmp_path: Path) -> None
 def test_xlsx_splits_large_receipt_json_across_metadata_cells(tmp_path: Path) -> None:
     snapshot = replace(
         make_snapshot(report=True),
-        provenance=ReportExportProvenance(
+        provenance=ExportProvenance(
+            build={"version": "0.0.0", "revision": "test"},
             report_id="test:activity",
             receipt={"lineage": ["reports.activity"], "sql": "x" * 40_000},
         ),

--- a/tests/moneybin/test_exports/test_report_snapshot.py
+++ b/tests/moneybin/test_exports/test_report_snapshot.py
@@ -15,6 +15,7 @@ from pydantic import JsonValue
 from pytest_mock import MockerFixture
 
 import moneybin.reports._framework.catalog as report_catalog
+from moneybin.build_info import get_build_info
 from moneybin.database import Database
 from moneybin.errors import UserError
 from moneybin.exports.renderers import render_parquet
@@ -169,7 +170,12 @@ def test_prepare_report_executes_once_and_preserves_the_report_receipt(
         "amount": Decimal("-30.00"),
     }
 
+    build = get_build_info()
     assert snapshot.provenance is not None
+    assert snapshot.provenance.build == {
+        "version": build.version,
+        "revision": build.revision,
+    }
     assert snapshot.provenance.report_id == "test:export"
     assert snapshot.provenance.receipt == {
         "report_id": "test:export",
@@ -285,6 +291,7 @@ def test_prepare_report_carries_a_degraded_reports_drift_into_the_receipt(
     )
 
     assert snapshot.provenance is not None
+    assert snapshot.provenance.receipt is not None
     assert snapshot.provenance.receipt["degraded"] is True
     assert snapshot.provenance.receipt["degraded_reason"] == reason
     # The artifact, not just the in-memory receipt: the manifest is what ships.
@@ -318,6 +325,7 @@ def test_prepare_report_carries_a_pending_duplicate_caveat_into_the_receipt(
     )
 
     assert snapshot.provenance is not None
+    assert snapshot.provenance.receipt is not None
     assert snapshot.provenance.receipt["degraded"] is True
     reason = str(snapshot.provenance.receipt["degraded_reason"])
     assert reason.startswith(f"{DEGRADED_PENDING_DEDUP}: 1 ")
@@ -443,6 +451,7 @@ def test_a_redacted_user_report_export_withholds_the_saved_query(
     )
 
     assert redacted.provenance is not None
+    assert redacted.provenance.receipt is not None
     assert redacted.provenance.receipt["sql"] is None
     assert redacted.manifest["provenance"]["receipt"]["sql"] is None  # type: ignore[index]
     assert "021000021" not in json.dumps(redacted.manifest)
@@ -456,6 +465,7 @@ def test_a_redacted_user_report_export_withholds_the_saved_query(
 
     # The author's own statement, published only where the values are too.
     assert unredacted.provenance is not None
+    assert unredacted.provenance.receipt is not None
     assert "021000021" in str(unredacted.provenance.receipt["sql"])
 
 
@@ -511,6 +521,7 @@ def test_a_redacted_user_report_export_withholds_a_sensitive_column_alias(
     assert "021000021" not in json.dumps(redacted.manifest)
     assert "021000021" not in json.dumps(redacted.data_dictionary)
     assert redacted.provenance is not None
+    assert redacted.provenance.receipt is not None
     assert set(redacted.provenance.receipt["output_classes"]) == {  # type: ignore[arg-type]
         "redacted_column_1",
         "redacted_column_2",
@@ -597,6 +608,7 @@ def test_a_redacted_user_report_export_withholds_a_sensitive_parameter_name(
     }
     assert redacted.subject.as_manifest()["parameters"] == expected
     assert redacted.provenance is not None
+    assert redacted.provenance.receipt is not None
     assert redacted.provenance.receipt["parameters"] == expected
     assert redacted.provenance.receipt["parameter_classes"] == {
         "redacted_parameter_1": DataClass.ROUTING_NUMBER.value,
@@ -776,6 +788,7 @@ def test_a_redacted_user_report_export_withholds_a_drifted_column_alias(
     )
 
     assert redacted.provenance is not None
+    assert redacted.provenance.receipt is not None
     assert redacted.provenance.receipt["degraded"] is True
     assert (
         redacted.provenance.receipt["degraded_reason"] == DEGRADED_STALE_CLASSIFICATION
@@ -792,6 +805,7 @@ def test_a_redacted_user_report_export_withholds_a_drifted_column_alias(
     # Same rule as the header: an unredacted export publishes the value itself,
     # so naming the column that carries it costs nothing.
     assert unredacted.provenance is not None
+    assert unredacted.provenance.receipt is not None
     reason = unredacted.provenance.receipt["degraded_reason"]
     assert isinstance(reason, str)
     assert reason.startswith(DEGRADED_STALE_CLASSIFICATION)

--- a/tests/moneybin/test_exports/test_sheets_delivery.py
+++ b/tests/moneybin/test_exports/test_sheets_delivery.py
@@ -39,7 +39,7 @@ from moneybin.exports.sheets import (
     _table_values,  # pyright: ignore[reportPrivateUsage]  # white-box validation test
     _validate_values,  # pyright: ignore[reportPrivateUsage]  # white-box validation test
 )
-from moneybin.exports.snapshot import PreparedExport, ReportExportProvenance
+from moneybin.exports.snapshot import ExportProvenance, PreparedExport
 from moneybin.exports.workbook_roles import workbook_role_lease
 from moneybin.repositories.export_destinations_repo import (
     ExportDestinationSpreadsheetConflictError,
@@ -322,7 +322,8 @@ def test_publish_chunks_large_manifest_and_dictionary_receipts(db: Database) -> 
     """Receipt JSON round-trips when it exceeds a Sheets cell's safe capacity."""
     snapshot = replace(
         make_snapshot(report=True),
-        provenance=ReportExportProvenance(
+        provenance=ExportProvenance(
+            build={"version": "0.0.0", "revision": "test"},
             report_id="test:activity",
             receipt={"lineage": ["reports.activity"], "sql": "x" * 60_000},
         ),

--- a/tests/moneybin/test_mcp/test_system_status_build.py
+++ b/tests/moneybin/test_mcp/test_system_status_build.py
@@ -11,19 +11,13 @@ was missing from a three-day-old server.
 from __future__ import annotations
 
 import subprocess  # noqa: S404  # reads HEAD to derive the expected value
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import version
 from pathlib import Path
 
 import pytest
 
 from moneybin.database import DatabaseLockError
-from moneybin.mcp.tools.system import (
-    _build_info,  # pyright: ignore[reportPrivateUsage]
-    _read_git_revision,  # pyright: ignore[reportPrivateUsage]
-    _read_package_version,  # pyright: ignore[reportPrivateUsage]
-    system_status,
-    system_status_coarse,
-)
+from moneybin.mcp.tools.system import system_status, system_status_coarse
 
 
 @pytest.mark.unit
@@ -78,99 +72,6 @@ async def test_source_checkout_reports_the_commit_it_is_running(
     data = system_status().to_dict()["data"]
 
     assert data["build"]["revision"] == head
-
-
-@pytest.mark.unit
-def test_version_is_resolved_at_import_not_per_call(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Upgrading the environment must not make a live server claim the new version.
-
-    ``importlib.metadata.version`` re-reads the installed distribution's
-    metadata on every call, so upgrading MoneyBin underneath a running server
-    would report the *new* version while the process still holds the old
-    modules. That is the stale-server scenario this whole block exists to
-    diagnose, and it is the worst place to be confidently wrong: an installed
-    wheel reports ``revision: null``, leaving ``version`` as the only signal.
-    """
-    captured = _build_info().version
-
-    def _upgraded(_name: str) -> str:
-        return "99.99.99"
-
-    monkeypatch.setattr("moneybin.mcp.tools.system.version", _upgraded)
-
-    assert _build_info().version == captured
-
-
-@pytest.mark.unit
-def test_absent_distribution_metadata_reports_no_version(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Unreadable metadata degrades the field; it must never fail the import.
-
-    The version is resolved at import, so an unguarded lookup would turn a
-    missing distribution into a server that cannot boot — trading a rare
-    degraded answer for a total outage on the one surface whose job is to keep
-    answering when everything else is broken.
-    """
-
-    def _missing(_name: str) -> str:
-        raise PackageNotFoundError("moneybin")
-
-    monkeypatch.setattr("moneybin.mcp.tools.system.version", _missing)
-
-    assert _read_package_version() is None
-
-
-@pytest.mark.unit
-def test_revision_is_absent_outside_a_source_checkout(tmp_path: Path) -> None:
-    """An installed wheel has no repository to interrogate; say so, don't guess."""
-    assert _read_git_revision(tmp_path) is None
-
-
-@pytest.mark.unit
-def test_revision_is_absent_when_the_repository_is_merely_an_ancestor() -> None:
-    """A directory *inside* someone's checkout is not that checkout's build.
-
-    ``git`` answers about the nearest enclosing repository, so an installed
-    wheel under a virtualenv in the user's own project would otherwise stamp
-    MoneyBin's build with that project's HEAD — a confident wrong answer where
-    the contract promises ``null``.
-    """
-    assert _read_git_revision(Path(__file__).resolve().parent) is None
-
-
-@pytest.mark.unit
-def test_revision_survives_a_checkout_path_containing_a_space(tmp_path: Path) -> None:
-    """A space in the checkout path must not silently blank the stamp.
-
-    ``git rev-parse --show-toplevel`` prints the path unquoted, so splitting its
-    two-line answer on arbitrary whitespace turns one such path into three
-    tokens and discards the revision. macOS paths routinely contain spaces, and
-    the failure is invisible: the field reads ``null``, which is also exactly
-    what a legitimate wheel install reports.
-    """
-    repo = tmp_path / "space test dir"
-    repo.mkdir()
-    for command in (
-        ["init", "-q"],
-        ["-c", "user.email=t@example.com", "-c", "user.name=t"]
-        + ["commit", "-q", "--allow-empty", "-m", "x"],
-    ):
-        subprocess.run(  # noqa: S603  # git with static args
-            ["git", "-C", str(repo), *command],  # noqa: S607
-            capture_output=True,
-            check=True,
-        )
-    head = subprocess.run(  # noqa: S603  # git with static args
-        ["git", "-C", str(repo), "rev-parse", "HEAD"],  # noqa: S607
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
-
-    assert _read_git_revision(repo) == head
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #448.

## Problem

A bundle export wrote `manifest.provenance: null` while a report export populated it. A bundle is the portability artifact — the one most likely to outlive the machine that made it — so it was the artifact least able to answer "which code wrote this file". The data already existed: `system_status.overview.build` reports the same version and revision.

## Change

The version/revision derivation moved out of the MCP adapter into a new `moneybin.build_info`, and both `system_status` and the export layer now read it from there. Putting it in a shared module rather than importing the adapter keeps the MCP→service layering direction intact; `mcp/tools/system.py` already carried a deferred import of `exports.service` to dodge a cycle, and reaching the other way would have tightened that knot.

`ReportExportProvenance` is generalized to `ExportProvenance`: a mandatory `build` for both subject kinds, with `report_id`/`receipt` now optional and populated for a report only. The alternative was a second, bundle-only provenance type sitting beside the report-only one — two shapes for one concept.

## Scope note

Two things go beyond the letter of the issue, both deliberate:

- **The report path also gained `build`.** The issue only asks for bundles, but a field that comes back null for one of two subject kinds sharing a type is a question a reviewer would have to ask. One shape, populated the same way for both.
- **`manifest.json` gains a key for report exports too.** This is an additive change to an on-disk format — a reader written against `artifact_version: 1` still finds `report_id` and `receipt` where it left them — so `ARTIFACT_VERSION` is unchanged. Flagging it because on-disk formats are a public contract; pre-launch posture in `design-principles.md` is what makes the additive change the right call rather than a version bump.

## Test plan

- `make check` — 0 errors (3 pre-existing `reportlab` warnings, unrelated).
- `make test` — 11561 passed, 4 skipped.
- `make test-integration` — 608 passed. Run because the diff changes an emitted artifact shape and touches the MCP surface.
- New: bundle provenance pinned non-null with `build` matching `get_build_info()`, and `report_id`/`receipt` null; the report test extended to pin the same `build`, so both subject kinds are covered per the issue's acceptance.

## Notes

Uses a `changelog.d/` fragment rather than a `CHANGELOG.md` edit, per #587.
