### PR TITLE
Test money-math invariants and gate combined coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
         if: always()
         with:
           name: coverage-data-unit-${{ matrix.group }}
-          path: .coverage.unit.${{ matrix.group }}
+          path: .coverage.unit.${{ matrix.group }}*
           include-hidden-files: true
 
   # Combine the per-suite, per-shard coverage data into one report. Runs even
@@ -298,7 +298,7 @@ jobs:
         if: always()
         with:
           name: coverage-data-integration-${{ matrix.group }}
-          path: .coverage.integration.${{ matrix.group }}
+          path: .coverage.integration.${{ matrix.group }}*
           include-hidden-files: true
 
   test-e2e:
@@ -357,7 +357,7 @@ jobs:
         if: always()
         with:
           name: coverage-data-e2e-${{ matrix.group }}
-          path: .coverage.e2e.${{ matrix.group }}
+          path: .coverage.e2e.${{ matrix.group }}*
           include-hidden-files: true
 
   test-privacy-performance:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,32 +154,32 @@ jobs:
       # pytest-split shards the unit suite across the matrix so wall-clock
       # scales with the number of free standard runners. strategy.job-total is
       # the matrix size, so --splits stays in lockstep with the `group` array.
-      # Each shard writes its own coverage data file; the `coverage` job below
-      # combines them into a single report.
+      # Each suite/shard writes its own coverage data file; the `coverage` job
+      # below combines unit, integration, and E2E execution into one report.
       - name: Test
         env:
-          COVERAGE_FILE: .coverage.${{ matrix.group }}
+          COVERAGE_FILE: .coverage.unit.${{ matrix.group }}
           # sys.monitoring-based coverage (PEP 669) on Python 3.12 — far lower
           # tracing overhead than the default C tracer. Needs coverage >= 7.4.
           COVERAGE_CORE: sysmon
         run: |
           uv run pytest tests/ -m unit -v -n logical \
             --splits ${{ strategy.job-total }} --group ${{ matrix.group }} \
-            --cov=src --cov-report= --durations=25
+            --cov=src --cov-report= --cov-fail-under=0 --durations=25
 
       - name: Upload coverage data
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: coverage-data-${{ matrix.group }}
-          path: .coverage.${{ matrix.group }}
+          name: coverage-data-unit-${{ matrix.group }}
+          path: .coverage.unit.${{ matrix.group }}
           include-hidden-files: true
 
-  # Combine the per-shard coverage data into one report. Runs even when a
-  # shard failed, so partial coverage still lands; waits on every shard.
+  # Combine the per-suite, per-shard coverage data into one report. Runs even
+  # when a shard failed, so partial coverage still lands; waits on every suite.
   coverage:
     name: Coverage report
-    needs: [changes, test-unit]
+    needs: [changes, test-unit, test-integration, test-e2e]
     if: ${{ always() && needs.changes.outputs.code == 'true' && github.event_name != 'schedule' && !inputs.record_durations }}
     runs-on: ubuntu-latest
     steps:
@@ -283,10 +283,23 @@ jobs:
       # dominated by one expensive module (test_demo_service.py,
       # test_stg_plaid_investments.py) can't parallelize out of it.
       - name: Test
+        env:
+          COVERAGE_FILE: .coverage.integration.${{ matrix.group }}
+          # sys.monitoring-based coverage (PEP 669) on Python 3.12 — far lower
+          # tracing overhead than the default C tracer. Needs coverage >= 7.4.
+          COVERAGE_CORE: sysmon
         run: |
           uv run pytest tests/ -m integration -v -n logical \
             --splits ${{ strategy.job-total }} --group ${{ matrix.group }} \
-            --durations=25
+            --cov=src --cov-report= --cov-fail-under=0 --durations=25
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: coverage-data-integration-${{ matrix.group }}
+          path: .coverage.integration.${{ matrix.group }}
+          include-hidden-files: true
 
   test-e2e:
     name: E2E tests (shard ${{ matrix.group }})
@@ -327,12 +340,25 @@ jobs:
       # helping in theory; it also adds runners, and CI + Scenarios + AI review
       # already dispatch 20 concurrent jobs (observed starting without
       # queueing, so the real ceiling is at least that -- it has not been
-      # measured). No coverage here, so no combine job.
+      # measured).
       - name: Test
