### PR TITLE
Point the loaders docstring at repositories, not ImportService

### DIFF
--- a/src/moneybin/loaders/__init__.py
+++ b/src/moneybin/loaders/__init__.py
@@ -9,9 +9,16 @@ the ``ImportsRepo`` that already owns ``app.imports`` for the same entity (MB-24
 Do NOT fold it into ``ImportService``, which an earlier version of this docstring
 proposed: ``extractors/tabular/extractor.py`` imports this module at module level,
 so moving it under ``services/`` creates the extractor-to-services inversion
-MB-246 exists to delete. Two prerequisites gate the move — MB-52 slice 2 must drop
-that extractor import, and ``raw.import_log`` must become ``app.import_log``,
-because ``repositories/`` owns ``app.*`` tables only.
+MB-246 exists to delete. One prerequisite gates the move: MB-52 slice 2 must drop
+that extractor import.
+
+The schema is a separate decision, NOT a prerequisite. ``BaseRepo`` describes
+itself as owning protected ``app.*`` tables and 33 of its 35 subclasses are
+``app.*``, but nothing enforces that and ``ManualInvestmentTransactionsRepo``
+already owns ``raw.manual_investment_transactions`` — so a ``raw.*`` repo is
+possible today. Whether ``raw.import_log`` should become ``app.import_log`` is
+worth deciding on its own merits; an on-disk schema change is a one-way door, and
+relocating this module does not require one.
 """
 
 __all__: list[str] = []

--- a/src/moneybin/loaders/__init__.py
+++ b/src/moneybin/loaders/__init__.py
@@ -1,9 +1,17 @@
-"""Residual loaders package — pending full migration to services/extractors.
+"""Residual package holding only ``import_log.py``; destination is ``repositories/``.
 
 Provider-specific loaders moved to ``src/moneybin/extractors/<name>/`` per
 ``docs/specs/extension-contracts.md`` (Plan 1 Tasks 2-4). What remains is
-``import_log.py``, whose migration into ``ImportService`` is tracked as a
-follow-up outside Plan 1's scope.
+``import_log.py`` — batch-lifecycle bookkeeping over ``raw.import_log``.
+
+Its destination is ``repositories/import_log_repo.py`` (``ImportLogRepo``), beside
+the ``ImportsRepo`` that already owns ``app.imports`` for the same entity (MB-248).
+Do NOT fold it into ``ImportService``, which an earlier version of this docstring
+proposed: ``extractors/tabular/extractor.py`` imports this module at module level,
+so moving it under ``services/`` creates the extractor-to-services inversion
+MB-246 exists to delete. Two prerequisites gate the move — MB-52 slice 2 must drop
+that extractor import, and ``raw.import_log`` must become ``app.import_log``,
+because ``repositories/`` owns ``app.*`` tables only.
 """
 
 __all__: list[str] = []


### PR DESCRIPTION
## Summary

`src/moneybin/loaders/__init__.py` advertised a migration plan that would introduce a layering inversion if anyone acted on it. This corrects the docstring and points it at the real destination. Docstring only — no behavior change.

The old text:

> *"What remains is `import_log.py`, whose migration into `ImportService` is tracked as a follow-up outside Plan 1's scope."*

## Why that plan is wrong

`extractors/tabular/extractor.py:26` imports `import_log` at module level. Moving the module under `services/` therefore creates an **extractor→services import** — the same inversion MB-246 exists to delete, and the one PR #585 had to add a guard allowlist for.

## Where it actually belongs

`repositories/imports_repo.py` already exists, and its own docstring draws the boundary:

> *"`app.imports` holds only the labels overlay (one row per labeled import); the import lifecycle writes `raw.import_log` (out of scope)."*

So one entity — an import batch — has its storage split across two packages, documented as a scope boundary rather than chosen as a design. `import_log` does exactly what a `*Repo` does: owns reads and mutations of one table, including status transitions (`importing` → `completed` / `failed` / `reverted`). Its destination is `repositories/import_log_repo.py` as `ImportLogRepo`, beside `ImportsRepo`.

One prerequisite gates that move, recorded in **MB-248** (blocked-by MB-52):

- **No extractor may import it.** `repositories/` is not a neutral below-services layer — `base.py` imports `moneybin.services.audit_service`, and nearly every repo module carries at least one `from moneybin.services` import. MB-52 slice 2 (tabular) drops the extractor's dependency as a side effect of adopting the `load()` seam PR #585 established, where the lifecycle service keeps `begin_import`/`finalize_import`.
**Correction (review round 1).** An earlier revision of this section listed a second prerequisite: that `raw.import_log` must first become `app.import_log`, because `repositories/` is "strictly `app.*` — verified across all 37 repo modules". **That claim was wrong, and Codex caught it.** Re-scanned by AST: there are 35 concrete `BaseRepo` subclasses; 33 own an `app.*` table, one (`LinkDecisionsRepoBase`) declares no `table_ref`, and `ManualInvestmentTransactionsRepo` owns `raw.manual_investment_transactions` (`tables.py:123`). `BaseRepo`'s own docstrings describe the contract as protected `app.*` tables in four places, but nothing enforces it and one subclass already departs from it.

So the schema question is a **separate decision, not a prerequisite**, and the docstring now says so. Stating it as a prerequisite was the more harmful error of the two: it would have bound a package relocation to an on-disk schema migration, which `.claude/rules/design-principles.md` classifies as a one-way public-contract change. Whether `raw.import_log` belongs in `app` is still worth deciding — AGENTS.md's layer table calls `raw` "untouched data from loaders" and `app` "user-state and application-managed metadata", and a mutable batch record MoneyBin writes itself reads as `app` — but it is its own decision on its own merits, and MB-248 does not wait on it.

Renaming the package to a neutral-layer name instead was considered and rejected: it invents a package that can only ever hold one module, named for a process rather than a thing, when the destination already exists.

## Decision record

Decided with the maintainer 2026-09-11 under MB-39. Full reasoning, sequence, and acceptance criteria: MB-248.

## Gates

- `make check`: clean — 0 ruff errors, 0 pyright errors (3 pre-existing `reportlab` stub warnings in an unrelated PDF test fixture).
- Blast-radius tests (the packages that import `moneybin.loaders`, plus the layering guards and the documentation policy): **167 passed**
  - `tests/moneybin/test_loaders/test_import_log.py`
  - `tests/moneybin/test_meta/test_imports.py`
  - `tests/moneybin/test_architecture/`
  - `tests/test_documentation_policy.py`

A docstring carries no behavior, so a broader run buys nothing here; the architecture guards are included because they are what reference `moneybin.loaders` by name.

## Test plan

- [x] `make check` clean repo-wide
- [x] 167 targeted tests pass
- [x] No behavior change — diff is one docstring, 11 insertions / 3 deletions in a single file


## Changelog exemption (`skip-changelog`)

The diff is one module docstring. There is no user-visible result to describe:
no CLI command, MCP tool, schema column, report, export, or on-disk format
changes, and no runtime code path is touched. `.claude/rules/shipping.md` routes
exactly this case to the `skip-changelog` label with the reason stated in the PR,
and `changelog.d/README.md` asks a fragment to describe a user-visible result —
so a fragment here would have to say "no user-visible change", which is weaker
than the label plus this paragraph.

The `Changelog fragments` check failed for this and only this reason:
`towncrier` ran successfully against the branch, read `CHANGELOG.md` fine, and
reported `No new newsfragments found on this branch` with `SKIP_CHANGELOG:
false`. It is not the frozen-`base.sha` three-dot `CHANGELOG.md` failure that
#585 hit — that guard passed here.