+        env:
+          COVERAGE_FILE: .coverage.e2e.${{ matrix.group }}
+          # sys.monitoring-based coverage (PEP 669) on Python 3.12 — far lower
+          # tracing overhead than the default C tracer. Needs coverage >= 7.4.
+          COVERAGE_CORE: sysmon
         run: |
           uv run pytest tests/ -m e2e -v -n logical \
             --splits ${{ strategy.job-total }} --group ${{ matrix.group }} \
-            --durations=25
+            --cov=src --cov-report= --cov-fail-under=0 --durations=25
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: coverage-data-e2e-${{ matrix.group }}
+          path: .coverage.e2e.${{ matrix.group }}
+          include-hidden-files: true
 
   record-test-durations:
     name: Record CI test durations

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,9 @@ test-all: venv ## Development: Run all tests except performance budgets with ver
 
 test-cov: venv ## Development: Run tests with coverage report
 	@echo "$(BLUE)🧪 Running tests with coverage...$(RESET)"
-	@uv run pytest --cov=src tests/ -m "unit and not slow" --durations=25
+	# The 92% gate belongs to CI's unit/integration/E2E aggregate, not this partial suite.
+	@uv run pytest --cov=src --cov-report= --cov-fail-under=0 tests/ -m "unit and not slow" --durations=25
+	@uv run coverage report --fail-under=0
 	@echo "$(BLUE)📊 Coverage report generated$(RESET)"
 
 test-integration: venv ## Development: Run integration tests only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -424,6 +424,9 @@ filterwarnings = [
 # Documentation: https://coverage.readthedocs.io/en/7.4.0/config.html#run-section
 source = ["src"]
 omit = ["*/tests/*", "*/test_*", "*/venv/*", "*/__pycache__/*"]
+# Coverage.py 7.10+ instruments Python subprocesses and writes separate,
+# suffixed data files that must be combined before reporting.
+patch = ["subprocess"]
 
 [tool.coverage.report]
 # Documentation: https://coverage.readthedocs.io/en/latest/config.html#report-section

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -427,6 +427,10 @@ omit = ["*/tests/*", "*/test_*", "*/venv/*", "*/__pycache__/*"]
 
 [tool.coverage.report]
 # Documentation: https://coverage.readthedocs.io/en/latest/config.html#report-section
+# The combined unit/integration/E2E baseline is 92.859% (MB-69, 2026-09-11).
+# Round down to a whole percentage point so normal environment variance cannot
+# fail the gate while any meaningful coverage regression does.
+fail_under = 92
 exclude_lines = [
     "pragma: no cover",
     "def __repr__",

--- a/tests/property/test_cost_basis_engine.py
+++ b/tests/property/test_cost_basis_engine.py
@@ -137,16 +137,71 @@ def test_fifo_and_hifo_ignore_input_order_when_transaction_identities_and_dates_
     ledger=_covered_ledger(),
     method=st.sampled_from(("fifo", "hifo", "specific", "average")),
 )
-def test_realized_gain_is_proceeds_minus_basis_to_the_cent(
+def test_realized_gain_proceeds_reconcile_to_each_sale_and_persist_as_cents(
     ledger: tuple[list[LedgerEvent], Decimal], method: str
 ) -> None:
-    """Each persisted gain reconciles its independently persisted monetary terms."""
+    """Each sale distributes its actual cash proceeds and persists cents."""
     events, _acquired_quantity = ledger
     _lots, gains = _run(events, method)
 
+    sale_proceeds = {
+        event.investment_transaction_id: abs(event.amount or D("0"))
+        for event in events
+        if event.type == "sell"
+    }
+    for disposal_txn_id, proceeds in sale_proceeds.items():
+        realized_for_sale = [
+            gain for gain in gains if gain.disposal_txn_id == disposal_txn_id
+        ]
+        assert sum((gain.proceeds for gain in realized_for_sale), D("0")) == proceeds
+
     for gain in gains:
+        assert gain.proceeds == gain.proceeds.quantize(D("0.01"))
+        assert gain.cost_basis == gain.cost_basis.quantize(D("0.01"))
         assert gain.gain_loss == gain.proceeds - gain.cost_basis
         assert gain.gain_loss == gain.gain_loss.quantize(D("0.01"))
+
+
+def test_a_one_cent_sale_across_three_equal_lots_assigns_the_rounding_residual() -> (
+    None
+):
+    """The final FIFO slice retains the penny the first two equal shares lose."""
+    events = [
+        LedgerEvent(
+            investment_transaction_id=f"buy-{index}",
+            account_id="account",
+            security_id="security",
+            trade_date=_BASE_DATE + timedelta(days=index),
+            original_acquisition_date=None,
+            type="buy",
+            quantity=D("1"),
+            price=None,
+            amount=D("-1.00"),
+            fees=None,
+            currency_code="USD",
+        )
+        for index in range(3)
+    ]
+    events.append(
+        LedgerEvent(
+            investment_transaction_id="sell",
+            account_id="account",
+            security_id="security",
+            trade_date=_BASE_DATE + timedelta(days=4),
+            original_acquisition_date=None,
+            type="sell",
+            quantity=D("-3"),
+            price=None,
+            amount=D("0.01"),
+            fees=None,
+            currency_code="USD",
+        )
+    )
+
+    _lots, gains = _run(events, "fifo")
+
+    assert [gain.proceeds for gain in gains] == [D("0.00"), D("0.00"), D("0.01")]
+    assert sum((gain.proceeds for gain in gains), D("0")) == D("0.01")
 
 
 def _lot_snapshot(lots: list[Lot]) -> list[tuple[object, ...]]:

--- a/tests/property/test_cost_basis_engine.py
+++ b/tests/property/test_cost_basis_engine.py
@@ -1,0 +1,177 @@
+"""Properties of the cost-basis engine's conservation and ordering contracts.
+
+Example tests in ``test_cost_basis_engine.py`` pin tax treatment and worked
+cases. These properties quantify over many valid ledgers, where a finite set
+of examples cannot establish that all four methods preserve quantity and that
+FIFO/HIFO are independent of the caller's container order.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import date, timedelta
+from decimal import Decimal
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from moneybin.investments.cost_basis import (
+    LedgerEvent,
+    Lot,
+    RealizedGain,
+    compute_lots_and_gains,
+)
+
+D = Decimal
+_BASE_DATE = date(2024, 1, 1)
+
+
+def _method(method: str) -> Callable[[str, str], str]:
+    return lambda _account_id, _security_id: method
+
+
+def _no_selections(_disposal_txn_id: str) -> list[tuple[str, Decimal]]:
+    return []
+
+
+@st.composite
+def _covered_ledger(
+    draw: st.DrawFn,
+) -> tuple[list[LedgerEvent], Decimal]:
+    """Create purchases followed by a sale that cannot be oversold."""
+    purchases = draw(
+        st.lists(
+            st.tuples(
+                st.integers(min_value=1, max_value=100),
+                st.integers(min_value=1, max_value=100_000),
+            ),
+            min_size=1,
+            max_size=6,
+        )
+    )
+    acquired_quantity = sum((D(quantity) for quantity, _cents in purchases), D("0"))
+    sold_quantity = D(draw(st.integers(min_value=1, max_value=int(acquired_quantity))))
+    sale_cents = draw(st.integers(min_value=1, max_value=100_000))
+
+    events = [
+        LedgerEvent(
+            investment_transaction_id=f"buy-{index}",
+            account_id="account",
+            security_id="security",
+            trade_date=_BASE_DATE + timedelta(days=index),
+            original_acquisition_date=None,
+            type="buy",
+            quantity=D(quantity),
+            price=None,
+            amount=-(D(cents) / D("100")),
+            fees=None,
+            currency_code="USD",
+        )
+        for index, (quantity, cents) in enumerate(purchases)
+    ]
+    events.append(
+        LedgerEvent(
+            investment_transaction_id="sell",
+            account_id="account",
+            security_id="security",
+            trade_date=_BASE_DATE + timedelta(days=len(purchases) + 1),
+            original_acquisition_date=None,
+            type="sell",
+            quantity=-sold_quantity,
+            price=None,
+            amount=D(sale_cents) / D("100"),
+            fees=None,
+            currency_code="USD",
+        )
+    )
+    return events, acquired_quantity
+
+
+def _run(
+    events: list[LedgerEvent], method: str
+) -> tuple[list[Lot], list[RealizedGain]]:
+    return compute_lots_and_gains(
+        events,
+        method_for=_method(method),
+        selections_for=_no_selections,
+    )
+
+
+@given(
+    ledger=_covered_ledger(),
+    method=st.sampled_from(("fifo", "hifo", "specific", "average")),
+)
+def test_cost_basis_methods_conserve_acquired_quantity(
+    ledger: tuple[list[LedgerEvent], Decimal], method: str
+) -> None:
+    """Every acquired unit is either open or represented by one realized gain."""
+    events, acquired_quantity = ledger
+    lots, gains = _run(events, method)
+
+    remaining_quantity = sum((lot.remaining_quantity for lot in lots), D("0"))
+    realized_quantity = sum((gain.quantity for gain in gains), D("0"))
+
+    assert remaining_quantity + realized_quantity == acquired_quantity
+
+
+@given(
+    ledger=_covered_ledger(),
+    method=st.sampled_from(("fifo", "hifo")),
+    data=st.data(),
+)
+def test_fifo_and_hifo_ignore_input_order_when_transaction_identities_and_dates_are_stable(
+    ledger: tuple[list[LedgerEvent], Decimal], method: str, data: st.DataObject
+) -> None:
+    """Permuting input must not alter an economically ordered ledger's output."""
+    events, _acquired_quantity = ledger
+    permuted_events = list(data.draw(st.permutations(events), label="input-order"))
+
+    lots, gains = _run(events, method)
+    reordered_lots, reordered_gains = _run(permuted_events, method)
+
+    assert _lot_snapshot(lots) == _lot_snapshot(reordered_lots)
+    assert _gain_snapshot(gains) == _gain_snapshot(reordered_gains)
+
+
+@given(
+    ledger=_covered_ledger(),
+    method=st.sampled_from(("fifo", "hifo", "specific", "average")),
+)
+def test_realized_gain_is_proceeds_minus_basis_to_the_cent(
+    ledger: tuple[list[LedgerEvent], Decimal], method: str
+) -> None:
+    """Each persisted gain reconciles its independently persisted monetary terms."""
+    events, _acquired_quantity = ledger
+    _lots, gains = _run(events, method)
+
+    for gain in gains:
+        assert gain.gain_loss == gain.proceeds - gain.cost_basis
+        assert gain.gain_loss == gain.gain_loss.quantize(D("0.01"))
+
+
+def _lot_snapshot(lots: list[Lot]) -> list[tuple[object, ...]]:
+    """Compare observable lot state without depending on result-list order."""
+    return sorted(
+        (
+            lot.lot_id,
+            lot.remaining_quantity,
+            lot.cost_basis_remaining,
+            lot.basis_incomplete,
+        )
+        for lot in lots
+    )
+
+
+def _gain_snapshot(gains: list[RealizedGain]) -> list[tuple[object, ...]]:
+    """Compare observable gain state without depending on result-list order."""
+    return sorted(
+        (
+            gain.realized_gain_id,
+            gain.lot_id,
+            gain.quantity,
+            gain.proceeds,
+            gain.cost_basis,
+            gain.gain_loss,
+        )
+        for gain in gains
+    )

--- a/tests/property/test_tabular_transaction_identifiers.py
+++ b/tests/property/test_tabular_transaction_identifiers.py
@@ -1,0 +1,120 @@
+"""Properties of tabular content-hash transaction identifiers.
+
+The occurrence suffix protects distinct same-content transactions from staging
+deduplication while retaining a re-importable bare identifier for the first
+row. These expectations are derived from the identifier contract's specified
+SHA-256 inputs, not from the transform implementation's counter.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from decimal import Decimal
+
+import polars as pl
+from hypothesis import given
+from hypothesis import strategies as st
+
+from moneybin.extractors.tabular.transforms import transform_dataframe
+
+_DATE = "01/15/2026"
+_ACCOUNT_ID = "property-account"
+D = Decimal
+
+
+def _ids_for(rows: list[tuple[str, str, str]]) -> list[str]:
+    """Run the public tabular transform without a source-provided ID column."""
+    dataframe = pl.DataFrame({
+        "Date": [row[0] for row in rows],
+        "Amount": [row[1] for row in rows],
+        "Description": [row[2] for row in rows],
+    })
+    result = transform_dataframe(
+        df=dataframe,
+        field_mapping={
+            "transaction_date": "Date",
+            "amount": "Amount",
+            "description": "Description",
+        },
+        date_format="%m/%d/%Y",
+        sign_convention="negative_is_expense",
+        number_format="us",
+        account_id=_ACCOUNT_ID,
+        source_file="property.csv",
+        source_type="csv",
+        source_origin="property",
+        import_id="property-import",
+    )
+    return result.transactions["transaction_id"].to_list()
+
+
+@given(
+    cents=st.integers(min_value=1, max_value=100_000),
+    description=st.text(
+        alphabet="ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ", min_size=1, max_size=30
+    ),
+    duplicate_count=st.integers(min_value=1, max_value=8),
+    unrelated_count=st.integers(min_value=0, max_value=8),
+)
+def test_content_hash_occurrences_keep_the_first_bare_and_make_every_twin_unique(
+    cents: int,
+    description: str,
+    duplicate_count: int,
+    unrelated_count: int,
+) -> None:
+    """N equal rows produce exactly the bare hash plus N - 1 occurrence hashes."""
+    amount = f"-{D(cents) / D('100'):.2f}"
+    repeated_row = (_DATE, amount, description)
+    unrelated_rows = [
+        ("01/14/2026", f"-{index + 1}.00", f"unrelated-{index}")
+        for index in range(unrelated_count)
+    ]
+    rows = unrelated_rows + [repeated_row] * duplicate_count
+
+    ids = _ids_for(rows)
+    repeated_ids = ids[unrelated_count:]
+    content_key = f"{_DATE}|{amount}|{description}|{_ACCOUNT_ID}"
+    expected_ids = {
+        "csv_"
+        + hashlib.sha256(
+            (content_key if occurrence == 0 else f"{content_key}|{occurrence}").encode()
+        ).hexdigest()[:16]
+        for occurrence in range(duplicate_count)
+    }
+
+    assert set(repeated_ids) == expected_ids
+    assert len(repeated_ids) == len(set(repeated_ids))
+    assert repeated_ids[0] == _content_hash_id(content_key)
+
+
+@given(
+    cents=st.integers(min_value=1, max_value=100_000),
+    description=st.text(
+        alphabet="ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ", min_size=1, max_size=30
+    ),
+    duplicate_count=st.integers(min_value=2, max_value=8),
+    unrelated_count=st.integers(min_value=1, max_value=8),
+)
+def test_inserting_unrelated_rows_does_not_rekey_any_content_occurrence(
+    cents: int,
+    description: str,
+    duplicate_count: int,
+    unrelated_count: int,
+) -> None:
+    """An unrelated file position cannot alter the repeated-content identifier set."""
+    amount = f"-{D(cents) / D('100'):.2f}"
+    repeated_rows = [(_DATE, amount, description)] * duplicate_count
+    unrelated_rows = [
+        ("01/14/2026", f"-{index + 1}.00", f"unrelated-{index}")
+        for index in range(unrelated_count)
+    ]
+
+    ids_before = _ids_for(repeated_rows)
+    ids_after = _ids_for(unrelated_rows + repeated_rows)[unrelated_count:]
+
+    assert ids_after == ids_before
+
+
+def _content_hash_id(content_key: str) -> str:
+    """The contract's bare content-hash ID, derived independently of the transform."""
+    return "csv_" + hashlib.sha256(content_key.encode()).hexdigest()[:16]


### PR DESCRIPTION
## Summary

Generated tests now check cost-basis quantity conservation, FIFO/HIFO ordering, Decimal gain reconciliation, and stable transaction identifiers for repeated tabular rows. CI combines coverage from unit, integration, and E2E shards and enforces a 92% floor on the aggregate; individual shards only collect coverage.

## Test plan

The implementation passed 135 focused tests, 11,573 unit tests, 609 integration tests, and 383 E2E tests before synchronization with main. Combined coverage was 92.859%, which supplies the rounded-down 92% floor. `make check` passed. A focused shard run passed with the per-shard override, and reporting its intentionally partial data correctly failed the aggregate threshold.

After synchronization, the monetary properties were strengthened to reconcile each sale's proceeds and exercise a one-cent allocation across three lots; 80 focused tests and `make check` passed. Final CI and pushed-head review remain pending; the full local suites were run before synchronization. Fixtures are synthetic. This is internal test and CI work with no runtime change, so `skip-changelog` applies.
